### PR TITLE
Fix dashboard names in testgrid config

### DIFF
--- a/testgrid/Makefile
+++ b/testgrid/Makefile
@@ -14,6 +14,10 @@
 
 TESTGRID_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
+ifndef GOOGLE_APPLICATION_CREDENTIALS
+  $(error GOOGLE_APPLICATION_CREDENTIALS not set)
+endif
+
 update-config:
 	bazel run @k8s//testgrid/cmd/configurator -- \
 		--yaml=$(TESTGRID_DIR)/config.yaml \

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -140,8 +140,8 @@ dashboards:
 dashboard_groups:
 - name: knative
   dashboard_names:
-  - serving
-  - build
-  - eventing
-  - build-templates
-  - docs
+  - knative-serving
+  - knative-build
+  - knative-eventing
+  - knative-build-templates
+  - knative-docs


### PR DESCRIPTION
Bonus: check credentials when uploading the config.