### PR TITLE
Add dep-collector and licenseclassifier to prow-tests image

### DIFF
--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -23,6 +23,8 @@ RUN docker-credential-gcr configure-docker
 RUN apt-get install -y uuid-runtime  # for uuidgen
 RUN go get github.com/google/go-containerregistry/cmd/ko
 RUN go get github.com/golang/dep/cmd/dep
+RUN go get github.com/mattmoor/dep-collector
+RUN go get github.com/google/licenseclassifier
 
 # Add our scripts
 ADD scripts/library.sh .


### PR DESCRIPTION
These two tools are used during presubmit tests for checking the licenses in dependencies.