### PR TITLE
Update/fix scripts in prow-tests image

### DIFF
--- a/images/prow-tests/scripts/e2e-tests.sh
+++ b/images/prow-tests/scripts/e2e-tests.sh
@@ -76,7 +76,7 @@ function teardown_test_resources() {
 function fail_test() {
   [[ $? -eq 0 ]] && return 0
   [[ -n $1 ]] && echo "ERROR: $1"
-  dump_k8s_info
+  dump_cluster_state
   exit 1
 }
 
@@ -130,16 +130,13 @@ function create_test_cluster() {
   echo -n "1"> ${TEST_RESULT_FILE}
   local test_cmd_args="--run-tests"
   (( EMIT_METRICS )) && test_cmd_args+=" --emit-metrics"
-  # Normalize script path; we can't use readlink because it's not available everywhere
-  local script=$0
-  [[ ${script} =~ ^[\./].* ]] || script="./$0"
-  script="$(cd ${script%/*} && echo $PWD/${script##*/})"
+  echo "Test script is ${E2E_SCRIPT}"
   kubetest "${CLUSTER_CREATION_ARGS[@]}" \
     --up \
     --down \
     --extract "gke-${SERVING_GKE_VERSION}" \
     --gcp-node-image ${SERVING_GKE_IMAGE} \
-    --test-cmd "${script}" \
+    --test-cmd "${E2E_SCRIPT}" \
     --test-cmd-args "${test_cmd_args}"
   # Delete target pools and health checks that might have leaked.
   # See https://github.com/knative/serving/issues/959 for details.
@@ -228,9 +225,16 @@ function success() {
 RUN_TESTS=0
 EMIT_METRICS=0
 USING_EXISTING_CLUSTER=1
+E2E_SCRIPT=""
 
 # Parse flags and initialize the test cluster.
 function initialize() {
+  # Normalize calling script path; we can't use readlink because it's not available everywhere
+  E2E_SCRIPT=$0
+  [[ ${E2E_SCRIPT} =~ ^[\./].* ]] || E2E_SCRIPT="./$0"
+  E2E_SCRIPT="$(cd ${E2E_SCRIPT%/*} && echo $PWD/${E2E_SCRIPT##*/})"
+  readonly E2E_SCRIPT
+
   cd ${REPO_ROOT_DIR}
   for parameter in $@; do
     case $parameter in

--- a/images/prow-tests/scripts/library.sh
+++ b/images/prow-tests/scripts/library.sh
@@ -234,3 +234,27 @@ function report_go_test() {
   bazel test ${targets} > /dev/null 2>&1
   return ${failed}
 }
+
+# Install the latest stable Knative/serving in the current cluster.
+function start_latest_knative_serving() {
+  header "Starting Knative Serving"
+  subheader "Installing Istio"
+  kubectl apply -f ${KNATIVE_ISTIO_YAML} || return 1
+  wait_until_pods_running istio-system || return 1
+  kubectl label namespace default istio-injection=enabled || return 1
+  subheader "Installing Knative Serving"
+  kubectl apply -f ${KNATIVE_SERVING_RELEASE} || return 1
+  wait_until_pods_running knative-serving || return 1
+  wait_until_pods_running knative-build || return 1
+}
+
+# Install the latest stable Knative/build in the current cluster.
+function start_latest_knative_build() {
+  header "Starting Knative Build"
+  subheader "Installing Istio"
+  kubectl apply -f ${KNATIVE_ISTIO_YAML} || return 1
+  wait_until_pods_running istio-system || return 1
+  subheader "Installing Knative Build"
+  kubectl apply -f ${KNATIVE_BUILD_RELEASE} || return 1
+  wait_until_pods_running knative-build || return 1
+}


### PR DESCRIPTION
* add functions in `library.sh` to install the latest Knative Serving and Knative Build;
* fix getting the canonical path to the end-to-end test script in `e2e-tests.sh`;
* fix call to `dump_cluster_state` on failure in `e2e-tests.sh`;