### PR TITLE
Disable bazel remote caching for Prow jobs

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -110,10 +110,10 @@ presets:
   - name: bazel-scratch
     mountPath: /bazel-scratch/.cache
 - labels:
-    preset-bazel-remote-cache-enabled: "true"
+    preset-bazel-remote-cache-enabled: "false"
   env:
   - name: BAZEL_REMOTE_CACHE_ENABLED
-    value: "true"
+    value: "false"
 
 presubmits:
   knative/serving:


### PR DESCRIPTION
The remote caching jobs are not configured, and anyway Knative is not using bazel to the point that remote caching is a benefit.

Disable it to avoid spurious error messages in the test logs.