### PR TITLE
[cov][prowjob] fix runAsNonRoot & CreateContainerConfigError

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -296,8 +296,6 @@ presubmits:
       containers:
       - image: gcr.io/knative-tests/test-infra/coverage-dev:latest-dev
         imagePullPolicy: Always
-        securityContext:
-          runAsNonRoot: true
         command:
         - "/coverage"
         args:


### PR DESCRIPTION
fix the following error:
container has runAsNonRoot and image will run as root: CreateContainerConfigError