### PR TITLE
Use $BASH_SOURCE instead of $0 for sourcing library.sh

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,3 +1,5 @@
 # Helper scripts
 
 This directory contains helper scripts used by Prow test jobs, as well and local development scripts.
+
+It lives in the `knative/test-infra` repository, and is exported to all other Knative repositories through the `git subtree split` branch `exported-scripts`, and usually lives in `test/scripts` in these repos.

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -37,7 +37,7 @@
 #    K8S_USER_OVERRIDE and DOCKER_REPO_OVERRIDE set will immediately start the
 #    tests against the cluster.
 
-source $(dirname $0)/library.sh
+source $(dirname ${BASH_SOURCE})/library.sh
 
 # Build a resource name based on $E2E_BASE_NAME, a suffix and $BUILD_NUMBER.
 # Restricts the name length to 40 chars (the limit for resource names in GCP).

--- a/scripts/presubmit-tests.sh
+++ b/scripts/presubmit-tests.sh
@@ -30,7 +30,7 @@
 # to run a specific set of tests. The flag --emit-metrics is used
 # to emit metrics when running the tests.
 
-source $(dirname $0)/library.sh
+source $(dirname ${BASH_SOURCE})/library.sh
 
 # Extensions or file patterns that don't require presubmit tests.
 readonly NO_PRESUBMIT_FILES=(\.md \.png ^OWNERS)

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -32,7 +32,7 @@
 #    All environment variables above, except KO_FLAGS, are marked read-only once
 #    parse_flags() is called.
 
-source $(dirname $0)/library.sh
+source $(dirname ${BASH_SOURCE})/library.sh
 
 # Simple banner for logging purposes.
 function banner() {


### PR DESCRIPTION
`$0` isn't available when sourcing a script.

Plus, update `README.md` to clarify how these files appear in other repos.