### PR TITLE
Use default GKE version for test cluster

### DIFF
--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -19,7 +19,7 @@
 # called from command line.
 
 # Default GKE version to be used with Knative Serving
-readonly SERVING_GKE_VERSION=latest
+readonly SERVING_GKE_VERSION=default
 readonly SERVING_GKE_IMAGE=cos
 
 # Public images and yaml files.


### PR DESCRIPTION
`gke-latest` points to head, and these images might not yet be available for platforms other than Linux (e.g., Mac).

`gke-default` points to the default k8s version used by GKE.

Fixes #40.