### PR TITLE
Download kubernetes for E2E tests ourselves

### DIFF
--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -19,7 +19,7 @@
 # called from command line.
 
 # Default GKE version to be used with Knative Serving
-readonly SERVING_GKE_VERSION=default
+readonly SERVING_GKE_VERSION=latest
 readonly SERVING_GKE_IMAGE=cos
 
 # Public images and yaml files.
@@ -165,8 +165,8 @@ function acquire_cluster_admin_role() {
   # might not have the necessary permission.
   local password=$(gcloud --format="value(masterAuth.password)" \
       container clusters describe $2 --zone=$3)
-  kubectl --username=admin --password=$password \
-      create clusterrolebinding cluster-admin-binding \
+  kubectl config set-credentials cluster-admin --username=admin --password=${password}
+  kubectl create clusterrolebinding cluster-admin-binding \
       --clusterrole=cluster-admin \
       --user=$1
 }


### PR DESCRIPTION
The current approach for running the E2E tests through `kubetest` is to let the tool magically download kubernetes and start the cluster.

To ensure that our tests don't unexpectedly break, we don't pin the kubernetes version to a particular one (https://github.com/knative/serving/pull/1294) but always use `latest`.

However, the concept of `latest` for kubetests means "kubernetes head", which can be broken (didn't happen so far) or doesn't support all platforms (OS X is the most common case).

Unfortunately, switching to `default` or `release/stable` translates to kubernetes 1.9, which is not recommended for Knative according to the docs.

This PR reverts the default GKE version to latest and adds the function `download_k8s()`: it will download the latest public, stable GKE binary supported by the test cluster and the client machine.

As a bonus, the function knocks out the `kubernetes-test.tar.gz` package; this 1.2GB package is not used by Knative tests, and is a severe burden on slower connections (anedoctal evidence: 20+ min download on my home network).

Fixes #40.

Bonus 1: fixes #80.
Bonus 2: fixes https://github.com/knative/serving/issues/1914.