### PR TITLE
Properly fix acquire_cluster_admin_role()

### DIFF
--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -164,10 +164,16 @@ function acquire_cluster_admin_role() {
   # might not have the necessary permission.
   local password=$(gcloud --format="value(masterAuth.password)" \
       container clusters describe $2 --zone=$3)
-  kubectl config set-credentials cluster-admin --username=admin --password=${password}
+  kubectl config set-credentials cluster-admin \
+      --username=admin --password=${password}
+  kubectl config set-context $(kubectl config current-context) \
+      --user=cluster-admin
   kubectl create clusterrolebinding cluster-admin-binding \
       --clusterrole=cluster-admin \
       --user=$1
+  # Reset back to the default account
+  gcloud container clusters get-credentials \
+      $2 --zone=$3 --project $(gcloud config get-value project)
 }
 
 # Runs a go test and generate a junit summary through bazel.


### PR DESCRIPTION
`kubectl` 1.11 doesn't recognize the `--username` and `--password` global flags anymore. Because the `prow-tests` image uses `kubectl` 1.8, the Prow jobs are not broken (yet).

The changes in #86 don't work because the context is not changed (nor restored), but the function works as long as the current user is an owner of the GCP project (which is not the case for Prow E2E test jobs).

This change updates the context for the cluster admin, creates the role binding, then reinstates the original context. This is more secure as no ACL changes are required for the current user, nor project wide ACL changes are performed.