### PR TITLE
Disable review_acts_as_approve

### DIFF
--- a/ci/prow/plugins.yaml
+++ b/ci/prow/plugins.yaml
@@ -16,7 +16,7 @@ approve:
 - repos:
   - knative
   implicit_self_approve: true
-  review_acts_as_approve: true
+  review_acts_as_approve: false
 
 plugins:
   knative:


### PR DESCRIPTION
It seems that it's causing some confusion during approval/lgtm, so let's disable it until things are figured out.