### PR TITLE
Deal with error when checking for modified files

### DIFF
--- a/scripts/presubmit-tests.sh
+++ b/scripts/presubmit-tests.sh
@@ -46,6 +46,10 @@ function exit_if_presubmit_not_required() {
   if [[ -n "${PULL_PULL_SHA}" ]]; then
     # On a presubmit job
     local changes="$(/workspace/githubhelper -list-changed-files)"
+    if [[ -z "${changes}" ]]; then
+      header "NO CHANGED FILES REPORTED, ASSUMING IT'S AN ERROR AND RUNNING TESTS ANYWAY"
+      return
+    fi
     local no_presubmit_pattern="${NO_PRESUBMIT_FILES[*]}"
     local no_presubmit_pattern="\(${no_presubmit_pattern// /\\|}\)$"
     echo -e "Changed files in commit ${PULL_PULL_SHA}:\n${changes}"


### PR DESCRIPTION
If we can't get the list of modified files in a PR, assume tests need to be run. This will avoid leaving changed unguarded by tests.