### PR TITLE
add missing paren to scripts/library.sh

### DIFF
--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -312,6 +312,7 @@ function run_lint_tool() {
     ${checker} ${params} ${file} || failed=1
   done
   return ${failed}
+}
 
 # Check links in the given markdown files.
 # Parameters: $1...$n - files to inspect


### PR DESCRIPTION
I think there might be a missing parenthesis in the library.sh script.  I've added a paren where I believe the missing one is.