### PR TITLE
setup prow jobs for knative/build-pipeline

### DIFF
--- a/ci/gubernator/config.yaml
+++ b/ci/gubernator/config.yaml
@@ -37,6 +37,8 @@ jobs:
   - pull-knative-build-templates-unit-tests
   - pull-knative-build-templates-build-tests
   - pull-knative-build-templates-integration-tests
+  - pull-knative-build-pipeline-build-tests
+  - pull-knative-build-pipeline-unit-tests
   - pull-knative-build-build-tests
   - pull-knative-build-unit-tests
   - pull-knative-build-integration-tests

--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -49,6 +49,7 @@ tide:
   queries:
   - repos:
     - knative/build
+    - knative/build-pipeline
     - knative/build-templates
     - knative/serving
     - knative/eventing
@@ -489,6 +490,91 @@ presubmits:
       - name: github-token
         secret:
           secretName: covbot-token
+
+  knative/build-pipeline:
+  - name: pull-knative-build-pipeline-build-tests
+    agent: kubernetes
+    context: pull-knative-build-pipeline-build-tests
+    always_run: true
+    rerun_command: "/test pull-knative-build-pipeline-build-tests"
+    trigger: "(?m)^/test (all|pull-knative-build-pipeline-build-tests),?(\\s+|$)"
+    labels:
+      preset-service-account: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+        imagePullPolicy: Always
+        args:
+        - "--ssh=/etc/ssh-knative/ssh-knative"
+        - "--scenario=kubernetes_execute_bazel"
+        - "--clean"
+        - "--job=$(JOB_NAME)"
+        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+        - "--root=/go/src"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://knative-prow/pr-logs"
+        - "--" # end bootstrap args, scenario args below
+        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
+        - "./test/presubmit-tests.sh"
+        - "--build-tests"
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "1Gi"
+        volumeMounts:
+        - mountPath: /etc/ssh-knative
+          name: ssh-knative
+      volumes:
+      - name: ssh-knative
+        secret:
+          defaultMode: 256
+          secretName: ssh-knative
+
+  - name: pull-knative-build-pipeline-unit-tests
+    agent: kubernetes
+    context: pull-knative-build-pipeline-unit-tests
+    always_run: true
+    rerun_command: "/test pull-knative-build-pipeline-unit-tests"
+    trigger: "(?m)^/test (all|pull-knative-build-pipeline-unit-tests),?(\\s+|$)"
+    labels:
+      preset-service-account: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+        imagePullPolicy: Always
+        args:
+        - "--ssh=/etc/ssh-knative/ssh-knative"
+        - "--scenario=kubernetes_execute_bazel"
+        - "--clean"
+        - "--job=$(JOB_NAME)"
+        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+        - "--root=/go/src"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://knative-prow/pr-logs"
+        - "--" # end bootstrap args, scenario args below
+        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
+        - "./test/presubmit-tests.sh"
+        - "--unit-tests"
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "1Gi"
+        volumeMounts:
+        - mountPath: /etc/ssh-knative
+          name: ssh-knative
+      volumes:
+      - name: ssh-knative
+        secret:
+          defaultMode: 256
+          secretName: ssh-knative
 
   knative/eventing:
   - name: pull-knative-eventing-build-tests


### PR DESCRIPTION
This PR adds the knative/build-pipeline repo to prow with build and unit test support:
prow/config.yaml jobs:
pull-knative-build-pipeline-build-tests
pull-knative-build-pipeline-unit-tests

gubernator/config.yaml jobs:
pull-knative-build-pipeline-build-tests
pull-knative-build-pipeline-unit-tests

I have updated knative/build-pipeline to use code similar to what is in knative/serving for prow to trigger, PR here:
https://github.com/knative/test-infra/pull/114

I tried to follow the docs here:
https://github.com/knative/test-infra/blob/master/ci/prow/prow_setup.md#setting-up-prow-for-a-new-repo