### PR TITLE
Fix the directory of ci-* jobs

### DIFF
--- a/ci/gubernator/config.yaml
+++ b/ci/gubernator/config.yaml
@@ -51,6 +51,7 @@ jobs:
   - pull-knative-caching-build-tests
   - pull-knative-caching-unit-tests
   - pull-knative-caching-integration-tests
+  knative-prow/logs:
   - ci-knative-serving-continuous
   - ci-knative-serving-release
   - ci-knative-serving-playground


### PR DESCRIPTION
They're in `knative-prow/logs`.