### PR TITLE
Fix SSH keys workaround for kubetest

### DIFF
--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -171,6 +171,7 @@ function create_test_cluster() {
   fi
   # SSH keys are not used, but kubetest checks for their existence.
   # Touch them so if they don't exist, empty files are create to satisfy the check.
+  mkdir -p $HOME/.ssh
   touch $HOME/.ssh/google_compute_engine.pub
   touch $HOME/.ssh/google_compute_engine
   # Clear user and cluster variables, so they'll be set to the test cluster.
@@ -220,10 +221,6 @@ function create_test_cluster() {
 
 # Setup the test cluster for running the tests.
 function setup_test_cluster() {
-  # Fail fast during setup.
-  set -o errexit
-  set -o pipefail
-
   # Set the required variables if necessary.
   if [[ -z ${K8S_USER_OVERRIDE} ]]; then
     export K8S_USER_OVERRIDE=$(gcloud config get-value core/account)
@@ -304,6 +301,10 @@ function initialize() {
   done
   readonly RUN_TESTS
   readonly EMIT_METRICS
+
+  # Fail fast during setup.
+  set -o errexit
+  set -o pipefail
 
   if (( ! RUN_TESTS )); then
     create_test_cluster


### PR DESCRIPTION
Create the `~/.ssh` dir if it doesn't exist, don't assume it always exist.

Bonus: fail fast also during cluster setup.