### PR TITLE
More fixes to test-infra

### DIFF
--- a/dummy.go
+++ b/dummy.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"fmt"
+)
+
+func main() {
+	fmt.Println("This is a dummy go file so `go dep` can be used with knative/test-infra repo")
+	fmt.Println("This file can be removed once the repo contains real, useful go code in the root dir")
+}


### PR DESCRIPTION
* Readd `dummy.go` to the root dir: Because we `dep` the root dir of `test-infra`, it must contain go code.
* Ignore `kubetest` failures in `e2e-tests.sh`: Cluster teardown failures shouldn't affect the test results.