### PR TITLE
Disable gcloud notification updates in Prow presubmit tests

### DIFF
--- a/scripts/presubmit-tests.sh
+++ b/scripts/presubmit-tests.sh
@@ -67,6 +67,8 @@ function main() {
 
   # Show the version of the tools we're using
   if (( IS_PROW )); then
+    # Disable gcloud update notifications
+    gcloud config set component_manager/disable_update_check true
     header "Current test setup"
     echo ">> gcloud SDK version"
     gcloud version


### PR DESCRIPTION
It's noisy and doesn't add value.