### PR TITLE
Change build-pipline merge method to `rebase`

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -65,6 +65,7 @@ tide:
     - do-not-merge/work-in-progress
   merge_method:
     knative: squash
+    knative/build-pipeline: rebase
   target_url: https://prow.knative.dev/tide.html
 
 presets:


### PR DESCRIPTION
For `knative/build-pipeline` we'd like to avoid the `squash` merge
method b/c it is interfering with our commits and commit messages.

For example this commit was created by Tide:
https://github.com/knative/build-pipeline/commit/01853c6a74216a9f809d71fc2236703f8b580f0c

In the original commits, there were actually 3 authors
https://github.com/knative/build-pipeline/pull/66/commits
but Tide wiped one (me!) out.

In general, squashing commmits without even giving the author a chance
to reword the message leads to pretty terrible commit messages, which
are bulleted lists of sometimes terrible individual commit messages, but
to each their own.

cc @aaron-prindle @tejal29 @pivotal-nader-ziada 