### PR TITLE
Allow base name of resource to be longer

### DIFF
--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -47,11 +47,11 @@ source $(dirname ${BASH_SOURCE})/library.sh
 function build_resource_name() {
   local prefix=${E2E_BASE_NAME}-$1
   local suffix=${BUILD_NUMBER}
-  # Restrict suffix length to 20 chars
+  # Restrict suffix length to 30 chars
   if [[ -n "${suffix}" ]]; then
-    suffix=${suffix:${#suffix}<20?0:-20}
+    suffix=${suffix:${#suffix}<30?0:-30}
   fi
-  echo "${prefix:0:20}${suffix}"
+  echo "${prefix:0:30}${suffix}"
 }
 
 # Test cluster parameters


### PR DESCRIPTION
When trying to run this script for knative/build-pipeline, the resource
name was getting truncated too early: 1) the resource names were all the
same and 2) they were invalid because they happened to end with `-`.

This resulted in errors like:
```
ERROR: (gcloud.compute.networks.describe) Could not fetch resource:
 - Invalid value 'kbuild-pipeline-e2e-'. Values must match the following regular expression: '[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?'
```

30 chars is pretty arbitrary so open to better solutions also!

This is for https://github.com/knative/build-pipeline/issues/16