### PR TITLE
Create a helper for running e2e go tests

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -46,7 +46,7 @@ This script will test that the latest Knative Serving nightly release works.
 source vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
 
 function teardown() {
-  echo "TODO: tear down Knative Serving"
+  echo "TODO: tear down test resources"
 }
 
 initialize $@
@@ -54,6 +54,9 @@ initialize $@
 start_latest_knative_serving
 
 wait_until_pods_running knative-serving || fail_test "Knative Serving is not up"
+
+# TODO: use go_test_e2e to run the tests.
+kubectl get pods || fail_test
 
 success
 ```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,3 +1,59 @@
 # Helper scripts
 
-This directory contains helper scripts used by Prow test jobs, as well and local development scripts.
+This directory contains helper scripts used by Prow test jobs, as well and
+local development scripts.
+
+## Using the `e2e-tests.sh` helper script
+
+This is a helper script for Knative E2E test scripts. To use it:
+
+1. Source the script.
+
+1. [optional] Write the `teardown()` function, which will tear down your test
+resources.
+
+1. [optional] Write the `dump_extra_cluster_state()` function. It will be
+called when a test fails, and can dump extra information about the current state
+of the cluster (tipically using `kubectl`).
+
+1. Call the `initialize()` function passing `$@` (without quotes).
+
+1. Write logic for the end-to-end tests. Run all go tests using `go_test_e2e()`
+(or `report_go_test()` if you need a more fine-grained control) and call
+`fail_test()` or `success()` if any of them failed. The environment variables
+`DOCKER_REPO_OVERRIDE`, `K8S_CLUSTER_OVERRIDE` and `K8S_USER_OVERRIDE` will be set
+according to the test cluster. You can also use the following boolean (0 is false,
+1 is true) environment variables for the logic:
+  * `EMIT_METRICS`: true if `--emit-metrics` is passed.
+  * `USING_EXISTING_CLUSTER`: true if the test cluster is an already existing one,
+and not a temporary cluster created by `kubetest`.
+All environment variables above are marked read-only.
+
+**Notes:**
+
+1. Calling your script without arguments will create a new cluster in the GCP
+project `$PROJECT_ID` and run the tests against it.
+
+1. Calling your script with `--run-tests` and the variables `K8S_CLUSTER_OVERRIDE`,
+`K8S_USER_OVERRIDE` and `DOCKER_REPO_OVERRIDE` set will immediately start the
+tests against the cluster.
+
+### A minimal end-to-end script runner
+
+This script will test that the latest Knative Serving nightly release works.
+
+```
+source vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
+
+function teardown() {
+  echo "TODO: tear down Knative Serving"
+}
+
+initialize $@
+
+start_latest_knative_serving
+
+wait_until_pods_running knative-serving || fail_test "Knative Serving is not up"
+
+success
+```

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -14,30 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This is a helper script for Knative E2E test scripts. To use it:
-# 1. Source this script.
-# 2. [optional] Write the teardown() function, which will tear down your test
-#    resources.
-# 3. [optional] Write the dump_extra_cluster_state() function. It will be called
-#    when a test fails, and can dump extra information about the current state of
-#    the cluster (tipically using kubectl).
-# 4. Call the initialize() function passing $@ (without quotes).
-# 5. Write logic for the end-to-end tests. Run all go tests using report_go_test()
-#    and call fail_test() or success() if any of them failed. The envitronment
-#    variables DOCKER_REPO_OVERRIDE, K8S_CLUSTER_OVERRIDE and K8S_USER_OVERRIDE
-#    will be set accordingly to the test cluster. You can also use the following
-#    boolean (0 is false, 1 is true) environment variables for the logic:
-#    EMIT_METRICS: true if --emit-metrics is passed.
-#    USING_EXISTING_CLUSTER: true if the test cluster is an already existing one,
-#                            and not a temporary cluster created by kubetest.
-#    All environment variables above are marked read-only.
-# Notes:
-# 1. Calling your script without arguments will create a new cluster in the GCP
-#    project $PROJECT_ID and run the tests against it.
-# 2. Calling your script with --run-tests and the variables K8S_CLUSTER_OVERRIDE,
-#    K8S_USER_OVERRIDE and DOCKER_REPO_OVERRIDE set will immediately start the
-#    tests against the cluster.
-
 source $(dirname ${BASH_SOURCE})/library.sh
 
 # Build a resource name based on $E2E_BASE_NAME, a suffix and $BUILD_NUMBER.
@@ -89,6 +65,14 @@ function fail_test() {
   [[ -n $1 ]] && echo "ERROR: $1"
   dump_cluster_state
   exit 1
+}
+
+# Run the given E2E tests (must be tagged as such).
+# Parameters: $1..$n - directories containing the tests to run.
+function go_test_e2e() {
+  local options=""
+  (( EMIT_METRICS )) && options="-emitmetrics"
+  report_go_test -v -tags=e2e -count=1 -timeout=20m $@ ${options}
 }
 
 # Download the k8s binaries required by kubetest.


### PR DESCRIPTION
Let's hide the complexity of running e2e go tests in `e2e-tests.sh`.

Bonus: move documentation to `README.md` to make it more visible.

Part of #170.