### PR TITLE
Don't set timeout in go_test_e2e

### DIFF
--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -68,11 +68,11 @@ function fail_test() {
 }
 
 # Run the given E2E tests (must be tagged as such).
-# Parameters: $1..$n - directories containing the tests to run.
+# Parameters: $1..$n - any go test flags, then directories containing the tests to run.
 function go_test_e2e() {
   local options=""
   (( EMIT_METRICS )) && options="-emitmetrics"
-  report_go_test -v -tags=e2e -count=1 -timeout=20m $@ ${options}
+  report_go_test -v -tags=e2e -count=1 $@ ${options}
 }
 
 # Download the k8s binaries required by kubetest.


### PR DESCRIPTION
Let the caller decide. Also clarify that arguments can be flags for go test (as long as they come first).