### PR TITLE
Redirect stderr to /dev/null

### DIFF
--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -94,7 +94,7 @@ function wait_until_object_does_not_exist() {
   fi
   echo -n "Waiting until ${DESCRIPTION} does not exist"
   for i in {1..150}; do  # timeout after 5 minutes
-    kubectl ${KUBECTL_ARGS} 2>&1 > /dev/null || return 0
+    kubectl ${KUBECTL_ARGS} > /dev/null 2>&1 || return 0
     echo -n "."
     sleep 2
   done


### PR DESCRIPTION
When using `wait_until_object_does_not_exist` to make sure that
namespaces do not exist (as part of teardown) before deploying to them
again in https://github.com/knative/build-pipeline/pull/87 we noticed
that we had errors popping up in the logs like this:

```
I1004 21:05:29.771] Waiting until namespace knative-build-pipeline does not exist........Error from server (NotFound): namespaces "knative-build-pipeline" not found
I1004 21:05:32.067] Waiting until namespace knative-build does not exist.Error from server (NotFound): namespaces "knative-build" not found
```

After looking into it more it seems like the way to redirect both stderr
and stdout to /dev/null is a bit counter intuitive
(http://mywiki.wooledge.org/BashFAQ/055) and the code that was here
before was actually:
1. Setting stderr to go to where stdout was currently going (terminal)
2. _Then_ setting stdout to go to /dev/null, but leaving stderr going to
  the terminal

Apparently the way to fix this is to point stdout at /dev/null first.