### PR TITLE
Don't build  resource names ending in "-"

### DIFF
--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -27,7 +27,9 @@ function build_resource_name() {
   if [[ -n "${suffix}" ]]; then
     suffix=${suffix:${#suffix}<20?0:-20}
   fi
-  echo "${prefix:0:20}${suffix}"
+  local name="${prefix:0:20}${suffix}"
+  # Ensure name doesn't end with "-"
+  echo "${name%-}"
 }
 
 # Test cluster parameters


### PR DESCRIPTION
Such names are invalid in GCP, and they can be generated in a local environment with a prefix that has the right length (e.g., "build-pipeline").