### PR TITLE
Add a job for measuring Knative Build latency

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -1492,6 +1492,7 @@ periodics:
       - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./test/presubmit-tests.sh"
       - "--all-tests"
+      - "--emit-metrics"
       # Bazel needs privileged mode in order to sandbox builds.
       securityContext:
         privileged: true
@@ -1530,6 +1531,26 @@ periodics:
       resources:
         requests:
           memory: "1Gi"
+- cron: "5 8 * * *" # Run at 01:05PST every day (08:05 UTC)
+  name: ci-knative-build-latency
+  agent: kubernetes
+  labels:
+    preset-service-account: "true"
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: build
+    base_ref: master
+    clone_uri: "https://github.com/knative/build.git"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/metrics:latest
+      imagePullPolicy: Always
+      command:
+      - "/metrics"
+      args:
+      - "--artifacts-dir=$(ARTIFACTS)"
+      - "--service-account=/etc/service-account/service-account.json"
 - cron: "0 1 * * *" # Run at 01:00 every day
   name: ci-knative-build-go-coverage
   agent: kubernetes

--- a/ci/testgrid/config.yaml
+++ b/ci/testgrid/config.yaml
@@ -75,6 +75,9 @@ test_groups:
 - name: pull-knative-build-test-coverage
   gcs_prefix: knative-prow/logs/ci-knative-build-go-coverage
   short_text_metric: coverage
+- name: ci-knative-build-latency
+  gcs_prefix: knative-prow/logs/ci-knative-build-latency
+  short_text_metric: latency
 - name: ci-knative-eventing-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-continuous
 - name: ci-knative-eventing-release
@@ -130,6 +133,10 @@ dashboards:
     test_group_name: ci-knative-build-release
   - name: coverage
     test_group_name: pull-knative-build-test-coverage
+    base_options: 'exclude-filter-by-regex=Overall&group-by-directory=&expand-groups=&sort-by-name='
+  - name: latency
+    test_group_name: ci-knative-build-latency
+    description: '95% latency in ms'
     base_options: 'exclude-filter-by-regex=Overall&group-by-directory=&expand-groups=&sort-by-name='
 - name: knative-eventing
   dashboard_tab:


### PR DESCRIPTION
Results will be displayed in a new tab in Testgrid, just like Serving.