### PR TITLE
Request Prow to automatically lint go code in PRs

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -1,0 +1,7 @@
+<!--
+Request Prow to automatically lint any go code in this PR:
+
+/lint
+-->
+
+Fixes #


### PR DESCRIPTION
Sneak `/lint` into the PR template, so hopefully this will trigger `/lint` automatically for most PRs we get. :)

(this is already being used in knative/serving)