### PR TITLE
Fix the name of source for aggregating metrics

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -1396,7 +1396,7 @@ periodics:
       command:
       - "/metrics"
       args:
-      - "--source-directory=ci-knative-serving-latency"
+      - "--source-directory=ci-knative-serving-continuous"
       - "--artifacts-dir=$(ARTIFACTS)"
       - "--service-account=/etc/service-account/service-account.json"
 - cron: "5 8 * * *" # Run at 01:05PST every day (08:05 UTC)
@@ -1550,7 +1550,7 @@ periodics:
       command:
       - "/metrics"
       args:
-      - "--source-directory=ci-knative-build-latency"
+      - "--source-directory=ci-knative-build-continuous"
       - "--artifacts-dir=$(ARTIFACTS)"
       - "--service-account=/etc/service-account/service-account.json"
 - cron: "0 1 * * *" # Run at 01:00 every day


### PR DESCRIPTION
Metrics are parsed from the continuous jobs.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->