### PR TITLE
Cleanup bazel after library-tests.sh finish

### DIFF
--- a/test/library-tests.sh
+++ b/test/library-tests.sh
@@ -29,6 +29,13 @@ function test_report() {
   grep "Done parsing 1 tests" ${REPORT} > /dev/null
 }
 
+# Cleanup bazel stuff to avoid confusing Prow
+function cleanup_bazel() {
+  bazel clean
+}
+
+trap cleanup_bazel EXIT
+
 header "Testing report_go_test"
 
 subheader "Test pass"


### PR DESCRIPTION
Otherwise Gubernator will report failures, even when all tests pass, because some tests do test that testcases failed (!).