### PR TITLE
Create the xml output needed for testgrid to get perf latency numbers

### DIFF
--- a/images/observed-concurrency/Dockerfile
+++ b/images/observed-concurrency/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM golang:1.10.2
+LABEL maintainer "Srinivas Hegde <srinivashegde@google.com>"
+RUN apt-get update && apt-get install -y --no-install-recommends
+
+COPY observed-concurrency /observed-concurrency
+ENTRYPOINT ["/observed-concurrency"]

--- a/images/observed-concurrency/Makefile
+++ b/images/observed-concurrency/Makefile
@@ -1,0 +1,32 @@
+
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+IMG = gcr.io/knative-tests/test-infra/observed-concurrency
+TAG := $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
+
+all: build
+
+build:
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build ../../tools/observed-concurrency
+	docker build -t $(IMG):$(TAG) .
+	docker tag $(IMG):$(TAG) $(IMG):latest
+
+push_versioned: build
+	docker push $(IMG):$(TAG)
+
+push_latest: build
+	docker push $(IMG):latest
+
+push: push_versioned push_latest

--- a/images/observed-concurrency/README.md
+++ b/images/observed-concurrency/README.md
@@ -1,0 +1,11 @@
+# Observed Concurrency Tool Image
+
+This directory contains the custom docker image used for calculating the performance latency from the performance test runs.
+
+## Building and publishing a new image
+
+To build and push a new image, just run `make push`.
+
+For testing purposes you can build an image but not push it; to do so, run `make build`.
+
+Note that you must have proper permission in the `knative-tests` project to push new images to the GCR.

--- a/tools/apicoverage/apicoverage.go
+++ b/tools/apicoverage/apicoverage.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	logDir         = "logs/ci-knative-serving-continuous/"
+	logDir         = "logs/ci-knative-serving-continuous"
 	buildFile      = "build-log.txt"
 	apiCoverage    = "api_coverage"
 	overallRoute   = "OverallRoute"

--- a/tools/gcs/gcs.go
+++ b/tools/gcs/gcs.go
@@ -33,7 +33,7 @@ import (
 
 const (
 	bucketName = "knative-prow"
-	latest     = "latest-build.txt"
+	latest     = "/latest-build.txt"
 )
 
 var client *storage.Client
@@ -50,6 +50,7 @@ func createStorageObject(filename string) *storage.ObjectHandle {
 
 // GetLatestBuildNumber gets the latest build number for the specified log directory
 func GetLatestBuildNumber(ctx context.Context, logDir string, sa string) (int, error) {
+	log.Printf("%s %s", logDir, latest)
 	contents, err := ReadGcsFile(ctx, logDir+latest, sa)
 	if err != nil {
 		return 0, err

--- a/tools/observed-concurrency/README.md
+++ b/tools/observed-concurrency/README.md
@@ -1,0 +1,14 @@
+# Observed concurrency
+This tool is designed to show the latency numbers calculated by the perf tests.
+
+## Read from GCS
+This tool reads the logs from the latest performance test run of knative/serving. 
+It uses the service account passed in or by default will use the GOOGLE_APPLICATION_CREDENTIALS variable to get the logs. 
+
+## Creating Output
+This tool creates an output xml in the prow artifacts directory. The prow artifacts directory is passed in or by default will use `./artifacts` directory.
+
+This output xml will be read by testgrid and displayed on the [dashboard](https://testgrid.knative.dev/knative-serving#perf-latency).
+
+## Prow Job
+There is a daily prow job that triggers this tool that is run at 02:05 AM PST. This tool will then generate the output xml which is then displayed in the testgrid dashboard.

--- a/tools/observed-concurrency/concurrency.go
+++ b/tools/observed-concurrency/concurrency.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// concurrency.go parses the latest log file of the perf test run and outputs the latency observed.
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+
+	"github.com/knative/test-infra/tools/gcs"
+	"github.com/knative/test-infra/tools/testgrid"
+)
+
+const (
+	logDir      = "logs/ci-knative-serving-performance"
+	buildFile   = "build-log.txt"
+	perfLatency = "perf_latency"
+	scaleTo5    = "ScaleTo5(ms)"
+)
+
+func getRelevantLogs(fields []string) *string {
+	// I1018 01:13:41.537]     5: 2002 ms
+	if len(fields) == 5 && fields[2] == "5:" {
+		return &fields[3]
+	}
+	return nil
+}
+
+func createTestgridXML(latency float32, dir string) {
+	tp := []testgrid.TestProperty{testgrid.TestProperty{Name: perfLatency, Value: latency}}
+	tc := []testgrid.TestCase{testgrid.TestCase{ClassName: perfLatency, Name: scaleTo5, Properties: testgrid.TestProperties{Property: tp}}}
+	ts := testgrid.TestSuite{TestCases: tc}
+
+	if err := testgrid.CreateXMLOutput(ts, dir); err != nil {
+		log.Fatalf("Cannot create the xml output file: %v", err)
+	}
+}
+
+func main() {
+
+	artifactsDir := flag.String("artifacts-dir", "./artifacts", "Directory to store the generated XML file")
+	serviceAccount := flag.String("service-account", os.Getenv("GOOGLE_APPLICATION_CREDENTIALS"), "JSON key file for service account to use")
+	flag.Parse()
+
+	// Read the latest-build.txt file to get the latest build number
+	ctx := context.Background()
+	num, err := gcs.GetLatestBuildNumber(ctx, logDir, *serviceAccount)
+	if err != nil {
+		log.Fatalf("Cannot get latest build number: %v", err)
+	}
+
+	// Get observed latency from the log file
+	latencyLogs := gcs.ParseLog(ctx, fmt.Sprintf("%s/%d/%s", logDir, num, buildFile), getRelevantLogs)
+	if len(latencyLogs) == 0 {
+		log.Fatalf("No relevant log statement found for latency")
+	}
+
+	if latency, err := strconv.ParseFloat(latencyLogs[0], 32); err != nil {
+		log.Fatalf("Cannot get latency: %v", err)
+	} else {
+		// Write the testgrid xml to artifacts
+		createTestgridXML(float32(latency), *artifactsDir)
+	}
+}


### PR DESCRIPTION
Also, fixes a minor typo when concatenating the filenames when querying GCS.

Part of https://github.com/knative/serving/issues/1981