### PR TITLE
Update prow and testgrid configs to show perf latency numbers

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -1419,6 +1419,26 @@ periodics:
       args:
       - "--artifacts-dir=$(ARTIFACTS)"
       - "--service-account=/etc/service-account/service-account.json"
+- cron: "5 9 * * *" # Run at 02:05 PST every day (09:05 UTC)
+  name: ci-knative-serving-performance-tool
+  agent: kubernetes
+  labels:
+    preset-service-account: "true"
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: master
+    clone_uri: "https://github.com/knative/serving.git"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/observed-concurrency:latest
+      imagePullPolicy: Always
+      command:
+      - "/apicoverage"
+      args:
+      - "--artifacts-dir=$(ARTIFACTS)"
+      - "--service-account=/etc/service-account/service-account.json"
 - cron: "0 1 * * *" # Run at 01:00 every day
   name: ci-knative-serving-go-coverage
   agent: kubernetes

--- a/ci/testgrid/config.yaml
+++ b/ci/testgrid/config.yaml
@@ -68,6 +68,9 @@ test_groups:
 - name: ci-knative-serving-api-coverage
   gcs_prefix: knative-prow/logs/ci-knative-serving-api-coverage
   short_text_metric: api_coverage
+- name: ci-knative-serving-performance
+  gcs_prefix: knative-prow/logs/ci-knative-serving-performance-tool
+  short_text_metric: perf_latency
 - name: ci-knative-build-continuous
   gcs_prefix: knative-prow/logs/ci-knative-build-continuous
 - name: ci-knative-build-release
@@ -124,6 +127,10 @@ dashboards:
   - name: api-coverage
     test_group_name: ci-knative-serving-api-coverage
     description: 'Conformance tests API coverage.'
+    base_options: 'exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name='
+  - name: performance
+    test_group_name: ci-knative-serving-performance-tool
+    description: 'Performance tests numbers'
     base_options: 'exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name='
 - name: knative-build
   dashboard_tab:


### PR DESCRIPTION
Prow config: Add a periodic job to parse the build-log from the daily perf run and get the latency numbers in the testgrid xml. This job is created in https://github.com/knative/test-infra/pull/201

Testgrid config: Add a new tab in knative/serving for showing performance latency from the xml generated from the tool and run in the above prow job.

Fixes knative/serving#1981