### PR TITLE
Expose docker daemon in knative/build e2e tests

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -359,6 +359,7 @@ presubmits:
       preset-service-account: "true"
       preset-bazel-scratch-dir: "true"
       preset-bazel-remote-cache-enabled: "true"
+      preset-dind-enabled: "true"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:latest


### PR DESCRIPTION
We're building a new build-base image in our e2e tests

Unblocks -  https://github.com/knative/build/pull/437