### PR TITLE
Adding a new TestGrid dashboard tab for conformance tests results

### DIFF
--- a/ci/testgrid/config.yaml
+++ b/ci/testgrid/config.yaml
@@ -135,6 +135,9 @@ dashboards:
     test_group_name: ci-knative-serving-api-coverage
     description: 'Conformance tests API coverage.'
     base_options: 'exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name='
+  - name: conformance-tests
+    test_group_name: ci-knative-serving-continuous
+    base_options: 'include-filter-by-regex=//knative/serving/test/conformance:&sort-by-name='
 - name: knative-build
   dashboard_tab:
   - name: continuous


### PR DESCRIPTION
PR adds a Dashboard tab for conformance tests results on https://testgrid.knative.dev/knative-serving dashboard.

Note: The current implementation has a limitation that it doesn't provide the summary "Overall" row. 

Fixes #162 
