### PR TITLE
Install kubetest if necessary when running E2E tests

### DIFF
--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -184,8 +184,8 @@ function create_test_cluster() {
   # Don't fail test for kubetest, as it might incorrectly report test failure
   # if teardown fails (for details, see success() below)
   set +o errexit
-  run_go_tool kubetest k8s.io/test-infra/kubetest \
-    "${CLUSTER_CREATION_ARGS[@]}" \
+  run_go_tool k8s.io/test-infra/kubetest \
+    kubetest "${CLUSTER_CREATION_ARGS[@]}" \
     --up \
     --down \
     --extract local \

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -184,7 +184,8 @@ function create_test_cluster() {
   # Don't fail test for kubetest, as it might incorrectly report test failure
   # if teardown fails (for details, see success() below)
   set +o errexit
-  kubetest "${CLUSTER_CREATION_ARGS[@]}" \
+  run_go_tool kubetest k8s.io/test-infra/kubetest \
+    "${CLUSTER_CREATION_ARGS[@]}" \
     --up \
     --down \
     --extract local \

--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -365,7 +365,7 @@ function run_go_tool() {
     go install $1
   fi
   shift 2
-  ${tool} $@
+  ${tool} "$@"
 }
 
 # Run dep-collector to update licenses.

--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -356,13 +356,13 @@ function start_latest_knative_build() {
 }
 
 # Run a go tool, installing it first if necessary.
-# Parameters: $1 - tool to run.
-#             $2 - tool package for go get.
+# Parameters: $1 - tool package for go get.
+#             $2 - tool to run.
 #             $3..$n - parameters passed to the tool.
 function run_go_tool() {
-  local tool=$1
+  local tool=$2
   if [[ -z "$(which ${tool})" ]]; then
-    go install $2
+    go install $1
   fi
   shift 2
   ${tool} $@
@@ -375,7 +375,7 @@ function update_licenses() {
   cd ${REPO_ROOT_DIR} || return 1
   local dst=$1
   shift
-  run_go_tool dep-collector ./vendor/github.com/knative/test-infra/tools/dep-collector $@ > ./${dst}
+  run_go_tool ./vendor/github.com/knative/test-infra/tools/dep-collector dep-collector $@ > ./${dst}
 }
 
 # Run dep-collector to check for forbidden liceses.
@@ -384,7 +384,7 @@ function check_licenses() {
   # Fetch the google/licenseclassifier for its license db
   go get -u github.com/google/licenseclassifier
   # Check that we don't have any forbidden licenses in our images.
-  run_go_tool dep-collector ./vendor/github.com/knative/test-infra/tools/dep-collector -check $@
+  run_go_tool ./vendor/github.com/knative/test-infra/tools/dep-collector dep-collector -check $@
 }
 
 # Run the given linter on the given files, checking it exists first.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -166,7 +166,7 @@ function branch_release() {
   fi
   git tag -a ${TAG} -m "${title}"
   git push $(git remote get-url upstream) tag ${TAG}
-  run_go_tool hub github.com/github/hub release create \
+  run_go_tool github.com/github/hub hub release create \
       --prerelease \
       ${attach} \
       --file=${description} \


### PR DESCRIPTION
Bonus: switch the order of `run_go_tool` parameters. It's a more natural way of reading, as `$2`...`$n` will simply be the real command to run.