### PR TITLE
handle USING_EXISTING_CLUSTER teardown consistently

### DIFF
--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -249,7 +249,7 @@ function setup_test_cluster() {
 
   trap teardown_test_resources EXIT
 
-  if (( USING_EXISTING_CLUSTER )) && function_exists teardown; then
+  if (( ! USING_EXISTING_CLUSTER )) && function_exists teardown; then
     echo "Deleting any previous SUT instance"
     teardown
   fi


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #235 

Note that on Line 52 it's being handled differently and seems to work there.
