### PR TITLE
Clearly display test failures on releases

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -136,7 +136,10 @@ function run_validation_tests() {
   if (( ! SKIP_TESTS )); then
     banner "Running release validation tests"
     # Run tests.
-    $1
+    if ! $1; then
+      banner "Release validation tests failed, aborting"
+      exit 1
+    fi
   fi
 }
 


### PR DESCRIPTION
AKA "display a banner when tests failed for a release, instead of just silently aborting the release"

Bonus: factor out common code in tests.