### PR TITLE
Fix removal of -v flag in parameters

### DIFF
--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -235,8 +235,8 @@ function acquire_cluster_admin_role() {
 function report_go_test() {
   # Run tests in verbose mode to capture details.
   # go doesn't like repeating -v, so remove if passed.
-  local args=("${@/-v}")
-  local go_test="go test -race -v ${args[@]}"
+  local args=" $@ "
+  local go_test="go test -race -v ${args/ -v / }"
   # Just run regular go tests if not on Prow.
   if (( ! IS_PROW )); then
     ${go_test}


### PR DESCRIPTION
Remove `-v` only if it's a standalone flag. IOW, do not remove when it's part of a different string parameter (e.g. `registry.svc.ci.namespace.org/ci-op-v5x1m4tr/stable:queue`). Previously, it would remove -v from the ci-op-v5x1m4tr string as well, resulting in ci-op5x1m4tr.