### PR TITLE
Add more generic methods to testgrid

### DIFF
--- a/tools/apicoverage/apicoverage.go
+++ b/tools/apicoverage/apicoverage.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	logDir         = "logs/ci-knative-serving-continuous/"
+	logDir         = "logs/ci-knative-serving-continuous"
 	buildFile      = "build-log.txt"
 	apiCoverage    = "api_coverage"
 	overallRoute   = "OverallRoute"

--- a/tools/gcs/gcs.go
+++ b/tools/gcs/gcs.go
@@ -50,8 +50,9 @@ func createStorageObject(filename string) *storage.ObjectHandle {
 
 // GetLatestBuildNumber gets the latest build number for the specified log directory
 func GetLatestBuildNumber(ctx context.Context, logDir string, sa string) (int, error) {
-	log.Printf("%s %s", logDir, latest)
-	contents, err := ReadGcsFile(ctx, logDir+latest, sa)
+	logFilePath := logDir + latest
+	log.Printf("Using %s to get latest build number", logFilePath)
+	contents, err := ReadGcsFile(ctx, logFilePath, sa)
 	if err != nil {
 		return 0, err
 	}

--- a/tools/gcs/gcs.go
+++ b/tools/gcs/gcs.go
@@ -33,7 +33,7 @@ import (
 
 const (
 	bucketName = "knative-prow"
-	latest     = "latest-build.txt"
+	latest     = "/latest-build.txt"
 )
 
 var client *storage.Client
@@ -50,6 +50,7 @@ func createStorageObject(filename string) *storage.ObjectHandle {
 
 // GetLatestBuildNumber gets the latest build number for the specified log directory
 func GetLatestBuildNumber(ctx context.Context, logDir string, sa string) (int, error) {
+	log.Printf("%s %s", logDir, latest)
 	contents, err := ReadGcsFile(ctx, logDir+latest, sa)
 	if err != nil {
 		return 0, err

--- a/tools/testgrid/testgrid.go
+++ b/tools/testgrid/testgrid.go
@@ -49,6 +49,22 @@ type TestSuite struct {
 	TestCases []TestCase `xml:"testcase"`
 }
 
+// GetArtifactsDir gets the aritfacts directory where we should put the artifacts.
+// By default, it will look at the env var ARTIFACTS.
+func GetArtifactsDir() string {
+	dir := os.Getenv("ARTIFACTS")
+	if dir == "" {
+		return "./artifacts"
+	}
+	return dir
+}
+
+// CreateTestgridXML junit xml file in the default artifacts directory
+func CreateTestgridXML(tc []TestCase) error {
+	ts := TestSuite{TestCases: tc}
+	return CreateXMLOutput(ts, GetArtifactsDir())
+}
+
 // CreateXMLOutput creates the junit xml file in the provided artifacts directory
 func CreateXMLOutput(ts TestSuite, artifactsDir string) error {
 	op, err := xml.MarshalIndent(ts, "", "  ")

--- a/tools/testgrid/testgrid.go
+++ b/tools/testgrid/testgrid.go
@@ -20,6 +20,7 @@ package testgrid
 
 import (
 	"encoding/xml"
+	"log"
 	"os"
 )
 
@@ -54,6 +55,7 @@ type TestSuite struct {
 func GetArtifactsDir() string {
 	dir := os.Getenv("ARTIFACTS")
 	if dir == "" {
+		log.Printf("Env variable ARTIFACTS not set. Using './artifacts' instead.")
 		return "./artifacts"
 	}
 	return dir


### PR DESCRIPTION
Also, passes in the correct path for getting logs for apicoverage.

Fixes #241, #244 
