### PR TITLE
Fix getting commit hash for tagging

### DIFF
--- a/images/prow-tests/Makefile
+++ b/images/prow-tests/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 IMG = gcr.io/knative-tests/test-infra/prow-tests
-TAG := $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
+TAG := $(shell date +v%Y%m%d)-$(shell git describe --always --dirty --exclude '*')
 
 all: build
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -110,10 +110,8 @@ function parse_flags() {
   fi
 
   if (( TAG_RELEASE )); then
-    local commit="$(git rev-parse --short HEAD)"
-    if [[ "$(git describe --dirty)" == *-dirty ]]; then
-      commit+="-dirty"
-    fi
+    # Get the commit, excluding any tags but keeping the "dirty" flag
+    local commit="$(git describe --always --dirty --exclude '*')"
     # Like kubernetes, image tag is vYYYYMMDD-commit
     TAG="v$(date +%Y%m%d)-${commit}"
   fi


### PR DESCRIPTION
Use a single canonical way.