### PR TITLE
Allow running different e2e tests on presubmit

### DIFF
--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -47,7 +47,7 @@ readonly REPO_ROOT_DIR="$(git rev-parse --show-toplevel)"
 #             $2 - banner message.
 function make_banner() {
     local msg="$1$1$1$1 $2 $1$1$1$1"
-    local border="${msg//[-0-9A-Za-z _.,]/$1}"
+    local border="${msg//[-0-9A-Za-z _.,\/]/$1}"
     echo -e "${border}\n${msg}\n${border}"
 }
 

--- a/scripts/presubmit-tests.sh
+++ b/scripts/presubmit-tests.sh
@@ -48,6 +48,11 @@ function exit_if_presubmit_not_required() {
   fi
 }
 
+function abort() {
+  echo "error: $@"
+  exit 1
+}
+
 # Process flags and run tests accordingly.
 function main() {
   exit_if_presubmit_not_required
@@ -65,50 +70,51 @@ function main() {
     go version
   fi
 
-  local all_parameters=$@
-  [[ -z $1 ]] && all_parameters="--all-tests"
+  [[ -z $1 ]] && set -- "--all-tests"
 
-  for parameter in ${all_parameters}; do
+  local TEST_TO_RUN=""
+
+  while [[ $# -ne 0 ]]; do
+    local parameter=$1
     case ${parameter} in
+      --build-tests) RUN_BUILD_TESTS=1 ;;
+      --unit-tests) RUN_UNIT_TESTS=1 ;;
+      --integration-tests) RUN_INTEGRATION_TESTS=1 ;;
+      --emit-metrics) EMIT_METRICS=1 ;;
       --all-tests)
         RUN_BUILD_TESTS=1
         RUN_UNIT_TESTS=1
         RUN_INTEGRATION_TESTS=1
+        ;;
+      --run-test)
         shift
+        [[ $# -ge 1 ]] || abort "missing executable after --run-test"
+        TEST_TO_RUN=$1
         ;;
-      --build-tests)
-        RUN_BUILD_TESTS=1
-        shift
-        ;;
-      --unit-tests)
-        RUN_UNIT_TESTS=1
-        shift
-        ;;
-      --integration-tests)
-        RUN_INTEGRATION_TESTS=1
-        shift
-        ;;
-      --emit-metrics)
-        EMIT_METRICS=1
-        shift
-        ;;
-      *)
-        echo "error: unknown option ${parameter}"
-        exit 1
-        ;;
+      *) abort "error: unknown option ${parameter}" ;;
     esac
+    shift
   done
 
   readonly RUN_BUILD_TESTS
   readonly RUN_UNIT_TESTS
   readonly RUN_INTEGRATION_TESTS
   readonly EMIT_METRICS
+  readonly TEST_TO_RUN
 
   cd ${REPO_ROOT_DIR}
 
   # Tests to be performed, in the right order if --all-tests is passed.
 
   local failed=0
+
+  if [[ -n "${TEST_TO_RUN}" ]]; then
+    if (( RUN_BUILD_TESTS || RUN_UNIT_TESTS || RUN_INTEGRATION_TESTS )); then
+      abort "--run-test must be used alone"
+    fi
+    ${TEST_TO_RUN} || failed=1
+  fi
+
   if (( RUN_BUILD_TESTS )); then
     build_tests || failed=1
   fi
@@ -116,21 +122,38 @@ function main() {
     unit_tests || failed=1
   fi
   if (( RUN_INTEGRATION_TESTS )); then
+    local e2e_failed=0
+    # Run pre-integration tests, if any
     if function_exists pre_integration_tests; then
-      pre_integration_tests || failed=1
+      if ! pre_integration_tests; then
+        failed=1
+        e2e_failed=1
+      fi
     fi
-    if (( ! failed )); then
+    # Don't run integration tests if pre-integration tests failed
+    if (( ! e2e_failed )); then
       if function_exists integration_tests; then
-        integration_tests || failed=1
+        if ! integration_tests; then
+          failed=1
+          e2e_failed=1
+        fi
       else
        local options=""
        (( EMIT_METRICS )) && options="--emit-metrics"
-       ./test/e2e-tests.sh ${options} || failed=1
+       for e2e_test in ./test/e2e-*tests.sh; do
+         echo "Running integration test ${e2e_test}"
+         if ! ${e2e_test} ${options}; then
+           failed=1
+           e2e_failed=1
+         fi
+       done
       fi
     fi
-    if (( ! failed )) && function_exists post_integration_tests; then
+    # Don't run post-integration
+    if (( ! e2e_failed )) && function_exists post_integration_tests; then
       post_integration_tests || failed=1
     fi
   fi
+
   exit ${failed}
 }

--- a/test/unit/e2e-custom-flag-tests.sh
+++ b/test/unit/e2e-custom-flag-tests.sh
@@ -27,7 +27,7 @@ source $(dirname $0)/../../scripts/e2e-tests.sh
 
 function parse_flags() {
   if [[ "$1" == "--smoke-test-custom-flag" ]]; then
-    echo "OK: --smoke-test-custom-flag passed"
+    echo ">> All tests passed"
     exit 0
   fi
   fail_test "Unexpected flag $1 passed"
@@ -35,4 +35,5 @@ function parse_flags() {
 
 # Script entry point.
 
+echo ">> Testing e2e custom flag"
 initialize --smoke-test-custom-flag

--- a/test/unit/library-tests.sh
+++ b/test/unit/library-tests.sh
@@ -36,15 +36,15 @@ function cleanup_bazel() {
 
 trap cleanup_bazel EXIT
 
-echo "Testing report_go_test"
+echo ">> Testing report_go_test"
 
-echo "Test pass"
+echo ">> Test that test passes"
 test_report TestSucceeds "^- TestSucceeds :PASS:"
 
-echo "Test fails with fatal"
+echo ">> Testing that test fails with fatal"
 test_report TestFailsWithFatal "^- TestFailsWithFatal :FAIL:"
 
-echo "Test fails with SIGQUIT"
+echo ">> Testing that test fails with SIGQUIT"
 test_report TestFailsWithSigQuit "^- TestFailsWithSigQuit :FAIL:"
 
-echo "All tests passed"
+echo ">> All tests passed"

--- a/test/unit/presubmit-full-custom-integration-tests.sh
+++ b/test/unit/presubmit-full-custom-integration-tests.sh
@@ -20,9 +20,9 @@ function check_results() {
   (( PRE_INTEGRATION_TESTS )) || failed "Pre integration tests did not run"
   (( CUSTOM_INTEGRATION_TESTS )) || failed "Custom integration tests did not run"
   (( POST_INTEGRATION_TESTS )) || failed "Post integration tests did not run"
-  echo "Test passed"
+  echo ">> All tests passed"
 }
 
-echo "Testing all custom test integration functions"
+echo ">> Testing all custom test integration functions"
 
 main $@

--- a/test/unit/presubmit-partial-custom-integration-tests.sh
+++ b/test/unit/presubmit-partial-custom-integration-tests.sh
@@ -22,10 +22,10 @@ function check_results() {
   (( ! PRE_INTEGRATION_TESTS )) || failed "Pre integration tests did run"
   (( CUSTOM_INTEGRATION_TESTS )) || failed "Custom integration tests did not run"
   (( ! POST_INTEGRATION_TESTS )) || failed "Post integration tests did run"
-  echo "Test passed"
+  echo ">> All tests passed"
 }
 
-echo "Testing custom test integration function"
+echo ">> Testing custom test integration function"
 
 unset -f pre_integration_tests
 unset -f post_integration_tests


### PR DESCRIPTION
This gives more flexibility to presubmit tests.

* `--run-test` allows running a specific E2E test (script)
* `--integration-tests` now runs all `e2e-*tests.sh` in `/test` by default

/cc jonjohnsonjr 