### PR TITLE
Run nightly releases on Knative 0.2 branch

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -1488,6 +1488,37 @@ periodics:
       resources:
         requests:
           memory: "1Gi"
+- cron: "15 8 * * *" # Run at 01:15PST every day (08:15 UTC)
+  name: ci-knative-serving-0.2-continuous
+  agent: kubernetes
+  labels:
+    preset-service-account: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-bazel-remote-cache-enabled: "true"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+      imagePullPolicy: Always
+      args:
+      - "--scenario=kubernetes_execute_bazel"
+      - "--clean"
+      - "--job=$(JOB_NAME)"
+      - "--repo=github.com/knative/serving=release-0.2"
+      - "--root=/go/src"
+      - "--service-account=/etc/service-account/service-account.json"
+      - "--upload=gs://knative-prow/logs"
+      - "--timeout=50" # Avoid overrun
+      - "--" # end bootstrap args, scenario args below
+      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
+      - "./hack/release.sh"
+      - "--nopublish"
+      - "--notag-release"
+      # Bazel needs privileged mode in order to sandbox builds.
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          memory: "1Gi"
 - cron: "1 8 * * *" # Run at 01:01PST every day (08:01 UTC)
   name: ci-knative-serving-release
   agent: kubernetes

--- a/ci/testgrid/config.yaml
+++ b/ci/testgrid/config.yaml
@@ -50,9 +50,14 @@ default_dashboard_tab:
   code_search_url_template:      # The URL template to visit when searching for changelists
     url: https://github.com/knative/serving/compare/<start-custom-0>...<end-custom-0>
 
+#################################################################
 # Test groups
+#################################################################
 
 test_groups:
+
+## Master branch (head)
+
 - name: ci-knative-serving-continuous
   gcs_prefix: knative-prow/logs/ci-knative-serving-continuous
 - name: ci-knative-serving-release
@@ -116,9 +121,19 @@ test_groups:
   gcs_prefix: knative-prow/logs/ci-knative-caching-go-coverage
   short_text_metric: coverage
 
+## release-0.2 branch
+
+- name: ci-knative-serving-0.2-continuous
+  gcs_prefix: knative-prow/logs/ci-knative-serving-0.2-continuous
+
+#################################################################
 # Dashboards
+#################################################################
 
 dashboards:
+
+## Master branch (head)
+
 - name: knative-serving
   dashboard_tab:
   - name: continuous
@@ -206,7 +221,16 @@ dashboards:
     test_group_name: pull-knative-caching-test-coverage
     base_options: 'exclude-filter-by-regex=Overall&group-by-directory=&expand-groups=&sort-by-name='
 
+## release-0.2 branch
+
+- name: knative-serving-0.2
+  dashboard_tab:
+  - name: continuous
+    test_group_name: ci-knative-serving-0.2-continuous
+
+#################################################################
 # Dashboard groups
+#################################################################
 
 dashboard_groups:
 - name: knative
@@ -220,3 +244,6 @@ dashboard_groups:
   - knative-docs
   - knative-pkg
   - knative-caching
+- name: knative-0.2
+  dashboard_names:
+  - knative-serving-0.2


### PR DESCRIPTION
* use a separate dashboard to avoid poluting the master dashboard
* releases are not published anywhere

Fixes knative/serving#2483.