### PR TITLE
Don't run upgrade tests against Knative releases 0.1 and 0.2

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -225,6 +225,9 @@ presubmits:
       preset-service-account: "true"
       preset-bazel-scratch-dir: "true"
       preset-bazel-remote-cache-enabled: "true"
+    skip_branches:  # Skip these branches, as test isn't available.
+    - release-0.1
+    - release-0.2
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:latest


### PR DESCRIPTION
They're not available on these branches and will always fail.