### PR TITLE
Dont use junit_bazel.xml as testgrid output filename 

### DIFF
--- a/tools/testgrid/testgrid.go
+++ b/tools/testgrid/testgrid.go
@@ -74,7 +74,8 @@ func CreateXMLOutput(ts TestSuite, artifactsDir string) error {
 		return err
 	}
 
-	outputFile := artifactsDir + "/junit_bazel.xml"
+	outputFile := artifactsDir + "/junit_knative.xml"
+	log.Printf("Storing output in %s", outputFile)
 	f, err := os.Create(outputFile)
 	if err != nil {
 		return err

--- a/tools/testgrid/testgrid.go
+++ b/tools/testgrid/testgrid.go
@@ -24,6 +24,12 @@ import (
 	"os"
 )
 
+const (
+	// Default filename to store output that acts as input to testgrid.
+	// Should be of the form junit_*.xml
+	filename = "/junit_knative.xml"
+)
+
 // TestProperty defines a property of the test
 type TestProperty struct {
 	Name  string  `xml:"name,attr"`
@@ -74,7 +80,7 @@ func CreateXMLOutput(ts TestSuite, artifactsDir string) error {
 		return err
 	}
 
-	outputFile := artifactsDir + "/junit_knative.xml"
+	outputFile := artifactsDir + filename
 	log.Printf("Storing output in %s", outputFile)
 	f, err := os.Create(outputFile)
 	if err != nil {


### PR DESCRIPTION
junit_bazel.xml conflicts with bazel output file and gets overwritten when the tests are finished. We need to use some other filename to proevent this conflict. But, we need some file called junit_*.xml for testgrid to pick it up. Moving to junit_knative instead.