### PR TITLE
Enable and configure milestone plugin

### DIFF
--- a/ci/prow/plugins.yaml
+++ b/ci/prow/plugins.yaml
@@ -18,6 +18,15 @@ approve:
   implicit_self_approve: true
   review_acts_as_approve: true
 
+repo_milestone:
+  # Default maintainer
+  '':
+    # You can curl the following endpoint in order to determine the github ID of
+    # your team responsible for maintaining the milestones:
+    # curl -H "Authorization: token <token>" https://api.github.com/orgs/<org-name>/teams
+    maintainers_id: 0
+    maintainers_team: knative-milestone-maintainers
+
 plugins:
   knative:
   - approve
@@ -33,6 +42,7 @@ plugins:
   - label
   - lgtm
   - lifecycle
+  - milestone
   - shrug
   - size
   - skip


### PR DESCRIPTION
The milestone plugin enables milestone maintainers (members of the Knative Milestone Maintainers team, TBD) to use the `/milestone v1.2.3` command to assign an issue to a milestone. Milestones must be created in advance by a user with write access.

This won't actually work until the maintainers team is created and its team id is filled in.

/cc @mattmoor