### PR TITLE
Enable dind for Knative 0.2 nightly releases

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -1498,6 +1498,7 @@ periodics:
     preset-service-account: "true"
     preset-bazel-scratch-dir: "true"
     preset-bazel-remote-cache-enabled: "true"
+    preset-dind-enabled: "true"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:latest


### PR DESCRIPTION
Releases are published to a local repository, so docker is required.