### PR TITLE
Use --match instead of --exclude for git describe

### DIFF
--- a/images/prow-tests/Makefile
+++ b/images/prow-tests/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 IMG = gcr.io/knative-tests/test-infra/prow-tests
-TAG := $(shell date +v%Y%m%d)-$(shell git describe --always --dirty --exclude '*')
+TAG := $(shell date +v%Y%m%d)-$(shell git describe --always --dirty --match '^$')
 
 all: build
 

--- a/scripts/presubmit-tests.sh
+++ b/scripts/presubmit-tests.sh
@@ -68,6 +68,8 @@ function main() {
     kubectl version
     echo ">> go version"
     go version
+    echo ">> git version"
+    git version
   fi
 
   [[ -z $1 ]] && set -- "--all-tests"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -111,7 +111,8 @@ function parse_flags() {
 
   if (( TAG_RELEASE )); then
     # Get the commit, excluding any tags but keeping the "dirty" flag
-    local commit="$(git describe --always --dirty --exclude '*')"
+    local commit="$(git describe --always --dirty --match '^$')"
+    [[ -n "${commit}" ]] || abort "Error getting the current commit"
     # Like kubernetes, image tag is vYYYYMMDD-commit
     TAG="v$(date +%Y%m%d)-${commit}"
   fi


### PR DESCRIPTION
Older git versions don't have --exclude, so we match an empty tag.

Bonus: show git version on presubmit tests.