### PR TITLE
Also handle "panic" log entries when parsing test output

### DIFF
--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -265,10 +265,11 @@ function report_go_test() {
     local field0="${fields[0]}"
     local field1="${fields[1]}"
     local name="${fields[2]}"
-    # Deal with a SIGQUIT log entry (usually a test timeout).
+    # Deal with a SIGQUIT or panic log entry (usually a test timeout).
     # This is a fallback in case there's no kill signal log entry.
     # SIGQUIT: quit
-    if [[ "${field0}" == "SIGQUIT:" ]]; then
+    # panic: test timed out after 5m0s
+    if [[ "${field0}" == "SIGQUIT:" || "${field0}" == "panic:" ]]; then
       name="${last_run}"
       field1="FAIL:"
       error="${fields[@]}"

--- a/test/library_test.go
+++ b/test/library_test.go
@@ -45,6 +45,12 @@ func TestFailsWithFatal(t *testing.T) {
 	signal(os.Interrupt)
 }
 
+func TestFailsWithPanic(t *testing.T) {
+	// Simulate a "panic" stack trace.
+	fmt.Println("panic: test timed out after 5m0s")
+	signal(os.Interrupt)
+}
+
 func TestFailsWithSigQuit(t *testing.T) {
 	signal(syscall.SIGQUIT)
 }

--- a/test/unit/library-tests.sh
+++ b/test/unit/library-tests.sh
@@ -36,13 +36,16 @@ function cleanup_bazel() {
 
 trap cleanup_bazel EXIT
 
-echo ">> Testing report_go_test"
+subheader "Tests for report_go_test()"
 
 echo ">> Test that test passes"
 test_report TestSucceeds "^- TestSucceeds :PASS:"
 
 echo ">> Testing that test fails with fatal"
 test_report TestFailsWithFatal "^- TestFailsWithFatal :FAIL:"
+
+echo ">> Testing that test fails with panic"
+test_report TestFailsWithPanic "^- TestFailsWithPanic :FAIL:"
 
 echo ">> Testing that test fails with SIGQUIT"
 test_report TestFailsWithSigQuit "^- TestFailsWithSigQuit :FAIL:"


### PR DESCRIPTION
For example: https://gubernator.knative.dev/build/knative-prow/pr-logs/pull/knative_serving/2597/pull-knative-serving-upgrade-tests/1068605263491108867/