### PR TITLE
add knative testgrid to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ a [PR dashboard](https://gubernator.knative.dev/pr) for contributions in the Kna
 
 ### TestGrid
 
-Knative provides a [health dashboard](https://testgrid.knative.dev/) to show test, code and release health for each repo. It covers key areas such as continous integration, code coverage, nightly release, conformance, performance and etc.
+Knative provides a [health dashboard](https://testgrid.knative.dev/) to show test, code and release health for each repo. It covers key areas such as continuous integration, code coverage, nightly release, conformance, performance and etc.
 
 ### E2E Testing
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Knative uses [Prow](https://github.com/kubernetes/test-infra/tree/master/prow) t
 Knative uses [gubernator](https://github.com/kubernetes/test-infra) to provide
 a [PR dashboard](https://gubernator.knative.dev/pr) for contributions in the Knative github organization.
 
+### TestGrid
+
+Knative provides a [health dashboard](https://testgrid.knative.dev/) to show test, code and release health for each repo. It covers key areas such as continous integration, code coverage, nightly release, conformance, performance and etc.
+
 ### E2E Testing
 
 Our E2E testing uses [kubetest](https://github.com/kubernetes/test-infra/blob/master/kubetest) to build/deploy/test Knative clusters.


### PR DESCRIPTION
we don't have Knative testgrid dashboard documented anywhere. This PR is to add such documentation so that contributors are aware of such dashboard. 