### PR TITLE
Allow setting GCR/GCS on command line for releases

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -163,7 +163,7 @@ also overrides the value of the `TAG` variable as `v<version>`.
 it's empty and `master` HEAD will be considered the release branch.
     * `RELEASE_NOTES`: contains the filename with the release notes if `--release-notes`
 was passed. The release notes is a simple markdown file.
-    * `RELEASE_GCS`: contains the GCS bucket name to store the manifests if
+    * `RELEASE_GCS_BUCKET`: contains the GCS bucket name to store the manifests if
 `--release-gcs` was passed, otherwise the default value `knative-nightly/<repo>` will be
 used. It is empty if `--publish` was not passed.
     * `KO_DOCKER_REPO`: contains the GCR to store the images if `--release-gcr` was

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -163,8 +163,14 @@ also overrides the value of the `TAG` variable as `v<version>`.
 it's empty and `master` HEAD will be considered the release branch.
     * `RELEASE_NOTES`: contains the filename with the release notes if `--release-notes`
 was passed. The release notes is a simple markdown file.
+    * `RELEASE_GCS`: contains the GCS bucket name to store the manifests if
+`--release-gcs` was passed, otherwise the default value `knative-nightly/<repo>` will be
+used. It is empty if `--publish` was not passed.
+    * `KO_DOCKER_REPO`: contains the GCR to store the images if `--release-gcr` was
+passed, otherwise the default value `gcr.io/knative-nightly` will be used. It is set to
+`ko.local` if `--publish` was not passed.
     * `SKIP_TESTS`: true if `--skip-tests` was passed. This is handled automatically
-by the run_validation_tests() function.
+by the `run_validation_tests()` function.
     * `TAG_RELEASE`: true if `--tag-release` was passed. In this case, the environment
 variable `TAG` will contain the release tag in the form `vYYYYMMDD-<commit_short_hash>`.
     * `PUBLISH_RELEASE`: true if `--publish` was passed. In this case, the environment
@@ -186,14 +192,12 @@ initialize $@
 run_validation_tests ./test/presubmit-tests.sh
 
 # config/ contains the manifests
-KO_DOCKER_REPO=gcr.io/knative-foo
 ko resolve ${KO_FLAGS} -f config/ > release.yaml
 
-tag_images_in_yaml release.yaml $KO_DOCKER_REPO $TAG
+tag_images_in_yaml release.yaml
 
 if (( PUBLISH_RELEASE )); then
-  # gs://knative-foo hosts the manifest
-  publish_yaml release.yaml knative-foo $TAG
+  publish_yaml release.yaml
 fi
 
 branch_release "Knative Foo" release.yaml

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -39,13 +39,13 @@ function tag_images_in_yaml() {
   done
 }
 
-# Copy the given yaml file to the $RELEASE_GCS bucket's "latest" directory.
-# If $TAG is not empty, also copy it to $RELEASE_GCS bucket's "previous" directory.
+# Copy the given yaml file to the $RELEASE_GCS_BUCKET bucket's "latest" directory.
+# If $TAG is not empty, also copy it to $RELEASE_GCS_BUCKET bucket's "previous" directory.
 # Parameters: $1 - yaml file to copy.
 function publish_yaml() {
-  gsutil cp $1 gs://${RELESASE_GCS}/latest/
+  gsutil cp $1 gs://${RELEASE_GCS_BUCKET}/latest/
   if [[ -n ${TAG} ]]; then
-    gsutil cp $1 gs://${RELEASE_GCS}/previous/${TAG}/
+    gsutil cp $1 gs://${RELEASE_GCS_BUCKET}/previous/${TAG}/
   fi
 }
 
@@ -58,7 +58,7 @@ TAG=""
 RELEASE_VERSION=""
 RELEASE_NOTES=""
 RELEASE_BRANCH=""
-RELEASE_GCS=""
+RELEASE_GCS_BUCKET=""
 KO_FLAGS=""
 KO_DOCKER_REPO=""
 
@@ -75,7 +75,7 @@ function parse_flags() {
   RELEASE_BRANCH=""
   KO_FLAGS="-P"
   KO_DOCKER_REPO="gcr.io/knative-nightly"
-  RELEASE_GCS="knative-nightly/$(basename ${REPO_ROOT_DIR})"
+  RELEASE_GCS_BUCKET="knative-nightly/$(basename ${REPO_ROOT_DIR})"
   local has_gcr_flag=0
   local has_gcs_flag=0
 
@@ -97,8 +97,8 @@ function parse_flags() {
       --release-gcs)
         shift
         [[ $# -ge 1 ]] || abort "missing GCS bucket after --release-gcs"
-        RELEASE_GCS=$1
-        has_gcs_flag=2
+        RELEASE_GCS_BUCKET=$1
+        has_gcs_flag=1
         ;;
       --version)
         shift
@@ -129,7 +129,7 @@ function parse_flags() {
     (( has_gcs_flag )) && echo "Not publishing the release, GCS flag is ignored"
     KO_DOCKER_REPO="ko.local"
     KO_FLAGS="-L ${KO_FLAGS}"
-    RELEASE_GCS=""
+    RELEASE_GCS_BUCKET=""
   fi
 
   if (( TAG_RELEASE )); then
@@ -154,7 +154,7 @@ function parse_flags() {
   readonly RELEASE_VERSION
   readonly RELEASE_NOTES
   readonly RELEASE_BRANCH
-  readonly RELEASE_GCS
+  readonly RELEASE_GCS_BUCKET
   readonly KO_DOCKER_REPO
 }
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -25,27 +25,28 @@ function banner() {
     make_banner "@" "$1"
 }
 
-# Tag images in the yaml file with a tag. If not tag is passed, does nothing.
+# Tag images in the yaml file.
+# $KO_DOCKER_REPO is the registry containing the images to tag with $TAG.
 # Parameters: $1 - yaml file to parse for images.
-#             $2 - registry where the images are stored.
-#             $3 - tag to apply (optional).
 function tag_images_in_yaml() {
-  [[ -z $3 ]] && return 0
+  [[ -z ${TAG} ]] && return 0
   local src_dir="${GOPATH}/src/"
   local BASE_PATH="${REPO_ROOT_DIR/$src_dir}"
-  echo "Tagging images under '${BASE_PATH}' with $3"
-  for image in $(grep -o "$2/${BASE_PATH}/[a-z\./-]\+@sha256:[0-9a-f]\+" $1); do
-    gcloud -q container images add-tag ${image} ${image%%@*}:$3
+  local DOCKER_BASE="${KO_DOCKER_REPO}/${BASE_PATH}"
+  echo "Tagging images under '${DOCKER_BASE}' with ${TAG}"
+  for image in $(grep -o "${DOCKER_BASE}/[a-z\./-]\+@sha256:[0-9a-f]\+" $1); do
+    gcloud -q container images add-tag ${image} ${image%%@*}:${TAG}
   done
 }
 
-# Copy the given yaml file to a GCS bucket. Image is tagged :latest, and optionally :$2.
+# Copy the given yaml file to the $RELEASE_GCS bucket's "latest" directory.
+# If $TAG is not empty, also copy it to $RELEASE_GCS bucket's "previous" directory.
 # Parameters: $1 - yaml file to copy.
-#             $2 - destination bucket name.
-#             $3 - tag to apply (optional).
 function publish_yaml() {
-  gsutil cp $1 gs://$2/latest/
-  [[ -n $3 ]] && gsutil cp $1 gs://$2/previous/$3/ || true
+  gsutil cp $1 gs://${RELESASE_GCS}/latest/
+  if [[ -n ${TAG} ]]; then
+    gsutil cp $1 gs://${RELEASE_GCS}/previous/${TAG}/
+  fi
 }
 
 # These are global environment variables.
@@ -57,7 +58,9 @@ TAG=""
 RELEASE_VERSION=""
 RELEASE_NOTES=""
 RELEASE_BRANCH=""
+RELEASE_GCS=""
 KO_FLAGS=""
+KO_DOCKER_REPO=""
 
 function abort() {
   echo "error: $@"
@@ -71,6 +74,11 @@ function parse_flags() {
   RELEASE_NOTES=""
   RELEASE_BRANCH=""
   KO_FLAGS="-P"
+  KO_DOCKER_REPO="gcr.io/knative-nightly"
+  RELEASE_GCS="knative-nightly/$(basename ${REPO_ROOT_DIR})"
+  local has_gcr_flag=0
+  local has_gcs_flag=0
+
   cd ${REPO_ROOT_DIR}
   while [[ $# -ne 0 ]]; do
     local parameter=$1
@@ -80,6 +88,18 @@ function parse_flags() {
       --notag-release) TAG_RELEASE=0 ;;
       --publish) PUBLISH_RELEASE=1 ;;
       --nopublish) PUBLISH_RELEASE=0 ;;
+      --release-gcr)
+        shift
+        [[ $# -ge 1 ]] || abort "missing GCR after --release-gcr"
+        KO_DOCKER_REPO=$1
+        has_gcr_flag=1
+        ;;
+      --release-gcs)
+        shift
+        [[ $# -ge 1 ]] || abort "missing GCS bucket after --release-gcs"
+        RELEASE_GCS=$1
+        has_gcs_flag=2
+        ;;
       --version)
         shift
         [[ $# -ge 1 ]] || abort "missing version after --version"
@@ -105,8 +125,11 @@ function parse_flags() {
 
   # Update KO_DOCKER_REPO and KO_FLAGS if we're not publishing.
   if (( ! PUBLISH_RELEASE )); then
+    (( has_gcr_flag )) && echo "Not publishing the release, GCR flag is ignored"
+    (( has_gcs_flag )) && echo "Not publishing the release, GCS flag is ignored"
     KO_DOCKER_REPO="ko.local"
     KO_FLAGS="-L ${KO_FLAGS}"
+    RELEASE_GCS=""
   fi
 
   if (( TAG_RELEASE )); then
@@ -131,6 +154,8 @@ function parse_flags() {
   readonly RELEASE_VERSION
   readonly RELEASE_NOTES
   readonly RELEASE_BRANCH
+  readonly RELEASE_GCS
+  readonly KO_DOCKER_REPO
 }
 
 # Run tests (unless --skip-tests was passed). Conveniently displays a banner indicating so.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -174,6 +174,10 @@ function run_validation_tests() {
 # Initialize everything (flags, workspace, etc) for a release.
 function initialize() {
   parse_flags $@
+  echo "- Destination GCR: ${KO_DOCKER_REPO}"
+  if (( PUBLISH_RELEASE )); then
+    echo "- Destination GCS: ${RELEASE_GCS_BUCKET}"
+  fi
   # Checkout specific branch, if necessary
   if (( BRANCH_RELEASE )); then
     git checkout upstream/${RELEASE_BRANCH} || abort "cannot checkout branch ${RELEASE_BRANCH}"

--- a/test/unit/release-tests.sh
+++ b/test/unit/release-tests.sh
@@ -88,36 +88,36 @@ echo ">> Testing initialization"
 test_function 1 "error: missing version" initialize --version
 test_function 1 "error: version format" initialize --version a
 test_function 1 "error: version format" initialize --version 0.0
-test_function 0 "" initialize --version 1.0.0
+test_function 0 "" parse_flags --version 1.0.0
 
 test_function 1 "error: missing branch" initialize --branch
 test_function 1 "error: branch name must be" initialize --branch a
 test_function 1 "error: branch name must be" initialize --branch 0.0
-test_function 0 "" initialize --branch release-0.0
+test_function 0 "" parse_flags --branch release-0.0
 
 test_function 1 "error: missing release notes" initialize --release-notes
 test_function 1 "error: file a doesn't" initialize --release-notes a
-test_function 0 "" initialize --release-notes $(mktemp)
+test_function 0 "" parse_flags --release-notes $(mktemp)
 
 test_function 1 "error: missing GCS" initialize --release-gcs
-test_function 0 "" initialize --release-gcs a --publish
+test_function 0 "" parse_flags --release-gcs a --publish
 
 test_function 1 "error: missing GCR" initialize --release-gcr
-test_function 0 "" initialize --release-gcr a --publish
+test_function 0 "" parse_flags --release-gcr a --publish
 
 echo ">> Testing GCR/GCS values"
 
-test_function 0 "GCR flag is ignored" call_function_post "echo :\$KO_DOCKER_REPO:" initialize --release-gcr foo
-test_function 0 "GCS flag is ignored" call_function_post "echo :\$RELEASE_GCS:" initialize --release-gcs foo
+test_function 0 "GCR flag is ignored" initialize --release-gcr foo
+test_function 0 "GCS flag is ignored" initialize --release-gcs foo
 
-test_function 0 ":ko.local:" call_function_post "echo :\$KO_DOCKER_REPO:" initialize
+test_function 0 "Destination GCR: ko.local" initialize
 test_function 0 "::" call_function_post "echo :\$RELEASE_GCS:" initialize
 
-test_function 0 ":gcr.io/knative-nightly:" call_function_post "echo :\$KO_DOCKER_REPO:" initialize --publish
-test_function 0 ":knative-nightly/test-infra:" call_function_post "echo :\$RELEASE_GCS:" initialize --publish
+test_function 0 "Destination GCR: gcr.io/knative-nightly" initialize --publish
+test_function 0 "Destination GCS: knative-nightly/test-infra" initialize --publish
 
-test_function 0 ":foo:" call_function_post "echo :\$KO_DOCKER_REPO:" initialize --release-gcr foo --publish
-test_function 0 ":foo:" call_function_post "echo :\$RELEASE_GCS:" initialize --release-gcs foo --publish
+test_function 0 "Destination GCR: foo" initialize --release-gcr foo --publish
+test_function 0 "Destination GCS: foo" initialize --release-gcs foo --publish
 
 echo ">> Testing release branching"
 

--- a/test/unit/release-tests.sh
+++ b/test/unit/release-tests.sh
@@ -67,12 +67,20 @@ function mock_branch_release() {
   branch_release "$@" 2>&1
 }
 
-function call_function() {
+function call_function_pre() {
   set -e
-  local init=$1
+  local init="$1"
   shift
   eval ${init}
   "$@" 2>&1
+}
+
+function call_function_post() {
+  set -e
+  local post="$1"
+  shift
+  "$@" 2>&1
+  eval ${post}
 }
 
 echo ">> Testing initialization"
@@ -91,17 +99,37 @@ test_function 1 "error: missing release notes" initialize --release-notes
 test_function 1 "error: file a doesn't" initialize --release-notes a
 test_function 0 "" initialize --release-notes $(mktemp)
 
+test_function 1 "error: missing GCS" initialize --release-gcs
+test_function 0 "" initialize --release-gcs a --publish
+
+test_function 1 "error: missing GCR" initialize --release-gcr
+test_function 0 "" initialize --release-gcr a --publish
+
+echo ">> Testing GCR/GCS values"
+
+test_function 0 "GCR flag is ignored" call_function_post "echo :\$KO_DOCKER_REPO:" initialize --release-gcr foo
+test_function 0 "GCS flag is ignored" call_function_post "echo :\$RELEASE_GCS:" initialize --release-gcs foo
+
+test_function 0 ":ko.local:" call_function_post "echo :\$KO_DOCKER_REPO:" initialize
+test_function 0 "::" call_function_post "echo :\$RELEASE_GCS:" initialize
+
+test_function 0 ":gcr.io/knative-nightly:" call_function_post "echo :\$KO_DOCKER_REPO:" initialize --publish
+test_function 0 ":knative-nightly/test-infra:" call_function_post "echo :\$RELEASE_GCS:" initialize --publish
+
+test_function 0 ":foo:" call_function_post "echo :\$KO_DOCKER_REPO:" initialize --release-gcr foo --publish
+test_function 0 ":foo:" call_function_post "echo :\$RELEASE_GCS:" initialize --release-gcs foo --publish
+
 echo ">> Testing release branching"
 
 test_function 0 "" branch_release
-test_function 129 "usage: git tag" call_function BRANCH_RELEASE=1 branch_release
-test_function 1 "No such file" call_function BRANCH_RELEASE=1 branch_release "K Foo" "a.yaml b.yaml"
+test_function 129 "usage: git tag" call_function_pre BRANCH_RELEASE=1 branch_release
+test_function 1 "No such file" call_function_pre BRANCH_RELEASE=1 branch_release "K Foo" "a.yaml b.yaml"
 test_function 0 "release create" mock_branch_release "K Foo" "$(mktemp) $(mktemp)"
 
 echo ">> Testing validation tests"
 
 test_function 0 "Running release validation" run_validation_tests true
-test_function 0 "" call_function SKIP_TESTS=1 run_validation_tests true
+test_function 0 "" call_function_pre SKIP_TESTS=1 run_validation_tests true
 test_function 0 "i_passed" run_validation_tests "echo i_passed"
 test_function 1 "validation tests failed" run_validation_tests false
 


### PR DESCRIPTION
Using environment variables can be dangerous, flags ensure we're explicitly setting values.
The default values point to the nightly GCR/GCS.

This also implies:
* no need for scripts to set `DOCKER_REPO_OVERRIDE` or `KO_DOCKER_REPO` by themselves
* helper functions use the values set by the flags