### PR TITLE
Deflake signal-based tests in library_test.go

### DIFF
--- a/test/library_test.go
+++ b/test/library_test.go
@@ -23,12 +23,15 @@ import (
 	"os"
 	"syscall"
 	"testing"
+	"time"
 )
 
 // signal sends a UNIX signal to the test process.
 func signal(s os.Signal) {
 	p, _ := os.FindProcess(os.Getpid())
 	_ = p.Signal(s)
+        // Sleep so test won't finish and signal will be received.
+	time.Sleep(999)
 }
 
 func TestSucceeds(t *testing.T) {


### PR DESCRIPTION
If the test finishes before the signal is received, the test fails. Sleeping for 999s avoids that.

See https://github.com/knative/test-infra/pull/289 for an example of this kind of failure.