### PR TITLE
Remove spurious link in coverage tool test data

### DIFF
--- a/tools/coverage/testgrid/cov-profile.txt/stdout.txt
+++ b/tools/coverage/testgrid/cov-profile.txt/stdout.txt
@@ -1,1 +1,0 @@
-/usr/local/google/home/syzf/Apps/golang/gopath/src/github.com/kubernetes/test-infra/coverage/testdata/artifacts/stdout.txt


### PR DESCRIPTION
The link points to a local dev file and breaks `dep ensure`.

Fixes https://github.com/knative/serving/issues/2626