### PR TITLE
Fix wrong repo name

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -1818,7 +1818,7 @@ periodics:
   decorate: true
   extra_refs:
   - org: knative
-    repo: build
+    repo: build-pipeline
     base_ref: master
     clone_uri: "https://github.com/knative/build-pipeline.git"
   spec:


### PR DESCRIPTION
This mismatch is potentially causing the following bug:

https://github.com/knative/test-infra/issues/264

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #264

