### PR TITLE
Periodical Prow job deleting old images

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -2148,7 +2148,26 @@ periodics:
       - "--profile-name=coverage_profile.txt"
       - "--cov-target=."
       - "--cov-threshold-percentage=80"
-
+- cron: "0 19 * * 1" # Run at 11:00PST/12:00PST every Monday (19:00 UTC)
+  name: ci-knative-cleanup
+  branches:
+  - master
+  agent: kubernetes
+  labels:
+    preset-service-account: "true"
+  decorate: true
+  clone_uri: "https://github.com/knative/test-infra.git"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+      imagePullPolicy: Always
+      command:
+      - "./tools/cleanup.sh"
+      args:
+      - "delete-old-gcr-images"
+      - "--project-resource-yaml ci/prow/boskos/resources.yaml"
+      - "--days-to-keep 90"
+  
 postsubmits:
   knative/serving:
   - name: post-knative-serving-go-coverage

--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -2162,7 +2162,7 @@ periodics:
     - image: gcr.io/knative-tests/test-infra/prow-tests:latest
       imagePullPolicy: Always
       command:
-      - "./tools/cleanup.sh"
+      - "./tools/cleanup/cleanup.sh"
       args:
       - "delete-old-gcr-images"
       - "--project-resource-yaml ci/prow/boskos/resources.yaml"

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -294,11 +294,6 @@ GCP_PROJECT=""
 E2E_SCRIPT=""
 E2E_CLUSTER_VERSION=""
 
-function abort() {
-  echo "error: $@"
-  exit 1
-}
-
 # Parse flags and initialize the test cluster.
 function initialize() {
   # Normalize calling script path; we can't use readlink because it's not available everywhere
@@ -357,11 +352,9 @@ function initialize() {
   (( IS_PROW )) && [[ -z "${GCP_PROJECT}" ]] && IS_BOSKOS=1
 
   # Safety checks
-
-  if [[ "${DOCKER_REPO_OVERRIDE}" =~ ^gcr.io/knative-(releases|nightly)/?$ ]]; then
-    abort "\$DOCKER_REPO_OVERRIDE is set to ${DOCKER_REPO_OVERRIDE}, which is forbidden"
-  fi
-
+  is_protected_gcr ${DOCKER_REPO_OVERRIDE} && \
+    abort "\$DOCKER_REPO_OVERRIDE set to ${DOCKER_REPO_OVERRIDE}, which is forbidden"
+  
   readonly RUN_TESTS
   readonly EMIT_METRICS
   readonly E2E_CLUSTER_VERSION

--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -43,7 +43,7 @@ readonly IS_PROW
 readonly REPO_ROOT_DIR="$(git rev-parse --show-toplevel)"
 
 # Print error message and exit 1
-# Parameters: $1..$n - error mesage to be displayed
+# Parameters: $1..$n - error message to be displayed
 function abort() {
   echo "error: $@"
   exit 1

--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -42,6 +42,8 @@ fi
 readonly IS_PROW
 readonly REPO_ROOT_DIR="$(git rev-parse --show-toplevel)"
 
+# Print error message and exit 1
+# Parameters: $1..$n - error mesage to be displayed
 function abort() {
   echo "error: $@"
   exit 1
@@ -423,22 +425,22 @@ function check_links_in_markdown() {
 }
 
 # Check format of the given markdown files.
-# Parameters: $1...$n - files to inspect
+# Parameters: $1..$n - files to inspect
 function lint_markdown() {
   # https://github.com/markdownlint/markdownlint
   run_lint_tool mdl "linting markdown files" "-r ~MD013" $@
 }
 
-# Return 0 if first argument is an integer, otherwise 1
+# Return 0 if the given parameter is an integer, otherwise 1
 # Parameters: $1 - an integer
 function is_int() {
-  [[ -n $1 && $1 =~ ^[0-9]+$ ]] && return 0
-  return 1
+  [[ -n $1 && $1 =~ ^[0-9]+$ ]]
 }
 
-# Safety checks, make sure not release/nightly gcr
+# Return 0 if the given parameter is the knative release/nightly gcr, 1
+# otherwise
 # Parameters: $1 - gcr name, e.g. gcr.io/knative-nightly
 function is_protected_gcr() {
-  [[ -n $1 && "$1" =~ "^gcr.io/knative-(releases|nightly)/?$" ]] && return 0
-  return 1
+  [[ -n $1 && "$1" =~ "^gcr.io/knative-(releases|nightly)/?$" ]]
 }
+

--- a/scripts/presubmit-tests.sh
+++ b/scripts/presubmit-tests.sh
@@ -48,11 +48,6 @@ function exit_if_presubmit_not_required() {
   fi
 }
 
-function abort() {
-  echo "error: $@"
-  exit 1
-}
-
 # Process flags and run tests accordingly.
 function main() {
   exit_if_presubmit_not_required

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -59,11 +59,6 @@ RELEASE_NOTES=""
 RELEASE_BRANCH=""
 KO_FLAGS=""
 
-function abort() {
-  echo "error: $@"
-  exit 1
-}
-
 # Parses flags and sets environment variables accordingly.
 function parse_flags() {
   TAG=""

--- a/test/unit/cleanup-tests.sh
+++ b/test/unit/cleanup-tests.sh
@@ -15,49 +15,49 @@
 # limitations under the License.
 
 source $(dirname $0)/helper.sh
-
-readonly _CLEANUP_SCRIPT="tools/cleanup/cleanup.sh"
-source "$(dirname ${BASH_SOURCE})/../../${_CLEANUP_SCRIPT}"
-
-readonly _SUCCESS=0
-readonly _FAILURE=1
+source "$(dirname $0)/../../tools/cleanup/cleanup.sh"
 
 readonly _FAKE_NIGHTLY_PROJECT_NAME="gcr.io/knative-nightly"
 readonly _FAKE_BOSKOS_PROJECT_NAME="gcr.io/fake-boskos-project"
 readonly _PROJECT_RESOURCE_YAML="ci/prow/boskos/resources.yaml"
 readonly _RE_PROJECT_NAME="knative-boskos-[a-zA-Z0-9]+"
 
+# Call "cleanup.sh" function with given paramters
+# Parameters: $1..$n - parameters passed to "cleanup.sh" script
+function cleanup_script() {
+  "./tools/cleanup/cleanup.sh" $@
+}
+
 set -e
 cd ${REPO_ROOT_DIR}
 
 echo ">> Testing directly invoking cleanup script"
 
-test_function ${_FAILURE} "error: unknown option" ${_CLEANUP_SCRIPT} "--option-not-exist"
-test_function ${_FAILURE} "error: missing project" ${_CLEANUP_SCRIPT} "delete-old-gcr-images-from-project"
-test_function ${_FAILURE} "error: missing resource" ${_CLEANUP_SCRIPT} "delete-old-gcr-images"
+test_function ${FAILURE} "error: unknown option" cleanup_script "action-not-exist"
+test_function ${FAILURE} "error: missing project" cleanup_script "delete-old-gcr-images-from-project"
+test_function ${FAILURE} "error: missing resource" cleanup_script "delete-old-gcr-images"
 
-test_function ${_FAILURE} "error: expecting value following" ${_CLEANUP_SCRIPT} "delete-old-gcr-images" --project-resource-yaml --dry-run
-test_function ${_FAILURE} "error: expecting value following" ${_CLEANUP_SCRIPT} "delete-old-gcr-images" --re-project-name --dry-run
-test_function ${_FAILURE} "error: expecting value following" ${_CLEANUP_SCRIPT} "delete-old-gcr-images" --project-to-cleanup --dry-run
-test_function ${_FAILURE} "error: expecting value following" ${_CLEANUP_SCRIPT} "delete-old-gcr-images" --days-to-keep --dry-run
+test_function ${FAILURE} "error: expecting value following" cleanup_script "delete-old-gcr-images" --project-resource-yaml --dry-run
+test_function ${FAILURE} "error: expecting value following" cleanup_script  "delete-old-gcr-images" --re-project-name --dry-run
+test_function ${FAILURE} "error: expecting value following" cleanup_script "delete-old-gcr-images" --project-to-cleanup --dry-run
+test_function ${FAILURE} "error: expecting value following" cleanup_script "delete-old-gcr-images" --days-to-keep --dry-run
 
-test_function ${_FAILURE} "error: days to keep" ${_CLEANUP_SCRIPT} "delete-old-gcr-images-from-project" --days-to-keep "a" --dry-run
-test_function ${_FAILURE} "error: expecting value following" ${_CLEANUP_SCRIPT} "delete-old-gcr-images" --days-to-keep --dry-run
-test_function ${_FAILURE} "error: days to keep" ${_CLEANUP_SCRIPT} "delete-old-gcr-images" --days-to-keep "a" --dry-run
+test_function ${FAILURE} "error: days to keep" cleanup_script "delete-old-gcr-images-from-project" --days-to-keep "a" --dry-run
+test_function ${FAILURE} "error: days to keep" cleanup_script "delete-old-gcr-images" --days-to-keep "a" --dry-run
 
 # Test individual functions
 echo ">> Testing deleting images from single project"
 
-test_function ${_FAILURE} "error: missing" delete_old_gcr_images_from_project 
-test_function ${_SUCCESS} "" mock_gcloud_function delete_old_gcr_images_from_project ${_FAKE_BOSKOS_PROJECT_NAME}
-test_function ${_SUCCESS} "" mock_gcloud_function delete_old_gcr_images_from_project ${_FAKE_BOSKOS_PROJECT_NAME} 1
+test_function ${FAILURE} "error: missing" delete_old_gcr_images_from_project 
+test_function ${SUCCESS} "" mock_gcloud_function delete_old_gcr_images_from_project ${_FAKE_BOSKOS_PROJECT_NAME}
+test_function ${SUCCESS} "" mock_gcloud_function delete_old_gcr_images_from_project ${_FAKE_BOSKOS_PROJECT_NAME} 1
 
 echo ">> Testing deleting images from multiple projects"
 
-test_function ${_FAILURE} "error: missing" delete_old_gcr_images
-test_function ${_FAILURE} "error: no project" delete_old_gcr_images "${_PROJECT_RESOURCE_YAML}file_not_exist" ${_RE_PROJECT_NAME}
-test_function ${_FAILURE} "error: no project" delete_old_gcr_images ${_PROJECT_RESOURCE_YAML} "${_RE_PROJECT_NAME}project-not-exist"
-test_function ${_SUCCESS} "Start" mock_gcloud_function delete_old_gcr_images ${_PROJECT_RESOURCE_YAML}
-test_function ${_SUCCESS} "Start" mock_gcloud_function delete_old_gcr_images ${_PROJECT_RESOURCE_YAML} ${_RE_PROJECT_NAME}
+test_function ${FAILURE} "error: missing" delete_old_gcr_images
+test_function ${FAILURE} "error: no project" delete_old_gcr_images "${_PROJECT_RESOURCE_YAML}file_not_exist" ${_RE_PROJECT_NAME}
+test_function ${FAILURE} "error: no project" delete_old_gcr_images ${_PROJECT_RESOURCE_YAML} "${_RE_PROJECT_NAME}project-not-exist"
+test_function ${SUCCESS} "Start" mock_gcloud_function delete_old_gcr_images ${_PROJECT_RESOURCE_YAML}
+test_function ${SUCCESS} "Start" mock_gcloud_function delete_old_gcr_images ${_PROJECT_RESOURCE_YAML} ${_RE_PROJECT_NAME}
 
 echo ">> All tests passed"

--- a/test/unit/cleanup-tests.sh
+++ b/test/unit/cleanup-tests.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source $(dirname $0)/helper.sh
+
+readonly _CLEANUP_SCRIPT="tools/cleanup/cleanup.sh"
+source "$(dirname ${BASH_SOURCE})/../../${_CLEANUP_SCRIPT}"
+
+readonly _SUCCESS=0
+readonly _FAILURE=1
+
+readonly _FAKE_NIGHTLY_PROJECT_NAME="gcr.io/knative-nightly"
+readonly _FAKE_BOSKOS_PROJECT_NAME="gcr.io/fake-boskos-project"
+readonly _PROJECT_RESOURCE_YAML="ci/prow/boskos/resources.yaml"
+readonly _RE_PROJECT_NAME="knative-boskos-[a-zA-Z0-9]+"
+
+set -e
+cd ${REPO_ROOT_DIR}
+
+echo ">> Testing directly invoking cleanup script"
+
+test_function ${_FAILURE} "error: unknown option" ${_CLEANUP_SCRIPT} "--option-not-exist"
+test_function ${_FAILURE} "error: missing project" ${_CLEANUP_SCRIPT} "delete-old-gcr-images-from-project"
+test_function ${_FAILURE} "error: missing resource" ${_CLEANUP_SCRIPT} "delete-old-gcr-images"
+
+test_function ${_FAILURE} "error: expecting value following" ${_CLEANUP_SCRIPT} "delete-old-gcr-images" --project-resource-yaml --dry-run
+test_function ${_FAILURE} "error: expecting value following" ${_CLEANUP_SCRIPT} "delete-old-gcr-images" --re-project-name --dry-run
+test_function ${_FAILURE} "error: expecting value following" ${_CLEANUP_SCRIPT} "delete-old-gcr-images" --project-to-cleanup --dry-run
+test_function ${_FAILURE} "error: expecting value following" ${_CLEANUP_SCRIPT} "delete-old-gcr-images" --days-to-keep --dry-run
+
+test_function ${_FAILURE} "error: days to keep" ${_CLEANUP_SCRIPT} "delete-old-gcr-images-from-project" --days-to-keep "a" --dry-run
+test_function ${_FAILURE} "error: expecting value following" ${_CLEANUP_SCRIPT} "delete-old-gcr-images" --days-to-keep --dry-run
+test_function ${_FAILURE} "error: days to keep" ${_CLEANUP_SCRIPT} "delete-old-gcr-images" --days-to-keep "a" --dry-run
+
+# Test individual functions
+echo ">> Testing deleting images from single project"
+
+test_function ${_FAILURE} "error: missing" delete_old_gcr_images_from_project 
+test_function ${_SUCCESS} "" mock_gcloud_function delete_old_gcr_images_from_project ${_FAKE_BOSKOS_PROJECT_NAME}
+test_function ${_SUCCESS} "" mock_gcloud_function delete_old_gcr_images_from_project ${_FAKE_BOSKOS_PROJECT_NAME} 1
+
+echo ">> Testing deleting images from multiple projects"
+
+test_function ${_FAILURE} "error: missing" delete_old_gcr_images
+test_function ${_FAILURE} "error: no project" delete_old_gcr_images "${_PROJECT_RESOURCE_YAML}file_not_exist" ${_RE_PROJECT_NAME}
+test_function ${_FAILURE} "error: no project" delete_old_gcr_images ${_PROJECT_RESOURCE_YAML} "${_RE_PROJECT_NAME}project-not-exist"
+test_function ${_SUCCESS} "Start" mock_gcloud_function delete_old_gcr_images ${_PROJECT_RESOURCE_YAML}
+test_function ${_SUCCESS} "Start" mock_gcloud_function delete_old_gcr_images ${_PROJECT_RESOURCE_YAML} ${_RE_PROJECT_NAME}
+
+echo ">> All tests passed"

--- a/test/unit/helper.sh
+++ b/test/unit/helper.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Call a function and verify its return value and output.
+# Parameters: $1 - expected return code.
+#             $2 - expected output ("" if no output is expected)
+#             $3 ..$n - function to call and its parameters.
+function test_function() {
+  local expected_retcode=$1
+  local expected_string=$2
+  local output="$(mktemp)"
+  local output_code="$(mktemp)"
+  shift 2
+  echo -n "$(trap '{ echo $? > ${output_code}; }' EXIT ; "$@")" &> ${output}
+  local retcode=$(cat ${output_code})
+  if [[ ${retcode} -ne ${expected_retcode} ]]; then
+    cat ${output}
+    echo "Return code ${retcode} doesn't match expected return code ${expected_retcode}"
+    return 1
+  fi
+  if [[ -n "${expected_string}" ]]; then
+    local found=1
+    grep "${expected_string}" ${output} > /dev/null || found=0
+    if (( ! found )); then
+      cat ${output}
+      echo "String '${expected_string}' not found"
+      return 1
+    fi
+  else
+    if [[ -s ${output} ]]; then
+      ls ${output}
+      cat ${output}
+      echo "Unexpected output"
+      return 1
+    fi
+  fi
+  echo "'$@' returns code ${expected_retcode} and displays '${expected_string}'"
+}
+
+# Mock gcloud function for testing purpose
+function mock_gcloud_function() {
+  set -e
+  function gcloud() {
+    echo ""
+  }
+  "$@" 2>&1
+}

--- a/test/unit/helper.sh
+++ b/test/unit/helper.sh
@@ -15,10 +15,14 @@
 # limitations under the License.
 
 
+# Useful exit code
+readonly SUCCESS=0
+readonly FAILURE=1
+
 # Call a function and verify its return value and output.
 # Parameters: $1 - expected return code.
 #             $2 - expected output ("" if no output is expected)
-#             $3 ..$n - function to call and its parameters.
+#             $3..$n - function to call and its parameters.
 function test_function() {
   local expected_retcode=$1
   local expected_string=$2
@@ -51,7 +55,8 @@ function test_function() {
   echo "'$@' returns code ${expected_retcode} and displays '${expected_string}'"
 }
 
-# Mock gcloud function for testing purpose
+# Run the function with gcloud mocked (does nothing and outputs nothing).
+# Parameters: $1..$n - parameters passed to the function.
 function mock_gcloud_function() {
   set -e
   function gcloud() {

--- a/test/unit/release-tests.sh
+++ b/test/unit/release-tests.sh
@@ -14,45 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+source $(dirname $0)/helper.sh
 source $(dirname $0)/../../scripts/release.sh
 
 set -e
-
-# Call a function and verify its return value and output.
-# Parameters: $1 - expected return code.
-#             $2 - expected output ("" if no output is expected)
-#             $3 ..$n - function to call and its parameters.
-function test_function() {
-  local expected_retcode=$1
-  local expected_string=$2
-  local output="$(mktemp)"
-  local output_code="$(mktemp)"
-  shift 2
-  echo -n "$(trap '{ echo $? > ${output_code}; }' EXIT ; "$@")" &> ${output}
-  local retcode=$(cat ${output_code})
-  if [[ ${retcode} -ne ${expected_retcode} ]]; then
-    cat ${output}
-    echo "Return code ${retcode} doesn't match expected return code ${expected_retcode}"
-    return 1
-  fi
-  if [[ -n "${expected_string}" ]]; then
-    local found=1
-    grep "${expected_string}" ${output} > /dev/null || found=0
-    if (( ! found )); then
-      cat ${output}
-      echo "String '${expected_string}' not found"
-      return 1
-    fi
-  else
-    if [[ -s ${output} ]]; then
-      ls ${output}
-      cat ${output}
-      echo "Unexpected output"
-      return 1
-    fi
-  fi
-  echo "'$@' returns code ${expected_retcode} and displays '${expected_string}'"
-}
 
 function mock_branch_release() {
   set -e

--- a/tools/cleanup/README.md
+++ b/tools/cleanup/README.md
@@ -1,0 +1,31 @@
+# Resources Clean Up Tool
+This tool is designed to clean up staled resources from gcr, for now it only deletes old images created during testing.
+
+## Basic Usage
+Directly invoke [cleanup.sh](cleanup.sh) script with certain flags. There is no-op if invoking or sourcing this script without argumements.
+
+### Clean up old images from multiple projects
+Projects to be cleaned up are expected to be defined in a `resources.yaml` file. To remove old images from them, call [cleanup.sh](cleanup.sh) with action "delete-old-gcr-images" and following flags:
+- "--project-resource-yaml" as path of `resources.yaml` file - Mandatory
+- "--re-project-name" for regex matching projects names - Optional, default `knative-boskos-[a-zA-Z0-9]+`
+- "--days-to-keep" - Optional, default `365`
+
+Example:
+
+```./cleanup.sh "delete-old-gcr-images" --project-resource-yaml "ci/prow/boskos/resources.yaml" --days-to-keep 90```
+
+### Clean up old images from specified project
+Cleaning up from specific project is supported, but not in "protected" projects, e.g. "release" or "nightly" projects. Call [cleanup.sh](cleanup.sh) with action "delete-old-gcr-images-from-project" and following flags:
+- "--project-to-cleanup" as name of gcr project, e.g. "gcr.io/foo" - Mandatory
+- "--days-to-keep" - Optional, default `365`
+
+Example:
+
+```./cleanup.sh "delete-old-gcr-images-from-project" --project-to-cleanup "gcr.io/foo" --days-to-keep 90```
+
+
+## Unit Testing
+Unit testing for this script lives under [test/unit/cleanup-tests.sh](/test/unit/cleanup-tests.sh)
+
+## Prow Job
+There is a weekly prow job that triggers this tool runs at 11:00/12:00PM(Day light saving) PST every Monday. This tool scans all gcr projects defined in [ci/prow/boskos/resources.yaml](/ci/prow/boskos/resources.yaml) and deletes images older than 90 days.

--- a/tools/cleanup/README.md
+++ b/tools/cleanup/README.md
@@ -2,9 +2,9 @@
 This tool is designed to clean up staled resources from gcr, for now it only deletes old images created during testing.
 
 ## Basic Usage
-Directly invoke [cleanup.sh](cleanup.sh) script with certain flags. There is no-op if invoking or sourcing this script without argumements.
+Directly invoke [cleanup.sh](cleanup.sh) script with certain flags. There is no-op if invoking or sourcing this script without arguments.
 
-### Clean up old images from multiple projects
+### Clean up old images from multiple gcr
 Projects to be cleaned up are expected to be defined in a `resources.yaml` file. To remove old images from them, call [cleanup.sh](cleanup.sh) with action "delete-old-gcr-images" and following flags:
 - "--project-resource-yaml" as path of `resources.yaml` file - Mandatory
 - "--re-project-name" for regex matching projects names - Optional, default `knative-boskos-[a-zA-Z0-9]+`
@@ -14,18 +14,14 @@ Example:
 
 ```./cleanup.sh "delete-old-gcr-images" --project-resource-yaml "ci/prow/boskos/resources.yaml" --days-to-keep 90```
 
-### Clean up old images from specified project
-Cleaning up from specific project is supported, but not in "protected" projects, e.g. "release" or "nightly" projects. Call [cleanup.sh](cleanup.sh) with action "delete-old-gcr-images-from-project" and following flags:
-- "--project-to-cleanup" as name of gcr project, e.g. "gcr.io/foo" - Mandatory
+### Clean up old images from specified gcr 
+Cleaning up from specific gcr is supported, except for some special ones (_knative-release_ and _knative-nightly_). Call [cleanup.sh](cleanup.sh) with action "delete-old-gcr-images-from-project" and following flags:
+- "--project-to-cleanup" as name of gcr, e.g. "gcr.io/foo" - Mandatory
 - "--days-to-keep" - Optional, default `365`
 
 Example:
 
 ```./cleanup.sh "delete-old-gcr-images-from-project" --project-to-cleanup "gcr.io/foo" --days-to-keep 90```
-
-
-## Unit Testing
-Unit testing for this script lives under [test/unit/cleanup-tests.sh](/test/unit/cleanup-tests.sh)
 
 ## Prow Job
 There is a weekly prow job that triggers this tool runs at 11:00/12:00PM(Day light saving) PST every Monday. This tool scans all gcr projects defined in [ci/prow/boskos/resources.yaml](/ci/prow/boskos/resources.yaml) and deletes images older than 90 days.

--- a/tools/cleanup/cleanup.sh
+++ b/tools/cleanup/cleanup.sh
@@ -14,9 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This is a script helping clean up stale resources
+# This is a script to clean up stale resources
 
-source $(dirname ${BASH_SOURCE})/../../scripts/library.sh
+source $(dirname $0)/../../scripts/library.sh
 
 # Global variables
 DAYS_TO_KEEP_IMAGES=365 # Keep images up to 1 year by default
@@ -53,7 +53,6 @@ function parse_args() {
         DAYS_TO_KEEP_IMAGES=$1
         ;;
       --dry-run)
-        shift
         DRY_RUN=1
         ;;
       *) abort "unknown option ${parameter}" ;;
@@ -70,11 +69,11 @@ function parse_args() {
 
   is_int $DAYS_TO_KEEP_IMAGES || abort "days to keep has to be integer"
 
-  (( $DRY_RUN )) && echo "-- Running in dry-run mode, no image deletion --"
+  (( DRY_RUN )) && echo "-- Running in dry-run mode, no image deletion --"
   echo "Removing images with following rules:"
   case ${FUNCTION_TO_RUN} in
     delete-old-gcr-images)
-      echo "- from project defined in $PROJECT_RESOURCE_YAML, matching $RE_PROJECT_NAME"
+      echo "- from projects defined in $PROJECT_RESOURCE_YAML, matching $RE_PROJECT_NAME"
       ;;
     delete-old-gcr-images-from-project)
       echo "- from project $PROJECT_TO_CLEANUP"

--- a/tools/cleanup/cleanup.sh
+++ b/tools/cleanup/cleanup.sh
@@ -1,0 +1,163 @@
+#!/bin/bash
+
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is a script helping clean up stale resources
+
+source $(dirname ${BASH_SOURCE})/../../scripts/library.sh
+
+# Global variables
+DAYS_TO_KEEP_IMAGES=365 # Keep images up to 1 year by default
+RE_PROJECT_NAME="knative-boskos-[a-zA-Z0-9]+"
+PROJECT_RESOURCE_YAML=""
+PROJECT_TO_CLEANUP=""
+DRY_RUN=0
+
+FUNCTION_TO_RUN=""
+
+
+function parse_args() {
+  while [[ $# -ne 0 ]]; do
+    local parameter=$1
+    case ${parameter} in
+      --project-resource-yaml)
+        [[ -z $2 || $2 =~ ^-- ]] && abort "expecting value following $1"
+        shift
+        PROJECT_RESOURCE_YAML=$1
+        ;;
+      --re-project-name)
+        [[ -z $2 || $2 =~ ^-- ]] && abort "expecting value following $1"
+        shift
+        RE_PROJECT_NAME=$1
+        ;;
+     --project-to-cleanup)
+        [[ -z $2 || $2 =~ ^-- ]] && abort "expecting value following $1"
+        shift
+        PROJECT_TO_CLEANUP=$1
+        ;;
+     --days-to-keep)
+        [[ -z $2 || $2 =~ ^-- ]] && abort "expecting value following $1"
+        shift
+        DAYS_TO_KEEP_IMAGES=$1
+        ;;
+      --dry-run)
+        shift
+        DRY_RUN=1
+        ;;
+      *) abort "unknown option ${parameter}" ;;
+    esac
+    shift
+  done
+
+  readonly DAYS_TO_KEEP_IMAGES
+  readonly PROJECT_RESOURCE_YAML
+  readonly RE_PROJECT_NAME
+  readonly PROJECT_TO_CLEANUP
+  readonly DRY_RUN
+
+
+  is_int $DAYS_TO_KEEP_IMAGES || abort "days to keep has to be integer"
+
+  (( $DRY_RUN )) && echo "-- Running in dry-run mode, no image deletion --"
+  echo "Removing images with following rules:"
+  case ${FUNCTION_TO_RUN} in
+    delete-old-gcr-images)
+      echo "- from project defined in $PROJECT_RESOURCE_YAML, matching $RE_PROJECT_NAME"
+      ;;
+    delete-old-gcr-images-from-project)
+      echo "- from project $PROJECT_TO_CLEANUP"
+      ;;
+    *) ;;
+  esac
+  echo "- older than $DAYS_TO_KEEP_IMAGES days"
+}
+
+# Delete old images in given GCR project
+# Parameters: $1 - gcr to be cleaned up, i.e. gcr.io/fooProj
+# Parameters: $2 - days to keep images
+function delete_old_gcr_images_from_project() {
+  local project_to_cleanup_override=$PROJECT_TO_CLEANUP
+  [[ $# -ge 1 ]] && project_to_cleanup_override=$1
+  
+  [[ -z ${project_to_cleanup_override} ]] && abort "missing project name"
+  is_protected_gcr ${project_to_cleanup_override} && \
+    abort "\$project_to_cleanup_override set to ${project_to_cleanup_override}, which is forbidden"
+
+  for image in $(gcloud --format='value(name)' container images list --repository=${project_to_cleanup_override}); do
+      echo "Checking ${image} for removal"
+
+      delete_old_gcr_images_from_project ${image} ${DAYS_TO_KEEP_IMAGES}
+
+      local target_date=$(date -d "`date`-${DAYS_TO_KEEP_IMAGES}days" +%Y-%m-%d)
+      for digest in $(gcloud --format='get(digest)' container images list-tags ${image} \
+          --filter="timestamp.datetime<${target_date}" --limit=99999); do
+        local full_image="${image}@${digest}"
+        if (( $DRY_RUN )); then
+          echo "DRYRUN - Deleting image: $full_image"
+        else
+          echo "Deleting image: $full_image"
+          gcloud container images delete -q --force-delete-tags ${full_image}
+        fi
+      done
+  done
+}
+
+# Delete old images in GCR projects defined in yaml file provided
+# Parameters: $1 - yaml file path defining projects to be cleaned up
+# Parameters: $2 - regex pattern for parsing projects' names
+# Parameters: $3 - days to keep images
+function delete_old_gcr_images() {
+  local project_resource_yaml_override=$PROJECT_RESOURCE_YAML
+  local re_project_name_override=$RE_PROJECT_NAME
+  [[ $# -ge 1 ]] && project_resource_yaml_override=$1
+  [[ $# -ge 2 ]] && re_project_name_override=$2
+
+  [[ -z ${project_resource_yaml_override} ]] && abort "missing resource yaml path"
+  [[ -z ${re_project_name_override} ]] && abort "missing regex pattern after resource yaml path"
+
+  local target_projects # delared here as local + assignment in one line always return 0 exit code  
+  target_projects=$(grep -Eio "${re_project_name_override}" "${project_resource_yaml_override}")
+  [[ $? -eq 0 ]] || abort "no project found in ${project_resource_yaml_override}"
+
+  for project in ${target_projects}; do
+    echo "Start deleting images from ${project}"
+    delete_old_gcr_images_from_project "gcr.io/${project}" $DAYS_TO_KEEP_IMAGES
+  done
+}
+
+
+cd ${REPO_ROOT_DIR}
+
+# Entry point
+# Dispatching commands to different functions
+if [[ $# -ne 0 ]]; then
+  case $1 in
+    delete-old-gcr-images)
+      FUNCTION_TO_RUN=$1
+      shift
+      parse_args $@
+      delete_old_gcr_images
+      ;;
+    delete-old-gcr-images-from-project)
+      FUNCTION_TO_RUN=$1
+      shift
+      parse_args $@
+      delete_old_gcr_images_from_project
+      ;;
+    *) abort "unknown option ${parameter}" ;;
+  esac
+else
+  warning "no params passed in, no ops. do not source this script unless you know what you are doing"
+fi


### PR DESCRIPTION
Instead of deleting the images in GCR after the test finishes, have a job to perform it from time to time (and only old images).

- Add `cleanup.sh` script under `tools`
- Add unit testing under `test/unit`
- Add Prow job calling this cleanup script periodically
- Remove `delete_gcr_images` function from common `library.sh`
- Refactor some common functions to library

After this PR, scripts/functions for images deletions will only live under `knative/test-infra` repo, and no jobs other than `cleanup-old-images` job should delete any images.

Fixes https://github.com/knative/test-infra/issues/276
