### PR TITLE
Add knative/observability to tide list

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -51,6 +51,7 @@ tide:
     - knative/build
     - knative/build-pipeline
     - knative/build-templates
+    - knative/observability
     - knative/serving
     - knative/eventing
     - knative/eventing-sources


### PR DESCRIPTION
Adds repo `knative/observability` to tide list so that PRs can be automatically merged once approved.

@adrcunha 
