### PR TITLE
 Add --service-account flag to cleanup.sh

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -76,7 +76,7 @@ presets:
     preset-test-account: "true"
   env:
   - name: GOOGLE_APPLICATION_CREDENTIALS
-    value: /etc/test-account/key.json
+    value: /etc/test-account/service-account.json
   volumes:
   - name: account
     secret:
@@ -96,7 +96,7 @@ presets:
     preset-nightly-account: "true"
   env:
   - name: GOOGLE_APPLICATION_CREDENTIALS
-    value: /etc/nightly-account/key.json
+    value: /etc/nightly-account/service-account.json
   volumes:
   - name: account
     secret:
@@ -163,7 +163,7 @@ presubmits:
         - "--job=$(JOB_NAME)"
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
-        - "--service-account=/etc/test-account/key.json"
+        - "--service-account=/etc/test-account/service-account.json"
         - "--upload=gs://knative-prow/pr-logs"
         - "--" # end bootstrap args, scenario args below
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
@@ -196,7 +196,7 @@ presubmits:
         - "--job=$(JOB_NAME)"
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
-        - "--service-account=/etc/test-account/key.json"
+        - "--service-account=/etc/test-account/service-account.json"
         - "--upload=gs://knative-prow/pr-logs"
         - "--" # end bootstrap args, scenario args below
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
@@ -229,7 +229,7 @@ presubmits:
         - "--job=$(JOB_NAME)"
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
-        - "--service-account=/etc/test-account/key.json"
+        - "--service-account=/etc/test-account/service-account.json"
         - "--upload=gs://knative-prow/pr-logs"
         - "--" # end bootstrap args, scenario args below
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
@@ -266,7 +266,7 @@ presubmits:
         - "--job=$(JOB_NAME)"
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
-        - "--service-account=/etc/test-account/key.json"
+        - "--service-account=/etc/test-account/service-account.json"
         - "--upload=gs://knative-prow/pr-logs"
         - "--" # end bootstrap args, scenario args below
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
@@ -369,7 +369,7 @@ presubmits:
         - "--job=$(JOB_NAME)"
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
-        - "--service-account=/etc/test-account/key.json"
+        - "--service-account=/etc/test-account/service-account.json"
         - "--upload=gs://knative-prow/pr-logs"
         - "--" # end bootstrap args, scenario args below
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
@@ -402,7 +402,7 @@ presubmits:
         - "--job=$(JOB_NAME)"
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
-        - "--service-account=/etc/test-account/key.json"
+        - "--service-account=/etc/test-account/service-account.json"
         - "--upload=gs://knative-prow/pr-logs"
         - "--" # end bootstrap args, scenario args below
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
@@ -436,7 +436,7 @@ presubmits:
         - "--job=$(JOB_NAME)"
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
-        - "--service-account=/etc/test-account/key.json"
+        - "--service-account=/etc/test-account/service-account.json"
         - "--upload=gs://knative-prow/pr-logs"
         - "--" # end bootstrap args, scenario args below
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
@@ -504,7 +504,7 @@ presubmits:
         - "--job=$(JOB_NAME)"
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
-        - "--service-account=/etc/test-account/key.json"
+        - "--service-account=/etc/test-account/service-account.json"
         - "--upload=gs://knative-prow/pr-logs"
         - "--" # end bootstrap args, scenario args below
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
@@ -537,7 +537,7 @@ presubmits:
         - "--job=$(JOB_NAME)"
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
-        - "--service-account=/etc/test-account/key.json"
+        - "--service-account=/etc/test-account/service-account.json"
         - "--upload=gs://knative-prow/pr-logs"
         - "--" # end bootstrap args, scenario args below
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
@@ -570,7 +570,7 @@ presubmits:
         - "--job=$(JOB_NAME)"
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
-        - "--service-account=/etc/test-account/key.json"
+        - "--service-account=/etc/test-account/service-account.json"
         - "--upload=gs://knative-prow/pr-logs"
         - "--" # end bootstrap args, scenario args below
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
@@ -638,7 +638,7 @@ presubmits:
         - "--job=$(JOB_NAME)"
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
-        - "--service-account=/etc/test-account/key.json"
+        - "--service-account=/etc/test-account/service-account.json"
         - "--upload=gs://knative-prow/pr-logs"
         - "--" # end bootstrap args, scenario args below
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
@@ -671,7 +671,7 @@ presubmits:
         - "--job=$(JOB_NAME)"
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
-        - "--service-account=/etc/test-account/key.json"
+        - "--service-account=/etc/test-account/service-account.json"
         - "--upload=gs://knative-prow/pr-logs"
         - "--" # end bootstrap args, scenario args below
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
@@ -704,7 +704,7 @@ presubmits:
         - "--job=$(JOB_NAME)"
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
-        - "--service-account=/etc/test-account/key.json"
+        - "--service-account=/etc/test-account/service-account.json"
         - "--upload=gs://knative-prow/pr-logs"
         - "--" # end bootstrap args, scenario args below
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
@@ -772,7 +772,7 @@ presubmits:
         - "--job=$(JOB_NAME)"
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
-        - "--service-account=/etc/test-account/key.json"
+        - "--service-account=/etc/test-account/service-account.json"
         - "--upload=gs://knative-prow/pr-logs"
         - "--" # end bootstrap args, scenario args below
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
@@ -805,7 +805,7 @@ presubmits:
         - "--job=$(JOB_NAME)"
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
-        - "--service-account=/etc/test-account/key.json"
+        - "--service-account=/etc/test-account/service-account.json"
         - "--upload=gs://knative-prow/pr-logs"
         - "--" # end bootstrap args, scenario args below
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
@@ -838,7 +838,7 @@ presubmits:
         - "--job=$(JOB_NAME)"
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
-        - "--service-account=/etc/test-account/key.json"
+        - "--service-account=/etc/test-account/service-account.json"
         - "--upload=gs://knative-prow/pr-logs"
         - "--" # end bootstrap args, scenario args below
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
@@ -906,7 +906,7 @@ presubmits:
         - "--job=$(JOB_NAME)"
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
-        - "--service-account=/etc/test-account/key.json"
+        - "--service-account=/etc/test-account/service-account.json"
         - "--upload=gs://knative-prow/pr-logs"
         - "--" # end bootstrap args, scenario args below
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
@@ -939,7 +939,7 @@ presubmits:
         - "--job=$(JOB_NAME)"
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
-        - "--service-account=/etc/test-account/key.json"
+        - "--service-account=/etc/test-account/service-account.json"
         - "--upload=gs://knative-prow/pr-logs"
         - "--" # end bootstrap args, scenario args below
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
@@ -972,7 +972,7 @@ presubmits:
         - "--job=$(JOB_NAME)"
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
-        - "--service-account=/etc/test-account/key.json"
+        - "--service-account=/etc/test-account/service-account.json"
         - "--upload=gs://knative-prow/pr-logs"
         - "--" # end bootstrap args, scenario args below
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
@@ -1040,7 +1040,7 @@ presubmits:
         - "--job=$(JOB_NAME)"
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
-        - "--service-account=/etc/test-account/key.json"
+        - "--service-account=/etc/test-account/service-account.json"
         - "--upload=gs://knative-prow/pr-logs"
         - "--" # end bootstrap args, scenario args below
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
@@ -1073,7 +1073,7 @@ presubmits:
         - "--job=$(JOB_NAME)"
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
-        - "--service-account=/etc/test-account/key.json"
+        - "--service-account=/etc/test-account/service-account.json"
         - "--upload=gs://knative-prow/pr-logs"
         - "--" # end bootstrap args, scenario args below
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
@@ -1106,7 +1106,7 @@ presubmits:
         - "--job=$(JOB_NAME)"
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
-        - "--service-account=/etc/test-account/key.json"
+        - "--service-account=/etc/test-account/service-account.json"
         - "--upload=gs://knative-prow/pr-logs"
         - "--" # end bootstrap args, scenario args below
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
@@ -1140,7 +1140,7 @@ presubmits:
         - "--job=$(JOB_NAME)"
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
-        - "--service-account=/etc/test-account/key.json"
+        - "--service-account=/etc/test-account/service-account.json"
         - "--upload=gs://knative-prow/pr-logs"
         - "--" # end bootstrap args, scenario args below
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
@@ -1173,7 +1173,7 @@ presubmits:
         - "--job=$(JOB_NAME)"
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
-        - "--service-account=/etc/test-account/key.json"
+        - "--service-account=/etc/test-account/service-account.json"
         - "--upload=gs://knative-prow/pr-logs"
         - "--" # end bootstrap args, scenario args below
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
@@ -1206,7 +1206,7 @@ presubmits:
         - "--job=$(JOB_NAME)"
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
-        - "--service-account=/etc/test-account/key.json"
+        - "--service-account=/etc/test-account/service-account.json"
         - "--upload=gs://knative-prow/pr-logs"
         - "--" # end bootstrap args, scenario args below
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
@@ -1274,7 +1274,7 @@ presubmits:
         - "--job=$(JOB_NAME)"
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
-        - "--service-account=/etc/test-account/key.json"
+        - "--service-account=/etc/test-account/service-account.json"
         - "--upload=gs://knative-prow/pr-logs"
         - "--" # end bootstrap args, scenario args below
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
@@ -1307,7 +1307,7 @@ presubmits:
         - "--job=$(JOB_NAME)"
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
-        - "--service-account=/etc/test-account/key.json"
+        - "--service-account=/etc/test-account/service-account.json"
         - "--upload=gs://knative-prow/pr-logs"
         - "--" # end bootstrap args, scenario args below
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
@@ -1340,7 +1340,7 @@ presubmits:
         - "--job=$(JOB_NAME)"
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
-        - "--service-account=/etc/test-account/key.json"
+        - "--service-account=/etc/test-account/service-account.json"
         - "--upload=gs://knative-prow/pr-logs"
         - "--" # end bootstrap args, scenario args below
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
@@ -1374,7 +1374,7 @@ presubmits:
         - "--job=$(JOB_NAME)"
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
-        - "--service-account=/etc/test-account/key.json"
+        - "--service-account=/etc/test-account/service-account.json"
         - "--upload=gs://knative-prow/pr-logs"
         - "--" # end bootstrap args, scenario args below
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
@@ -1407,7 +1407,7 @@ presubmits:
         - "--job=$(JOB_NAME)"
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
-        - "--service-account=/etc/test-account/key.json"
+        - "--service-account=/etc/test-account/service-account.json"
         - "--upload=gs://knative-prow/pr-logs"
         - "--" # end bootstrap args, scenario args below
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
@@ -1440,7 +1440,7 @@ presubmits:
         - "--job=$(JOB_NAME)"
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
-        - "--service-account=/etc/test-account/key.json"
+        - "--service-account=/etc/test-account/service-account.json"
         - "--upload=gs://knative-prow/pr-logs"
         - "--" # end bootstrap args, scenario args below
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
@@ -1505,7 +1505,7 @@ periodics:
       - "--job=$(JOB_NAME)"
       - "--repo=github.com/knative/serving"
       - "--root=/go/src"
-      - "--service-account=/etc/test-account/key.json"
+      - "--service-account=/etc/test-account/service-account.json"
       - "--upload=gs://knative-prow/logs"
       - "--timeout=100" # Avoid overrun
       - "--" # end bootstrap args, scenario args below
@@ -1537,7 +1537,7 @@ periodics:
       - "--job=$(JOB_NAME)"
       - "--repo=github.com/knative/serving=release-0.2"
       - "--root=/go/src"
-      - "--service-account=/etc/test-account/key.json"
+      - "--service-account=/etc/test-account/service-account.json"
       - "--upload=gs://knative-prow/logs"
       - "--timeout=50" # Avoid overrun
       - "--" # end bootstrap args, scenario args below
@@ -1568,7 +1568,7 @@ periodics:
       - "--job=$(JOB_NAME)"
       - "--repo=github.com/knative/serving"
       - "--root=/go/src"
-      - "--service-account=/etc/nightly-account/key.json"
+      - "--service-account=/etc/nightly-account/service-account.json"
       - "--upload=gs://knative-prow/logs"
       - "--timeout=90" # 1.5h
       - "--" # end bootstrap args, scenario args below
@@ -1599,7 +1599,7 @@ periodics:
       - "--job=$(JOB_NAME)"
       - "--repo=github.com/knative/serving"
       - "--root=/go/src"
-      - "--service-account=/etc/test-account/key.json"
+      - "--service-account=/etc/test-account/service-account.json"
       - "--upload=gs://knative-prow/logs"
       - "--timeout=90" # 1.5h
       - "--" # end bootstrap args, scenario args below
@@ -1632,7 +1632,7 @@ periodics:
       args:
       - "--source-directory=ci-knative-serving-continuous"
       - "--artifacts-dir=$(ARTIFACTS)"
-      - "--service-account=/etc/test-account/key.json"
+      - "--service-account=/etc/test-account/service-account.json"
 - cron: "5 8 * * *" # Run at 01:05PST every day (08:05 UTC)
   name: ci-knative-serving-api-coverage
   agent: kubernetes
@@ -1652,7 +1652,7 @@ periodics:
       - "/apicoverage"
       args:
       - "--artifacts-dir=$(ARTIFACTS)"
-      - "--service-account=/etc/test-account/key.json"
+      - "--service-account=/etc/test-account/service-account.json"
 - cron: "0 1 * * *" # Run at 01:00 every day
   name: ci-knative-serving-go-coverage
   agent: kubernetes
@@ -1690,7 +1690,7 @@ periodics:
       - "--job=$(JOB_NAME)"
       - "--repo=github.com/knative/serving"
       - "--root=/go/src"
-      - "--service-account=/etc/test-account/key.json"
+      - "--service-account=/etc/test-account/service-account.json"
       - "--upload=gs://knative-prow/logs"
       - "--timeout=50" # Avoid overrun
       - "--" # end bootstrap args, scenario args below
@@ -1720,7 +1720,7 @@ periodics:
       - "--job=$(JOB_NAME)"
       - "--repo=github.com/knative/build"
       - "--root=/go/src"
-      - "--service-account=/etc/test-account/key.json"
+      - "--service-account=/etc/test-account/service-account.json"
       - "--upload=gs://knative-prow/logs"
       - "--timeout=50" # Avoid overrun
       - "--" # end bootstrap args, scenario args below
@@ -1752,7 +1752,7 @@ periodics:
       - "--job=$(JOB_NAME)"
       - "--repo=github.com/knative/build"
       - "--root=/go/src"
-      - "--service-account=/etc/nightly-account/key.json"
+      - "--service-account=/etc/nightly-account/service-account.json"
       - "--upload=gs://knative-prow/logs"
       - "--timeout=90" # 1.5h
       - "--" # end bootstrap args, scenario args below
@@ -1786,7 +1786,7 @@ periodics:
       args:
       - "--source-directory=ci-knative-build-continuous"
       - "--artifacts-dir=$(ARTIFACTS)"
-      - "--service-account=/etc/test-account/key.json"
+      - "--service-account=/etc/test-account/service-account.json"
 - cron: "0 1 * * *" # Run at 01:00 every day
   name: ci-knative-build-go-coverage
   agent: kubernetes
@@ -1826,7 +1826,7 @@ periodics:
       - "--job=$(JOB_NAME)"
       - "--repo=github.com/knative/build-pipeline"
       - "--root=/go/src"
-      - "--service-account=/etc/nightly-account/key.json"
+      - "--service-account=/etc/nightly-account/service-account.json"
       - "--upload=gs://knative-prow/logs"
       - "--timeout=90" # 1.5h
       - "--" # end bootstrap args, scenario args below
@@ -1878,7 +1878,7 @@ periodics:
       - "--job=$(JOB_NAME)"
       - "--repo=github.com/knative/docs"
       - "--root=/go/src"
-      - "--service-account=/etc/test-account/key.json"
+      - "--service-account=/etc/test-account/service-account.json"
       - "--upload=gs://knative-prow/logs"
       - "--timeout=50" # Avoid overrun
       - "--" # end bootstrap args, scenario args below
@@ -1929,7 +1929,7 @@ periodics:
       - "--job=$(JOB_NAME)"
       - "--repo=github.com/knative/eventing"
       - "--root=/go/src"
-      - "--service-account=/etc/test-account/key.json"
+      - "--service-account=/etc/test-account/service-account.json"
       - "--upload=gs://knative-prow/logs"
       - "--timeout=50" # Avoid overrun
       - "--" # end bootstrap args, scenario args below
@@ -1959,7 +1959,7 @@ periodics:
       - "--job=$(JOB_NAME)"
       - "--repo=github.com/knative/eventing"
       - "--root=/go/src"
-      - "--service-account=/etc/nightly-account/key.json"
+      - "--service-account=/etc/nightly-account/service-account.json"
       - "--upload=gs://knative-prow/logs"
       - "--timeout=90" # 1.5h
       - "--" # end bootstrap args, scenario args below
@@ -2011,7 +2011,7 @@ periodics:
       - "--job=$(JOB_NAME)"
       - "--repo=github.com/knative/eventing-sources"
       - "--root=/go/src"
-      - "--service-account=/etc/test-account/key.json"
+      - "--service-account=/etc/test-account/service-account.json"
       - "--upload=gs://knative-prow/logs"
       - "--timeout=50" # Avoid overrun
       - "--" # end bootstrap args, scenario args below
@@ -2041,7 +2041,7 @@ periodics:
       - "--job=$(JOB_NAME)"
       - "--repo=github.com/knative/eventing-sources"
       - "--root=/go/src"
-      - "--service-account=/etc/nightly-account/key.json"
+      - "--service-account=/etc/nightly-account/service-account.json"
       - "--upload=gs://knative-prow/logs"
       - "--timeout=90" # 1.5h
       - "--" # end bootstrap args, scenario args below
@@ -2093,7 +2093,7 @@ periodics:
       - "--job=$(JOB_NAME)"
       - "--repo=github.com/knative/build-templates"
       - "--root=/go/src"
-      - "--service-account=/etc/test-account/key.json"
+      - "--service-account=/etc/test-account/service-account.json"
       - "--upload=gs://knative-prow/logs"
       - "--timeout=50" # Avoid overrun
       - "--" # end bootstrap args, scenario args below
@@ -2124,7 +2124,7 @@ periodics:
       - "--job=$(JOB_NAME)"
       - "--repo=github.com/knative/pkg"
       - "--root=/go/src"
-      - "--service-account=/etc/test-account/key.json"
+      - "--service-account=/etc/test-account/service-account.json"
       - "--upload=gs://knative-prow/logs"
       - "--timeout=50" # Avoid overrun
       - "--" # end bootstrap args, scenario args below
@@ -2175,7 +2175,7 @@ periodics:
       - "--job=$(JOB_NAME)"
       - "--repo=github.com/knative/caching"
       - "--root=/go/src"
-      - "--service-account=/etc/test-account/key.json"
+      - "--service-account=/etc/test-account/service-account.json"
       - "--upload=gs://knative-prow/logs"
       - "--timeout=50" # Avoid overrun
       - "--" # end bootstrap args, scenario args below
@@ -2210,13 +2210,13 @@ periodics:
       - "--cov-threshold-percentage=80"
 - cron: "0 19 * * 1" # Run at 11:00PST/12:00PST every Monday (19:00 UTC)
   name: ci-knative-cleanup
-  branches:
-  - master
   agent: kubernetes
-  labels:
-    preset-service-account: "true"
   decorate: true
-  clone_uri: "https://github.com/knative/test-infra.git"
+  extra_refs:
+  - org: knative
+    repo: test-infra
+    base_ref: master
+    clone_uri: "https://github.com/knative/test-infra.git"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:latest
@@ -2227,6 +2227,7 @@ periodics:
       - "delete-old-gcr-images"
       - "--project-resource-yaml ci/prow/boskos/resources.yaml"
       - "--days-to-keep 90"
+      - "--service-account /etc/test-account/service-account.json"
   
 postsubmits:
   knative/serving:

--- a/test/unit/cleanup-tests.sh
+++ b/test/unit/cleanup-tests.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 source $(dirname $0)/helper.sh
-source "$(dirname $0)/../../tools/cleanup/cleanup.sh"
+source $(dirname $0)/../../tools/cleanup/cleanup-functions.sh
 
 readonly _FAKE_NIGHTLY_PROJECT_NAME="gcr.io/knative-nightly"
 readonly _FAKE_BOSKOS_PROJECT_NAME="gcr.io/fake-boskos-project"
@@ -29,35 +29,35 @@ function cleanup_script() {
 }
 
 set -e
+
 cd ${REPO_ROOT_DIR}
 
 echo ">> Testing directly invoking cleanup script"
 
 test_function ${FAILURE} "error: unknown option" cleanup_script "action-not-exist"
-test_function ${FAILURE} "error: missing project" cleanup_script "delete-old-gcr-images-from-project"
+test_function ${FAILURE} "error: missing gcr" cleanup_script "delete-old-images-from-gcr"
 test_function ${FAILURE} "error: missing resource" cleanup_script "delete-old-gcr-images"
 
 test_function ${FAILURE} "error: expecting value following" cleanup_script "delete-old-gcr-images" --project-resource-yaml --dry-run
 test_function ${FAILURE} "error: expecting value following" cleanup_script  "delete-old-gcr-images" --re-project-name --dry-run
-test_function ${FAILURE} "error: expecting value following" cleanup_script "delete-old-gcr-images" --project-to-cleanup --dry-run
+test_function ${FAILURE} "error: expecting value following" cleanup_script "delete-old-gcr-images" --gcr-to-cleanup --dry-run
 test_function ${FAILURE} "error: expecting value following" cleanup_script "delete-old-gcr-images" --days-to-keep --dry-run
 
-test_function ${FAILURE} "error: days to keep" cleanup_script "delete-old-gcr-images-from-project" --days-to-keep "a" --dry-run
+test_function ${FAILURE} "error: days to keep" cleanup_script "delete-old-images-from-gcr" --days-to-keep "a" --dry-run
 test_function ${FAILURE} "error: days to keep" cleanup_script "delete-old-gcr-images" --days-to-keep "a" --dry-run
 
 # Test individual functions
 echo ">> Testing deleting images from single project"
 
-test_function ${FAILURE} "error: missing" delete_old_gcr_images_from_project 
-test_function ${SUCCESS} "" mock_gcloud_function delete_old_gcr_images_from_project ${_FAKE_BOSKOS_PROJECT_NAME}
-test_function ${SUCCESS} "" mock_gcloud_function delete_old_gcr_images_from_project ${_FAKE_BOSKOS_PROJECT_NAME} 1
+test_function ${FAILURE} "error: missing gcr" delete_old_images_from_gcr
+test_function ${FAILURE} "error: missing days" delete_old_images_from_gcr ${_FAKE_BOSKOS_PROJECT_NAME}
+test_function ${SUCCESS} "" mock_gcloud_function delete_old_images_from_gcr ${_FAKE_BOSKOS_PROJECT_NAME} 1
 
 echo ">> Testing deleting images from multiple projects"
 
-test_function ${FAILURE} "error: missing" delete_old_gcr_images
-test_function ${FAILURE} "error: no project" delete_old_gcr_images "${_PROJECT_RESOURCE_YAML}file_not_exist" ${_RE_PROJECT_NAME}
-test_function ${FAILURE} "error: no project" delete_old_gcr_images ${_PROJECT_RESOURCE_YAML} "${_RE_PROJECT_NAME}project-not-exist"
-test_function ${SUCCESS} "Start" mock_gcloud_function delete_old_gcr_images ${_PROJECT_RESOURCE_YAML}
-test_function ${SUCCESS} "Start" mock_gcloud_function delete_old_gcr_images ${_PROJECT_RESOURCE_YAML} ${_RE_PROJECT_NAME}
+test_function ${FAILURE} "error: missing resource" delete_old_gcr_images
+test_function ${FAILURE} "error: missing regex" delete_old_gcr_images "file"
+test_function ${FAILURE} "error: missing days" delete_old_gcr_images "file" "regex"
+test_function ${SUCCESS} "Start" mock_gcloud_function delete_old_gcr_images ${_PROJECT_RESOURCE_YAML} ${_RE_PROJECT_NAME} 99
 
 echo ">> All tests passed"

--- a/tools/cleanup/README.md
+++ b/tools/cleanup/README.md
@@ -1,27 +1,34 @@
 # Resources Clean Up Tool
-This tool is designed to clean up staled resources from gcr, for now it only deletes old images created during testing.
+
+This tool is designed to clean up stale resources from gcr, for now it only deletes old images created during testing.
 
 ## Basic Usage
+
 Directly invoke [cleanup.sh](cleanup.sh) script with certain flags. There is no-op if invoking or sourcing this script without arguments.
 
-### Clean up old images from multiple gcr
+By default the current gcloud credentials are used to delete the images. If necessary, use the flag `--service-account _key-file.json_` to specify a service account that will be performing the access to the gcr.
+
+### Clean up old images from multiple gcrs
+
 Projects to be cleaned up are expected to be defined in a `resources.yaml` file. To remove old images from them, call [cleanup.sh](cleanup.sh) with action "delete-old-gcr-images" and following flags:
 - "--project-resource-yaml" as path of `resources.yaml` file - Mandatory
-- "--re-project-name" for regex matching projects names - Optional, default `knative-boskos-[a-zA-Z0-9]+`
+- "--re-project-name" for regex matching projects names - Optional, defaults to `knative-boskos-[a-zA-Z0-9]+`
 - "--days-to-keep" - Optional, default `365`
 
 Example:
 
 ```./cleanup.sh "delete-old-gcr-images" --project-resource-yaml "ci/prow/boskos/resources.yaml" --days-to-keep 90```
 
-### Clean up old images from specified gcr 
-Cleaning up from specific gcr is supported, except for some special ones (_knative-release_ and _knative-nightly_). Call [cleanup.sh](cleanup.sh) with action "delete-old-gcr-images-from-project" and following flags:
-- "--project-to-cleanup" as name of gcr, e.g. "gcr.io/foo" - Mandatory
+### Clean up old images from a specific gcr
+
+Cleaning up from a specific gcr is supported, except for some special ones (_knative-release_ and _knative-nightly_). Call [cleanup.sh](cleanup.sh) with action "delete-old-images-from-gcr" and following flags:
+- "--gcr-to-cleanup" as name of gcr, e.g. "gcr.io/foo" - Mandatory
 - "--days-to-keep" - Optional, default `365`
 
 Example:
 
-```./cleanup.sh "delete-old-gcr-images-from-project" --project-to-cleanup "gcr.io/foo" --days-to-keep 90```
+```./cleanup.sh "delete-old-images-from-gcr" --gcr-to-cleanup "gcr.io/foo" --days-to-keep 90```
 
 ## Prow Job
+
 There is a weekly prow job that triggers this tool runs at 11:00/12:00PM(Day light saving) PST every Monday. This tool scans all gcr projects defined in [ci/prow/boskos/resources.yaml](/ci/prow/boskos/resources.yaml) and deletes images older than 90 days.

--- a/tools/cleanup/cleanup-functions.sh
+++ b/tools/cleanup/cleanup-functions.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Functions for cleaning up GCRs.
+# It doesn't do anything when called from command line.
+
+source $(dirname $0)/../../scripts/library.sh
+
+# Delete old images in the given GCR.
+# Parameters: $1 - gcr to be cleaned up (e.g. gcr.io/fooProj)
+#             $2 - days to keep images
+function delete_old_images_from_gcr() {
+  [[ -z $1 ]] && abort "missing gcr name"
+  [[ -z $2 ]] && abort "missing days to keep images"
+
+  is_protected_gcr $1 && \
+    abort "Target GCR set to $1, which is forbidden"
+
+  for image in $(gcloud --format='value(name)' container images list --repository=$1); do
+      echo "Checking ${image} for removal"
+
+      delete_old_images_from_gcr ${image} $2
+
+      local target_date=$(date -d "`date`-$2days" +%Y-%m-%d)
+      for digest in $(gcloud --format='get(digest)' container images list-tags ${image} \
+          --filter="timestamp.datetime<${target_date}" --limit=99999); do
+        local full_image="${image}@${digest}"
+        echo "Deleting image: ${full_image}"
+        if (( DRY_RUN )); then
+          echo "[DRY RUN] gcloud container images delete -q --force-delete-tags ${full_image}"
+        else
+          gcloud container images delete -q --force-delete-tags ${full_image}
+        fi
+      done
+  done
+}
+
+# Delete old images in the GCP projects defined in the yaml file provided.
+# Parameters: $1 - yaml file path defining projects that will be cleaned up
+#             $2 - regex pattern for parsing the project names
+#             $3 - days to keep images
+function delete_old_gcr_images() {
+  [[ -z $1 ]] && abort "missing resource yaml path"
+  [[ -z $2 ]] && abort "missing regex pattern for project name"
+  [[ -z $3 ]] && abort "missing days to keep images"
+
+  local target_projects # delared here as local + assignment in one line always return 0 exit code
+  target_projects="$(grep -Eio "$2" "$1")"
+  [[ $? -eq 0 ]] || abort "no project found in $1"
+
+  for project in ${target_projects}; do
+    echo "Start deleting images from ${project}"
+    delete_old_images_from_gcr "gcr.io/${project}" $3
+  done
+}

--- a/tools/cleanup/cleanup.sh
+++ b/tools/cleanup/cleanup.sh
@@ -16,147 +16,71 @@
 
 # This is a script to clean up stale resources
 
-source $(dirname $0)/../../scripts/library.sh
+source $(dirname $0)/cleanup-functions.sh
 
 # Global variables
 DAYS_TO_KEEP_IMAGES=365 # Keep images up to 1 year by default
 RE_PROJECT_NAME="knative-boskos-[a-zA-Z0-9]+"
 PROJECT_RESOURCE_YAML=""
-PROJECT_TO_CLEANUP=""
+GCR_TO_CLEANUP=""
 DRY_RUN=0
-
-FUNCTION_TO_RUN=""
 
 
 function parse_args() {
   while [[ $# -ne 0 ]]; do
     local parameter=$1
     case ${parameter} in
-      --project-resource-yaml)
+      --dry-run) DRY_RUN=1 ;;
+      *)
         [[ -z $2 || $2 =~ ^-- ]] && abort "expecting value following $1"
         shift
-        PROJECT_RESOURCE_YAML=$1
-        ;;
-      --re-project-name)
-        [[ -z $2 || $2 =~ ^-- ]] && abort "expecting value following $1"
-        shift
-        RE_PROJECT_NAME=$1
-        ;;
-     --project-to-cleanup)
-        [[ -z $2 || $2 =~ ^-- ]] && abort "expecting value following $1"
-        shift
-        PROJECT_TO_CLEANUP=$1
-        ;;
-     --days-to-keep)
-        [[ -z $2 || $2 =~ ^-- ]] && abort "expecting value following $1"
-        shift
-        DAYS_TO_KEEP_IMAGES=$1
-        ;;
-      --dry-run)
-        DRY_RUN=1
-        ;;
-      *) abort "unknown option ${parameter}" ;;
+        case ${parameter} in
+          --project-resource-yaml) PROJECT_RESOURCE_YAML=$1 ;;
+          --re-project-name) RE_PROJECT_NAME=$1 ;;
+          --gcr-to-cleanup) GCR_TO_CLEANUP=$1 ;;
+          --days-to-keep) DAYS_TO_KEEP_IMAGES=$1 ;;
+          --service-account)
+            gcloud auth activate-service-account --key-file=$1 || exit 1
+            ;;
+          *) abort "unknown option ${parameter}" ;;
+        esac
     esac
     shift
   done
 
+  is_int ${DAYS_TO_KEEP_IMAGES} || abort "days to keep has to be integer"
+
   readonly DAYS_TO_KEEP_IMAGES
   readonly PROJECT_RESOURCE_YAML
   readonly RE_PROJECT_NAME
-  readonly PROJECT_TO_CLEANUP
+  readonly GCR_TO_CLEANUP
   readonly DRY_RUN
-
-
-  is_int $DAYS_TO_KEEP_IMAGES || abort "days to keep has to be integer"
-
-  (( DRY_RUN )) && echo "-- Running in dry-run mode, no image deletion --"
-  echo "Removing images with following rules:"
-  case ${FUNCTION_TO_RUN} in
-    delete-old-gcr-images)
-      echo "- from projects defined in $PROJECT_RESOURCE_YAML, matching $RE_PROJECT_NAME"
-      ;;
-    delete-old-gcr-images-from-project)
-      echo "- from project $PROJECT_TO_CLEANUP"
-      ;;
-    *) ;;
-  esac
-  echo "- older than $DAYS_TO_KEEP_IMAGES days"
 }
 
-# Delete old images in given GCR project
-# Parameters: $1 - gcr to be cleaned up, i.e. gcr.io/fooProj
-# Parameters: $2 - days to keep images
-function delete_old_gcr_images_from_project() {
-  local project_to_cleanup_override=$PROJECT_TO_CLEANUP
-  [[ $# -ge 1 ]] && project_to_cleanup_override=$1
-  
-  [[ -z ${project_to_cleanup_override} ]] && abort "missing project name"
-  is_protected_gcr ${project_to_cleanup_override} && \
-    abort "\$project_to_cleanup_override set to ${project_to_cleanup_override}, which is forbidden"
-
-  for image in $(gcloud --format='value(name)' container images list --repository=${project_to_cleanup_override}); do
-      echo "Checking ${image} for removal"
-
-      delete_old_gcr_images_from_project ${image} ${DAYS_TO_KEEP_IMAGES}
-
-      local target_date=$(date -d "`date`-${DAYS_TO_KEEP_IMAGES}days" +%Y-%m-%d)
-      for digest in $(gcloud --format='get(digest)' container images list-tags ${image} \
-          --filter="timestamp.datetime<${target_date}" --limit=99999); do
-        local full_image="${image}@${digest}"
-        if (( $DRY_RUN )); then
-          echo "DRYRUN - Deleting image: $full_image"
-        else
-          echo "Deleting image: $full_image"
-          gcloud container images delete -q --force-delete-tags ${full_image}
-        fi
-      done
-  done
-}
-
-# Delete old images in GCR projects defined in yaml file provided
-# Parameters: $1 - yaml file path defining projects to be cleaned up
-# Parameters: $2 - regex pattern for parsing projects' names
-# Parameters: $3 - days to keep images
-function delete_old_gcr_images() {
-  local project_resource_yaml_override=$PROJECT_RESOURCE_YAML
-  local re_project_name_override=$RE_PROJECT_NAME
-  [[ $# -ge 1 ]] && project_resource_yaml_override=$1
-  [[ $# -ge 2 ]] && re_project_name_override=$2
-
-  [[ -z ${project_resource_yaml_override} ]] && abort "missing resource yaml path"
-  [[ -z ${re_project_name_override} ]] && abort "missing regex pattern after resource yaml path"
-
-  local target_projects # delared here as local + assignment in one line always return 0 exit code  
-  target_projects=$(grep -Eio "${re_project_name_override}" "${project_resource_yaml_override}")
-  [[ $? -eq 0 ]] || abort "no project found in ${project_resource_yaml_override}"
-
-  for project in ${target_projects}; do
-    echo "Start deleting images from ${project}"
-    delete_old_gcr_images_from_project "gcr.io/${project}" $DAYS_TO_KEEP_IMAGES
-  done
-}
-
+# Script entry point
 
 cd ${REPO_ROOT_DIR}
 
-# Entry point
-# Dispatching commands to different functions
-if [[ $# -ne 0 ]]; then
-  case $1 in
-    delete-old-gcr-images)
-      FUNCTION_TO_RUN=$1
-      shift
-      parse_args $@
-      delete_old_gcr_images
-      ;;
-    delete-old-gcr-images-from-project)
-      FUNCTION_TO_RUN=$1
-      shift
-      parse_args $@
-      delete_old_gcr_images_from_project
-      ;;
-    *) abort "unknown option ${parameter}" ;;
-  esac
-else
-  warning "no params passed in, no ops. do not source this script unless you know what you are doing"
+if [[ -z $1 ]]; then
+  abort "missing parameters to the tool"
 fi
+
+FUNCTION_TO_RUN=$1
+shift
+parse_args $@
+
+(( DRY_RUN )) && echo "-- Running in dry-run mode, no image deletion --"
+
+echo "Removing images with following rules:"
+echo "- older than ${DAYS_TO_KEEP_IMAGES} days"
+case ${FUNCTION_TO_RUN} in
+  delete-old-gcr-images)
+    echo "- from projects defined in '${PROJECT_RESOURCE_YAML}', matching '${RE_PROJECT_NAME}"
+    delete_old_gcr_images "${PROJECT_RESOURCE_YAML}" "${RE_PROJECT_NAME}" "${DAYS_TO_KEEP_IMAGES}"
+    ;;
+  delete-old-images-from-gcr)
+    echo "- from gcr '${GCR_TO_CLEANUP}'"
+    delete_old_images_from_gcr "${GCR_TO_CLEANUP}" "${DAYS_TO_KEEP_IMAGES}"
+    ;;
+  *) abort "unknown option '${FUNCTION_TO_RUN}'" ;;
+esac


### PR DESCRIPTION
This is required when running the script from Prow jobs, to establish the authentication.

Bonuses:
* used the term "gcr" instead of project to clearly differentiate from the GCP projects parsed from a YAML file
* separated the deletion functions for testing purposes
* assorted code refactoring, documentation, simplification, fixing and nitpicking