### PR TITLE
Add job to back up artifacts

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -131,6 +131,20 @@ presets:
   - name: service-account
     mountPath: /etc/service-account
     readOnly: true
+# backups service account
+- labels:
+    preset-backup-account: "true"
+  env:
+  - name: GOOGLE_APPLICATION_CREDENTIALS
+    value: /etc/backup-account/service-account.json
+  volumes:
+  - name: account
+    secret:
+      secretName: backup-account
+  volumeMounts:
+  - name: account
+    mountPath: /etc/backup-account
+    readOnly: true
 # docker-in-docker presets
 - labels:
     preset-dind-enabled: "true"
@@ -1739,6 +1753,20 @@ periodics:
       - "./hack/release.sh"
       - "--publish"
       - "--tag-release"
+- cron: "15 9 * * *" # Run at 02:15PST every day (09:15 UTC)
+  name: ci-knative-backup-artifacts
+  agent: kubernetes
+  labels:
+    preset-backup-account: "true"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/backups:latest
+      imagePullPolicy: Always
+      command:
+      - "/backup.sh"
+      resources:
+        requests:
+          memory: "1Gi"
 - cron: "0 1 * * *" # Run at 01:00 every day
   name: ci-knative-eventing-sources-go-coverage
   agent: kubernetes

--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -1764,9 +1764,6 @@ periodics:
       imagePullPolicy: Always
       command:
       - "/backup.sh"
-      resources:
-        requests:
-          memory: "1Gi"
 - cron: "0 1 * * *" # Run at 01:00 every day
   name: ci-knative-eventing-sources-go-coverage
   agent: kubernetes

--- a/images/backups/Dockerfile
+++ b/images/backups/Dockerfile
@@ -1,0 +1,26 @@
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/go-containerregistry/gcrane as gcrane
+
+FROM gcr.io/cloud-builders/gcloud-slim
+LABEL maintainer "Jon Johnson <jonjohnson@google.com>"
+
+# Copy the gcrane binary from the gcrane builder (it is built with ko).
+COPY --from=gcrane /ko-app /bin/gcrane
+
+# Copy the entrypoint shell script.
+COPY . .
+
+ENTRYPOINT ["/backup.sh"]

--- a/images/backups/Makefile
+++ b/images/backups/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 IMG = gcr.io/knative-tests/test-infra/backups
-TAG := $(shell date +v%Y%m%d)-$(shell git describe --always --dirty --match '^$')
+TAG := $(shell date +v%Y%m%d)-$(shell git describe --always --dirty --match '^$$')
 
 all: build
 

--- a/images/backups/Makefile
+++ b/images/backups/Makefile
@@ -1,0 +1,30 @@
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+IMG = gcr.io/knative-tests/test-infra/backups
+TAG := $(shell date +v%Y%m%d)-$(shell git describe --always --dirty --match '^$')
+
+all: build
+
+build:
+	docker build -t $(IMG):$(TAG) -f Dockerfile ../..
+	docker tag $(IMG):$(TAG) $(IMG):latest
+
+push_versioned: build
+	docker push $(IMG):$(TAG)
+
+push_latest: build
+	docker push $(IMG):latest
+
+push: push_versioned push_latest

--- a/images/backups/README.md
+++ b/images/backups/README.md
@@ -1,0 +1,13 @@
+# Knative Backups Image
+
+This directory contains the custom Docker image used by our backups job.
+
+## Building and publishing a new image
+
+To build and push a new image, just run `make push`.
+
+For testing purposes you can build an image but not push it; to do so, run
+`make build`.
+
+Note that you must have proper permission in the `knative-tests` project to
+push new images to the GCR.

--- a/images/backups/backup.sh
+++ b/images/backups/backup.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is a script to backup knative released images and yaml to the
+# knative-backups project.
+
+echo "Copying images"
+gcrane cp -r gcr.io/knative-releases gcr.io/knative-backups
+
+echo "Copying kubernetes manifests"
+gsutil -m cp -r gs://knative-releases gs://knative-backups


### PR DESCRIPTION
WIP because I'm not sure if this is the right way to do this, happy to receive any guidance 😄 

This copies images from `gcr.io/knative-releases` into `gcr.io/knative-backups` once a day.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

See: https://github.com/knative/serving/issues/2553

**TODO:**
- [x] Create `gcr.io/knative-backups`.
- [x] Create new service account.
- [x] Give read access to `gcr.io/knative-releases` (it's already public).
- [x] Give write access to ONLY `gcr.io/knative-backups`.