### PR TITLE
webhook based API-Coverage tool resource tree definition

### DIFF
--- a/tools/webhook-apicoverage/resourcetree/README.md
+++ b/tools/webhook-apicoverage/resourcetree/README.md
@@ -1,0 +1,8 @@
+# Resource Tree
+
+resourcetree package contains types and interfaces that define a resource tree(n-ary tree based representation of an API resource). Each resource tree is composed of nodes which have data encapsulated inside [nodeData](node.go) and operations that can be performed on each node in the interface [INode](node.go). Type of a node is logically defined by reflect.Kind. Each node type is expected to satisfy the [INode](node.go) interface.  
+
+##Resource Forest  
+[ResourceForest](resourceforest.go) groups all resource trees that are part of an API version into a single construct and defines operations that span across them. As an example for Knative Serving, we will have individual resource trees for Configuration, Revision, Route and Service, and they are encapsulated inside a resource forest under version v1alpha1. Example of an operation that spans resource trees would be to get coverage details for outlined types connected using ConnectedNodes.
+
+ConnectedNodes represent connections between nodes that are of same type(reflect.Type) and belong to same package but span across different trees or branches of same tree. An example of ConnectedNodes would be v1alpha1.Route.Spec.Traffic and v1alpha1.Route.Status.Traffic, both these Traffic fields are of type v1alpha1.TrafficTarget, but are present in different paths inside the resource tree. ConnectedNodes connects these two nodes, and a outlining of this type would present the coverage across the two branches and gives a unified view of what fields are covered.

--- a/tools/webhook-apicoverage/resourcetree/arraykindnode.go
+++ b/tools/webhook-apicoverage/resourcetree/arraykindnode.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcetree
+
+import (
+	"reflect"
+)
+
+//ArrayKindNode represents resource tree node of types reflect.Kind.Array and reflect.Kind.Slice
+type ArrayKindNode struct {
+	nodeData
+	arrKind reflect.Kind // Array type e.g. []int will store reflect.Kind.Int. This is required for type-expansion and value-evaluation decisions.
+}
+
+func (a *ArrayKindNode ) getData() nodeData {
+	return a.nodeData
+}
+
+func (a *ArrayKindNode ) initialize(field string, parent INode, t reflect.Type, rt *ResourceTree) {
+	a.nodeData.initialize(field, parent, t, rt)
+	a.arrKind = t.Elem().Kind()
+}

--- a/tools/webhook-apicoverage/resourcetree/basictypekindnode.go
+++ b/tools/webhook-apicoverage/resourcetree/basictypekindnode.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcetree
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+)
+
+//BasicTypeKindNode represents resource tree node of basic types like int, float, etc.
+type BasicTypeKindNode struct {
+	nodeData
+	values map[string]bool // Values seen for this node. Useful for enum types.
+	possibleEnum bool // Flag to indicate if this is a possible enum.
+}
+
+func (b *BasicTypeKindNode) getData() nodeData {
+	return b.nodeData
+}
+
+func (b *BasicTypeKindNode) initialize(field string, parent INode, t reflect.Type, rt *ResourceTree) {
+	b.nodeData.initialize(field, parent, t, rt)
+	b.values = make(map[string]bool)
+	b.nodeData.leafNode = true
+}
+
+func (b *BasicTypeKindNode) isNil(v reflect.Value) (bool, string) {
+	switch v.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		if v.Int() != 0 {
+			return false, strconv.Itoa(int(v.Int()))
+		}
+	case reflect.Uint, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		if v.Uint() != 0 {
+			return false, strconv.FormatUint(v.Uint(), 10)
+		}
+	case reflect.Float32, reflect.Float64:
+		if v.Float() != 0 {
+			return false, fmt.Sprintf("%f", v.Float())
+		}
+	case reflect.String:
+		if v.Len() != 0 {
+			return false, v.String()
+		}
+	case reflect.Bool:
+		return false, strconv.FormatBool(v.Bool())
+	}
+
+	return true, ""
+}

--- a/tools/webhook-apicoverage/resourcetree/node.go
+++ b/tools/webhook-apicoverage/resourcetree/node.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcetree
+
+import (
+	"reflect"
+)
+
+//node.go contains types and interfaces pertaining to nodes inside resource tree.
+
+//INode interface defines methods that can be performed on each node in the resource tree.
+type INode interface {
+	getData() nodeData
+	initialize(field string, parent INode, t reflect.Type, rt *ResourceTree)
+}
+
+//nodeData is the data stored in each node of the resource tree.
+type nodeData struct {
+	field string // Represents the Name of the field e.g. field name inside the struct.
+	tree *ResourceTree // Reference back to the resource tree. Required for cross-tree traversal(connected nodes traversal)
+	fieldType reflect.Type // Required as type information is not available during tree traversal.
+	nodePath string // Path in the resource tree reaching this node.
+	parent INode // Link back to parent.
+	children map[string]INode // Child nodes are keyed using field names(nodeData.field).
+	leafNode bool // Storing this as an additional field because type-analysis determines the value, which gets used later in value-evaluation
+	covered bool
+}
+
+func (nd *nodeData) initialize(field string, parent INode, t reflect.Type, rt *ResourceTree) {
+	nd.field = field
+	nd.tree = rt
+	nd.parent = parent
+	nd.nodePath = parent.getData().nodePath + "." + field
+	nd.children = make(map[string]INode)
+
+	// For types that are part of the standard package, we treat them as leaf nodes and don't expand further.
+	//https://golang.org/pkg/reflect/#StructField.
+	if len(t.PkgPath()) == 0 {
+		nd.leafNode = true
+	}
+}

--- a/tools/webhook-apicoverage/resourcetree/otherkindnode.go
+++ b/tools/webhook-apicoverage/resourcetree/otherkindnode.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcetree
+
+import (
+	"reflect"
+)
+
+//OtherKindNode represents nodes in the resource tree of types like maps, interfaces, etc
+type OtherKindNode struct {
+	nodeData
+}
+
+func (o *OtherKindNode) getData() nodeData {
+	return o.nodeData
+}
+
+func (o *OtherKindNode) initialize(field string, parent INode, t reflect.Type, rt *ResourceTree) {
+	o.nodeData.initialize(field, parent, t, rt)
+	o.nodeData.leafNode = true
+}

--- a/tools/webhook-apicoverage/resourcetree/ptrkindnode.go
+++ b/tools/webhook-apicoverage/resourcetree/ptrkindnode.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcetree
+
+import (
+	"reflect"
+)
+
+//PtrKindNode represents nodes in the resource tree of type reflect.Kind.Ptr, reflect.Kind.UnsafePointer, etc.
+type PtrKindNode struct {
+	nodeData
+	objKind reflect.Kind // Type of the object being pointed to. Eg: *int will store reflect.Kind.Int. This is required for type-expansion and value-evaluation decisions.
+}
+
+func (p *PtrKindNode) getData() nodeData {
+	return p.nodeData
+}
+
+func (p *PtrKindNode) initialize(field string, parent INode, t reflect.Type, rt *ResourceTree) {
+	p.nodeData.initialize(field, parent, t, rt)
+	p.objKind = t.Elem().Kind()
+}

--- a/tools/webhook-apicoverage/resourcetree/resourceforest.go
+++ b/tools/webhook-apicoverage/resourcetree/resourceforest.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcetree
+
+import (
+	"container/list"
+)
+
+//ResourceForest represents the top-level forest that contains individual resource trees for top-level resource types and all connected nodes across resource trees.
+type ResourceForest struct {
+	Version string
+	TopLevelTrees map[string]INode // Key is ResourceTree.ResourceName
+	ConnectedNodes map[string]list.List // Head of the linked list keyed by nodeData.fieldType.pkg + nodeData.fieldType.Name()
+}

--- a/tools/webhook-apicoverage/resourcetree/resourcetree.go
+++ b/tools/webhook-apicoverage/resourcetree/resourcetree.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcetree
+
+import (
+	"reflect"
+)
+
+//ResourceTree encapsulates a tree corresponding to a resource type.
+type ResourceTree struct {
+	ResourceName string
+	Root INode
+	forest *ResourceForest
+}
+
+func (r *ResourceTree) createNode(field string, parent INode, t reflect.Type) INode {
+	var n INode
+	switch t.Kind() {
+	case reflect.Struct:
+		n = new(StructKindNode)
+	case reflect.Array, reflect.Slice:
+		n = new(ArrayKindNode)
+	case reflect.Ptr, reflect.UnsafePointer, reflect.Uintptr:
+		n = new(PtrKindNode)
+	case reflect.Bool, reflect.String, reflect.Float32, reflect.Float64,
+		reflect.Int, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		n = new(BasicTypeKindNode)
+	default:
+		n = new(OtherKindNode) // Maps, interfaces, etc
+	}
+
+	n.initialize(field, parent, t, r)
+	return n
+}
+
+func (r *ResourceTree) initializeNodeData(field string, parent INode, t reflect.Type) nodeData {
+	nd := nodeData{
+		field:     field,
+		tree:      r,
+		nodePath:  parent.getData().nodePath + "." + field,
+		parent:    parent,
+		children:  make(map[string]INode),
+	}
+
+	// For types that are part of the standard package, we treat them as leaf nodes and don't expand further.
+	//https://golang.org/pkg/reflect/#StructField.
+	if len(t.PkgPath()) == 0 {
+		nd.leafNode = true
+	}
+
+	return nd
+}

--- a/tools/webhook-apicoverage/resourcetree/structkindnode.go
+++ b/tools/webhook-apicoverage/resourcetree/structkindnode.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcetree
+
+import (
+	"reflect"
+)
+
+//StructKindNode represents nodes in the resource tree of type reflect.Kind.Struct
+type StructKindNode struct {
+	nodeData
+}
+
+func (s *StructKindNode) getData() nodeData {
+	return s.nodeData
+}
+
+func (s *StructKindNode) initialize(field string, parent INode, t reflect.Type, rt *ResourceTree) {
+	s.nodeData.initialize(field, parent, t, rt)
+}


### PR DESCRIPTION
This changeset introduces resource tree used for the webhook based
API coverage tool. It only contains base structure which will be
used in the following iterations to build the resource tree and perform
coverage analysis on it. README.md has more details.