### PR TITLE
x509: CPU denial of service in chain validation[CVE-2018-16875]

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -17,16 +17,16 @@
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "1868ff68d6079e31b2f09b828b58d62e57ca8e9636edff699247c9108518570b",
-    url = "https://github.com/bazelbuild/rules_go/releases/download/0.11.1/rules_go-0.11.1.tar.gz",
+    url = "https://github.com/bazelbuild/rules_go/releases/download/0.16.5/rules_go-0.16.5.tar.gz",
+    sha256 = "7be7dc01f1e0afdba6c8eb2b43d2fa01c743be1b9273ab1eaf6c233df078d705",
 )
-
 load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
+go_rules_dependencies()
 
 go_rules_dependencies()
 
 go_register_toolchains(
-    go_version = "1.10.2",
+    go_version = "1.11.3",
 )
 
 git_repository(


### PR DESCRIPTION
From golang/go#29233

> Package crypto/x509 parses and validates X.509-encoded keys and certificates. It's supposed to handle certificate chains provided by an attacker with reasonable resource use.

> The crypto/x509 package does not limit the amount of work performed for each chain verification, which might allow attackers to craft pathological inputs leading to a CPU denial of service. Go TLS servers accepting client certificates and TLS clients verifying certificates are affected.

Go 1.11.3 and 1.10.6 have been released with this fixed.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->


