### PR TITLE
Also display docker version when running presubmit tests

### DIFF
--- a/scripts/presubmit-tests.sh
+++ b/scripts/presubmit-tests.sh
@@ -67,6 +67,10 @@ function main() {
     git version
     echo ">> bazel version"
     bazel version 2> /dev/null
+    if [[ "${DOCKER_IN_DOCKER_ENABLED}" == "true" ]]; then
+      echo ">> docker version"
+      docker version
+    fi
   fi
 
   [[ -z $1 ]] && set -- "--all-tests"


### PR DESCRIPTION
But only if dind is enabled, otherwise we'll get an ugly error message.