### PR TITLE
Make cleanup job passing by adding placeholder in artifacts

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -2230,6 +2230,7 @@ periodics:
       - "--project-resource-yaml ci/prow/boskos/resources.yaml"
       - "--days-to-keep 90"
       - "--service-account /etc/test-account/service-account.json"
+      - "--artifacts=$(ARTIFACTS)"
   
 postsubmits:
   knative/serving:

--- a/test/unit/cleanup-tests.sh
+++ b/test/unit/cleanup-tests.sh
@@ -39,9 +39,10 @@ test_function ${FAILURE} "error: missing gcr" cleanup_script "delete-old-images-
 test_function ${FAILURE} "error: missing resource" cleanup_script "delete-old-gcr-images"
 
 test_function ${FAILURE} "error: expecting value following" cleanup_script "delete-old-gcr-images" --project-resource-yaml --dry-run
-test_function ${FAILURE} "error: expecting value following" cleanup_script  "delete-old-gcr-images" --re-project-name --dry-run
+test_function ${FAILURE} "error: expecting value following" cleanup_script "delete-old-gcr-images" --re-project-name --dry-run
 test_function ${FAILURE} "error: expecting value following" cleanup_script "delete-old-gcr-images" --gcr-to-cleanup --dry-run
 test_function ${FAILURE} "error: expecting value following" cleanup_script "delete-old-gcr-images" --days-to-keep --dry-run
+test_function ${FAILURE} "error: expecting value following" cleanup_script "delete-old-gcr-images" --artifacts --dry-run
 
 test_function ${FAILURE} "error: days to keep" cleanup_script "delete-old-images-from-gcr" --days-to-keep "a" --dry-run
 test_function ${FAILURE} "error: days to keep" cleanup_script "delete-old-gcr-images" --days-to-keep "a" --dry-run

--- a/tools/cleanup/cleanup.sh
+++ b/tools/cleanup/cleanup.sh
@@ -23,6 +23,7 @@ DAYS_TO_KEEP_IMAGES=365 # Keep images up to 1 year by default
 RE_PROJECT_NAME="knative-boskos-[a-zA-Z0-9]+"
 PROJECT_RESOURCE_YAML=""
 GCR_TO_CLEANUP=""
+ARTIFACTS_DIR=""
 DRY_RUN=0
 
 
@@ -39,6 +40,7 @@ function parse_args() {
           --re-project-name) RE_PROJECT_NAME=$1 ;;
           --gcr-to-cleanup) GCR_TO_CLEANUP=$1 ;;
           --days-to-keep) DAYS_TO_KEEP_IMAGES=$1 ;;
+          --artifacts) ARTIFACTS_DIR=$1 ;;
           --service-account)
             gcloud auth activate-service-account --key-file=$1 || exit 1
             ;;
@@ -54,6 +56,7 @@ function parse_args() {
   readonly PROJECT_RESOURCE_YAML
   readonly RE_PROJECT_NAME
   readonly GCR_TO_CLEANUP
+  readonly ARTIFACTS_DIR
   readonly DRY_RUN
 }
 
@@ -84,3 +87,9 @@ case ${FUNCTION_TO_RUN} in
     ;;
   *) abort "unknown option '${FUNCTION_TO_RUN}'" ;;
 esac
+
+# Gubernator considers job failure if "junit_*.xml" not found under artifact,
+#   create a placeholder file to make this job succeed
+if [[ ! -z ${ARTIFACTS_DIR} ]]; then
+  echo "<testsuite time='0'/>" > "${ARTIFACTS_DIR}/junit_knative.xml"
+fi


### PR DESCRIPTION
Gubernator consider job failure if no `junit_*.xml` file found under artifacts, add placeholder file under artifacts to make it pass