### PR TITLE
Fix cleanup job parameter

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -2291,7 +2291,7 @@ periodics:
       - "--project-resource-yaml ci/prow/boskos/resources.yaml"
       - "--days-to-keep 90"
       - "--service-account /etc/test-account/service-account.json"
-      - "--artifacts=$(ARTIFACTS)"
+      - "--artifacts $(ARTIFACTS)"
   
 postsubmits:
   knative/serving:


### PR DESCRIPTION
there was a equal sign accidentally committed in previous PR, it would fail cleanup job due to missing parameters