### PR TITLE
Use the prow-tests image with the "stable" tag

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -175,7 +175,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
         args:
         - "--scenario=kubernetes_execute_bazel"
@@ -208,7 +208,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
         args:
         - "--scenario=kubernetes_execute_bazel"
@@ -241,7 +241,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
         args:
         - "--scenario=kubernetes_execute_bazel"
@@ -278,7 +278,7 @@ presubmits:
     - release-0.2
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
         args:
         - "--scenario=kubernetes_execute_bazel"
@@ -381,7 +381,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
         args:
         - "--scenario=kubernetes_execute_bazel"
@@ -414,7 +414,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
         args:
         - "--scenario=kubernetes_execute_bazel"
@@ -448,7 +448,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
         args:
         - "--scenario=kubernetes_execute_bazel"
@@ -516,7 +516,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
         args:
         - "--scenario=kubernetes_execute_bazel"
@@ -549,7 +549,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
         args:
         - "--scenario=kubernetes_execute_bazel"
@@ -582,7 +582,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
         args:
         - "--scenario=kubernetes_execute_bazel"
@@ -650,7 +650,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
         args:
         - "--scenario=kubernetes_execute_bazel"
@@ -683,7 +683,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
         args:
         - "--scenario=kubernetes_execute_bazel"
@@ -716,7 +716,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
         args:
         - "--scenario=kubernetes_execute_bazel"
@@ -784,7 +784,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
         args:
         - "--scenario=kubernetes_execute_bazel"
@@ -817,7 +817,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
         args:
         - "--scenario=kubernetes_execute_bazel"
@@ -850,7 +850,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
         args:
         - "--scenario=kubernetes_execute_bazel"
@@ -918,7 +918,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
         args:
         - "--scenario=kubernetes_execute_bazel"
@@ -951,7 +951,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
         args:
         - "--scenario=kubernetes_execute_bazel"
@@ -984,7 +984,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
         args:
         - "--scenario=kubernetes_execute_bazel"
@@ -1052,7 +1052,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
         args:
         - "--scenario=kubernetes_execute_bazel"
@@ -1085,7 +1085,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
         args:
         - "--scenario=kubernetes_execute_bazel"
@@ -1118,7 +1118,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
         args:
         - "--scenario=kubernetes_execute_bazel"
@@ -1152,7 +1152,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
         args:
         - "--scenario=kubernetes_execute_bazel"
@@ -1185,7 +1185,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
         args:
         - "--scenario=kubernetes_execute_bazel"
@@ -1218,7 +1218,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
         args:
         - "--scenario=kubernetes_execute_bazel"
@@ -1286,7 +1286,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
         args:
         - "--scenario=kubernetes_execute_bazel"
@@ -1319,7 +1319,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
         args:
         - "--scenario=kubernetes_execute_bazel"
@@ -1352,7 +1352,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
         args:
         - "--scenario=kubernetes_execute_bazel"
@@ -1386,7 +1386,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
         args:
         - "--scenario=kubernetes_execute_bazel"
@@ -1419,7 +1419,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
         args:
         - "--scenario=kubernetes_execute_bazel"
@@ -1452,7 +1452,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
         args:
         - "--scenario=kubernetes_execute_bazel"
@@ -1517,7 +1517,7 @@ periodics:
     preset-bazel-remote-cache-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
       args:
       - "--scenario=kubernetes_execute_bazel"
@@ -1549,7 +1549,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
       args:
       - "--scenario=kubernetes_execute_bazel"
@@ -1580,7 +1580,7 @@ periodics:
     preset-bazel-remote-cache-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
       args:
       - "--scenario=kubernetes_execute_bazel"
@@ -1611,7 +1611,7 @@ periodics:
     preset-bazel-remote-cache-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
       args:
       - "--scenario=kubernetes_execute_bazel"
@@ -1652,7 +1652,7 @@ periodics:
     preset-bazel-remote-cache-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
       args:
       - "--scenario=kubernetes_execute_bazel"
@@ -1743,7 +1743,7 @@ periodics:
     preset-bazel-remote-cache-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
       args:
       - "--scenario=kubernetes_execute_bazel"
@@ -1773,7 +1773,7 @@ periodics:
     preset-bazel-remote-cache-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
       args:
       - "--scenario=kubernetes_execute_bazel"
@@ -1805,7 +1805,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
       args:
       - "--scenario=kubernetes_execute_bazel"
@@ -1879,7 +1879,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
       args:
       - "--scenario=kubernetes_execute_bazel"
@@ -1931,7 +1931,7 @@ periodics:
     preset-bazel-remote-cache-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
       args:
       - "--scenario=kubernetes_execute_bazel"
@@ -1982,7 +1982,7 @@ periodics:
     preset-bazel-remote-cache-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
       args:
       - "--scenario=kubernetes_execute_bazel"
@@ -2012,7 +2012,7 @@ periodics:
     preset-bazel-remote-cache-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
       args:
       - "--scenario=kubernetes_execute_bazel"
@@ -2064,7 +2064,7 @@ periodics:
     preset-bazel-remote-cache-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
       args:
       - "--scenario=kubernetes_execute_bazel"
@@ -2094,7 +2094,7 @@ periodics:
     preset-bazel-remote-cache-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
       args:
       - "--scenario=kubernetes_execute_bazel"
@@ -2146,7 +2146,7 @@ periodics:
     preset-bazel-remote-cache-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
       args:
       - "--scenario=kubernetes_execute_bazel"
@@ -2177,7 +2177,7 @@ periodics:
     preset-bazel-remote-cache-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
       args:
       - "--scenario=kubernetes_execute_bazel"
@@ -2228,7 +2228,7 @@ periodics:
     preset-bazel-remote-cache-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
       args:
       - "--scenario=kubernetes_execute_bazel"
@@ -2282,7 +2282,7 @@ periodics:
     clone_uri: "https://github.com/knative/test-infra.git"
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:latest
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
       command:
       - "./tools/cleanup/cleanup.sh"

--- a/images/prow-tests/README.md
+++ b/images/prow-tests/README.md
@@ -8,6 +8,8 @@ To build and push a new image, just run `make push`.
 
 For testing purposes you can build an image but not push it; to do so, run `make build`.
 
+The Prow jobs are configured to use the `prow-tests` image tagged with `stable`. This tag must be manually set in GCR using the Cloud Console.
+
 Note that you must have proper permission in the `knative-tests` project to push new images to the GCR.
 
 The `prow-tests` image is pinned on a specific `kubekins` image; update `Dockerfile` if you need to use a newer/different image. This will basically define the versions of `bazel`, `go`, `kubectl` and other build tools.


### PR DESCRIPTION
This will avoid issues with the automatic "latest" tagging when building new images.

The "stable" tag must be manually set (as explained in the documentation).