### PR TITLE
Georeplicate images during release

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -35,6 +35,11 @@ function tag_images_in_yaml() {
   echo "Tagging images under '${DOCKER_BASE}' with ${TAG}"
   for image in $(grep -o "${DOCKER_BASE}/[a-z\./-]\+@sha256:[0-9a-f]\+" $1); do
     gcloud -q container images add-tag ${image} ${image%%@*}:${TAG}
+
+    # Georeplicate to {us,eu,asia}.gcr.io
+    gcloud -q container images add-tag ${image} us.${image%%@*}:${TAG}
+    gcloud -q container images add-tag ${image} eu.${image%%@*}:${TAG}
+    gcloud -q container images add-tag ${image} asia.${image%%@*}:${TAG}
   done
 }
 


### PR DESCRIPTION
This tags images in gcr.io/knative-releases as
{us,eu,asia}.gcr.io/knative-releases as well.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

If there's a nice way to test this better, let me know, but I tested this change in isolation from `release.sh` with this script.

`georeplicate.sh`:
```bash
TAG="georeplicated"
TEST_REPO="gcr.io/jonjohnson-test/ko/helloworld-6ff6a48702d2f0ff1473a2223e9fe0f3"
IMAGES=$(gcrane ls $TEST_REPO | grep "@")

echo "BEFORE"
gcrane ls $TEST_REPO
gcrane ls us.$TEST_REPO
gcrane ls eu.$TEST_REPO
gcrane ls asia.$TEST_REPO

echo "COPYING"
for image in $IMAGES; do
  gcloud -q container images add-tag ${image} ${image%%@*}:${TAG}

  # Georeplicate to {us,eu,asia}.gcr.io
  gcloud -q container images add-tag ${image} us.${image%%@*}:${TAG}
  gcloud -q container images add-tag ${image} eu.${image%%@*}:${TAG}
  gcloud -q container images add-tag ${image} asia.${image%%@*}:${TAG}
done

echo "AFTER"
gcrane ls $TEST_REPO
gcrane ls us.$TEST_REPO
gcrane ls eu.$TEST_REPO
gcrane ls asia.$TEST_REPO

```

Output:
```
BEFORE
gcr.io/jonjohnson-test/ko/helloworld-6ff6a48702d2f0ff1473a2223e9fe0f3@sha256:b10d1d5aa57f741beaec875431b8aff0a376223b9f16e3753a89502d2c6d70fb
gcr.io/jonjohnson-test/ko/helloworld-6ff6a48702d2f0ff1473a2223e9fe0f3:latest
us.gcr.io/jonjohnson-test/ko/helloworld-6ff6a48702d2f0ff1473a2223e9fe0f3@sha256:b10d1d5aa57f741beaec875431b8aff0a376223b9f16e3753a89502d2c6d70fb
us.gcr.io/jonjohnson-test/ko/helloworld-6ff6a48702d2f0ff1473a2223e9fe0f3:latest
eu.gcr.io/jonjohnson-test/ko/helloworld-6ff6a48702d2f0ff1473a2223e9fe0f3@sha256:b10d1d5aa57f741beaec875431b8aff0a376223b9f16e3753a89502d2c6d70fb
eu.gcr.io/jonjohnson-test/ko/helloworld-6ff6a48702d2f0ff1473a2223e9fe0f3:latest
asia.gcr.io/jonjohnson-test/ko/helloworld-6ff6a48702d2f0ff1473a2223e9fe0f3@sha256:b10d1d5aa57f741beaec875431b8aff0a376223b9f16e3753a89502d2c6d70fb
asia.gcr.io/jonjohnson-test/ko/helloworld-6ff6a48702d2f0ff1473a2223e9fe0f3:latest
COPYING
Created [gcr.io/jonjohnson-test/ko/helloworld-6ff6a48702d2f0ff1473a2223e9fe0f3:georeplicated].
Updated [gcr.io/jonjohnson-test/ko/helloworld-6ff6a48702d2f0ff1473a2223e9fe0f3@sha256:b10d1d5aa57f741beaec875431b8aff0a376223b9f16e3753a89502d2c6d70fb].
Created [us.gcr.io/jonjohnson-test/ko/helloworld-6ff6a48702d2f0ff1473a2223e9fe0f3:georeplicated].
Updated [gcr.io/jonjohnson-test/ko/helloworld-6ff6a48702d2f0ff1473a2223e9fe0f3@sha256:b10d1d5aa57f741beaec875431b8aff0a376223b9f16e3753a89502d2c6d70fb].
Created [eu.gcr.io/jonjohnson-test/ko/helloworld-6ff6a48702d2f0ff1473a2223e9fe0f3:georeplicated].
Updated [gcr.io/jonjohnson-test/ko/helloworld-6ff6a48702d2f0ff1473a2223e9fe0f3@sha256:b10d1d5aa57f741beaec875431b8aff0a376223b9f16e3753a89502d2c6d70fb].
Created [asia.gcr.io/jonjohnson-test/ko/helloworld-6ff6a48702d2f0ff1473a2223e9fe0f3:georeplicated].
Updated [gcr.io/jonjohnson-test/ko/helloworld-6ff6a48702d2f0ff1473a2223e9fe0f3@sha256:b10d1d5aa57f741beaec875431b8aff0a376223b9f16e3753a89502d2c6d70fb].
AFTER
gcr.io/jonjohnson-test/ko/helloworld-6ff6a48702d2f0ff1473a2223e9fe0f3@sha256:b10d1d5aa57f741beaec875431b8aff0a376223b9f16e3753a89502d2c6d70fb
gcr.io/jonjohnson-test/ko/helloworld-6ff6a48702d2f0ff1473a2223e9fe0f3:georeplicated
gcr.io/jonjohnson-test/ko/helloworld-6ff6a48702d2f0ff1473a2223e9fe0f3:latest
us.gcr.io/jonjohnson-test/ko/helloworld-6ff6a48702d2f0ff1473a2223e9fe0f3@sha256:b10d1d5aa57f741beaec875431b8aff0a376223b9f16e3753a89502d2c6d70fb
us.gcr.io/jonjohnson-test/ko/helloworld-6ff6a48702d2f0ff1473a2223e9fe0f3:georeplicated
us.gcr.io/jonjohnson-test/ko/helloworld-6ff6a48702d2f0ff1473a2223e9fe0f3:latest
eu.gcr.io/jonjohnson-test/ko/helloworld-6ff6a48702d2f0ff1473a2223e9fe0f3@sha256:b10d1d5aa57f741beaec875431b8aff0a376223b9f16e3753a89502d2c6d70fb
eu.gcr.io/jonjohnson-test/ko/helloworld-6ff6a48702d2f0ff1473a2223e9fe0f3:georeplicated
eu.gcr.io/jonjohnson-test/ko/helloworld-6ff6a48702d2f0ff1473a2223e9fe0f3:latest
asia.gcr.io/jonjohnson-test/ko/helloworld-6ff6a48702d2f0ff1473a2223e9fe0f3@sha256:b10d1d5aa57f741beaec875431b8aff0a376223b9f16e3753a89502d2c6d70fb
asia.gcr.io/jonjohnson-test/ko/helloworld-6ff6a48702d2f0ff1473a2223e9fe0f3:georeplicated
asia.gcr.io/jonjohnson-test/ko/helloworld-6ff6a48702d2f0ff1473a2223e9fe0f3:latest
```

See https://github.com/knative/serving/issues/2599