### PR TITLE
webhook based API-Coverage tool: Value analysis

### DIFF
--- a/tools/webhook-apicoverage/resourcetree/README.md
+++ b/tools/webhook-apicoverage/resourcetree/README.md
@@ -1,12 +1,50 @@
 # Resource Tree
 
-resourcetree package contains types and interfaces that define a resource tree(n-ary tree based representation of an API resource). Each resource tree is composed of nodes which have data encapsulated inside [nodeData](node.go) and operations that can be performed on each node in the interface [NodeInterface](node.go). Type of a node is logically defined by reflect.Kind. Each node type is expected to satisfy the [NodeInterface](node.go) interface.  
+resourcetree package contains types and interfaces that define a resource
+tree(n-ary tree based representation of an API resource). Each resource
+tree is composed of nodes which have data encapsulated inside [nodeData](node.go)
+and operations that can be performed on each node in the interface [NodeInterface](node.go).
+Type of a node is logically defined by reflect.Kind. Each node type is expected
+to satisfy the [NodeInterface](node.go) interface.
 
-## Resource Forest  
-[ResourceForest](resourceforest.go) groups all resource trees that are part of an API version into a single construct and defines operations that span across them. As an example for Knative Serving, we will have individual resource trees for Configuration, Revision, Route and Service, and they are encapsulated inside a resource forest under version v1alpha1. Example of an operation that spans resource trees would be to get coverage details for outlined types connected using ConnectedNodes.
+## Resource Forest
 
-ConnectedNodes represent connections between nodes that are of same type(reflect.Type) and belong to same package but span across different trees or branches of same tree. An example of ConnectedNodes would be v1alpha1.Route.Spec.Traffic and v1alpha1.Route.Status.Traffic, both these Traffic fields are of type v1alpha1.TrafficTarget, but are present in different paths inside the resource tree. ConnectedNodes connects these two nodes, and an outlining of this type would present the coverage across the two branches and gives a unified view of what fields are covered.
-ConnectedNodes represent connections between nodes that are of same type(reflect.Type) and belong to same package but span across different trees or branches of same tree. An example of ConnectedNodes would be v1alpha1.Route.Spec.Traffic and v1alpha1.Route.Status.Traffic, both these Traffic fields are of type v1alpha1.TrafficTarget, but are present in different paths inside the resource tree. ConnectedNodes connects these two nodes, and an outlining of this type would present the coverage across the two branches and gives a unified view of what fields are covered.
+[ResourceForest](resourceforest.go) groups all resource trees that are part
+of an API version into a single construct and defines operations that span
+across them. As an example for Knative Serving, we will have individual
+resource trees for Configuration, Revision, Route and Service, and they
+are encapsulated inside a resource forest under version v1alpha1. Example
+of an operation that spans resource trees would be to get coverage details
+for outlined types connected using ConnectedNodes.
+
+ConnectedNodes represent connections between nodes that are of same
+type(reflect.Type) and belong to same package but span across different
+trees or branches of same tree. An example of ConnectedNodes would be
+v1alpha1.Route.Spec.Traffic and v1alpha1.Route.Status.Traffic, both these
+Traffic fields are of type v1alpha1.TrafficTarget, but are present in different
+paths inside the resource tree. ConnectedNodes connects these two nodes, and
+an outlining of this type would present the coverage across the two branches
+and gives a unified view of what fields are covered. ConnectedNodes represent
+connections between nodes that are of same type(reflect.Type) and belong to
+same package but span across different trees or branches of same tree. An
+example of ConnectedNodes would be v1alpha1.Route.Spec.Traffic and
+v1alpha1.Route.Status.Traffic, both these Traffic fields are of type
+v1alpha1.TrafficTarget, but are present in different paths inside the resource
+tree. ConnectedNodes connects these two nodes, and an outlining of this type
+would present the coverage across the two branches and gives a unified view of
+what fields are covered.
 
 ## Type Analysis
-A Resource tree is using reflect.Type. Each node type is expected to implement NodeInterface method *buildChildNodes(t reflect.Type)*. Inside this method each node creates child nodes based on its type, for e.g. StructKindNode creates one child for each field defined in the struct. Type analysis are defined inside [typeanalyzer_tests](typeanalyzer_test.go)  
+
+A Resource tree is built using reflect.Type Each node type is expected to
+implement NodeInterface method *buildChildNodes(t reflect.Type)*. Inside
+this method each node creates child nodes based on its type, for e.g.
+StructKindNode creates one child for each field defined in the struct.
+Type analysis are defined inside [typeanalyzer_tests](buildChildNodes_test.go)
+
+## Value Analysis
+
+A Resource tree is updated using reflect.Value Each node type is expected
+to implement NodeInterface method *updateCoverage(v reflect.Value)*.
+Inisde this method each node updates its nodeData.covered field based on
+whether the reflect.Value parameter being passed is set or not.

--- a/tools/webhook-apicoverage/resourcetree/arraykindnode.go
+++ b/tools/webhook-apicoverage/resourcetree/arraykindnode.go
@@ -20,7 +20,9 @@ import (
 	"reflect"
 )
 
-const arrayNodeNameSuffix = "-arr"
+const (
+	arrayNodeNameSuffix = "-arr"
+)
 
 // ArrayKindNode represents resource tree node of types reflect.Kind.Array and reflect.Kind.Slice
 type ArrayKindNode struct {
@@ -42,4 +44,13 @@ func (a *ArrayKindNode) buildChildNodes(t reflect.Type) {
 	childNode := a.tree.createNode(childName, a, t.Elem())
 	a.children[childName] = childNode
 	childNode.buildChildNodes(t.Elem())
+}
+
+func (a *ArrayKindNode) updateCoverage(v reflect.Value) {
+	if !v.IsNil() {
+		a.covered = true
+		for i := 0; i < v.Len(); i++ {
+			a.children[a.field + arrayNodeNameSuffix].updateCoverage(v.Index(i))
+		}
+	}
 }

--- a/tools/webhook-apicoverage/resourcetree/basictypekindnode.go
+++ b/tools/webhook-apicoverage/resourcetree/basictypekindnode.go
@@ -45,6 +45,15 @@ func (b *BasicTypeKindNode) buildChildNodes(t reflect.Type) {
 	}
 }
 
+func (b *BasicTypeKindNode) updateCoverage(v reflect.Value) {
+	if value := b.string(v); len(value) > 0 {
+		if b.possibleEnum || b.fieldType.Kind() == reflect.Bool {
+			b.addValue(value)
+		}
+		b.covered = true
+	}
+}
+
 func (b *BasicTypeKindNode) string(v reflect.Value) string {
 	switch v.Kind() {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
@@ -68,4 +77,10 @@ func (b *BasicTypeKindNode) string(v reflect.Value) string {
 	}
 
 	return ""
+}
+
+func (b *BasicTypeKindNode) addValue(value string) {
+	if _, ok := b.values[value]; !ok {
+		b.values[value] = true
+	}
 }

--- a/tools/webhook-apicoverage/resourcetree/buildChildNodes_test.go
+++ b/tools/webhook-apicoverage/resourcetree/buildChildNodes_test.go
@@ -17,27 +17,9 @@ limitations under the License.
 package resourcetree
 
 import (
-	"container/list"
 	"reflect"
 	"testing"
 )
-
-func getTestTree(treeName string, t reflect.Type) *ResourceTree {
-	forest := ResourceForest{
-		Version: "TestVersion",
-		ConnectedNodes: make(map[string]*list.List),
-		TopLevelTrees: make(map[string]NodeInterface),
-	}
-
-	tree := ResourceTree{
-		ResourceName: treeName,
-		forest: &forest,
-	}
-
-	tree.BuildResourceTree(t)
-	forest.TopLevelTrees[treeName] = tree.Root
-	return &tree
-}
 
 func TestSimpleStructType(t *testing.T) {
 	tree := getTestTree(basicTypeName, reflect.TypeOf(baseType{}))
@@ -69,7 +51,7 @@ func TestOtherType(t *testing.T) {
 
 func TestCombinedType(t *testing.T) {
 	tree := getTestTree(combinedTypeName, reflect.TypeOf(combinedNodeType{}))
-	if err := verifyResourceForest(tree.forest); err != nil {
+	if err := verifyResourceForest(tree.Forest); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/tools/webhook-apicoverage/resourcetree/node.go
+++ b/tools/webhook-apicoverage/resourcetree/node.go
@@ -27,6 +27,7 @@ type NodeInterface interface {
 	getData() nodeData
 	initialize(field string, parent NodeInterface, t reflect.Type, rt *ResourceTree)
 	buildChildNodes(t reflect.Type)
+	updateCoverage(v reflect.Value)
 }
 
 //nodeData is the data stored in each node of the resource tree.

--- a/tools/webhook-apicoverage/resourcetree/otherkindnode.go
+++ b/tools/webhook-apicoverage/resourcetree/otherkindnode.go
@@ -35,3 +35,9 @@ func (o *OtherKindNode) initialize(field string, parent NodeInterface, t reflect
 }
 
 func (o *OtherKindNode) buildChildNodes(t reflect.Type) {}
+
+func (o *OtherKindNode) updateCoverage(v reflect.Value) {
+	if !v.IsNil() {
+		o.covered = true
+	}
+}

--- a/tools/webhook-apicoverage/resourcetree/ptrkindnode.go
+++ b/tools/webhook-apicoverage/resourcetree/ptrkindnode.go
@@ -20,7 +20,9 @@ import (
 	"reflect"
 )
 
-const ptrNodeNameSuffice = "-ptr"
+const (
+	ptrNodeNameSuffix = "-ptr"
+)
 
 // PtrKindNode represents nodes in the resource tree of type reflect.Kind.Ptr, reflect.Kind.UnsafePointer, etc.
 type PtrKindNode struct {
@@ -38,8 +40,15 @@ func (p *PtrKindNode) initialize(field string, parent NodeInterface, t reflect.T
 }
 
 func (p *PtrKindNode) buildChildNodes(t reflect.Type) {
-	childName := p.field + ptrNodeNameSuffice
+	childName := p.field + ptrNodeNameSuffix
 	childNode := p.tree.createNode(childName, p, t.Elem())
 	p.children[childName] = childNode
 	childNode.buildChildNodes(t.Elem())
+}
+
+func (p *PtrKindNode) updateCoverage(v reflect.Value) {
+	if !v.IsNil() {
+		p.covered = true
+		p.children[p.field + ptrNodeNameSuffix].updateCoverage(v.Elem())
+	}
 }

--- a/tools/webhook-apicoverage/resourcetree/resourceforest.go
+++ b/tools/webhook-apicoverage/resourcetree/resourceforest.go
@@ -23,6 +23,6 @@ import (
 // ResourceForest represents the top-level forest that contains individual resource trees for top-level resource types and all connected nodes across resource trees.
 type ResourceForest struct {
 	Version string
-	TopLevelTrees map[string]NodeInterface // Key is ResourceTree.ResourceName
+	TopLevelTrees map[string]ResourceTree // Key is ResourceTree.ResourceName
 	ConnectedNodes map[string]*list.List // Head of the linked list keyed by nodeData.fieldType.pkg + nodeData.fieldType.Name()
 }

--- a/tools/webhook-apicoverage/resourcetree/resourcetree.go
+++ b/tools/webhook-apicoverage/resourcetree/resourcetree.go
@@ -25,7 +25,7 @@ import (
 type ResourceTree struct {
 	ResourceName string
 	Root NodeInterface
-	forest *ResourceForest
+	Forest *ResourceForest
 }
 
 func (r *ResourceTree) createNode(field string, parent NodeInterface, t reflect.Type) NodeInterface {
@@ -49,10 +49,10 @@ func (r *ResourceTree) createNode(field string, parent NodeInterface, t reflect.
 
 	if len(t.PkgPath()) != 0 {
 		typeName := t.PkgPath() + "." + t.Name()
-		if _, ok := r.forest.ConnectedNodes[typeName]; !ok {
-			r.forest.ConnectedNodes[typeName] = list.New()
+		if _, ok := r.Forest.ConnectedNodes[typeName]; !ok {
+			r.Forest.ConnectedNodes[typeName] = list.New()
 		}
-		r.forest.ConnectedNodes[typeName].PushBack(n)
+		r.Forest.ConnectedNodes[typeName].PushBack(n)
 	}
 
 	return n
@@ -62,4 +62,9 @@ func (r *ResourceTree) createNode(field string, parent NodeInterface, t reflect.
 func (r *ResourceTree) BuildResourceTree(t reflect.Type) {
 	r.Root = r.createNode(r.ResourceName, nil, t)
 	r.Root.buildChildNodes(t)
+}
+
+// UpdateCoverage updates coverage data in the resource tree based on the provided reflect.Value
+func (r *ResourceTree) UpdateCoverage(v reflect.Value) {
+	r.Root.updateCoverage(v)
 }

--- a/tools/webhook-apicoverage/resourcetree/structkindnode.go
+++ b/tools/webhook-apicoverage/resourcetree/structkindnode.go
@@ -68,3 +68,14 @@ func (s *StructKindNode) isTimeNode(t reflect.Type) bool {
 		return false
 	}
 }
+
+func (s *StructKindNode) updateCoverage(v reflect.Value) {
+	if v.IsValid() {
+		s.covered = true
+		if !s.leafNode {
+			for i := 0; i < v.NumField(); i++ {
+				s.children[v.Type().Field(i).Name].updateCoverage(v.Field(i))
+			}
+		}
+	}
+}

--- a/tools/webhook-apicoverage/resourcetree/timetypenode.go
+++ b/tools/webhook-apicoverage/resourcetree/timetypenode.go
@@ -35,3 +35,11 @@ func (ti *TimeTypeNode) initialize(field string, parent NodeInterface, t reflect
 }
 
 func (ti *TimeTypeNode) buildChildNodes(t reflect.Type) {}
+
+func (ti *TimeTypeNode) updateCoverage(v reflect.Value) {
+	if v.Type().Kind() == reflect.Struct && v.IsValid() {
+		ti.covered = true
+	} else if v.Type().Kind() == reflect.Ptr && !v.IsNil() {
+		ti.covered = true
+	}
+}

--- a/tools/webhook-apicoverage/resourcetree/updateCoverage_test.go
+++ b/tools/webhook-apicoverage/resourcetree/updateCoverage_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcetree
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSimpleStructValue(t *testing.T) {
+	tree := getTestTree(basicTypeName, reflect.TypeOf(baseType{}))
+	tree.UpdateCoverage(reflect.ValueOf(getBaseTypeValue()))
+	if err := verifyBaseTypeValue("", tree.Root); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPtrValueAllCovered(t *testing.T) {
+	tree := getTestTree(ptrTypeName, reflect.TypeOf(ptrType{}))
+	tree.UpdateCoverage(reflect.ValueOf(getPtrTypeValueAllCovered()))
+	if err := verifyPtrValueAllCovered(tree.Root); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPtrValueSomeCovered(t *testing.T) {
+	tree := getTestTree(ptrTypeName, reflect.TypeOf(ptrType{}))
+	tree.UpdateCoverage(reflect.ValueOf(getPtrTypeValueSomeCovered()))
+	if err := verifyPtrValueSomeCovered(tree.Root); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestArrValueAllCovered(t *testing.T) {
+	tree := getTestTree(arrayTypeName, reflect.TypeOf(arrayType{}))
+	tree.UpdateCoverage(reflect.ValueOf(getArrValueAllCovered()))
+	if err := verifyArryValueAllCovered(tree.Root); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestArrValueSomeCovered(t *testing.T) {
+	tree := getTestTree(arrayTypeName, reflect.TypeOf(arrayType{}))
+	tree.UpdateCoverage(reflect.ValueOf(getArrValueSomeCovered()))
+	if err := verifyArrValueSomeCovered(tree.Root); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestOtherValue(t *testing.T) {
+	tree := getTestTree(otherTypeName, reflect.TypeOf(otherType{}))
+	tree.UpdateCoverage(reflect.ValueOf(getOtherTypeValue()))
+	if err := verifyOtherTypeValue(tree.Root); err != nil {
+		t.Fatal(err)
+	}
+}
+


### PR DESCRIPTION
This changeset adds next iteration in the webhook based API-Coverage
tool by introducing value analysis that updates the resource tree. Each
node is expected to implement NodeInterface method updateCoverage(v
reflect.Value). Inside this method each node updates its
nodeData.coverage field value based on wether the passed reflect.Value
parameter is set or not.