### PR TITLE
Create a separate xml file for each test when creating testgrid output

### DIFF
--- a/shared/testgrid/testgrid.go
+++ b/shared/testgrid/testgrid.go
@@ -26,9 +26,8 @@ import (
 )
 
 const (
-	// Filename to store output that acts as input to testgrid.
-	// Should be of the form junit_*.xml
-	Filename = "junit_knative.xml"
+	filePrefix = "junit_"
+	extension = ".xml"
 	artifactsDir = "./artifacts"
 )
 
@@ -83,24 +82,24 @@ func GetArtifactsDir() (string, error) {
 	return dir, nil
 }
 
-// CreateTestgridXML junit xml file in the default artifacts directory
-func CreateTestgridXML(tc []TestCase) error {
+// CreateTestgridXML creates junit_<TestName>.xml in the artifacts directory
+func CreateTestgridXML(tc []TestCase, testName string) error {
 	ts := TestSuite{TestCases: tc}
 	dir, err := GetArtifactsDir()
 	if err != nil {
 		return err
 	}
-	return CreateXMLOutput(ts, dir)
+	return CreateXMLOutput(ts, dir, testName)
 }
 
 // CreateXMLOutput creates the junit xml file in the provided artifacts directory
-func CreateXMLOutput(ts TestSuite, artifactsDir string) error {
+func CreateXMLOutput(ts TestSuite, artifactsDir, testName string) error {
 	op, err := xml.MarshalIndent(ts, "", "  ")
 	if err != nil {
 		return err
 	}
 
-	outputFile := artifactsDir + "/" + Filename
+	outputFile := artifactsDir + "/" + filePrefix + testName + extension
 	log.Printf("Storing output in %s", outputFile)
 	f, err := os.OpenFile(outputFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {

--- a/shared/testgrid/testgrid_test.go
+++ b/shared/testgrid/testgrid_test.go
@@ -24,8 +24,13 @@ import (
 	"github.com/knative/test-infra/shared/testgrid"
 )
 
+const (
+	filename = "junit_test.xml"
+	name     = "test"
+)
+
 func checkFileText(t *testing.T, expected string) {
-	d, err := ioutil.ReadFile(testgrid.Filename)
+	d, err := ioutil.ReadFile(filename)
 	if err != nil {
 		t.Errorf("Failed to open test file: %v", err)
 	}
@@ -60,19 +65,19 @@ func TestGetArtifacts(t *testing.T) {
 
 func TestXMLOutput(t *testing.T) {
 	// Create a test file
-	if err := testgrid.CreateXMLOutput(testgrid.TestSuite{}, "."); err != nil {
+	if err := testgrid.CreateXMLOutput(testgrid.TestSuite{}, ".", name); err != nil {
 		t.Fatalf("Error when creating xml output file: %v", err)
 	}
 	checkFileText(t, "<testsuite></testsuite>\n")
 
 	// Make sure we can append to the file
-	if err := testgrid.CreateXMLOutput(testgrid.TestSuite{}, "."); err != nil {
+	if err := testgrid.CreateXMLOutput(testgrid.TestSuite{}, ".", name); err != nil {
 		t.Fatalf("Error when creating xml output file: %v", err)
 	}
 	checkFileText(t, "<testsuite></testsuite>\n<testsuite></testsuite>\n")
 
 	// Delete the test file created
-	if err := os.Remove("./" + testgrid.Filename); err != nil {
+	if err := os.Remove("./" + filename); err != nil {
 		t.Logf("Cannot delete test file")
 	}
 }

--- a/tools/apicoverage/apicoverage.go
+++ b/tools/apicoverage/apicoverage.go
@@ -212,7 +212,7 @@ func createTestgridXML(coverage *OverallAPICoverage, artifactsDir string) {
 	tc = append(tc, createCases(overallService, coverage.ServiceAPICovered, coverage.ServiceAPINotCovered)...)
 	ts := testgrid.TestSuite{TestCases: tc}
 
-	if err := testgrid.CreateXMLOutput(ts, artifactsDir); err != nil {
+	if err := testgrid.CreateXMLOutput(ts, artifactsDir, "apicoverage"); err != nil {
 		log.Fatalf("Cannot create the xml output file: %v", err)
 	}
 }


### PR DESCRIPTION
Fixes the ussue of creating malformed xml. Part of fixing #335 