### PR TITLE
Redirect stderr to stdout

### DIFF
--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -44,6 +44,9 @@ readonly IS_PROW
 readonly REPO_ROOT_DIR="$(git rev-parse --show-toplevel)"
 readonly REPO_NAME="$(basename ${REPO_ROOT_DIR})"
 
+# On a Prow job, redirect stderr to stdout so it's synchronously added to log
+(( IS_PROW )) && exec 2>&1
+
 # Print error message and exit 1
 # Parameters: $1..$n - error message to be displayed
 function abort() {


### PR DESCRIPTION
Do it on Prow jobs, so error messages sent to stderr are synchronously added to log.

For example, search for `lstat test/config/`:
* Before: https://storage.googleapis.com/knative-prow/pr-logs/pull/knative_serving/2745/pull-knative-serving-integration-tests/1076297323824287744/build-log.txt
* After: https://storage.googleapis.com/knative-prow/pr-logs/pull/knative_serving/2813/pull-knative-serving-integration-tests/1079418637556649986/build-log.txt