### PR TITLE
Also update E2E test return value on failures

### DIFF
--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -271,6 +271,8 @@ function setup_test_cluster() {
   set +o pipefail
 }
 
+# Set the return code that the test script will return.
+# Parameters: $1 - return code (0-255)
 function set_test_return_code() {
   # kubetest teardown might fail and thus incorrectly report failure of the
   # script, even if the tests pass.

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -63,14 +63,6 @@ function teardown_test_resources() {
   rm -fr kubernetes kubernetes.tar.gz
 }
 
-# Exit test, dumping current state info.
-# Parameters: $1 - error message (optional).
-function fail_test() {
-  [[ -n $1 ]] && echo "ERROR: $1"
-  dump_cluster_state
-  exit 1
-}
-
 # Run the given E2E tests. Assume tests are tagged e2e, unless `-tags=XXX` is passed.
 # Parameters: $1..$n - any go test flags, then directories containing the tests to run.
 function go_test_e2e() {
@@ -179,8 +171,8 @@ function create_test_cluster() {
   # be a writeable docker repo.
   export K8S_USER_OVERRIDE=
   export K8S_CLUSTER_OVERRIDE=
-  # Assume test failed (see more details at the end of this script).
-  echo -n "1"> ${TEST_RESULT_FILE}
+  # Assume test failed (see details in set_test_return_code()).
+  set_test_return_code 1
   local test_cmd_args="--run-tests"
   (( EMIT_METRICS )) && test_cmd_args+=" --emit-metrics"
   [[ -n "${GCP_PROJECT}" ]] && test_cmd_args+=" --gcp-project ${GCP_PROJECT}"
@@ -279,17 +271,30 @@ function setup_test_cluster() {
   set +o pipefail
 }
 
-function success() {
+function set_test_return_code() {
   # kubetest teardown might fail and thus incorrectly report failure of the
   # script, even if the tests pass.
   # We store the real test result to return it later, ignoring any teardown
   # failure in kubetest.
   # TODO(adrcunha): Get rid of this workaround.
-  echo -n "0"> ${TEST_RESULT_FILE}
+  echo -n "$1"> ${TEST_RESULT_FILE}
+}
+
+function success() {
+  set_test_return_code 0
   echo "**************************************"
   echo "***        E2E TESTS PASSED        ***"
   echo "**************************************"
   exit 0
+}
+
+# Exit test, dumping current state info.
+# Parameters: $1 - error message (optional).
+function fail_test() {
+  set_test_return_code 1
+  [[ -n $1 ]] && echo "ERROR: $1"
+  dump_cluster_state
+  exit 1
 }
 
 RUN_TESTS=0


### PR DESCRIPTION
Don't rely on "failed" being the default/current state.

Bonus: factor out the return code workaround in a separate function.