### PR TITLE
Add save as json option to load generator results

### DIFF
--- a/shared/loadgenerator/loadgenerator.go
+++ b/shared/loadgenerator/loadgenerator.go
@@ -19,17 +19,22 @@ limitations under the License.
 package loadgenerator
 
 import (
+	"encoding/json"
 	"fmt"
+	"log"
+	"os"
 	"time"
 
 	"fortio.org/fortio/fhttp"
 	"fortio.org/fortio/periodic"
+	"github.com/knative/test-infra/shared/testgrid"
 )
 
 const (
-	p50 = 50.0
-	p90 = 90.0
-	p99 = 99.0
+	p50     = 50.0
+	p90     = 90.0
+	p99     = 99.0
+	jsonExt = ".json"
 )
 
 // GeneratorOptions provides knobs to run the perf test
@@ -76,4 +81,31 @@ func (g *GeneratorOptions) CreateRunnerOptions(resolvableDomain bool) *fhttp.HTT
 func (g *GeneratorOptions) RunLoadTest(resolvableDomain bool) (*GeneratorResults, error) {
 	r, err := fhttp.RunHTTPTest(g.CreateRunnerOptions(resolvableDomain))
 	return &GeneratorResults{Result: r}, err
+}
+
+// SaveJSON saves the results as Json in the artifacts directory
+func (gr *GeneratorResults) SaveJSON(testName string) error {
+	dir, err := testgrid.GetArtifactsDir()
+	if err != nil {
+		return err
+	}
+
+	outputFile := dir + "/" + testName + jsonExt
+	log.Printf("Storing json output in %s", outputFile)
+	f, err := os.OpenFile(outputFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+
+	defer f.Close()
+	json, err := json.Marshal(gr)
+	if err != nil {
+		return err
+	}
+	_, err = f.Write(json)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/shared/loadgenerator/loadgenerator.go
+++ b/shared/loadgenerator/loadgenerator.go
@@ -102,8 +102,7 @@ func (gr *GeneratorResults) SaveJSON(testName string) error {
 	if err != nil {
 		return err
 	}
-	_, err = f.Write(json)
-	if err != nil {
+	if _, err = f.Write(json); err != nil {
 		return err
 	}
 

--- a/shared/loadgenerator/loadgenerator_test.go
+++ b/shared/loadgenerator/loadgenerator_test.go
@@ -17,10 +17,12 @@ limitations under the License.
 package loadgenerator_test
 
 import (
+	"os"
 	"testing"
 	"time"
 
 	"github.com/knative/test-infra/shared/loadgenerator"
+	"github.com/knative/test-infra/shared/testgrid"
 )
 
 const (
@@ -68,5 +70,23 @@ func TestCreateRunnerOptions(t *testing.T) {
 
 	if opts.HTTPOptions.URL != testUrl {
 		t.Fatalf("Url is %s. Expected %s", opts.HTTPOptions.URL, testUrl)
+	}
+}
+
+func TestSaveJSON(t *testing.T) {
+	res := &loadgenerator.GeneratorResults{}
+	err := res.SaveJSON("TestSaveJSON")
+	if err != nil {
+		t.Fatalf("Cannot save JSON: %v", err)
+	}
+
+	// Delete the test json file created
+	dir, err := testgrid.GetArtifactsDir()
+	if err == nil {
+		err = os.Remove(dir + "/" + "TestSaveJSON.json")
+	}
+
+	if err != nil {
+		t.Logf("Cannot delete test file: %v", err)
 	}
 }


### PR DESCRIPTION
This will provide an option to perf tests to save the results in the artifacts directory as JSON. We will be using this later for benchmarking.