### PR TITLE
raise coverage threshold for knative/build to 80%

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -436,7 +436,7 @@ presubmits:
         - "--artifacts=$(ARTIFACTS)"
         - "--profile-name=coverage_profile.txt"
         - "--cov-target=."
-        - "--cov-threshold-percentage=50"
+        - "--cov-threshold-percentage=80"
         - "--github-token=/etc/github-token/token"
         volumeMounts:
         - name: github-token


### PR DESCRIPTION
As agreed here
https://github.com/knative/build/issues/447

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
