### PR TITLE
Remove build from serving release

### DIFF
--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -265,6 +265,8 @@ function start_latest_knative_serving() {
   kubectl apply -f ${KNATIVE_ISTIO_YAML} || return 1
   wait_until_pods_running istio-system || return 1
   kubectl label namespace default istio-injection=enabled || return 1
+  subheader "Installing Knative Build"
+  kubectl apply -f ${KNATIVE_BUILD_RELEASE} || return 1
   subheader "Installing Knative Serving"
   echo "Installing Serving from ${KNATIVE_SERVING_RELEASE}"
   kubectl apply -f ${KNATIVE_SERVING_RELEASE} || return 1

--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -26,7 +26,7 @@ readonly SERVING_GKE_IMAGE=cos
 readonly KNATIVE_BASE_YAML_SOURCE=https://storage.googleapis.com/knative-nightly/@/latest
 readonly KNATIVE_ISTIO_CRD_YAML=${KNATIVE_BASE_YAML_SOURCE/@/serving}/istio-crds.yaml
 readonly KNATIVE_ISTIO_YAML=${KNATIVE_BASE_YAML_SOURCE/@/serving}/istio.yaml
-readonly KNATIVE_SERVING_RELEASE=${KNATIVE_BASE_YAML_SOURCE/@/serving}/release.yaml
+readonly KNATIVE_SERVING_RELEASE=${KNATIVE_BASE_YAML_SOURCE/@/serving}/serving.yaml
 readonly KNATIVE_BUILD_RELEASE=${KNATIVE_BASE_YAML_SOURCE/@/build}/release.yaml
 readonly KNATIVE_EVENTING_RELEASE=${KNATIVE_BASE_YAML_SOURCE/@/eventing}/release.yaml
 


### PR DESCRIPTION
This is needed for https://github.com/knative/serving/pull/2821 as it looks like the release URL is hard-coded in the `library.sh` file.

I'm not sure how to test this in combination with https://github.com/knative/serving/pull/2821, my current thought is to try it by hand.