### PR TITLE
Don't lint markdown files in /vendor

### DIFF
--- a/scripts/presubmit-tests.sh
+++ b/scripts/presubmit-tests.sh
@@ -110,7 +110,8 @@ function run_build_tests() {
 # * check licenses in `/cmd` (if it exists)
 function default_build_test_runner() {
   local failed=0
-  local mdfiles="$(echo "${CHANGED_FILES}" | grep \.md$)"
+  # Ignore markdown files in /vendor
+  local mdfiles="$(echo "${CHANGED_FILES}" | grep \.md$ | grep -v ^vendor/)"
   if [[ -n "${mdfiles}" ]]; then
     subheader "Linting the markdown files"
     lint_markdown ${mdfiles} || failed=1

--- a/tools/dep-collector/README.md
+++ b/tools/dep-collector/README.md
@@ -5,20 +5,21 @@ dependencies that have been pulled into the idiomatic `vendor/` directory.
 The resulting file from running `dep-collector` is intended for inclusion
 in container images to respect the licenses of the included software.
 
-### Basic Usage
+## Basic Usage
 
 You can run `dep-collector` on one or more Go import paths as entrypoints,
 and it will:
+
 1. Walk the transitive dependencies to identify vendored software packages,
 1. Search for licenses for each vendored dependency,
 1. Dump a file containing the licenses for each vendored import.
 
 For example (single import path):
+
 ```shell
 $ dep-collector .
 ===========================================================
 Import: github.com/mattmoor/dep-collector/vendor/github.com/google/licenseclassifier
-
 
                                  Apache License
                            Version 2.0, January 2004
@@ -40,13 +41,13 @@ Import: github.com/mattmoor/warm-image/vendor/cloud.google.com/go
                         http://www.apache.org/licenses/
 ```
 
-### CSV Usage
+## CSV Usage
 
 You can also run `dep-collector` in a mode that produces CSV output,
 including basic classification of the license.
 
 > In order to run dep-collector in this mode, you must first run:
->   go get github.com/google/licenseclassifier
+> go get github.com/google/licenseclassifier
 
 For example:
 
@@ -59,25 +60,26 @@ github.com/sergi/go-diff,Static,,https://github.com/mattmoor/dep-collector/blob/
 ```
 
 The columns here are:
+
 * Import Path,
 * How the dependency is linked in (always reports "static"),
 * A column for whether any modifications have been made (always empty),
 * The URL by which to access the license file (assumes `master`),
 * A classification of what license this is ([using this](https://github.com/google/licenseclassifier)).
 
-
-### Check mode
+## Check mode
 
 `dep-collector` also includes a mode that will check for "forbidden" licenses.
 
 > In order to run dep-collector in this mode, you must first run:
->   go get github.com/google/licenseclassifier
+> go get github.com/google/licenseclassifier
 
 For example (failing):
+
 ```shell
 $ dep-collector -check ./foo/bar/baz
 2018/07/20 22:01:29 Error checking license collection: Errors validating licenses:
-Found matching forbidden license in "foo.io/bar/vendor/github.com/BurntSushi/toml": WTFPL
+Found matching forbidden license in "foo.io/bar/vendor/github.com/BurntSushi/toml":WTFPL
 ```
 
 For example (passing):


### PR DESCRIPTION
Bonus: linted dep-collector's `README.md`.