### PR TITLE
Properly find e2e tests to run in the default runner

### DIFF
--- a/scripts/presubmit-tests.sh
+++ b/scripts/presubmit-tests.sh
@@ -205,7 +205,7 @@ function default_integration_test_runner() {
   local options=""
   local failed=0
   (( EMIT_METRICS )) && options="--emit-metrics"
-  for e2e_test in ./test/e2e-*tests.sh; do
+  for e2e_test in $(find test/ -name e2e-*tests.sh); do
     echo "Running integration test ${e2e_test}"
     if ! ${e2e_test} ${options}; then
       failed=1


### PR DESCRIPTION
Listing scripts to run using shell expansion fails if there are no scripts in `/test` (shell expansion won't occur, and the raw string will be interpreted as a script name). Use `find` instead, which can deal with this edge case.