### PR TITLE
Allow setting E2E test cluster region, zone and machine type

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -84,6 +84,18 @@ main $@
 
 This is a helper script for Knative E2E test scripts. To use it:
 
+1. [optional] Customize the test cluster. Set the following environment variables
+   if the default values don't fit your needs:
+
+   - `E2E_CLUSTER_REGION`: Cluster region, defaults to `us-central1`.
+   - `E2E_CLUSTER_ZONE`: Cluster zone (e.g., `a`), defaults to none (i.e. use a regional
+     cluster).
+   - `E2E_CLUSTER_MACHINE`: Cluster node machine type, defaultrs to `n1-standard-4}`.
+   - `E2E_MIN_CLUSTER_NODES`: Minimum number of nodes in the cluster when autoscaling,
+     defaults to 1.
+   - `E2E_MAX_CLUSTER_NODES`: Maximum number of nodes in the cluster when autoscaling,
+     defaults to 3.
+
 1. Source the script.
 
 1. [optional] Write the `teardown()` function, which will tear down your test
@@ -130,9 +142,14 @@ This is a helper script for Knative E2E test scripts. To use it:
 
 This script will test that the latest Knative Serving nightly release works. It
 defines a special flag (`--no-knative-wait`) that causes the script not to
-wait for Knative Serving to be up before running the tests.
+wait for Knative Serving to be up before running the tests. It also requires that
+the test cluster is created in a specific region, `us-west2`.
 
 ```bash
+
+# This test requires a cluster in LA
+E2E_CLUSTER_REGION=us-west2
+
 source vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
 
 function teardown() {

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -90,7 +90,7 @@ This is a helper script for Knative E2E test scripts. To use it:
    - `E2E_CLUSTER_REGION`: Cluster region, defaults to `us-central1`.
    - `E2E_CLUSTER_ZONE`: Cluster zone (e.g., `a`), defaults to none (i.e. use a regional
      cluster).
-   - `E2E_CLUSTER_MACHINE`: Cluster node machine type, defaultrs to `n1-standard-4}`.
+   - `E2E_CLUSTER_MACHINE`: Cluster node machine type, defaults to `n1-standard-4}`.
    - `E2E_MIN_CLUSTER_NODES`: Minimum number of nodes in the cluster when autoscaling,
      defaults to 1.
    - `E2E_MAX_CLUSTER_NODES`: Maximum number of nodes in the cluster when autoscaling,

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -36,17 +36,23 @@ function build_resource_name() {
 }
 
 # Test cluster parameters
-readonly E2E_BASE_NAME="k${REPO_NAME}"
-readonly E2E_CLUSTER_NAME=$(build_resource_name e2e-cls)
-readonly E2E_NETWORK_NAME=$(build_resource_name e2e-net)
-readonly E2E_CLUSTER_REGION=us-central1
-readonly E2E_CLUSTER_MACHINE=n1-standard-4
-readonly TEST_RESULT_FILE=/tmp/${E2E_BASE_NAME}-e2e-result
+
+# Configurable parameters
+readonly E2E_CLUSTER_REGION=${E2E_CLUSTER_REGION:-us-central1}
+# By default we use regional clusters.
+readonly E2E_CLUSTER_ZONE=${E2E_CLUSTER_ZONE:-}
+readonly E2E_CLUSTER_MACHINE=${E2E_CLUSTER_MACHINE:-n1-standard-4}
+
 # Each knative repository may have a different cluster size requirement here,
 # so we allow calling code to set these parameters.  If they are not set we
 # use some sane defaults.
 readonly E2E_MIN_CLUSTER_NODES=${E2E_MIN_CLUSTER_NODES:-1}
 readonly E2E_MAX_CLUSTER_NODES=${E2E_MAX_CLUSTER_NODES:-3}
+
+readonly E2E_BASE_NAME="k${REPO_NAME}"
+readonly E2E_CLUSTER_NAME=$(build_resource_name e2e-cls)
+readonly E2E_NETWORK_NAME=$(build_resource_name e2e-net)
+readonly TEST_RESULT_FILE=/tmp/${E2E_BASE_NAME}-e2e-result
 
 # Flag whether test is using a boskos GCP project
 IS_BOSKOS=0
@@ -148,13 +154,15 @@ function create_test_cluster() {
   echo "Cluster will have a minimum of ${E2E_MIN_CLUSTER_NODES} and a maximum of ${E2E_MAX_CLUSTER_NODES} nodes."
 
   # Smallest cluster required to run the end-to-end-tests
+  local geoflag="--gcp-region=${E2E_CLUSTER_REGION}"
+  [[ -n "${E2E_CLUSTER_ZONE}" ]] && geoflag="--gcp-zone=${E2E_CLUSTER_REGION}-${E2E_CLUSTER_ZONE}"
   local CLUSTER_CREATION_ARGS=(
     --gke-create-args="--enable-autoscaling --min-nodes=${E2E_MIN_CLUSTER_NODES} --max-nodes=${E2E_MAX_CLUSTER_NODES} --scopes=cloud-platform --enable-basic-auth --no-issue-client-certificate"
     --gke-shape={\"default\":{\"Nodes\":${E2E_MIN_CLUSTER_NODES}\,\"MachineType\":\"${E2E_CLUSTER_MACHINE}\"}}
     --provider=gke
     --deployment=gke
     --cluster="${E2E_CLUSTER_NAME}"
-    --gcp-region="${E2E_CLUSTER_REGION}"
+    ${geoflag}
     --gcp-network="${E2E_NETWORK_NAME}"
     --gke-environment=prod
   )
@@ -237,10 +245,10 @@ function setup_test_cluster() {
   if [[ -z ${K8S_CLUSTER_OVERRIDE} ]]; then
     USING_EXISTING_CLUSTER=0
     export K8S_CLUSTER_OVERRIDE=$(kubectl config current-context)
-    acquire_cluster_admin_role ${K8S_USER_OVERRIDE} ${E2E_CLUSTER_NAME} ${E2E_CLUSTER_REGION}
+    acquire_cluster_admin_role ${K8S_USER_OVERRIDE} ${E2E_CLUSTER_NAME} ${E2E_CLUSTER_REGION} ${E2E_CLUSTER_ZONE}
     # Make sure we're in the default namespace. Currently kubetest switches to
     # test-pods namespace when creating the cluster.
-    kubectl config set-context $K8S_CLUSTER_OVERRIDE --namespace=default
+    kubectl config set-context ${K8S_CLUSTER_OVERRIDE} --namespace=default
   fi
   readonly USING_EXISTING_CLUSTER
 

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -23,6 +23,9 @@
 # Calling this script without arguments will create a new cluster in
 # project $PROJECT_ID, run the tests and delete the cluster.
 
+# Use us-central1-f to reduce the pressure on us-central1-a
+E2E_CLUSTER_ZONE=f
+
 source $(dirname $0)/../scripts/e2e-tests.sh
 
 # Script entry point.


### PR DESCRIPTION
This allow projects and tests to meet specific needs.

Documentation is now up-to-date about customizing the test cluster.

Fixes #383 ("workaround" is a better choice of word actually)