### PR TITLE
Remove trailing LF and spaces from a GitHub token

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -194,7 +194,8 @@ function parse_flags() {
         case ${parameter} in
           --github-token)
             [[ ! -f "$1" ]] && abort "file $1 doesn't exist"
-            GITHUB_TOKEN="$(cat $1)"
+            # Remove any trailing newline/space from token
+            GITHUB_TOKEN="$(echo -n $(cat $1))"
             [[ -n "${GITHUB_TOKEN}" ]] || abort "file $1 is empty"
             ;;
           --release-gcr)

--- a/test/unit/release-tests.sh
+++ b/test/unit/release-tests.sh
@@ -61,6 +61,10 @@ test_function ${SUCCESS} "" parse_flags --release-gcs a --publish
 test_function ${FAILURE} "error: missing parameter" initialize --release-gcr
 test_function ${SUCCESS} "" parse_flags --release-gcr a --publish
 
+token_file=$(mktemp)
+echo -e "abc " > ${token_file}
+test_function ${SUCCESS} ":abc:" call_function_post "echo :\$GITHUB_TOKEN:" initialize --github-token ${token_file}
+
 echo ">> Testing GCR/GCS values"
 
 test_function ${SUCCESS} "GCR flag is ignored" initialize --release-gcr foo


### PR DESCRIPTION
They break the authentication if present.

Fixes #388.