### PR TITLE
increasing images cleanup job timeout to 8 hours

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -1900,6 +1900,8 @@ periodics:
   labels:
     preset-test-account: "true"
   decorate: true
+  decoration_config:
+    timeout: 28800000000000 # 8 hours
   extra_refs:
   - org: knative
     repo: test-infra


### PR DESCRIPTION
Initial images cleanup job timed out after 2 hours, while working on the 11th boskos gcr. As there are 20 boskos gcr, it will take at least 4 hours for the entire job, increasing timeout to 8 hours to be safe.