### PR TITLE
Make --version a standalone flag

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -221,7 +221,8 @@ This is a helper script for Knative release scripts. To use it:
      variable `TAG` will contain the release tag in the form `vYYYYMMDD-<commit_short_hash>`.
    - `PUBLISH_RELEASE`: true if `--publish` was passed. In this case, the environment
      variable `KO_FLAGS` will be updated with the `-L` option.
-   - `BRANCH_RELEASE`: true if both `--version` and `--publish-release` were passed.
+   - `PUBLISH_TO_GITHUB`: true if `--version`, `--branch` and `--publish-release`
+     were passed.
 
    All boolean environment variables default to false for safety.
 

--- a/test/unit/release-tests.sh
+++ b/test/unit/release-tests.sh
@@ -21,7 +21,7 @@ set -e
 
 function mock_branch_release() {
   set -e
-  BRANCH_RELEASE=1
+  PUBLISH_TO_GITHUB=1
   TAG=sometag
   function git() {
 	echo $@
@@ -79,11 +79,11 @@ test_function ${SUCCESS} "published to 'knative-nightly/test-infra'" initialize 
 test_function ${SUCCESS} "Destination GCR: foo" initialize --release-gcr foo --publish
 test_function ${SUCCESS} "published to 'foo'" initialize --release-gcs foo --publish
 
-echo ">> Testing release branching"
+echo ">> Testing publishing to GitHub"
 
 test_function ${SUCCESS} "" branch_release
-test_function 129 "usage: git tag" call_function_pre BRANCH_RELEASE=1 branch_release
-test_function ${FAILURE} "No such file" call_function_pre BRANCH_RELEASE=1 branch_release "K Foo" "a.yaml b.yaml"
+test_function 129 "usage: git tag" call_function_pre PUBLISH_TO_GITHUB=1 branch_release
+test_function ${FAILURE} "No such file" call_function_pre PUBLISH_TO_GITHUB=1 branch_release "K Foo" "a.yaml b.yaml"
 test_function ${SUCCESS} "release create" mock_branch_release "K Foo" "$(mktemp) $(mktemp)"
 
 echo ">> Testing validation tests"


### PR DESCRIPTION
It can now be used to arbitrarily tag any release. To publish a release to GitHub though, `--version`, `--publish` and `--branch` must specified (current behavior).

Bonuses:
* rename the `BRANCH_RELEASE` variable for clarity.
* clearly log if release is published to GitHub and if it's being built from a branch.

Fixes #395.