### PR TITLE
raise coverage threshold to 80% for PR in Serving

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -288,7 +288,7 @@ presubmits:
         - "--artifacts=$(ARTIFACTS)"
         - "--profile-name=coverage_profile.txt"
         - "--cov-target=."
-        - "--cov-threshold-percentage=50"
+        - "--cov-threshold-percentage=80"
         - "--github-token=/etc/github-token/token"
         volumeMounts:
         - name: github-token


### PR DESCRIPTION
As approved here: https://github.com/knative/serving/issues/2347

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #
