### PR TITLE
webhook based API-Coverage tool: resourcetree traversal

### DIFF
--- a/tools/webhook-apicoverage/coveragecalculator/README.md
+++ b/tools/webhook-apicoverage/coveragecalculator/README.md
@@ -1,0 +1,8 @@
+# Coverage Calculator
+
+`coveragecalculator` package contains types and helper methods pertaining to
+coverage calculation. Package includes type [TypeCoverage](coveragedata.go)
+to represent coverage data for a particular API object type. This is the
+wire contract between the webhook server running inside the K8 cluster and any
+client using the API-Coverage tool. All API calls into the webhook-server would
+return response containing this object to represent coverage data.

--- a/tools/webhook-apicoverage/coveragecalculator/coveragedata.go
+++ b/tools/webhook-apicoverage/coveragecalculator/coveragedata.go
@@ -1,0 +1,23 @@
+package coveragecalculator
+
+// FieldCoverage represents coverage data for a field.
+type FieldCoverage struct {
+	Field string `json:"Field"`
+	Values []string `json:"Values"`
+	Coverage bool `json:"Covered"`
+}
+
+// Merge operation merges the field coverage data when multiple nodes represent the same type. (e.g. ConnectedNodes traversal)
+func (f *FieldCoverage) Merge(coverage bool, values []string) {
+	if coverage {
+		f.Coverage = coverage
+		f.Values = append(f.Values, values...)
+	}
+}
+
+// TypeCoverage encapsulates type information and field coverage.
+type TypeCoverage struct {
+	Package string `json:"Package"`
+	Type string `json:"Type"`
+	Fields map[string]*FieldCoverage `json:"Fields"`
+}

--- a/tools/webhook-apicoverage/resourcetree/README.md
+++ b/tools/webhook-apicoverage/resourcetree/README.md
@@ -24,15 +24,7 @@ v1alpha1.Route.Spec.Traffic and v1alpha1.Route.Status.Traffic, both these
 Traffic fields are of type v1alpha1.TrafficTarget, but are present in different
 paths inside the resource tree. ConnectedNodes connects these two nodes, and
 an outlining of this type would present the coverage across the two branches
-and gives a unified view of what fields are covered. ConnectedNodes represent
-connections between nodes that are of same type(reflect.Type) and belong to
-same package but span across different trees or branches of same tree. An
-example of ConnectedNodes would be v1alpha1.Route.Spec.Traffic and
-v1alpha1.Route.Status.Traffic, both these Traffic fields are of type
-v1alpha1.TrafficTarget, but are present in different paths inside the resource
-tree. ConnectedNodes connects these two nodes, and an outlining of this type
-would present the coverage across the two branches and gives a unified view of
-what fields are covered.
+and gives a unified view of what fields are covered.
 
 ## Type Analysis
 
@@ -48,3 +40,21 @@ A Resource tree is updated using reflect.Value Each node type is expected
 to implement NodeInterface method *updateCoverage(v reflect.Value)*.
 Inisde this method each node updates its nodeData.covered field based on
 whether the reflect.Value parameter being passed is set or not.
+
+## Rules
+
+To define traversal pattern on a [resourcetree](../resourcetree/resourcetree.go)
+`coveragecalculator` package supports defining rules that are applied during
+apicoverage walk-through. Currently the tool supports two types of Rule objects:
+
+  1. `NodeRules`: Enforces node level semantics. e.g.: Avoid traversing any type
+    that belong to a particular package. To enforce this rule, the repo would
+    define an object that implements the [NodeRule](rule.go) interface's
+    `Apply(nodeInterface  resourcetree.NodeInterface) bool` method and pass that
+    onto the `resourcetree` traversal routine.
+
+  1. `FieldRules`: Enforces field level semantics. e.g. Avoid calculating
+    coverage for any field that starts with prefix `deprecated`. To enforce this
+    rule, the repo would define an object that implements [FieldRule](rule.go)
+    interface's `Apply(fieldName string) bool` method and pass that onto the
+    `resourcetree` traversal routine.

--- a/tools/webhook-apicoverage/resourcetree/arraykindnode.go
+++ b/tools/webhook-apicoverage/resourcetree/arraykindnode.go
@@ -18,6 +18,8 @@ package resourcetree
 
 import (
 	"reflect"
+
+	"github.com/knative/test-infra/tools/webhook-apicoverage/coveragecalculator"
 )
 
 const (
@@ -53,4 +55,14 @@ func (a *ArrayKindNode) updateCoverage(v reflect.Value) {
 			a.children[a.field + arrayNodeNameSuffix].updateCoverage(v.Index(i))
 		}
 	}
+}
+
+func (a *ArrayKindNode) buildCoverageData(typeCoverage []coveragecalculator.TypeCoverage, nodeRules NodeRules, fieldRules FieldRules) {
+	if a.arrKind == reflect.Struct {
+		a.children[a.field + arrayNodeNameSuffix].buildCoverageData(typeCoverage, nodeRules, fieldRules)
+	}
+}
+
+func (a *ArrayKindNode) getValues() ([]string) {
+	return nil
 }

--- a/tools/webhook-apicoverage/resourcetree/node.go
+++ b/tools/webhook-apicoverage/resourcetree/node.go
@@ -18,6 +18,8 @@ package resourcetree
 
 import (
 	"reflect"
+
+	"github.com/knative/test-infra/tools/webhook-apicoverage/coveragecalculator"
 )
 
 // node.go contains types and interfaces pertaining to nodes inside resource tree.
@@ -28,6 +30,8 @@ type NodeInterface interface {
 	initialize(field string, parent NodeInterface, t reflect.Type, rt *ResourceTree)
 	buildChildNodes(t reflect.Type)
 	updateCoverage(v reflect.Value)
+	buildCoverageData(typeCoverage []coveragecalculator.TypeCoverage, nodeRules NodeRules, fieldRules FieldRules)
+	getValues() ([]string)
 }
 
 //nodeData is the data stored in each node of the resource tree.

--- a/tools/webhook-apicoverage/resourcetree/otherkindnode.go
+++ b/tools/webhook-apicoverage/resourcetree/otherkindnode.go
@@ -18,6 +18,8 @@ package resourcetree
 
 import (
 	"reflect"
+
+	"github.com/knative/test-infra/tools/webhook-apicoverage/coveragecalculator"
 )
 
 // OtherKindNode represents nodes in the resource tree of types like maps, interfaces, etc
@@ -40,4 +42,11 @@ func (o *OtherKindNode) updateCoverage(v reflect.Value) {
 	if !v.IsNil() {
 		o.covered = true
 	}
+}
+
+// no-op as the coverage is calculated as field coverage in parent node.
+func (o * OtherKindNode) buildCoverageData(typeCoverage []coveragecalculator.TypeCoverage, nodeRules NodeRules, fieldRules FieldRules) {}
+
+func (o *OtherKindNode) getValues() ([]string) {
+	return nil
 }

--- a/tools/webhook-apicoverage/resourcetree/ptrkindnode.go
+++ b/tools/webhook-apicoverage/resourcetree/ptrkindnode.go
@@ -18,6 +18,8 @@ package resourcetree
 
 import (
 	"reflect"
+
+	"github.com/knative/test-infra/tools/webhook-apicoverage/coveragecalculator"
 )
 
 const (
@@ -51,4 +53,14 @@ func (p *PtrKindNode) updateCoverage(v reflect.Value) {
 		p.covered = true
 		p.children[p.field + ptrNodeNameSuffix].updateCoverage(v.Elem())
 	}
+}
+
+func (p *PtrKindNode) buildCoverageData(typeCoverage []coveragecalculator.TypeCoverage, nodeRules NodeRules, fieldRules FieldRules) {
+	if p.objKind == reflect.Struct {
+		p.children[p.field + ptrNodeNameSuffix].buildCoverageData(typeCoverage, nodeRules, fieldRules)
+	}
+}
+
+func (p *PtrKindNode) getValues() ([]string) {
+	return nil
 }

--- a/tools/webhook-apicoverage/resourcetree/resourcetree.go
+++ b/tools/webhook-apicoverage/resourcetree/resourcetree.go
@@ -19,6 +19,8 @@ package resourcetree
 import (
 	"container/list"
 	"reflect"
+
+	"github.com/knative/test-infra/tools/webhook-apicoverage/coveragecalculator"
 )
 
 // ResourceTree encapsulates a tree corresponding to a resource type.
@@ -67,4 +69,11 @@ func (r *ResourceTree) BuildResourceTree(t reflect.Type) {
 // UpdateCoverage updates coverage data in the resource tree based on the provided reflect.Value
 func (r *ResourceTree) UpdateCoverage(v reflect.Value) {
 	r.Root.updateCoverage(v)
+}
+
+// GetCoverageData calculates the coverage information for a resource tree by applying provided Node and Field rules.
+func (r *ResourceTree) BuildCoverageData(nodeRules NodeRules, fieldRules FieldRules) ([]coveragecalculator.TypeCoverage) {
+	typeCoverage := []coveragecalculator.TypeCoverage{}
+	r.Root.buildCoverageData(typeCoverage, nodeRules, fieldRules)
+	return typeCoverage
 }

--- a/tools/webhook-apicoverage/resourcetree/rule.go
+++ b/tools/webhook-apicoverage/resourcetree/rule.go
@@ -1,0 +1,33 @@
+package resourcetree
+
+// rule.go contains different rules that can be defined to control resource tree traversal.
+
+// NodeRules encapsulates all the node level rules defined by a repo.
+type NodeRules struct {
+	rules []func(nodeInterface NodeInterface) bool
+}
+
+// Apply runs all the rules defined by a repo against a node.
+func (n *NodeRules) Apply(node NodeInterface) bool {
+	for _, rule := range n.rules {
+		if !rule(node) {
+			return false
+		}
+	}
+	return true
+}
+
+// FieldRules encapsulates all the field level rules defined by a repo.
+type FieldRules struct {
+	rules []func(fieldName string) bool
+}
+
+// Apply runs all the rules defined by a repo against a field.
+func (f *FieldRules) Apply(fieldName string) bool {
+	for _, rule := range f.rules {
+		if !rule(fieldName) {
+			return false
+		}
+	}
+	return true
+}

--- a/tools/webhook-apicoverage/resourcetree/structkindnode.go
+++ b/tools/webhook-apicoverage/resourcetree/structkindnode.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resourcetree
 
 import (
+	"github.com/knative/test-infra/tools/webhook-apicoverage/coveragecalculator"
 	"reflect"
 )
 
@@ -78,4 +79,23 @@ func (s *StructKindNode) updateCoverage(v reflect.Value) {
 			}
 		}
 	}
+}
+
+func (s *StructKindNode) buildCoverageData(typeCoverage []coveragecalculator.TypeCoverage, nodeRules NodeRules, fieldRules FieldRules) {
+	if len(s.children) == 0 {
+		return
+	}
+
+	coverage := s.tree.Forest.getConnectedNodeCoverage(s.fieldType, fieldRules)
+	typeCoverage = append(typeCoverage, coverage)
+
+	for _, value := range s.children {
+		if value.getData().covered && nodeRules.Apply(value){
+			value.buildCoverageData(typeCoverage, nodeRules, fieldRules)
+		}
+	}
+}
+
+func (s *StructKindNode) getValues() ([]string) {
+	return nil
 }

--- a/tools/webhook-apicoverage/resourcetree/timetypenode.go
+++ b/tools/webhook-apicoverage/resourcetree/timetypenode.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package resourcetree
 
-import "reflect"
+import (
+	"reflect"
+
+	"github.com/knative/test-infra/tools/webhook-apicoverage/coveragecalculator"
+)
 
 // TimeTypeNode is a node type that encapsulates fields that are internally time based. E.g metav1.ObjectMeta.CreationTimestamp or metav1.ObjectMeta.DeletionTimestamp.
 // These are internally of type metav1.Time which use standard time type, but their values are specified as timestamp strings with parsing logic to create time objects. For
@@ -42,4 +46,11 @@ func (ti *TimeTypeNode) updateCoverage(v reflect.Value) {
 	} else if v.Type().Kind() == reflect.Ptr && !v.IsNil() {
 		ti.covered = true
 	}
+}
+
+// no-op as the coverage is calculated as field coverage in parent node.
+func (ti *TimeTypeNode) buildCoverageData(typeCoverage []coveragecalculator.TypeCoverage, nodeRules NodeRules, fieldRules FieldRules) {}
+
+func (ti *TimeTypeNode) getValues() ([]string) {
+	return nil
 }


### PR DESCRIPTION
This changeset introduces the coveragecalculator package to the webhook based API Coverage tool. This package contains mechanism to provide rules to control resource tree traversal as well as add the
wire-contract that the webhook server would expose to any client using the tool to get API coverage data. README.md file has more information.