### PR TITLE
webhook based API-Coverage tool: Export NodeData type

### DIFF
--- a/tools/webhook-apicoverage/resourcetree/arraykindnode.go
+++ b/tools/webhook-apicoverage/resourcetree/arraykindnode.go
@@ -28,38 +28,39 @@ const (
 
 // ArrayKindNode represents resource tree node of types reflect.Kind.Array and reflect.Kind.Slice
 type ArrayKindNode struct {
-	nodeData
+	NodeData
 	arrKind reflect.Kind // Array type e.g. []int will store reflect.Kind.Int. This is required for type-expansion and value-evaluation decisions.
 }
 
-func (a *ArrayKindNode ) getData() nodeData {
-	return a.nodeData
+// GetData returns node data
+func (a *ArrayKindNode ) GetData() NodeData {
+	return a.NodeData
 }
 
 func (a *ArrayKindNode ) initialize(field string, parent NodeInterface, t reflect.Type, rt *ResourceTree) {
-	a.nodeData.initialize(field, parent, t, rt)
+	a.NodeData.initialize(field, parent, t, rt)
 	a.arrKind = t.Elem().Kind()
 }
 
 func (a *ArrayKindNode) buildChildNodes(t reflect.Type) {
-	childName := a.field + arrayNodeNameSuffix
-	childNode := a.tree.createNode(childName, a, t.Elem())
-	a.children[childName] = childNode
+	childName := a.Field + arrayNodeNameSuffix
+	childNode := a.Tree.createNode(childName, a, t.Elem())
+	a.Children[childName] = childNode
 	childNode.buildChildNodes(t.Elem())
 }
 
 func (a *ArrayKindNode) updateCoverage(v reflect.Value) {
 	if !v.IsNil() {
-		a.covered = true
+		a.Covered = true
 		for i := 0; i < v.Len(); i++ {
-			a.children[a.field + arrayNodeNameSuffix].updateCoverage(v.Index(i))
+			a.Children[a.Field + arrayNodeNameSuffix].updateCoverage(v.Index(i))
 		}
 	}
 }
 
 func (a *ArrayKindNode) buildCoverageData(typeCoverage []coveragecalculator.TypeCoverage, nodeRules NodeRules, fieldRules FieldRules) {
 	if a.arrKind == reflect.Struct {
-		a.children[a.field + arrayNodeNameSuffix].buildCoverageData(typeCoverage, nodeRules, fieldRules)
+		a.Children[a.Field + arrayNodeNameSuffix].buildCoverageData(typeCoverage, nodeRules, fieldRules)
 	}
 }
 

--- a/tools/webhook-apicoverage/resourcetree/basictypekindnode.go
+++ b/tools/webhook-apicoverage/resourcetree/basictypekindnode.go
@@ -26,34 +26,35 @@ import (
 
 // BasicTypeKindNode represents resource tree node of basic types like int, float, etc.
 type BasicTypeKindNode struct {
-	nodeData
+	NodeData
 	values map[string]bool // Values seen for this node. Useful for enum types.
 	possibleEnum bool // Flag to indicate if this is a possible enum.
 }
 
-func (b *BasicTypeKindNode) getData() nodeData {
-	return b.nodeData
+// GetData returns node data
+func (b *BasicTypeKindNode) GetData() NodeData {
+	return b.NodeData
 }
 
 func (b *BasicTypeKindNode) initialize(field string, parent NodeInterface, t reflect.Type, rt *ResourceTree) {
-	b.nodeData.initialize(field, parent, t, rt)
+	b.NodeData.initialize(field, parent, t, rt)
 	b.values = make(map[string]bool)
-	b.nodeData.leafNode = true
+	b.NodeData.LeafNode = true
 }
 
 func (b *BasicTypeKindNode) buildChildNodes(t reflect.Type) {
 	// Treating bools as possible enums to support tighter coverage information.
-	if t.Name() != t.Kind().String() || b.fieldType.Kind() == reflect.Bool {
+	if t.Name() != t.Kind().String() || b.FieldType.Kind() == reflect.Bool {
 		b.possibleEnum = true
 	}
 }
 
 func (b *BasicTypeKindNode) updateCoverage(v reflect.Value) {
 	if value := b.string(v); len(value) > 0 {
-		if b.possibleEnum || b.fieldType.Kind() == reflect.Bool {
+		if b.possibleEnum || b.FieldType.Kind() == reflect.Bool {
 			b.addValue(value)
 		}
-		b.covered = true
+		b.Covered = true
 	}
 }
 

--- a/tools/webhook-apicoverage/resourcetree/buildChildNodes_test.go
+++ b/tools/webhook-apicoverage/resourcetree/buildChildNodes_test.go
@@ -23,28 +23,28 @@ import (
 
 func TestSimpleStructType(t *testing.T) {
 	tree := getTestTree(basicTypeName, reflect.TypeOf(baseType{}))
-	if err := verifyBaseTypeNode("", tree.Root.getData()); err  != nil {
+	if err := verifyBaseTypeNode("", tree.Root.GetData()); err  != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestPtrType(t *testing.T) {
 	tree := getTestTree(ptrTypeName, reflect.TypeOf(ptrType{}))
-	if err := verifyPtrNode(tree.Root.getData()); err != nil {
+	if err := verifyPtrNode(tree.Root.GetData()); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestArrayType(t *testing.T) {
 	tree := getTestTree(arrayTypeName, reflect.TypeOf(arrayType{}))
-	if err := verifyArrayNode(tree.Root.getData()); err != nil {
+	if err := verifyArrayNode(tree.Root.GetData()); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestOtherType(t *testing.T) {
 	tree := getTestTree(otherTypeName, reflect.TypeOf(otherType{}))
-	if err := verifyOtherTypeNode(tree.Root.getData()); err != nil {
+	if err := verifyOtherTypeNode(tree.Root.GetData()); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/tools/webhook-apicoverage/resourcetree/node.go
+++ b/tools/webhook-apicoverage/resourcetree/node.go
@@ -26,7 +26,7 @@ import (
 
 // NodeInterface defines methods that can be performed on each node in the resource tree.
 type NodeInterface interface {
-	getData() nodeData
+	GetData() NodeData
 	initialize(field string, parent NodeInterface, t reflect.Type, rt *ResourceTree)
 	buildChildNodes(t reflect.Type)
 	updateCoverage(v reflect.Value)
@@ -34,28 +34,28 @@ type NodeInterface interface {
 	getValues() ([]string)
 }
 
-//nodeData is the data stored in each node of the resource tree.
-type nodeData struct {
-	field string // Represents the Name of the field e.g. field name inside the struct.
-	tree *ResourceTree // Reference back to the resource tree. Required for cross-tree traversal(connected nodes traversal)
-	fieldType reflect.Type // Required as type information is not available during tree traversal.
-	nodePath string // Path in the resource tree reaching this node.
-	parent NodeInterface // Link back to parent.
-	children map[string]NodeInterface // Child nodes are keyed using field names(nodeData.field).
-	leafNode bool // Storing this as an additional field because type-analysis determines the value, which gets used later in value-evaluation
-	covered bool
+// NodeData is the data stored in each node of the resource tree.
+type NodeData struct {
+	Field string // Represents the Name of the field e.g. field name inside the struct.
+	Tree *ResourceTree // Reference back to the resource tree. Required for cross-tree traversal(connected nodes traversal)
+	FieldType reflect.Type // Required as type information is not available during tree traversal.
+	NodePath string // Path in the resource tree reaching this node.
+	Parent NodeInterface // Link back to parent.
+	Children map[string]NodeInterface // Child nodes are keyed using field names(nodeData.field).
+	LeafNode bool // Storing this as an additional field because type-analysis determines the value, which gets used later in value-evaluation
+	Covered bool
 }
 
-func (nd *nodeData) initialize(field string, parent NodeInterface, t reflect.Type, rt *ResourceTree) {
-	nd.field = field
-	nd.tree = rt
-	nd.parent = parent
-	nd.fieldType = t
-	nd.children = make(map[string]NodeInterface)
+func (nd *NodeData) initialize(field string, parent NodeInterface, t reflect.Type, rt *ResourceTree) {
+	nd.Field = field
+	nd.Tree = rt
+	nd.Parent = parent
+	nd.FieldType = t
+	nd.Children = make(map[string]NodeInterface)
 
 	if parent != nil {
-		nd.nodePath = parent.getData().nodePath + "." + field
+		nd.NodePath = parent.GetData().NodePath + "." + field
 	} else {
-		nd.nodePath = field
+		nd.NodePath = field
 	}
 }

--- a/tools/webhook-apicoverage/resourcetree/otherkindnode.go
+++ b/tools/webhook-apicoverage/resourcetree/otherkindnode.go
@@ -24,23 +24,24 @@ import (
 
 // OtherKindNode represents nodes in the resource tree of types like maps, interfaces, etc
 type OtherKindNode struct {
-	nodeData
+	NodeData
 }
 
-func (o *OtherKindNode) getData() nodeData {
-	return o.nodeData
+// GetData returns node data
+func (o *OtherKindNode) GetData() NodeData {
+	return o.NodeData
 }
 
 func (o *OtherKindNode) initialize(field string, parent NodeInterface, t reflect.Type, rt *ResourceTree) {
-	o.nodeData.initialize(field, parent, t, rt)
-	o.nodeData.leafNode = true
+	o.NodeData.initialize(field, parent, t, rt)
+	o.NodeData.LeafNode = true
 }
 
 func (o *OtherKindNode) buildChildNodes(t reflect.Type) {}
 
 func (o *OtherKindNode) updateCoverage(v reflect.Value) {
 	if !v.IsNil() {
-		o.covered = true
+		o.Covered = true
 	}
 }
 

--- a/tools/webhook-apicoverage/resourcetree/ptrkindnode.go
+++ b/tools/webhook-apicoverage/resourcetree/ptrkindnode.go
@@ -28,36 +28,37 @@ const (
 
 // PtrKindNode represents nodes in the resource tree of type reflect.Kind.Ptr, reflect.Kind.UnsafePointer, etc.
 type PtrKindNode struct {
-	nodeData
+	NodeData
 	objKind reflect.Kind // Type of the object being pointed to. Eg: *int will store reflect.Kind.Int. This is required for type-expansion and value-evaluation decisions.
 }
 
-func (p *PtrKindNode) getData() nodeData {
-	return p.nodeData
+// GetData returns node data
+func (p *PtrKindNode) GetData() NodeData {
+	return p.NodeData
 }
 
 func (p *PtrKindNode) initialize(field string, parent NodeInterface, t reflect.Type, rt *ResourceTree) {
-	p.nodeData.initialize(field, parent, t, rt)
+	p.NodeData.initialize(field, parent, t, rt)
 	p.objKind = t.Elem().Kind()
 }
 
 func (p *PtrKindNode) buildChildNodes(t reflect.Type) {
-	childName := p.field + ptrNodeNameSuffix
-	childNode := p.tree.createNode(childName, p, t.Elem())
-	p.children[childName] = childNode
+	childName := p.Field + ptrNodeNameSuffix
+	childNode := p.Tree.createNode(childName, p, t.Elem())
+	p.Children[childName] = childNode
 	childNode.buildChildNodes(t.Elem())
 }
 
 func (p *PtrKindNode) updateCoverage(v reflect.Value) {
 	if !v.IsNil() {
-		p.covered = true
-		p.children[p.field + ptrNodeNameSuffix].updateCoverage(v.Elem())
+		p.Covered = true
+		p.Children[p.Field + ptrNodeNameSuffix].updateCoverage(v.Elem())
 	}
 }
 
 func (p *PtrKindNode) buildCoverageData(typeCoverage []coveragecalculator.TypeCoverage, nodeRules NodeRules, fieldRules FieldRules) {
 	if p.objKind == reflect.Struct {
-		p.children[p.field + ptrNodeNameSuffix].buildCoverageData(typeCoverage, nodeRules, fieldRules)
+		p.Children[p.Field + ptrNodeNameSuffix].buildCoverageData(typeCoverage, nodeRules, fieldRules)
 	}
 }
 

--- a/tools/webhook-apicoverage/resourcetree/resourceforest.go
+++ b/tools/webhook-apicoverage/resourcetree/resourceforest.go
@@ -42,13 +42,13 @@ func (r *ResourceForest) getConnectedNodeCoverage(fieldType reflect.Type, fieldR
 	if value, ok := r.ConnectedNodes[fieldType.PkgPath() + "." + fieldType.Name()]; ok {
 		for elem := value.Front(); elem != nil; elem = elem.Next() {
 			node := elem.Value.(NodeInterface)
-			for field, v := range node.getData().children {
+			for field, v := range node.GetData().Children {
 				if fieldRules.Apply(field) {
 					if _, ok := coverage.Fields[field]; !ok {
 						coverage.Fields[field] = new(coveragecalculator.FieldCoverage)
 					}
 					// merge values across the list.
-					coverage.Fields[field].Merge(v.getData().covered, v.getValues())
+					coverage.Fields[field].Merge(v.GetData().Covered, v.getValues())
 				}
 			}
 		}

--- a/tools/webhook-apicoverage/resourcetree/resourcetree.go
+++ b/tools/webhook-apicoverage/resourcetree/resourcetree.go
@@ -71,7 +71,7 @@ func (r *ResourceTree) UpdateCoverage(v reflect.Value) {
 	r.Root.updateCoverage(v)
 }
 
-// GetCoverageData calculates the coverage information for a resource tree by applying provided Node and Field rules.
+// BuildCoverageData calculates the coverage information for a resource tree by applying provided Node and Field rules.
 func (r *ResourceTree) BuildCoverageData(nodeRules NodeRules, fieldRules FieldRules) ([]coveragecalculator.TypeCoverage) {
 	typeCoverage := []coveragecalculator.TypeCoverage{}
 	r.Root.buildCoverageData(typeCoverage, nodeRules, fieldRules)

--- a/tools/webhook-apicoverage/resourcetree/test_util.go
+++ b/tools/webhook-apicoverage/resourcetree/test_util.go
@@ -125,16 +125,16 @@ func getTestTree(treeName string, t reflect.Type) *ResourceTree {
 	return &tree
 }
 
-func verifyBaseTypeNode(logPrefix string, data nodeData) error {
-	if len(data.children) != 2 {
-		return fmt.Errorf("%s Expected 2 children got only : %d", logPrefix, len(data.children))
+func verifyBaseTypeNode(logPrefix string, data NodeData) error {
+	if len(data.Children) != 2 {
+		return fmt.Errorf("%s Expected 2 Children got only : %d", logPrefix, len(data.Children))
 	}
 
-	if value, ok := data.children["field1"]; ok {
-		n := value.getData()
-		if !n.leafNode || n.fieldType.Kind() != reflect.String || n.fieldType.PkgPath() != "" || len(n.children) != 0 {
-			return fmt.Errorf("%s Unexpected field: field1. Expected leafNode:true, Kind: %s, pkgPath: '' Children: 0 Found leafNode: %t Kind: %s pkgPath: %s Children:%d",
-				logPrefix, reflect.String, n.leafNode, n.fieldType.Kind(), n.fieldType.PkgPath(), len(n.children))
+	if value, ok := data.Children["field1"]; ok {
+		n := value.GetData()
+		if !n.LeafNode || n.FieldType.Kind() != reflect.String || n.FieldType.PkgPath() != "" || len(n.Children) != 0 {
+			return fmt.Errorf("%s Unexpected field: field1. Expected LeafNode:true, Kind: %s, pkgPath: '' Children: 0 Found LeafNode: %t Kind: %s pkgPath: %s Children:%d",
+				logPrefix, reflect.String, n.LeafNode, n.FieldType.Kind(), n.FieldType.PkgPath(), len(n.Children))
 		}
 	} else {
 		return fmt.Errorf("%s field1 child Not found", logPrefix)
@@ -143,89 +143,89 @@ func verifyBaseTypeNode(logPrefix string, data nodeData) error {
 	return nil
 }
 
-func verifyPtrNode(data nodeData) error {
-	if len(data.children) != 2 {
-		return fmt.Errorf("Expected 2 children got: %d", len(data.children))
+func verifyPtrNode(data NodeData) error {
+	if len(data.Children) != 2 {
+		return fmt.Errorf("Expected 2 Children got: %d", len(data.Children))
 	}
 
-	child := data.children["structPtr"]
-	if len(child.getData().children) != 1 {
-		return fmt.Errorf("Unexpected size for field:structPtr. Expected : 1, Found : %d", len(child.getData().children))
+	child := data.Children["structPtr"]
+	if len(child.GetData().Children) != 1 {
+		return fmt.Errorf("Unexpected size for field:structPtr. Expected : 1, Found : %d", len(child.GetData().Children))
 	}
 
-	child = child.getData().children["structPtr-ptr"]
-	if err := verifyBaseTypeNode("child structPtr-ptr: ", child.getData()); err != nil {
+	child = child.GetData().Children["structPtr-ptr"]
+	if err := verifyBaseTypeNode("child structPtr-ptr: ", child.GetData()); err != nil {
 		return err
 	}
 
-	child = data.children["basePtr"]
-	if len(child.getData().children) != 1 {
-		return fmt.Errorf("Unexpected size for field:basePtr. Expected : 1 Found : %d", len(child.getData().children))
+	child = data.Children["basePtr"]
+	if len(child.GetData().Children) != 1 {
+		return fmt.Errorf("Unexpected size for field:basePtr. Expected : 1 Found : %d", len(child.GetData().Children))
 	}
 
-	child = child.getData().children["basePtr-ptr"]
-	d := child.getData()
-	if d.fieldType.Kind() != reflect.Float32 || !d.leafNode || d.fieldType.PkgPath() != "" || len(d.children) != 0 {
-		return fmt.Errorf("Unexpected field:basePtr-ptr: Expected: Kind: %s, leafNode: true, pkgPath: '' Children: 0 Found Kind: %s, leafNode: %t, pkgPath: %s children:%d",
-			reflect.Float32, d.fieldType.Kind(), d.leafNode, d.fieldType.PkgPath(), len(d.children))
+	child = child.GetData().Children["basePtr-ptr"]
+	d := child.GetData()
+	if d.FieldType.Kind() != reflect.Float32 || !d.LeafNode || d.FieldType.PkgPath() != "" || len(d.Children) != 0 {
+		return fmt.Errorf("Unexpected field:basePtr-ptr: Expected: Kind: %s, LeafNode: true, pkgPath: '' Children: 0 Found Kind: %s, LeafNode: %t, pkgPath: %s Children:%d",
+			reflect.Float32, d.FieldType.Kind(), d.LeafNode, d.FieldType.PkgPath(), len(d.Children))
 	}
 
 	return nil
 }
 
-func verifyArrayNode(data nodeData) error {
-	if len(data.children) != 2 {
-		return fmt.Errorf("Expected 2 children got: %d", len(data.children))
+func verifyArrayNode(data NodeData) error {
+	if len(data.Children) != 2 {
+		return fmt.Errorf("Expected 2 Children got: %d", len(data.Children))
 	}
 
-	child := data.children["structArr"]
-	d := child.getData()
-	if d.fieldType.Kind() != reflect.Slice {
-		return fmt.Errorf("Unexpected kind for field:structArr: Expected : %s Found: %s", reflect.Slice, d.fieldType.Kind())
-	} else if len(d.children) != 1 {
-		return fmt.Errorf("Unexpected number of children for field:structArr: Expected : 1 Found : %d", len(d.children))
+	child := data.Children["structArr"]
+	d := child.GetData()
+	if d.FieldType.Kind() != reflect.Slice {
+		return fmt.Errorf("Unexpected kind for field:structArr: Expected : %s Found: %s", reflect.Slice, d.FieldType.Kind())
+	} else if len(d.Children) != 1 {
+		return fmt.Errorf("Unexpected number of Children for field:structArr: Expected : 1 Found : %d", len(d.Children))
 	}
 
-	child = child.getData().children["structArr-arr"]
-	if err := verifyBaseTypeNode("child structArr-arr:", child.getData()); err != nil {
+	child = child.GetData().Children["structArr-arr"]
+	if err := verifyBaseTypeNode("child structArr-arr:", child.GetData()); err != nil {
 		return err
 	}
 
-	child = data.children["baseArr"]
-	d = child.getData()
-	if d.fieldType.Kind() != reflect.Slice {
-		return fmt.Errorf("Unexpected kind for field:baseArr: Expected : %s Found : %s", reflect.Slice, d.fieldType.Kind())
-	} else if len(d.children) != 1 {
-		return fmt.Errorf("Unexpected number of children for field:baseArr: Expected : 1 Found : %d", len(d.children))
+	child = data.Children["baseArr"]
+	d = child.GetData()
+	if d.FieldType.Kind() != reflect.Slice {
+		return fmt.Errorf("Unexpected kind for field:baseArr: Expected : %s Found : %s", reflect.Slice, d.FieldType.Kind())
+	} else if len(d.Children) != 1 {
+		return fmt.Errorf("Unexpected number of Children for field:baseArr: Expected : 1 Found : %d", len(d.Children))
 	}
 
-	child = child.getData().children["baseArr-arr"]
-	d = child.getData()
-	if d.fieldType.Kind() != reflect.Bool || !d.leafNode || d.fieldType.PkgPath() != "" || len(d.children) != 0 {
-		return fmt.Errorf("Unexpected field:baseArr-arr Expected kind: %s, leafNode: true, pkgPath: '', children:0 Found: kind: %s, leafNode: %t, pkgPath: %s, children:%d",
-			reflect.Bool, d.fieldType.Kind(), d.leafNode, d.fieldType.PkgPath(), len(d.children))
+	child = child.GetData().Children["baseArr-arr"]
+	d = child.GetData()
+	if d.FieldType.Kind() != reflect.Bool || !d.LeafNode || d.FieldType.PkgPath() != "" || len(d.Children) != 0 {
+		return fmt.Errorf("Unexpected field:baseArr-arr Expected kind: %s, LeafNode: true, pkgPath: '', Children:0 Found: kind: %s, LeafNode: %t, pkgPath: %s, Children:%d",
+			reflect.Bool, d.FieldType.Kind(), d.LeafNode, d.FieldType.PkgPath(), len(d.Children))
 	}
 
 	return nil
 }
 
-func verifyOtherTypeNode(data nodeData) error {
-	if len(data.children) != 2 {
-		return fmt.Errorf("OtherTypeVerification: Expected 2 children got: %d", len(data.children))
+func verifyOtherTypeNode(data NodeData) error {
+	if len(data.Children) != 2 {
+		return fmt.Errorf("OtherTypeVerification: Expected 2 Children got: %d", len(data.Children))
 	}
 
-	child := data.children["structMap"]
-	d := child.getData()
-	if d.fieldType.Kind() != reflect.Map || !d.leafNode || len(d.children) != 0 {
-		return fmt.Errorf("Unexpected field:structMap - Expected Kind: %s, leafNode: true, children:0 Found Kind: %s, leafNode: %t, children: %d",
-			reflect.Map, d.fieldType.Kind(), d.leafNode, len(d.children))
+	child := data.Children["structMap"]
+	d := child.GetData()
+	if d.FieldType.Kind() != reflect.Map || !d.LeafNode || len(d.Children) != 0 {
+		return fmt.Errorf("Unexpected field:structMap - Expected Kind: %s, LeafNode: true, Children:0 Found Kind: %s, LeafNode: %t, Children: %d",
+			reflect.Map, d.FieldType.Kind(), d.LeafNode, len(d.Children))
 	}
 
-	child = data.children["baseMap"]
-	d = child.getData()
-	if d.fieldType.Kind() != reflect.Map || !d.leafNode || len(d.children) != 0 {
-		return fmt.Errorf("Unexpected field:structMap - Expected Kind: %s, leafNode: true, children: 0 Found kind: %s, leafNode: %t, children: %d",
-			reflect.Map, d.fieldType.Kind(), d.leafNode, len(d.children))
+	child = data.Children["baseMap"]
+	d = child.GetData()
+	if d.FieldType.Kind() != reflect.Map || !d.LeafNode || len(d.Children) != 0 {
+		return fmt.Errorf("Unexpected field:structMap - Expected Kind: %s, LeafNode: true, Children: 0 Found kind: %s, LeafNode: %t, Children: %d",
+			reflect.Map, d.FieldType.Kind(), d.LeafNode, len(d.Children))
 	}
 
 	return nil
@@ -254,41 +254,41 @@ func verifyResourceForest(forest *ResourceForest) error {
 }
 
 func verifyBaseTypeValue(logPrefix string, node NodeInterface) error {
-	if !node.getData().covered {
-		return errors.New(logPrefix + " Node marked as not-covered. Expected to be covered")
+	if !node.GetData().Covered {
+		return errors.New(logPrefix + " Node marked as not-Covered. Expected to be Covered")
 	}
 
-	if !node.getData().children["field1"].getData().covered {
-		return errors.New(logPrefix + " field1 marked as not-covered. Expected to be covered")
+	if !node.GetData().Children["field1"].GetData().Covered {
+		return errors.New(logPrefix + " field1 marked as not-Covered. Expected to be Covered")
 	}
 
-	if node.getData().children["field2"].getData().covered {
-		return errors.New(logPrefix + " field2 marked as covered. Expected to be not-covered")
+	if node.GetData().Children["field2"].GetData().Covered {
+		return errors.New(logPrefix + " field2 marked as Covered. Expected to be not-Covered")
 	}
 
 	return nil
 }
 
 func verifyPtrValueAllCovered(node NodeInterface) error {
-	if !node.getData().covered {
-		return errors.New("Node marked as not-covered. Expected to be covered")
+	if !node.GetData().Covered {
+		return errors.New("Node marked as not-Covered. Expected to be Covered")
 	}
 
-	child := node.getData().children["basePtr"]
-	if !child.getData().covered {
-		return errors.New("field:base_ptr marked as not-covered. Expected to be covered")
+	child := node.GetData().Children["basePtr"]
+	if !child.GetData().Covered {
+		return errors.New("field:base_ptr marked as not-Covered. Expected to be Covered")
 	}
 
-	if !child.getData().children["basePtr" + ptrNodeNameSuffix].getData().covered {
-		return errors.New("field:basePtr" + ptrNodeNameSuffix + "marked as not-covered. Expected to be covered" )
+	if !child.GetData().Children["basePtr" + ptrNodeNameSuffix].GetData().Covered {
+		return errors.New("field:basePtr" + ptrNodeNameSuffix + "marked as not-Covered. Expected to be Covered" )
 	}
 
-	child = node.getData().children["structPtr"]
-	if !child.getData().covered {
-		return errors.New("field:structPtr marked as not-covered. Expected to be covered")
+	child = node.GetData().Children["structPtr"]
+	if !child.GetData().Covered {
+		return errors.New("field:structPtr marked as not-Covered. Expected to be Covered")
 	}
 
-	if err := verifyBaseTypeValue("field:structPtr" + ptrNodeNameSuffix, child.getData().children["structPtr" + ptrNodeNameSuffix]); err != nil {
+	if err := verifyBaseTypeValue("field:structPtr" + ptrNodeNameSuffix, child.GetData().Children["structPtr" + ptrNodeNameSuffix]); err != nil {
 		return err
 	}
 
@@ -296,25 +296,25 @@ func verifyPtrValueAllCovered(node NodeInterface) error {
 }
 
 func verifyPtrValueSomeCovered(node NodeInterface) error {
-	if !node.getData().covered {
-		return errors.New("Node marked as not-covered. Expected to be covered")
+	if !node.GetData().Covered {
+		return errors.New("Node marked as not-Covered. Expected to be Covered")
 	}
 
-	child := node.getData().children["basePtr"]
-	if child.getData().covered {
-		return errors.New("field:basePtr marked as covered. Expected to be not-covered")
+	child := node.GetData().Children["basePtr"]
+	if child.GetData().Covered {
+		return errors.New("field:basePtr marked as Covered. Expected to be not-Covered")
 	}
 
-	if child.getData().children["basePtr" + ptrNodeNameSuffix].getData().covered {
-		return errors.New("field:basePtr" + ptrNodeNameSuffix + "marked as covered. Expected to be not-covered" )
+	if child.GetData().Children["basePtr" + ptrNodeNameSuffix].GetData().Covered {
+		return errors.New("field:basePtr" + ptrNodeNameSuffix + "marked as Covered. Expected to be not-Covered" )
 	}
 
-	child = node.getData().children["structPtr"]
-	if !child.getData().covered {
-		return errors.New("field:structPtr marked as not-covered. Expected to be covered")
+	child = node.GetData().Children["structPtr"]
+	if !child.GetData().Covered {
+		return errors.New("field:structPtr marked as not-Covered. Expected to be Covered")
 	}
 
-	if err := verifyBaseTypeValue("field:structPtr" + ptrNodeNameSuffix, child.getData().children["structPtr" + ptrNodeNameSuffix]); err != nil {
+	if err := verifyBaseTypeValue("field:structPtr" + ptrNodeNameSuffix, child.GetData().Children["structPtr" + ptrNodeNameSuffix]); err != nil {
 		return err
 	}
 
@@ -322,60 +322,60 @@ func verifyPtrValueSomeCovered(node NodeInterface) error {
 }
 
 func verifyArryValueAllCovered(node NodeInterface) error {
-	if !node.getData().covered {
-		return errors.New("Node marked as not-covered. Expected to be covered")
+	if !node.GetData().Covered {
+		return errors.New("Node marked as not-Covered. Expected to be Covered")
 	}
 
-	child := node.getData().children["baseArr"]
-	if !child.getData().covered {
-		return errors.New("field:baseArr marked as not-covered. Expected to be covered")
+	child := node.GetData().Children["baseArr"]
+	if !child.GetData().Covered {
+		return errors.New("field:baseArr marked as not-Covered. Expected to be Covered")
 	}
 
-	if !child.getData().children["baseArr" + arrayNodeNameSuffix].getData().covered {
-		return errors.New("field:baseArr" + arrayNodeNameSuffix + " marked as not-covered. Expected to be covered" )
+	if !child.GetData().Children["baseArr" + arrayNodeNameSuffix].GetData().Covered {
+		return errors.New("field:baseArr" + arrayNodeNameSuffix + " marked as not-Covered. Expected to be Covered" )
 	}
 
-	child = node.getData().children["structArr"]
-	if !child.getData().covered {
-		return errors.New("field:structArr marked as not-covered. Expected to be covered")
+	child = node.GetData().Children["structArr"]
+	if !child.GetData().Covered {
+		return errors.New("field:structArr marked as not-Covered. Expected to be Covered")
 	}
 
-	child = child.getData().children["structArr" + arrayNodeNameSuffix]
-	if !child.getData().covered {
-		return errors.New("structArr" + arrayNodeNameSuffix + " marked as not-covered. Expected to be covered")
+	child = child.GetData().Children["structArr" + arrayNodeNameSuffix]
+	if !child.GetData().Covered {
+		return errors.New("structArr" + arrayNodeNameSuffix + " marked as not-Covered. Expected to be Covered")
 	}
 
-	if !child.getData().children["field1"].getData().covered {
-		return errors.New("structArr" + arrayNodeNameSuffix + ".field1 marked as not-covered. Expected to be covered")
+	if !child.GetData().Children["field1"].GetData().Covered {
+		return errors.New("structArr" + arrayNodeNameSuffix + ".field1 marked as not-Covered. Expected to be Covered")
 	}
 
-	if !child.getData().children["field2"].getData().covered {
-		return errors.New("structArr" + arrayNodeNameSuffix +".field1 marked as not-covered. Expected to be covered")
+	if !child.GetData().Children["field2"].GetData().Covered {
+		return errors.New("structArr" + arrayNodeNameSuffix +".field1 marked as not-Covered. Expected to be Covered")
 	}
 
 	return nil
 }
 
 func verifyArrValueSomeCovered(node NodeInterface) error {
-	if !node.getData().covered {
-		return errors.New("Node marked as not-covered. Expected to be covered")
+	if !node.GetData().Covered {
+		return errors.New("Node marked as not-Covered. Expected to be Covered")
 	}
 
-	child := node.getData().children["baseArr"]
-	if child.getData().covered {
-		return errors.New("field:baseArr marked as covered. Expected to be not-covered")
+	child := node.GetData().Children["baseArr"]
+	if child.GetData().Covered {
+		return errors.New("field:baseArr marked as Covered. Expected to be not-Covered")
 	}
 
-	if child.getData().children["baseArr" + arrayNodeNameSuffix].getData().covered {
-		return errors.New("field:baseArr" + arrayNodeNameSuffix + " marked as covered. Expected to be not-covered" )
+	if child.GetData().Children["baseArr" + arrayNodeNameSuffix].GetData().Covered {
+		return errors.New("field:baseArr" + arrayNodeNameSuffix + " marked as Covered. Expected to be not-Covered" )
 	}
 
-	child = node.getData().children["structArr"]
-	if !child.getData().covered {
-		return errors.New("field:structArr marked as not-covered. Expected to be covered")
+	child = node.GetData().Children["structArr"]
+	if !child.GetData().Covered {
+		return errors.New("field:structArr marked as not-Covered. Expected to be Covered")
 	}
 
-	if err := verifyBaseTypeValue("field:structArr" + arrayNodeNameSuffix, child.getData().children["structArr" + arrayNodeNameSuffix]); err != nil {
+	if err := verifyBaseTypeValue("field:structArr" + arrayNodeNameSuffix, child.GetData().Children["structArr" + arrayNodeNameSuffix]); err != nil {
 		return err
 	}
 
@@ -383,16 +383,16 @@ func verifyArrValueSomeCovered(node NodeInterface) error {
 }
 
 func verifyOtherTypeValue(node NodeInterface) error {
-	if !node.getData().covered {
-		return errors.New("Node marked as not-covered. Expected to be covered")
+	if !node.GetData().Covered {
+		return errors.New("Node marked as not-Covered. Expected to be Covered")
 	}
 
-	if !node.getData().children["structMap"].getData().covered {
-		return errors.New("field:structMap marked as not-covered. Expected to be covered")
+	if !node.GetData().Children["structMap"].GetData().Covered {
+		return errors.New("field:structMap marked as not-Covered. Expected to be Covered")
 	}
 
-	if node.getData().children["baseMap"].getData().covered {
-		return errors.New("field:baseMap marked as covered. Expected to be not-covered")
+	if node.GetData().Children["baseMap"].GetData().Covered {
+		return errors.New("field:baseMap marked as Covered. Expected to be not-Covered")
 	}
 
 	return nil

--- a/tools/webhook-apicoverage/resourcetree/timetypenode.go
+++ b/tools/webhook-apicoverage/resourcetree/timetypenode.go
@@ -26,25 +26,26 @@ import (
 // These are internally of type metav1.Time which use standard time type, but their values are specified as timestamp strings with parsing logic to create time objects. For
 // use-case we only care if the value is set, so we create TimeTypeNodes and mark them as leafnodes.
 type TimeTypeNode struct {
-	nodeData
+	NodeData
 }
 
-func (ti *TimeTypeNode) getData() nodeData {
-	return ti.nodeData
+// GetData returns node data
+func (ti *TimeTypeNode) GetData() NodeData {
+	return ti.NodeData
 }
 
 func (ti *TimeTypeNode) initialize(field string, parent NodeInterface, t reflect.Type, rt *ResourceTree) {
-	ti.nodeData.initialize(field, parent, t, rt)
-	ti.leafNode = true
+	ti.NodeData.initialize(field, parent, t, rt)
+	ti.LeafNode = true
 }
 
 func (ti *TimeTypeNode) buildChildNodes(t reflect.Type) {}
 
 func (ti *TimeTypeNode) updateCoverage(v reflect.Value) {
 	if v.Type().Kind() == reflect.Struct && v.IsValid() {
-		ti.covered = true
+		ti.Covered = true
 	} else if v.Type().Kind() == reflect.Ptr && !v.IsNil() {
-		ti.covered = true
+		ti.Covered = true
 	}
 }
 


### PR DESCRIPTION
NodeData type needs to be exported as writing rules requires access
to this type as we expect rules to be written per repo.