### PR TITLE
Remove mentions to the (now unused) general service account

### DIFF
--- a/ci/prow/boskos/config.yaml
+++ b/ci/prow/boskos/config.yaml
@@ -116,11 +116,11 @@ spec:
       - name: boskos-janitor
         image: gcr.io/k8s-testimages/janitor:v20180619-83c62c891
         args:
-        - --service-account=/etc/service-account/service-account.json
+        - --service-account=/etc/test-account/service-account.json
         - --resource-type=gke-project
         - --pool-size=10
         volumeMounts:
-        - mountPath: /etc/service-account
+        - mountPath: /etc/test-account
           name: service
           readOnly: true
       volumes:

--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -81,15 +81,9 @@ presets:
   - name: account
     secret:
       secretName: test-account
-  - name: service-account
-    secret:
-      secretName: service-account
   volumeMounts:
   - name: account
     mountPath: /etc/test-account
-    readOnly: true
-  - name: service-account
-    mountPath: /etc/service-account
     readOnly: true
 # nightly release service account
 - labels:
@@ -101,15 +95,9 @@ presets:
   - name: account
     secret:
       secretName: nightly-account
-  - name: service-account
-    secret:
-      secretName: service-account
   volumeMounts:
   - name: account
     mountPath: /etc/nightly-account
-    readOnly: true
-  - name: service-account
-    mountPath: /etc/service-account
     readOnly: true
 # versioned release service account
 - labels:
@@ -121,15 +109,9 @@ presets:
   - name: account
     secret:
       secretName: release-account
-  - name: service-account
-    secret:
-      secretName: service-account
   volumeMounts:
   - name: account
     mountPath: /etc/release-account
-    readOnly: true
-  - name: service-account
-    mountPath: /etc/service-account
     readOnly: true
 # backups service account
 - labels:


### PR DESCRIPTION
All jobs now use specific service accounts.