### PR TITLE
Don't keep a copy of test-infra in prow-tests

### DIFF
--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -46,8 +46,13 @@ RUN npm install -g markdown-link-check
 RUN gem install mixlib-config -v 2.2.4  # required because ruby is 2.1
 RUN gem install mdl
 
+# Temporarily add test-infra to the image to build custom tools
 ADD . /go/src/github.com/knative/test-infra
 
-# Extra custom tools
+# Build custom tools in the container
+RUN make -C /go/src/github.com/knative/test-infra/tools/githubhelper
 RUN cp /go/src/github.com/knative/test-infra/tools/githubhelper/githubhelper .
 RUN go install github.com/knative/test-infra/tools/dep-collector
+
+# Remove test-infra from the container
+RUN rm -fr /go/src/github.com/knative/test-infra

--- a/images/prow-tests/Makefile
+++ b/images/prow-tests/Makefile
@@ -18,7 +18,6 @@ TAG := $(shell date +v%Y%m%d)-$(shell git describe --always --dirty --match '^$$
 all: build
 
 build:
-	make -C ../../tools/githubhelper
 	docker build -t $(IMG):$(TAG) -f Dockerfile ../..
 	docker tag $(IMG):$(TAG) $(IMG):latest
 


### PR DESCRIPTION
Bonus: also build githubhelper in the container, for compatibility sake.

Fixes #406.