### PR TITLE
Add a presubmit job to run perf tests

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -314,6 +314,7 @@ presubmits:
       - name: github-token
         secret:
           secretName: covbot-token
+
   - name: pull-knative-serving-perf-tests
     agent: kubernetes
     context: pull-knative-serving-perf-tests
@@ -325,6 +326,7 @@ presubmits:
     skip_branches:  # Skip these branches, as test isn't available.
     - release-0.1
     - release-0.2
+    - release-0.3
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable

--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -317,7 +317,7 @@ presubmits:
   - name: pull-knative-serving-perf-tests
     agent: kubernetes
     context: pull-knative-serving-perf-tests
-    always_run: true
+    always_run: false
     rerun_command: "/test pull-knative-serving-perf-tests"
     trigger: "(?m)^/test (all|pull-knative-serving-perf-tests),?(\\s+|$)"
     labels:

--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -314,6 +314,32 @@ presubmits:
       - name: github-token
         secret:
           secretName: covbot-token
+  - name: pull-knative-serving-perf-tests
+    agent: kubernetes
+    context: pull-knative-serving-perf-tests
+    always_run: true
+    rerun_command: "/test pull-knative-serving-perf-tests"
+    trigger: "(?m)^/test (all|pull-knative-serving-perf-tests),?(\\s+|$)"
+    labels:
+      preset-test-account: "true"
+    skip_branches:  # Skip these branches, as test isn't available.
+    - release-0.1
+    - release-0.2
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        args:
+        - "--scenario=kubernetes_execute_bazel"
+        - "--clean"
+        - "--job=$(JOB_NAME)"
+        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+        - "--root=/go/src"
+        - "--service-account=/etc/test-account/service-account.json"
+        - "--upload=gs://knative-prow/pr-logs"
+        - "--" # end bootstrap args, scenario args below
+        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
+        - "./test/performance-tests.sh"
 
   knative/build:
   - name: pull-knative-build-build-tests


### PR DESCRIPTION
This just adds it to the config and allows us to test it on any PR's. Not adding this to list of auto running jobs per PR.