### PR TITLE
Do not lint or check links for deleted Markdown docs

### DIFF
--- a/scripts/presubmit-tests.sh
+++ b/scripts/presubmit-tests.sh
@@ -112,6 +112,14 @@ function markdown_build_tests() {
   (( DISABLE_MD_LINTING && DISABLE_MD_LINK_CHECK )) && return 0
   # Get changed markdown files (ignore /vendor)
   local mdfiles="$(echo "${CHANGED_FILES}" | grep \.md$ | grep -v ^vendor/)"
+  # Filter out deleted files
+  for file in $mdfiles; do
+    local existing_files=""
+    if [[ -f "$file" ]]; then
+      existing_files="$existing_files $file"
+    fi
+    mdfiles=existing_files
+  done
   [[ -z "${mdfiles}" ]] && return 0
   local failed=0
   if (( ! DISABLE_MD_LINTING )); then

--- a/scripts/presubmit-tests.sh
+++ b/scripts/presubmit-tests.sh
@@ -110,15 +110,10 @@ function run_build_tests() {
 # Perform markdown build tests if necessary, unless disabled.
 function markdown_build_tests() {
   (( DISABLE_MD_LINTING && DISABLE_MD_LINK_CHECK )) && return 0
-  # Get changed markdown files (ignore /vendor)
-  local mdfiles="$(echo "${CHANGED_FILES}" | grep \.md$ | grep -v ^vendor/)"
-  # Filter out deleted files
-  for file in $mdfiles; do
-    local existing_files=""
-    if [[ -f "$file" ]]; then
-      existing_files="$existing_files $file"
-    fi
-    mdfiles=existing_files
+  # Get changed markdown files (ignore /vendor and deleted files)
+  local mdfiles=""
+  for file in $(echo "${CHANGED_FILES}" | grep \.md$ | grep -v ^vendor/); do
+    [[ -f "{file}" ]] && mdfiles="${mdfiles} ${file}"
   done
   [[ -z "${mdfiles}" ]] && return 0
   local failed=0


### PR DESCRIPTION
Deleting a Markdown document results in a failed pre-submit test as it
attempts to lint and check the links of the document that no longer
exists.

See https://github.com/knative/serving/pull/2962 for example failure

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->