### PR TITLE
Adding MD024 rule for exclude

### DIFF
--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -366,7 +366,7 @@ function check_links_in_markdown() {
 # Parameters: $1..$n - files to inspect
 function lint_markdown() {
   # https://github.com/markdownlint/markdownlint
-  run_lint_tool mdl "linting markdown files" "-r ~MD013" $@
+  run_lint_tool mdl "linting markdown files" "-r ~MD013,~MD024" $@
 }
 
 # Return whether the given parameter is an integer.


### PR DESCRIPTION
When ignoring `MD024`, we are not getting bogus warnings about **Multiple headers with the same content** anymore.

This is sometimes needed. See this file:
https://github.com/knative/eventing/blob/master/docs/spec/interfaces.md#control-plane

IMO it's reasonable to have multiple Data Plane / Control Plane headers in one document, especially when that is in _different_ subsections

cc @evankanderson @grantr 