### PR TITLE
Allow customizing the markdown lint tool

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -22,6 +22,11 @@ This is a helper script to run the presubmit tests. To use it:
    `test-infra/scripts` directory. To override it, create a file with the same
    name, containing the custom config in the `/test` directory.
 
+   The markdown lint tool ignores long lines by default. Its configuration file,
+   `markdown-lint-config.rc`, lives in the `test-infra/scripts` directory. To
+   override it, create a file with the same name, containing the custom config
+   in the `/test` directory.
+
 1. [optional] Customize the default build test runner, if you're using it. Set
    the following environment variables if the default values don't fit your needs:
 

--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -366,7 +366,9 @@ function check_links_in_markdown() {
 # Parameters: $1..$n - files to inspect
 function lint_markdown() {
   # https://github.com/markdownlint/markdownlint
-  run_lint_tool mdl "linting markdown files" "-r ~MD013" $@
+  local config="${REPO_ROOT_DIR}/test/markdown-lint-config.rc"
+  [[ ! -e ${config} ]] && config="${_TEST_INFRA_SCRIPTS_DIR}/markdown-lint-config.rc"
+  run_lint_tool mdl "linting markdown files" "-c ${config}" $@
 }
 
 # Return whether the given parameter is an integer.

--- a/scripts/markdown-lint-config.rc
+++ b/scripts/markdown-lint-config.rc
@@ -1,0 +1,5 @@
+# For help, see
+# https://github.com/markdownlint/markdownlint/blob/master/docs/configuration.md 
+
+# Ignore long lines
+rules "~MD013"


### PR DESCRIPTION
* Ignore long lines by default (current behavior)
* Allow per-repo custom config in `/test`

Fixes #417.