### PR TITLE
Don't show server version when displaying test setup

### DIFF
--- a/scripts/presubmit-tests.sh
+++ b/scripts/presubmit-tests.sh
@@ -253,7 +253,7 @@ function main() {
     echo ">> gcloud SDK version"
     gcloud version
     echo ">> kubectl version"
-    kubectl version
+    kubectl version --client
     echo ">> go version"
     go version
     echo ">> git version"


### PR DESCRIPTION
It might not be available, specially on a local runs. Furthermore, it's not relevant as tests didn't start yet.

/cc @nbarthwal