### PR TITLE
Assorted fixes to e2e test infra

### DIFF
--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -206,6 +206,7 @@ function get_app_pods() {
 #             $3 - cluster region
 #             $4 - cluster zone, optional
 function acquire_cluster_admin_role() {
+  echo "Acquiring cluster-admin role for user '$1'"
   local geoflag="--region=$3"
   [[ -n $4 ]] && geoflag="--zone=$3-$4"
   # Get the password of the admin and use it, as the service account (or the user)

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -23,9 +23,6 @@
 # Calling this script without arguments will create a new cluster in
 # project $PROJECT_ID, run the tests and delete the cluster.
 
-# Use us-central1-f to reduce the pressure on us-central1-a
-E2E_CLUSTER_ZONE=f
-
 source $(dirname $0)/../scripts/e2e-tests.sh
 
 # Script entry point.


### PR DESCRIPTION
* stop using deprecate cluster creation flag in `kubetest`
* fix passing extra flags for cluster creation
* allow using gcloud beta features for cluster creation
* pass-through custom flags defined by the e2e script
* use 10GB disks in test cluster to save resources

Bonus:
* don't force zone f for e2e tests 