### PR TITLE
Run all e2e tests on us-west1

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -77,6 +77,8 @@ presets:
   env:
   - name: GOOGLE_APPLICATION_CREDENTIALS
     value: /etc/test-account/service-account.json
+  - name: E2E_CLUSTER_REGION
+    value: us-west1
   volumes:
   - name: account
     secret:
@@ -91,6 +93,8 @@ presets:
   env:
   - name: GOOGLE_APPLICATION_CREDENTIALS
     value: /etc/nightly-account/service-account.json
+  - name: E2E_CLUSTER_REGION
+    value: us-west1
   volumes:
   - name: account
     secret:
@@ -105,6 +109,8 @@ presets:
   env:
   - name: GOOGLE_APPLICATION_CREDENTIALS
     value: /etc/release-account/service-account.json
+  - name: E2E_CLUSTER_REGION
+    value: us-west1
   volumes:
   - name: account
     secret:


### PR DESCRIPTION
us-central1 is too busy and lately have been experiencing stockouts too frequently.