### PR TITLE
Remove GITHUB_BOT_TOKEN from Prow config

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -77,8 +77,6 @@ presets:
   env:
   - name: GOOGLE_APPLICATION_CREDENTIALS
     value: /etc/test-account/service-account.json
-  - name: GITHUB_BOT_TOKEN
-    value: /etc/test-account/github_bot_token
   - name: E2E_CLUSTER_REGION
     value: us-west1
   volumes:


### PR DESCRIPTION
Using an authenticated account doesn't solve #374.