### PR TITLE
Move fileHandle Close() invocation after error checking

### DIFF
--- a/shared/gcs/gcs.go
+++ b/shared/gcs/gcs.go
@@ -94,10 +94,10 @@ func Upload(ctx context.Context, bucketName, dstPath, srcPath string) error {
 		return err
 	}
 	dst := createStorageObject(bucketName, dstPath).NewWriter(ctx)
-	defer dst.Close()
 	if _, err = io.Copy(dst, src); nil != err {
 		return err
 	}
+	dst.Close()
 	return nil
 }
 
@@ -105,10 +105,10 @@ func Upload(ctx context.Context, bucketName, dstPath, srcPath string) error {
 func Read(ctx context.Context, bucketName, filePath string) ([]byte, error) {
 	var contents []byte
 	f, err := NewReader(ctx, bucketName, filePath)
-	defer f.Close()
 	if err != nil {
 		return contents, err
 	}
+	defer f.Close()
 	contents, err = ioutil.ReadAll(f)
 	if err != nil {
 		return contents, err

--- a/shared/prow/prow.go
+++ b/shared/prow/prow.go
@@ -280,10 +280,10 @@ func (b *Build) ParseLog(checkLog func(s []string) *string) ([]string, error) {
 	var logs []string
 
 	f, err := gcs.NewReader(ctx, b.Bucket, b.GetBuildLogPath())
-	defer f.Close()
 	if err != nil {
 		return logs, err
 	}
+	defer f.Close()
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
 		if s := checkLog(strings.Fields(scanner.Text())); s != nil {


### PR DESCRIPTION
There are currently a couple of places where Close() of fileHandle was invoked before error checking, which could cause NullReference error if the fileHandle is nil. Moving it below error checking to avoid this problem
