### PR TITLE
Check existence of GCS path should also work for directory path

### DIFF
--- a/shared/gcs/gcs.go
+++ b/shared/gcs/gcs.go
@@ -41,18 +41,17 @@ func Authenticate(ctx context.Context, serviceAccount string) error {
 	return err
 }
 
-// Exist checks if path exist under gcs bucket,
+// Exists checks if path exist under gcs bucket,
 // this path can either be a directory or a file.
-func Exist(ctx context.Context, bucketName, storagePath string) bool {
-	// Check if this is a directory,
-	// gcs directory paths are virtual paths, they automatically got deleted if there is no child file
-	it := getObjectsIter(ctx, bucketName, strings.TrimRight(storagePath, " /") + "/", "")
-	if _, err := it.Next(); nil == err {
-		return true
-	}
+func Exists(ctx context.Context, bucketName, storagePath string) bool {
 	// Check if this is a file
 	handle := createStorageObject(bucketName, storagePath)
-	_, err := handle.Attrs(ctx)
+	if _, err := handle.Attrs(ctx); nil == err {
+		return true
+	}
+	// Check if this is a directory,
+	// gcs directory paths are virtual paths, they automatically got deleted if there is no child file
+	_, err := getObjectsIter(ctx, bucketName, strings.TrimRight(storagePath, " /") + "/", "").Next()
 	return nil == err
 }
 

--- a/shared/prow/prow.go
+++ b/shared/prow/prow.go
@@ -236,12 +236,12 @@ func (j *Job) GetLatestBuilds(count int) []Build {
 
 // IsStarted check if build has started by looking at "started.json" file
 func (b *Build) IsStarted() bool {
-	return gcs.Exist(ctx, BucketName, path.Join(b.StoragePath, StartedJSON))
+	return gcs.Exists(ctx, BucketName, path.Join(b.StoragePath, StartedJSON))
 }
 
 // IsFinished check if build has finished by looking at "finished.json" file
 func (b *Build) IsFinished() bool {
-	return gcs.Exist(ctx, BucketName, path.Join(b.StoragePath, FinishedJSON))
+	return gcs.Exists(ctx, BucketName, path.Join(b.StoragePath, FinishedJSON))
 }
 
 // GetStartedTime gets started timestamp of a build,


### PR DESCRIPTION
Currently, existence of GCS path is implemented by looking at object handle, but GCS directories are virtual objects, so there is no object handle associated with it, thus it would return false if the path is a directory. This PR checks for both files and directories.