### PR TITLE
Make productivity oncall schedule visible to community

### DIFF
--- a/tools/oncall/oncall.html
+++ b/tools/oncall/oncall.html
@@ -31,15 +31,6 @@ function build_table(req) {
 		var person = oncall[key];
 		html += '<h2>' + key + ': ';
         //construct HTML content
-
-		if (person == "chaodai") {
-			person = "chaodaiG";
-		} else if (person == "syzf") { 
-			person = "steuhs";
-		} else if (person == "eklawitter") {
-			person = "ericKlawitter"; 
-		}
-
 		if (person) {
 			html += '<a href="https://github.com/' + person + '">';
 			html += person + '<img src="https://github.com/' + person + '.png?size=125"></a>';
@@ -51,7 +42,6 @@ function build_table(req) {
 
 	// trivial XSS, but storage.googleapis.com is even more trivial XSS!
 	document.getElementById('oncall').innerHTML = html;
-
 	document.getElementById('updated').innerText = req.getResponseHeader('date');
 }
 

--- a/tools/oncall/oncall.html
+++ b/tools/oncall/oncall.html
@@ -31,15 +31,7 @@ function build_table(req) {
 		var key = keys[i];
 		var person = oncall[key];
 		html += '<h2>' + key + ': ';
-
-        if (person == "chaodai") {
-            person = "chaodaiG";
-        } else if (person == "syzf") { 
-            person = "steuhs";
-        } else if (person == "eklawitter") {
-            person = "ericKlawitter"; 
-        }
-        
+        //construct HTML content
 		if (person) {
 			html += '<a href="https://github.com/' + person + '">';
 			html += person + '<img src="https://github.com/' + person + '.png?size=125"></a>';

--- a/tools/oncall/oncall.html
+++ b/tools/oncall/oncall.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<!-- To "deploy": gsutil cp -Z oncall.html gs://knative-infra-oncall/ -->
+<html>
+<script>
+// extracted/modified from kubernetes/test-infra/test-infra/maintenance/oncall.html
+function get(uri, callback) {
+	if (uri[0] === '/') {
+		// Matches /bucket/file/path -> [..., "bucket", "file/path"]
+		var groups = uri.match(/([^/:]+)\/(.*)/);
+		var bucket = groups[1], path = groups[2];
+		var url = 'https://www.googleapis.com/storage/v1/b/' + bucket + '/o/' +
+			encodeURIComponent(path) + '?alt=media';
+	} else {
+		var url = uri;
+	}
+	var req = new XMLHttpRequest();
+	req.open('GET', url);
+	req.onload = function(resp) {
+		callback(req);
+	}
+	req.send();
+}
+
+function build_table(req) {
+	var data = req.response;
+	var oncall = JSON.parse(data).Oncall;
+	var keys = Object.keys(oncall).sort();
+
+	var html = ''
+	for (var i = 0; i < keys.length; i++) {
+		var key = keys[i];
+		var person = oncall[key];
+		html += '<h2>' + key + ': ';
+
+        if (person == "chaodai") {
+            person = "chaodaiG";
+        } else if (person == "syzf") { 
+            person = "steuhs";
+        } else if (person == "eklawitter") {
+            person = "ericKlawitter"; 
+        }
+        
+		if (person) {
+			html += '<a href="https://github.com/' + person + '">';
+			html += person + '<img src="https://github.com/' + person + '.png?size=125"></a>';
+		} else {
+			html += 'None'
+		}
+		html += '</h2>';
+	}
+
+	// trivial XSS, but storage.googleapis.com is even more trivial XSS!
+	document.getElementById('oncall').innerHTML = html;
+
+	document.getElementById('updated').innerText = req.getResponseHeader('date');
+}
+
+get('oncall.json', build_table);
+</script>
+<title>Knative Tools/Infra Oncall Rotation</title>
+<style>
+body { background-color: #eee; padding-left: 30%; }
+img { padding-left: 10px; max-width: 125px; }
+</style>
+<body>
+<h1>Knative Tools/Infra Oncall Rotation</h1>
+<p>Updated: <span id="updated">Never</span></a>
+<div id="oncall">Loading...</div>
+<sub><a href="https://storage.googleapis.com/knative-infra-oncall/oncall.json">data source</a></sub>
+</body>
+</html>


### PR DESCRIPTION
This is the first part of creating an OSS community visible oncall schedule page. 
https://storage.googleapis.com/knative-infra-oncall/oncall.html

It reads from oncall.json which right now is hard coded to current oncall. This change allows community visibility, and the above url will be posted to knative slack. 

The next step is to auto-update oncall.json from google oncall scheduler. 

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #439 
