### PR TITLE
Don't lint links starting with /, ./, or ../

### DIFF
--- a/scripts/markdown-link-check-config.json
+++ b/scripts/markdown-link-check-config.json
@@ -4,7 +4,7 @@
             "pattern": "^https?://localhost($|[:/].*)"
         },
         {
-            "pattern": "^.?[/][\\w].*"
+            "pattern": "^(\\.|\\.\\.)?/.*"
         }
     ]
 }


### PR DESCRIPTION
We don't want lint to check links starting with `/`, `./`, or `../`, as this will falsely report dead links. This updates the regex to reflect these rules.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
