### PR TITLE
Group performance tests by target in TestGrid

### DIFF
--- a/ci/testgrid/config.yaml
+++ b/ci/testgrid/config.yaml
@@ -163,7 +163,7 @@ dashboards:
     base_options: 'include-filter-by-regex=test/conformance\.&sort-by-name='
   - name: performance
     test_group_name: ci-knative-serving-performance
-    base_options: 'exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name='
+    base_options: 'exclude-filter-by-regex=Overall$&group-by-target=&expand-groups=&sort-by-name='
 - name: knative-build
   dashboard_tab:
   - name: continuous


### PR DESCRIPTION
Currently performance tests are grouped by directory, which doesn't apply as 'group by directory' is intended for tests named after file names, and this is different from how performance tests are named. Change it to group by target, so that some of the tests can be grouped based on test targets