### PR TITLE
Create xml output from testcases for testgrid

### DIFF
--- a/shared/loadgenerator/loadgenerator.go
+++ b/shared/loadgenerator/loadgenerator.go
@@ -46,6 +46,7 @@ type GeneratorOptions struct {
 	Domain         string
 	RequestTimeout time.Duration
 	QPS            float64
+	AllowInitialErrors bool
 }
 
 // GeneratorResults contains the results of running the per test
@@ -73,7 +74,7 @@ func (g *GeneratorOptions) CreateRunnerOptions(resolvableDomain bool) *fhttp.HTT
 			QPS:         g.QPS,
 		},
 		HTTPOptions:        *o,
-		AllowInitialErrors: true,
+		AllowInitialErrors: g.AllowInitialErrors,
 	}
 }
 

--- a/shared/testgrid/testgrid.go
+++ b/shared/testgrid/testgrid.go
@@ -44,13 +44,16 @@ func createDir(dirPath string) error {
 }
 
 // CreateXMLOutput creates the junit xml file in the provided artifacts directory
-func CreateXMLOutput(testSuites *junit.TestSuites, testName string) error {
+func CreateXMLOutput(tc []junit.TestCase, testName string) error {
+	ts := junit.TestSuites{}
+	ts.AddTestSuite(&junit.TestSuite{Name: testName, TestCases: tc})
+
 	// ensure artifactsDir exist, in case not invoked from this script
 	artifactsDir := prow.GetLocalArtifactsDir()
 	if err := createDir(artifactsDir); nil != err {
 		return err
 	}
-	op, err := testSuites.ToBytes("", "  ")
+	op, err := ts.ToBytes("", "  ")
 	if err != nil {
 		return err
 	}

--- a/shared/testgrid/testgrid_test.go
+++ b/shared/testgrid/testgrid_test.go
@@ -39,7 +39,7 @@ func checkFileText(resultFile, expected string, t *testing.T) {
 		t.Fatalf("Failed to open test file: %v", err)
 	}
 	if s != expected {
-		t.Fatalf("Actual text: %s, Expected text: %s", s, expected)
+		t.Fatalf("Got:\n%s, Want:\n %s", s, expected)
 	}
 }
 
@@ -48,17 +48,17 @@ func TestXMLOutput(t *testing.T) {
 	defer os.Remove(resultFile)
 
 	// Create a test suites
-	testSuites := junit.TestSuites{}
+	tc := []junit.TestCase{}
+	want := `<testsuites>
+  <testsuite name="test" time="0" failures="0" tests="0">
+    <properties></properties>
+  </testsuite>
+</testsuites>
+`
 
 	// Create a test file
-	if err := testgrid.CreateXMLOutput(&testSuites, name); err != nil {
+	if err := testgrid.CreateXMLOutput(tc, name); err != nil {
 		t.Fatalf("Error when creating xml output file: %v", err)
 	}
-	checkFileText(resultFile, "<testsuites></testsuites>\n", t)
-
-	// Make sure we can append to the file
-	if err := testgrid.CreateXMLOutput(&testSuites, name); err != nil {
-		t.Fatalf("Error when creating xml output file: %v", err)
-	}
-	checkFileText(resultFile, "<testsuites></testsuites>\n<testsuites></testsuites>\n", t)
+	checkFileText(resultFile, want, t)
 }


### PR DESCRIPTION
This prevents every test to create a testsuite from the testcases and pass it in. 

Also, allow perf test to set AllowForInitialErrors. Do not default to false as the test will still indicate PASS even if it fails.

Part of https://github.com/knative/serving/issues/3154