### PR TITLE
Bash script unit tests don't print output if passed

### DIFF
--- a/test/unit/test-helper.sh
+++ b/test/unit/test-helper.sh
@@ -52,7 +52,7 @@ function test_function() {
       return 1
     fi
   fi
-  echo "'$@' returns code ${expected_retcode} and displays '${expected_string}'"
+  echo "'$@' returns code ${expected_retcode} and output matches with expected"
 }
 
 # Test helper that calls two functions in sequence.


### PR DESCRIPTION
Currently bash script unit tests print exit code and output to console when test passed. These outputs are sometimes treated as error messages by Gubernator, which could make it hard to find real errors in logs.
For example:
```
I0211 18:56:54.647] >> Testing flag parsing
I0211 18:56:54.654] 'parse_flags --version' returns code 1 and displays 'error: missing parameter'
I0211 18:56:54.661] 'parse_flags --version a' returns code 1 and displays 'error: version format'
I0211 18:56:54.668] 'parse_flags --version 0.0' returns code 1 and displays 'error: version format'
I0211 18:56:54.683] 'parse_flags --version 1.0.0' returns code 0 and displays ''
```
Lines 2 to 4 are marked as yellow in Gubernator as they contains "error"