### PR TITLE
webhook-apicoverage: apicovareage-recorder

### DIFF
--- a/tools/webhook-apicoverage/resourcetree/resourceforest.go
+++ b/tools/webhook-apicoverage/resourcetree/resourceforest.go
@@ -31,6 +31,16 @@ type ResourceForest struct {
 	ConnectedNodes map[string]*list.List // Head of the linked list keyed by nodeData.fieldType.pkg + nodeData.fieldType.Name()
 }
 
+// AddResourceTree adds a resource tree to the resource forest.
+func (r *ResourceForest) AddResourceTree(resourceName string, resourceType reflect.Type) {
+	tree := ResourceTree{
+		ResourceName: resourceName,
+		Forest: r,
+	}
+	tree.BuildResourceTree(resourceType)
+	r.TopLevelTrees[resourceName] = tree
+}
+
 // getConnectedNodeCoverage calculates the outlined coverage for a Type using ConnectedNodes linkedlist. We traverse through each element in the linkedlist and merge
 // coverage data into a single coveragecalculator.TypeCoverage object.
 func (r *ResourceForest) getConnectedNodeCoverage(fieldType reflect.Type, fieldRules FieldRules, ignoredFields coveragecalculator.IgnoredFields) (coveragecalculator.TypeCoverage) {

--- a/tools/webhook-apicoverage/webhook/README.md
+++ b/tools/webhook-apicoverage/webhook/README.md
@@ -22,9 +22,23 @@ providing following three parameters:
  e.g: knative-serving while calling this method would
  provide rules that will handle API Objects like `Service`,
  `Configuration`, `Route` and `Revision`.
-
+1. `namespace`: Namespace name where the webhook would be installed.
 1. `stop` channel: Channel to terminate webhook's web server.
 
 `SetupWebhook()` method in its implementation creates a TLS based web server
 and registers the webhook by creating a ValidatingWebhookConfiguration
 object inside the K8 cluster.
+
+[APICoverageRecorder](apicoverage_recorder.go) type inside the package
+encapsulates the apicoverage recording capabilities. Repo using this type
+is expected to set:
+
+1. `ResourceForest`: Specifying the version and initializing the [ResourceTrees](../resourcetree/resourcetree.go)
+1. `ResourceMap`: Identifying the resources whose APICoverage needs to be
+ calculated.
+1. `NodeRules`: [NodeRules](../resourcetree/rule.go) that are applicable for
+ the repo.
+1. `FieldRules`: [FieldRules](../resourcetree/rule.go) that are applicable for
+ the repo.
+1. `DisplayRules`: [DisplayRules](../view/jsontype_display.go) to be used by
+ `GetResourceCoverage` method.

--- a/tools/webhook-apicoverage/webhook/apicoverage_recorder.go
+++ b/tools/webhook-apicoverage/webhook/apicoverage_recorder.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"reflect"
+
+	"github.com/knative/pkg/webhook"
+	"github.com/knative/test-infra/tools/webhook-apicoverage/coveragecalculator"
+	"github.com/knative/test-infra/tools/webhook-apicoverage/resourcetree"
+	"github.com/knative/test-infra/tools/webhook-apicoverage/view"
+	"go.uber.org/zap"
+	"k8s.io/api/admission/v1beta1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+)
+
+var (
+	decoder = serializer.NewCodecFactory(runtime.NewScheme()).UniversalDeserializer()
+)
+
+const (
+	// ResourceQueryParam query param name to provide the resource.
+	ResourceQueryParam = "resource"
+)
+
+// APICoverageRecorder type contains resource tree to record API coverage for resources.
+type APICoverageRecorder struct {
+	Logger *zap.SugaredLogger
+	ResourceForest resourcetree.ResourceForest
+	ResourceMap map[schema.GroupVersionKind]webhook.GenericCRD
+	NodeRules resourcetree.NodeRules
+	FieldRules resourcetree.FieldRules
+	DisplayRules view.DisplayRules
+}
+
+// Init initializes the resources trees for set resources.
+func (a *APICoverageRecorder) Init() {
+	for resourceKind, resourceObj := range a.ResourceMap {
+		a.ResourceForest.AddResourceTree(resourceKind.Kind, reflect.ValueOf(resourceObj).Elem().Type())
+	}
+}
+
+// RecordResourceCoverage updates the resource tree with the request.
+func (a *APICoverageRecorder) RecordResourceCoverage(w http.ResponseWriter, r *http.Request) {
+	var (
+		body []byte
+		err error
+	)
+
+	if body, err = ioutil.ReadAll(r.Body); err != nil {
+		a.Logger.Errorf("Failed reading request body: %v", err)
+		a.writeAdmissionResponse(a.getAdmissionResponse(false, "Admission Denied"), w)
+		return
+	}
+
+	review := &v1beta1.AdmissionReview{}
+	if _, _, err := decoder.Decode(body, nil, review); err != nil {
+		a.Logger.Errorf("Unable to decode request: %v", err)
+		a.writeAdmissionResponse(a.getAdmissionResponse(false, "Admission Denied"), w)
+		return
+	}
+
+	gvk := schema.GroupVersionKind {
+		Group:   review.Request.Kind.Group,
+		Version: review.Request.Kind.Version,
+		Kind:    review.Request.Kind.Kind,
+	}
+	if err := json.Unmarshal(review.Request.Object.Raw, a.ResourceMap[gvk]); err != nil {
+		a.Logger.Errorf("Failed unmarshalling review.Request.Object.Raw for type: %s Error: %v", a.ResourceMap[gvk], err)
+		a.writeAdmissionResponse(a.getAdmissionResponse(false, "Admission Denied"), w)
+		return
+	}
+	resourceTree := a.ResourceForest.TopLevelTrees[gvk.Kind]
+	resourceTree.UpdateCoverage(reflect.ValueOf(a.ResourceMap[gvk]).Elem())
+	a.writeAdmissionResponse(a.getAdmissionResponse(true, "Welcome Aboard"), w)
+}
+
+func (a *APICoverageRecorder) getAdmissionResponse(allowed bool, message string) (*v1beta1.AdmissionResponse) {
+	return &v1beta1.AdmissionResponse{
+		Allowed: allowed,
+		Result: &v1.Status{
+			Message: message,
+		},
+	}
+}
+
+func (a *APICoverageRecorder) writeAdmissionResponse(admissionResp *v1beta1.AdmissionResponse, w http.ResponseWriter) {
+	responseInBytes, err := json.Marshal(admissionResp)
+	if err != nil {
+		a.Logger.Errorf("Failing mashalling review response: %v", err)
+	}
+
+	if _, err := w.Write(responseInBytes); err != nil {
+		a.Logger.Errorf("%v", err)
+	}
+}
+
+// GetResourceCoverage retrieves resource coverage data for the passed in resource via query param.
+func (a *APICoverageRecorder) GetResourceCoverage(w http.ResponseWriter, r *http.Request) {
+	resource := r.URL.Query().Get(ResourceQueryParam)
+	if _, ok := a.ResourceForest.TopLevelTrees[resource]; !ok {
+		fmt.Fprintf(w, "Resource information not found for resource: %s", resource)
+		return
+	}
+
+	var ignoredFields coveragecalculator.IgnoredFields
+	ignoredFieldsFilePath := os.Getenv("KO_DATA_PATH") + "/ignoredfields.yaml"
+	if err := ignoredFields.ReadFromFile(ignoredFieldsFilePath); err != nil {
+		fmt.Fprintf(w, "Error reading file: %s", ignoredFieldsFilePath)
+	}
+
+	tree := a.ResourceForest.TopLevelTrees[resource]
+	typeCoverage := tree.BuildCoverageData(a.NodeRules, a.FieldRules, ignoredFields)
+
+	jsonLikeDisplay := view.GetJSONTypeDisplay(typeCoverage, a.DisplayRules)
+	fmt.Fprint(w, jsonLikeDisplay)
+}


### PR DESCRIPTION
This changeset adds code that would be used across all repos for apicoverage calculations. Specifically this adds APICoverageRecorder type and helper methods around building webhook configuration.

ResourceForest type is all appended by a helper method to add resource tree.
