### PR TITLE
Flaky test reporting(part #2): define data structure and data collection

### DIFF
--- a/shared/prow/prow.go
+++ b/shared/prow/prow.go
@@ -151,8 +151,8 @@ func NewJob(jobName, jobType, repoName string, pullID int) *Job {
 	return &job
 }
 
-// Exists checks if the storage path of a job exists in gcs or not
-func (j *Job) Exists() bool {
+// PathExists checks if the storage path of a job exists in gcs or not
+func (j *Job) PathExists() bool {
 	return gcs.Exists(ctx, BucketName, j.StoragePath)
 }
 

--- a/shared/prow/prow.go
+++ b/shared/prow/prow.go
@@ -151,6 +151,11 @@ func NewJob(jobName, jobType, repoName string, pullID int) *Job {
 	return &job
 }
 
+// Exists checks if the storage path of a job exists in gcs or not
+func (j *Job) Exists() bool {
+	return gcs.Exists(ctx, BucketName, j.StoragePath)
+}
+
 // GetLatestBuildNumber gets the latest build number for job
 func (j *Job) GetLatestBuildNumber() (int, error) {
 	logFilePath := path.Join(j.StoragePath, Latest)
@@ -263,6 +268,11 @@ func (b *Build) GetFinishTime() (int64, error) {
 	return finished.Timestamp, nil
 }
 
+// GetArtifacts gets gcs path for all artifacts of current build
+func (b *Build) GetArtifacts() []string {
+	return gcs.ListDirectChildren(ctx, BucketName, b.GetArtifactsDir())
+}
+
 // GetArtifactsDir gets gcs path for artifacts of current build
 func(b *Build) GetArtifactsDir() string {
 	return path.Join(b.StoragePath, ArtifactsDir)
@@ -271,6 +281,12 @@ func(b *Build) GetArtifactsDir() string {
 // GetBuildLogPath gets "build-log.txt" path for current build
 func (b *Build) GetBuildLogPath() string {
 	return path.Join(b.StoragePath, BuildLog)
+}
+
+// ReadFile reads given file of current build,
+// relPath is the file path relative to build directory
+func (b *Build) ReadFile(relPath string) ([]byte, error) {
+	return gcs.Read(ctx, BucketName, path.Join(b.StoragePath, relPath))
 }
 
 // ParseLog parses the build log and returns the lines where the checkLog func does not return an empty slice,

--- a/tools/flaky-test-reporter/config.go
+++ b/tools/flaky-test-reporter/config.go
@@ -23,12 +23,15 @@ import (
 )
 
 const (
-	buildsCount         = 10 // Builds to be analyzed
-	requiredCount       = 8 // Minimal number of results to be counted as valid results for each testcase
-	threshold           = 0.05 // Don't do anything if found more than 5% tests flaky
+	// Builds to be analyzed, this is an arbitrary number
+	buildsCount         = 10
+	// Minimal number of results to be counted as valid results for each testcase, this is an arbitrary number
+	requiredCount       = 8
+	// Don't do anything if found more than 5% tests flaky, this is an arbitrary number
+	threshold           = 0.05
 )
 
 // jobConfigs defines which job to be monitored for giving repo
 var jobConfigs = []JobConfig{
-	{"ci-knative-serving-continuous", "serving", prow.PostsubmitJob},
+	{"ci-knative-serving-continuous", "serving", prow.PostsubmitJob}, // CI flow for serving repo
 }

--- a/tools/flaky-test-reporter/config.go
+++ b/tools/flaky-test-reporter/config.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// config.go contains data structure shared by all components of this package
+
+package main
+
+import (
+	"github.com/knative/test-infra/shared/prow"
+)
+
+const (
+	buildsCount         = 10 // Builds to be analyzed
+	requiredCount       = 8 // Minimal number of results to be counted as valid results for each testcase
+	threshold           = 0.05 // Don't do anything if found more than 5% tests flaky
+)
+
+var jobConfigs = []jobConfig{
+	{"ci-knative-serving-continuous", "serving", prow.PostsubmitJob},
+}

--- a/tools/flaky-test-reporter/config.go
+++ b/tools/flaky-test-reporter/config.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// config.go contains data structure shared by all components of this package
+// config.go contains configurations for flaky tests reporting
 
 package main
 
@@ -28,6 +28,7 @@ const (
 	threshold           = 0.05 // Don't do anything if found more than 5% tests flaky
 )
 
-var jobConfigs = []jobConfig{
+// jobConfigs defines which job to be monitored for giving repo
+var jobConfigs = []JobConfig{
 	{"ci-knative-serving-continuous", "serving", prow.PostsubmitJob},
 }

--- a/tools/flaky-test-reporter/main.go
+++ b/tools/flaky-test-reporter/main.go
@@ -55,13 +55,13 @@ func main() {
 		log.Printf("collecting results for repo '%s'\n", jc.Repo)
 		rd, err := collectTestResultsForRepo(&jc)
 		if nil != err {
-			log.Printf("Error collecting results for repo: %v", err)
-			continue
+			log.Fatalf("Error collecting results for repo '%s': %v", jc.Repo, err)
 		}
 		if err = createArtifactForRepo(rd); nil != err {
-			log.Printf("%s", err.Error())
-			continue
+			log.Fatalf("Error creating artifacts for repo '%s': %v", jc.Repo, err)
 		}
 		repoDataAll = append(repoDataAll, rd)
 	}
+
+	// TODO(chaodaiG): pass repoDataAll to functions for Github issues tracking and Slack notification
 }

--- a/tools/flaky-test-reporter/main.go
+++ b/tools/flaky-test-reporter/main.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// flaky-test-reporter collects test results from continuous flows,
+// identifies flaky tests, tracking flaky tests related github issues, 
+// and sends slack notifications.
+
+package main
+
+import (
+	"flag"
+	"log"
+	"os"
+
+	"github.com/knative/test-infra/shared/prow"
+)
+
+func main() {
+	serviceAccount := flag.String("service-account", os.Getenv("GOOGLE_APPLICATION_CREDENTIALS"), "JSON key file for service account to use")
+	dryrun         := flag.Bool("dry-run", false, "dry run switch")
+	flag.Parse()
+
+	if nil != dryrun && true == *dryrun {
+		log.Printf("running in [dry run mode]")
+	}
+	
+	prow.Initialize(*serviceAccount) // Explicit authenticate with gcs Client
+
+	// Clean up local artifacts directory, this will be used later for artifacts uploads
+	err := os.RemoveAll(prow.GetLocalArtifactsDir()) // this function returns nil if path not found
+	if nil == err {
+		if _, err = os.Stat(prow.GetLocalArtifactsDir()); os.IsNotExist(err) {
+			err = os.MkdirAll(prow.GetLocalArtifactsDir(), 0777)
+		}
+	}
+	if nil != err {
+		log.Fatalf("Failed preparing local artifacts directory: %v", err)
+	}
+
+	var repoDataAll []*RepoData
+	for _, jc := range jobConfigs {
+		log.Printf("collecting results for repo '%s'\n", jc.Repo)
+		rd, err := collectTestResultsForRepo(&jc)
+		if nil != err {
+			log.Printf("Error collecting results for repo: %v", err)
+			continue
+		}
+		if err = createArtifactForRepo(rd); nil != err {
+			log.Printf("%s", err.Error())
+			continue
+		}
+		repoDataAll = append(repoDataAll, rd)
+	}
+}

--- a/tools/flaky-test-reporter/result.go
+++ b/tools/flaky-test-reporter/result.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// result.go contains structs and functions for common results
+
+package main
+
+import (
+	"strings"
+	"strconv"
+	"log"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/knative/test-infra/shared/junit"
+)
+
+const (
+	buildsCount         = 10 // Builds to be analyzed
+	requiredCount       = 8 // Minimal number of results to be counted as valid results for each testcase
+	threshold           = 0.05 // Don't do anything if found more than 5% tests flaky
+)
+
+// repoData struct contains all configurations and test results for a repo
+type repoData struct {
+	config *jobConfig
+	testStats []*testStat
+	buildIDs  []int // all build IDs scanned in this run
+	lastBuildStartTime *int64 // useful for 
+}
+
+// jobConfig is initial configuration for a given repo, defines which job to scan
+type jobConfig struct {
+	name  string
+	repo  string
+	t     string // Use shorthand as "type" is a reserved name
+}
+
+// testStat represents test results of a single testcase across all builds,
+// passed, skipped and failed contains buildIDs with corresponding results
+type testStat struct {
+	testName string
+	passed   []int
+	skipped  []int
+	failed   []int
+}
+
+func (ts *testStat) isValid() bool {
+	return len(ts.passed) + len(ts.failed) >= requiredCount
+}
+
+func (ts *testStat) isFlaky() bool {
+	return ts.isValid() && len(ts.failed) > 0
+}
+
+func (ts *testStat) isPassed() bool {
+	return ts.isValid() && len(ts.failed) == 0
+}
+
+func readFromJunitFile(filePath string) *junit.TestSuites {
+	contents, err := ioutil.ReadFile(filePath)
+	if nil != err {
+		log.Fatalf("%v", err)
+		return nil
+	}
+	suites, err := junit.UnMarshal(contents)
+	if nil != err {
+		log.Fatalf("%v", err)
+		return nil
+	}
+	return suites
+}


### PR DESCRIPTION
Since flaky test reporting is designed to do both Github issues tracking and Slack notification, defines a common data structure to be used by data collector, Github issues creator, and Slack notifier is needed. This PR:
- defines data structure for storing configuration and test results for a repo
- collecting data from continuous runs and feed them into the data structure defined above

Part of: #132 