### PR TITLE
Bump plank version from 20180709-7109caeb1 to 20190109-716fe27

### DIFF
--- a/ci/prow/cluster.yaml
+++ b/ci/prow/cluster.yaml
@@ -148,7 +148,7 @@ spec:
       serviceAccountName: "plank"
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:v20180709-7109caeb1
+        image: gcr.io/k8s-prow/plank:v20190109-716fe27
         args:
         - --dry-run=false
         volumeMounts:


### PR DESCRIPTION
Timeout configuration override in `ci-knative-cleanup` job didn't work, as it uses latest configuration format, but our Prow instance is using an old version of plank. Bump plank version so that it can work.