### PR TITLE
Add some defaults to non mandatory values for loadgenerator

### DIFF
--- a/shared/loadgenerator/loadgenerator.go
+++ b/shared/loadgenerator/loadgenerator.go
@@ -31,10 +31,12 @@ import (
 )
 
 const (
-	p50     = 50.0
-	p90     = 90.0
-	p99     = 99.0
-	jsonExt = ".json"
+	p50      = 50.0
+	p90      = 90.0
+	p99      = 99.0
+	duration = 1 * time.Minute
+	qps 	 = 10
+	jsonExt  = ".json"
 )
 
 // GeneratorOptions provides knobs to run the perf test
@@ -54,8 +56,20 @@ type GeneratorResults struct {
 	Result *fhttp.HTTPRunnerResults
 }
 
+// addDefaults adds default values to non mandatory params
+func (g *GeneratorOptions) addDefaults() {
+	if (g.RequestTimeout == 0) {
+		g.RequestTimeout = duration
+	}
+
+	if (g.QPS == 0) {
+		g.QPS = qps
+	}
+}
+
 // CreateRunnerOptions sets up the fortio client with the knobs needed to run the load test
 func (g *GeneratorOptions) CreateRunnerOptions(resolvableDomain bool) *fhttp.HTTPRunnerOptions {
+	g.addDefaults()
 	o := fhttp.NewHTTPOptions(g.URL)
 
 	o.NumConnections = g.NumConnections

--- a/shared/loadgenerator/loadgenerator_test.go
+++ b/shared/loadgenerator/loadgenerator_test.go
@@ -39,7 +39,6 @@ func getOptions() *loadgenerator.GeneratorOptions {
 		NumConnections: testNum,
 		URL:            testUrl,
 		Domain:         testUrl,
-		RequestTimeout: testTime,
 		QPS:            testQPS,
 	}
 }


### PR DESCRIPTION
Since we defines these in the struct, we are setting these values to 0 by default, causing the timeout and QPS to be 0. This causes fortio to fail as soon as it sends a request. 

This should fix the library defaults for https://github.com/knative/serving/issues/3154