### PR TITLE
update release yaml path from build

### DIFF
--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -27,7 +27,7 @@ readonly KNATIVE_BASE_YAML_SOURCE=https://storage.googleapis.com/knative-nightly
 readonly KNATIVE_ISTIO_CRD_YAML=${KNATIVE_BASE_YAML_SOURCE/@/serving}/istio-crds.yaml
 readonly KNATIVE_ISTIO_YAML=${KNATIVE_BASE_YAML_SOURCE/@/serving}/istio.yaml
 readonly KNATIVE_SERVING_RELEASE=${KNATIVE_BASE_YAML_SOURCE/@/serving}/serving.yaml
-readonly KNATIVE_BUILD_RELEASE=${KNATIVE_BASE_YAML_SOURCE/@/build}/release.yaml
+readonly KNATIVE_BUILD_RELEASE=${KNATIVE_BASE_YAML_SOURCE/@/build}/build.yaml
 readonly KNATIVE_EVENTING_RELEASE=${KNATIVE_BASE_YAML_SOURCE/@/eventing}/release.yaml
 
 # Conveniently set GOPATH if unset


### PR DESCRIPTION
CI in eventing and build-templates are both failing due to `release.yaml` renamed  to `build.yaml` at Jan 11th. The reason why it was not broken in the past month was because the old `release.yaml` published a month back was not cleaned. It started failing as now the old files are deleted yesterday.

Part of: https://github.com/knative/eventing/issues/804