### PR TITLE
Remove unnecessary bundling: serving and build, and build and istio.

### DIFF
--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -281,7 +281,6 @@ function start_latest_knative_serving() {
   echo "Installing Serving from ${KNATIVE_SERVING_RELEASE}"
   kubectl apply -f ${KNATIVE_SERVING_RELEASE} || return 1
   wait_until_pods_running knative-serving || return 1
-  wait_until_pods_running knative-build || return 1
 }
 
 # Install the latest stable Knative/build in the current cluster.

--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -277,9 +277,6 @@ function start_latest_knative_serving() {
   kubectl apply -f ${KNATIVE_ISTIO_YAML} || return 1
   wait_until_pods_running istio-system || return 1
   kubectl label namespace default istio-injection=enabled || return 1
-  subheader "Installing Knative Build"
-  echo "Installing Build from ${KNATIVE_BUILD_RELEASE}"
-  kubectl apply -f ${KNATIVE_BUILD_RELEASE} || return 1
   subheader "Installing Knative Serving"
   echo "Installing Serving from ${KNATIVE_SERVING_RELEASE}"
   kubectl apply -f ${KNATIVE_SERVING_RELEASE} || return 1
@@ -290,10 +287,6 @@ function start_latest_knative_serving() {
 # Install the latest stable Knative/build in the current cluster.
 function start_latest_knative_build() {
   header "Starting Knative Build"
-  subheader "Installing Istio"
-  echo "Installing Istio from ${KNATIVE_ISTIO_YAML}"
-  kubectl apply -f ${KNATIVE_ISTIO_YAML} || return 1
-  wait_until_pods_running istio-system || return 1
   subheader "Installing Knative Build"
   echo "Installing Build from ${KNATIVE_BUILD_RELEASE}"
   kubectl apply -f ${KNATIVE_BUILD_RELEASE} || return 1


### PR DESCRIPTION
Related to https://github.com/knative/eventing/issues/804 -- eventing doesn't need build at all, and build doesn't depend on istio, so clean that up, too. (We may need to add an "install only istio" step somewhere, but I don't see where yet.)

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->