### PR TITLE
Default build test skips checking license if there is no go code

### DIFF
--- a/scripts/presubmit-tests.sh
+++ b/scripts/presubmit-tests.sh
@@ -139,6 +139,9 @@ function default_build_test_runner() {
   markdown_build_tests || failed=1
   # For documentation PRs, just check the md files
   (( IS_DOCUMENTATION_PR )) && return ${failed}
+  # Skip build test if there is no go code
+  local go_pkg_dirs="$(go list ./...)"
+  [[ -z "${go_pkg_dirs}" ]] && return ${failed}
   # Ensure all the code builds
   subheader "Checking that go code builds"
   go build -v ./... || failed=1
@@ -154,7 +157,7 @@ function default_build_test_runner() {
   fi
   # Check that we don't have any forbidden licenses in our images.
   subheader "Checking for forbidden licenses"
-  check_licenses $(go list ./...) || failed=1
+  check_licenses ${go_pkg_dirs} || failed=1
   return ${failed}
 }
 


### PR DESCRIPTION
build test default test runner could fail at checking licenses step if there is no go code exists in a repo, as it's expecting at least one path passed in as parameter. Skipping checking licenses if there is no go code, skipping build as well