### PR TITLE
let 0 statement go file pass coverage threshold

### DIFF
--- a/tools/coverage/calc/base.go
+++ b/tools/coverage/calc/base.go
@@ -147,6 +147,7 @@ func (c *Coverage) IsCoverageLow(covThresholdInt int) bool {
 	if err == nil {
 		return ratio < covThreshold
 	}
+	// go file with no statement should not be marked as low coverage file
 	return false
 }
 

--- a/tools/coverage/calc/base.go
+++ b/tools/coverage/calc/base.go
@@ -147,7 +147,7 @@ func (c *Coverage) IsCoverageLow(covThresholdInt int) bool {
 	if err == nil {
 		return ratio < covThreshold
 	}
-	return true
+	return false
 }
 
 func SortCoverages(cs []Coverage) {

--- a/tools/coverage/calc/delta.go
+++ b/tools/coverage/calc/delta.go
@@ -112,16 +112,18 @@ func (changes *GroupChanges) processChangedFiles(
 		pathFromProfile := githubUtil.FilePathProfileToGithub(inc.base.Name())
 		fmt.Printf("checking if this file is in github change list: %s", pathFromProfile)
 		if (*githubFilePaths)[pathFromProfile] == true {
-			fmt.Printf("\tYes!\n")
+			fmt.Printf("\tYes!")
 			*rows = append(*rows, inc.githubBotRow(i, pathFromProfile))
 			*isEmpty = false
 
 			if inc.new.IsCoverageLow(covThres) {
+				fmt.Printf("\t(Coverage low!)")
 				*isCoverageLow = true
 			}
 		} else {
-			fmt.Printf("\tNo\n")
+			fmt.Printf("\tNo")
 		}
+		fmt.Printf("\n")
 	}
 	fmt.Println("End of Finding joining set of changed files from profile & github")
 	return


### PR DESCRIPTION
1. Go file with no statement should not be marked as low coverage file.
2. Added logs when a file is marked as low coverage file. This will help debugging to see if a file is marked wrongly

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #
