### PR TITLE
Make --run-test skip unnecessary testing on presubmit

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -223,6 +223,7 @@ presubmits:
         - "./test/presubmit-tests.sh"
         - "--run-test"
         - "./test/e2e-tests.sh"
+        - "--run-presubmit-tests"
 
   - name: pull-knative-serving-upgrade-tests
     agent: kubernetes

--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -223,7 +223,6 @@ presubmits:
         - "./test/presubmit-tests.sh"
         - "--run-test"
         - "./test/e2e-tests.sh"
-        - "--run-presubmit-tests"
 
   - name: pull-knative-serving-upgrade-tests
     agent: kubernetes

--- a/scripts/presubmit-tests.sh
+++ b/scripts/presubmit-tests.sh
@@ -238,6 +238,7 @@ function default_integration_test_runner() {
 RUN_BUILD_TESTS=0
 RUN_UNIT_TESTS=0
 RUN_INTEGRATION_TESTS=0
+RUN_PRESUBMIT_TESTS=0
 EMIT_METRICS=0
 
 # Process flags and run tests accordingly.
@@ -279,6 +280,7 @@ function main() {
       --build-tests) RUN_BUILD_TESTS=1 ;;
       --unit-tests) RUN_UNIT_TESTS=1 ;;
       --integration-tests) RUN_INTEGRATION_TESTS=1 ;;
+      --run-presubmit-tests) RUN_PRESUBMIT_TESTS=1 ;;
       --emit-metrics) EMIT_METRICS=1 ;;
       --all-tests)
         RUN_BUILD_TESTS=1
@@ -298,6 +300,7 @@ function main() {
   readonly RUN_BUILD_TESTS
   readonly RUN_UNIT_TESTS
   readonly RUN_INTEGRATION_TESTS
+  readonly RUN_PRESUBMIT_TESTS
   readonly EMIT_METRICS
   readonly TEST_TO_RUN
 
@@ -311,6 +314,7 @@ function main() {
     if (( RUN_BUILD_TESTS || RUN_UNIT_TESTS || RUN_INTEGRATION_TESTS )); then
       abort "--run-test must be used alone"
     fi
+    (( RUN_PRESUBMIT_TESTS )) && (( IS_DOCUMENTATION_PR )) && exit ${failed}
     ${TEST_TO_RUN} || failed=1
   fi
 

--- a/scripts/presubmit-tests.sh
+++ b/scripts/presubmit-tests.sh
@@ -238,7 +238,6 @@ function default_integration_test_runner() {
 RUN_BUILD_TESTS=0
 RUN_UNIT_TESTS=0
 RUN_INTEGRATION_TESTS=0
-RUN_PRESUBMIT_TESTS=0
 EMIT_METRICS=0
 
 # Process flags and run tests accordingly.
@@ -280,7 +279,6 @@ function main() {
       --build-tests) RUN_BUILD_TESTS=1 ;;
       --unit-tests) RUN_UNIT_TESTS=1 ;;
       --integration-tests) RUN_INTEGRATION_TESTS=1 ;;
-      --run-presubmit-tests) RUN_PRESUBMIT_TESTS=1 ;;
       --emit-metrics) EMIT_METRICS=1 ;;
       --all-tests)
         RUN_BUILD_TESTS=1
@@ -300,7 +298,6 @@ function main() {
   readonly RUN_BUILD_TESTS
   readonly RUN_UNIT_TESTS
   readonly RUN_INTEGRATION_TESTS
-  readonly RUN_PRESUBMIT_TESTS
   readonly EMIT_METRICS
   readonly TEST_TO_RUN
 
@@ -314,7 +311,8 @@ function main() {
     if (( RUN_BUILD_TESTS || RUN_UNIT_TESTS || RUN_INTEGRATION_TESTS )); then
       abort "--run-test must be used alone"
     fi
-    (( RUN_PRESUBMIT_TESTS )) && (( IS_DOCUMENTATION_PR )) && exit ${failed}
+    # If this is a presubmit run, but a documentation-only PR, don't run the test
+    (( IS_PRESUBMIT && IS_DOCUMENTATION_PR )) && exit 0
     ${TEST_TO_RUN} || failed=1
   fi
 


### PR DESCRIPTION
`presubmit-tests.sh` is used by both presubmit and continuous jobs, they don't always execute the same set of tests. Also add logic to skip running tests for documentation only PRs if it's presubmit test