### PR TITLE
Update go version to 1.12rc1 in prow-tests docker image

### DIFF
--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -29,6 +29,11 @@ RUN docker-credential-gcr configure-docker
 RUN apt-get install -y uuid-runtime  # for uuidgen
 RUN apt-get install -y rubygems  # for mdl
 
+# Update go version to 1.12rc1
+RUN go get golang.org/dl/go1.12rc1
+RUN go1.12rc1 download
+RUN cp $(which go1.12rc1) $(which go)
+
 # Extra tools through go get
 RUN go get -u github.com/google/go-containerregistry/cmd/ko
 RUN go get -u github.com/golang/dep/cmd/dep


### PR DESCRIPTION
A new feature in serving websockets need to use go1.12rc1 version. Instead of manually installing this version in serving repo, updating it in prow-tests image, so that all jobs use consistent go version

Related: https://github.com/knative/serving/pull/3240

Part of: #486 