### PR TITLE
Updates to the Prow config generator

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -71,87 +71,6 @@ tide:
     knative: squash
     knative/build-pipeline: rebase
   target_url: https://prow.knative.dev/tide
-presets:
-# test run service account
-- labels:
-    preset-test-account: "true"
-  env:
-  - name: GOOGLE_APPLICATION_CREDENTIALS
-    value: /etc/test-account/service-account.json
-  - name: E2E_CLUSTER_REGION
-    value: us-west1
-  volumes:
-  - name: account
-    secret:
-      secretName: test-account
-  volumeMounts:
-  - name: account
-    mountPath: /etc/test-account
-    readOnly: true
-# nightly release service account
-- labels:
-    preset-nightly-account: "true"
-  env:
-  - name: GOOGLE_APPLICATION_CREDENTIALS
-    value: /etc/nightly-account/service-account.json
-  - name: E2E_CLUSTER_REGION
-    value: us-west1
-  volumes:
-  - name: account
-    secret:
-      secretName: nightly-account
-  volumeMounts:
-  - name: account
-    mountPath: /etc/nightly-account
-    readOnly: true
-# versioned release service account
-- labels:
-    preset-release-account: "true"
-  env:
-  - name: GOOGLE_APPLICATION_CREDENTIALS
-    value: /etc/release-account/service-account.json
-  - name: E2E_CLUSTER_REGION
-    value: us-west1
-  volumes:
-  - name: account
-    secret:
-      secretName: release-account
-  - name: hub-token
-    secret:
-      secretName: hub-token
-  volumeMounts:
-  - name: account
-    mountPath: /etc/release-account
-    readOnly: true
-  - name: hub-token
-    mountPath: /etc/hub-token
-    readOnly: true
-# backups service account
-- labels:
-    preset-backup-account: "true"
-  env:
-  - name: GOOGLE_APPLICATION_CREDENTIALS
-    value: /etc/backup-account/service-account.json
-  volumes:
-  - name: account
-    secret:
-      secretName: backup-account
-  volumeMounts:
-  - name: account
-    mountPath: /etc/backup-account
-    readOnly: true
-# docker-in-docker presets
-- labels:
-    preset-dind-enabled: "true"
-  env:
-  - name: DOCKER_IN_DOCKER_ENABLED
-    value: "true"
-  volumes:
-  - name: docker-graph
-    emptyDir: {}
-  volumeMounts:
-  - name: docker-graph
-    mountPath: /docker-graph
 presubmits:
   knative/serving:
   - name: pull-knative-serving-build-tests
@@ -160,8 +79,6 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-knative-serving-build-tests"
     trigger: "(?m)^/test (all|pull-knative-serving-build-tests),?(\\s+|$)"
-    labels:
-      preset-test-account: "true"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -178,14 +95,25 @@ presubmits:
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--build-tests"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-west1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
   - name: pull-knative-serving-unit-tests
     agent: kubernetes
     context: pull-knative-serving-unit-tests
     always_run: true
     rerun_command: "/test pull-knative-serving-unit-tests"
     trigger: "(?m)^/test (all|pull-knative-serving-unit-tests),?(\\s+|$)"
-    labels:
-      preset-test-account: "true"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -202,14 +130,25 @@ presubmits:
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--unit-tests"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-west1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
   - name: pull-knative-serving-integration-tests
     agent: kubernetes
     context: pull-knative-serving-integration-tests
     always_run: true
     rerun_command: "/test pull-knative-serving-integration-tests"
     trigger: "(?m)^/test (all|pull-knative-serving-integration-tests),?(\\s+|$)"
-    labels:
-      preset-test-account: "true"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -227,14 +166,25 @@ presubmits:
         - "./test/presubmit-tests.sh"
         - "--run-test"
         - "./test/e2e-tests.sh"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-west1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
   - name: pull-knative-serving-upgrade-tests
     agent: kubernetes
     context: pull-knative-serving-upgrade-tests
     always_run: true
     rerun_command: "/test pull-knative-serving-upgrade-tests"
     trigger: "(?m)^/test (all|pull-knative-serving-upgrade-tests),?(\\s+|$)"
-    labels:
-      preset-test-account: "true"
     skip_branches:
     - "release-0.1"
     - "release-0.2"
@@ -255,9 +205,20 @@ presubmits:
         - "./test/presubmit-tests.sh"
         - "--run-test"
         - "./test/e2e-upgrade-tests.sh"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-west1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
   - name: pull-knative-serving-go-coverage
-    labels:
-      preset-test-account: "true"
     agent: kubernetes
     context: pull-knative-serving-go-coverage
     always_run: true
@@ -279,18 +240,16 @@ presubmits:
         - "--profile-name=coverage_profile.txt"
         - "--cov-target=."
         - "--cov-threshold-percentage=80"
-        - "--github-token=/etc/github-token/token"
+        - "--github-token=/etc/covbot-token/token"
         volumeMounts:
-        - name: github-token
-          mountPath: /etc/github-token
+        - name: covbot-token
+          mountPath: /etc/covbot-token
           readOnly: true
       volumes:
-      - name: github-token
+      - name: covbot-token
         secret:
           secretName: covbot-token
   - name: pull-knative-serving-go-coverage-dev
-    labels:
-      preset-test-account: "true"
     agent: kubernetes
     context: pull-knative-serving-go-coverage-dev
     always_run: false
@@ -312,13 +271,13 @@ presubmits:
         - "--profile-name=coverage_profile.txt"
         - "--cov-target=."
         - "--cov-threshold-percentage=80"
-        - "--github-token=/etc/github-token/token"
+        - "--github-token=/etc/covbot-token/token"
         volumeMounts:
-        - name: github-token
-          mountPath: /etc/github-token
+        - name: covbot-token
+          mountPath: /etc/covbot-token
           readOnly: true
       volumes:
-      - name: github-token
+      - name: covbot-token
         secret:
           secretName: covbot-token
   - name: pull-knative-serving-perf-tests
@@ -327,8 +286,6 @@ presubmits:
     always_run: false
     rerun_command: "/test pull-knative-serving-perf-tests"
     trigger: "(?m)^/test (all|pull-knative-serving-perf-tests),?(\\s+|$)"
-    labels:
-      preset-test-account: "true"
     skip_branches:
     - "release-0.1"
     - "release-0.2"
@@ -348,6 +305,19 @@ presubmits:
         - "--" # end bootstrap args, scenario args below
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/performance-tests.sh"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-west1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
   knative/build:
   - name: pull-knative-build-build-tests
     agent: kubernetes
@@ -355,8 +325,6 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-knative-build-build-tests"
     trigger: "(?m)^/test (all|pull-knative-build-build-tests),?(\\s+|$)"
-    labels:
-      preset-test-account: "true"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -373,14 +341,25 @@ presubmits:
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--build-tests"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-west1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
   - name: pull-knative-build-unit-tests
     agent: kubernetes
     context: pull-knative-build-unit-tests
     always_run: true
     rerun_command: "/test pull-knative-build-unit-tests"
     trigger: "(?m)^/test (all|pull-knative-build-unit-tests),?(\\s+|$)"
-    labels:
-      preset-test-account: "true"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -397,15 +376,25 @@ presubmits:
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--unit-tests"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-west1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
   - name: pull-knative-build-integration-tests
     agent: kubernetes
     context: pull-knative-build-integration-tests
     always_run: true
     rerun_command: "/test pull-knative-build-integration-tests"
     trigger: "(?m)^/test (all|pull-knative-build-integration-tests),?(\\s+|$)"
-    labels:
-      preset-test-account: "true"
-      preset-dind-enabled: "true"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -424,9 +413,26 @@ presubmits:
         - "--integration-tests"
         securityContext:
           privileged: true
+        volumeMounts:
+        - name: docker-graph
+          mountPath: /docker-graph
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: "true"
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-west1
+      volumes:
+      - name: docker-graph
+        emptyDir: {}
+      - name: test-account
+        secret:
+          secretName: test-account
   - name: pull-knative-build-go-coverage
-    labels:
-      preset-test-account: "true"
     agent: kubernetes
     context: pull-knative-build-go-coverage
     always_run: true
@@ -448,13 +454,13 @@ presubmits:
         - "--profile-name=coverage_profile.txt"
         - "--cov-target=."
         - "--cov-threshold-percentage=80"
-        - "--github-token=/etc/github-token/token"
+        - "--github-token=/etc/covbot-token/token"
         volumeMounts:
-        - name: github-token
-          mountPath: /etc/github-token
+        - name: covbot-token
+          mountPath: /etc/covbot-token
           readOnly: true
       volumes:
-      - name: github-token
+      - name: covbot-token
         secret:
           secretName: covbot-token
   knative/build-pipeline:
@@ -464,8 +470,6 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-knative-build-pipeline-build-tests"
     trigger: "(?m)^/test (all|pull-knative-build-pipeline-build-tests),?(\\s+|$)"
-    labels:
-      preset-test-account: "true"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -482,14 +486,25 @@ presubmits:
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--build-tests"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-west1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
   - name: pull-knative-build-pipeline-unit-tests
     agent: kubernetes
     context: pull-knative-build-pipeline-unit-tests
     always_run: true
     rerun_command: "/test pull-knative-build-pipeline-unit-tests"
     trigger: "(?m)^/test (all|pull-knative-build-pipeline-unit-tests),?(\\s+|$)"
-    labels:
-      preset-test-account: "true"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -506,14 +521,25 @@ presubmits:
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--unit-tests"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-west1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
   - name: pull-knative-build-pipeline-integration-tests
     agent: kubernetes
     context: pull-knative-build-pipeline-integration-tests
     always_run: true
     rerun_command: "/test pull-knative-build-pipeline-integration-tests"
     trigger: "(?m)^/test (all|pull-knative-build-pipeline-integration-tests),?(\\s+|$)"
-    labels:
-      preset-test-account: "true"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -530,9 +556,20 @@ presubmits:
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--integration-tests"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-west1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
   - name: pull-knative-build-pipeline-go-coverage
-    labels:
-      preset-test-account: "true"
     agent: kubernetes
     context: pull-knative-build-pipeline-go-coverage
     always_run: true
@@ -554,13 +591,13 @@ presubmits:
         - "--profile-name=coverage_profile.txt"
         - "--cov-target=."
         - "--cov-threshold-percentage=50"
-        - "--github-token=/etc/github-token/token"
+        - "--github-token=/etc/covbot-token/token"
         volumeMounts:
-        - name: github-token
-          mountPath: /etc/github-token
+        - name: covbot-token
+          mountPath: /etc/covbot-token
           readOnly: true
       volumes:
-      - name: github-token
+      - name: covbot-token
         secret:
           secretName: covbot-token
   knative/eventing:
@@ -570,8 +607,6 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-knative-eventing-build-tests"
     trigger: "(?m)^/test (all|pull-knative-eventing-build-tests),?(\\s+|$)"
-    labels:
-      preset-test-account: "true"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -588,14 +623,25 @@ presubmits:
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--build-tests"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-west1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
   - name: pull-knative-eventing-unit-tests
     agent: kubernetes
     context: pull-knative-eventing-unit-tests
     always_run: true
     rerun_command: "/test pull-knative-eventing-unit-tests"
     trigger: "(?m)^/test (all|pull-knative-eventing-unit-tests),?(\\s+|$)"
-    labels:
-      preset-test-account: "true"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -612,14 +658,25 @@ presubmits:
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--unit-tests"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-west1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
   - name: pull-knative-eventing-integration-tests
     agent: kubernetes
     context: pull-knative-eventing-integration-tests
     always_run: true
     rerun_command: "/test pull-knative-eventing-integration-tests"
     trigger: "(?m)^/test (all|pull-knative-eventing-integration-tests),?(\\s+|$)"
-    labels:
-      preset-test-account: "true"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -636,9 +693,20 @@ presubmits:
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--integration-tests"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-west1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
   - name: pull-knative-eventing-go-coverage
-    labels:
-      preset-test-account: "true"
     agent: kubernetes
     context: pull-knative-eventing-go-coverage
     always_run: true
@@ -660,13 +728,13 @@ presubmits:
         - "--profile-name=coverage_profile.txt"
         - "--cov-target=."
         - "--cov-threshold-percentage=50"
-        - "--github-token=/etc/github-token/token"
+        - "--github-token=/etc/covbot-token/token"
         volumeMounts:
-        - name: github-token
-          mountPath: /etc/github-token
+        - name: covbot-token
+          mountPath: /etc/covbot-token
           readOnly: true
       volumes:
-      - name: github-token
+      - name: covbot-token
         secret:
           secretName: covbot-token
   knative/eventing-sources:
@@ -676,8 +744,6 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-knative-eventing-sources-build-tests"
     trigger: "(?m)^/test (all|pull-knative-eventing-sources-build-tests),?(\\s+|$)"
-    labels:
-      preset-test-account: "true"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -694,14 +760,25 @@ presubmits:
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--build-tests"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-west1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
   - name: pull-knative-eventing-sources-unit-tests
     agent: kubernetes
     context: pull-knative-eventing-sources-unit-tests
     always_run: true
     rerun_command: "/test pull-knative-eventing-sources-unit-tests"
     trigger: "(?m)^/test (all|pull-knative-eventing-sources-unit-tests),?(\\s+|$)"
-    labels:
-      preset-test-account: "true"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -718,14 +795,25 @@ presubmits:
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--unit-tests"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-west1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
   - name: pull-knative-eventing-sources-integration-tests
     agent: kubernetes
     context: pull-knative-eventing-sources-integration-tests
     always_run: true
     rerun_command: "/test pull-knative-eventing-sources-integration-tests"
     trigger: "(?m)^/test (all|pull-knative-eventing-sources-integration-tests),?(\\s+|$)"
-    labels:
-      preset-test-account: "true"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -742,9 +830,20 @@ presubmits:
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--integration-tests"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-west1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
   - name: pull-knative-eventing-sources-go-coverage
-    labels:
-      preset-test-account: "true"
     agent: kubernetes
     context: pull-knative-eventing-sources-go-coverage
     always_run: true
@@ -766,13 +865,13 @@ presubmits:
         - "--profile-name=coverage_profile.txt"
         - "--cov-target=."
         - "--cov-threshold-percentage=50"
-        - "--github-token=/etc/github-token/token"
+        - "--github-token=/etc/covbot-token/token"
         volumeMounts:
-        - name: github-token
-          mountPath: /etc/github-token
+        - name: covbot-token
+          mountPath: /etc/covbot-token
           readOnly: true
       volumes:
-      - name: github-token
+      - name: covbot-token
         secret:
           secretName: covbot-token
   knative/docs:
@@ -782,8 +881,6 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-knative-docs-build-tests"
     trigger: "(?m)^/test (all|pull-knative-docs-build-tests),?(\\s+|$)"
-    labels:
-      preset-test-account: "true"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -800,14 +897,25 @@ presubmits:
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--build-tests"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-west1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
   - name: pull-knative-docs-unit-tests
     agent: kubernetes
     context: pull-knative-docs-unit-tests
     always_run: true
     rerun_command: "/test pull-knative-docs-unit-tests"
     trigger: "(?m)^/test (all|pull-knative-docs-unit-tests),?(\\s+|$)"
-    labels:
-      preset-test-account: "true"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -824,14 +932,25 @@ presubmits:
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--unit-tests"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-west1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
   - name: pull-knative-docs-integration-tests
     agent: kubernetes
     context: pull-knative-docs-integration-tests
     always_run: true
     rerun_command: "/test pull-knative-docs-integration-tests"
     trigger: "(?m)^/test (all|pull-knative-docs-integration-tests),?(\\s+|$)"
-    labels:
-      preset-test-account: "true"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -848,9 +967,20 @@ presubmits:
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--integration-tests"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-west1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
   - name: pull-knative-docs-go-coverage
-    labels:
-      preset-test-account: "true"
     agent: kubernetes
     context: pull-knative-docs-go-coverage
     always_run: true
@@ -872,13 +1002,13 @@ presubmits:
         - "--profile-name=coverage_profile.txt"
         - "--cov-target=."
         - "--cov-threshold-percentage=50"
-        - "--github-token=/etc/github-token/token"
+        - "--github-token=/etc/covbot-token/token"
         volumeMounts:
-        - name: github-token
-          mountPath: /etc/github-token
+        - name: covbot-token
+          mountPath: /etc/covbot-token
           readOnly: true
       volumes:
-      - name: github-token
+      - name: covbot-token
         secret:
           secretName: covbot-token
   knative/build-templates:
@@ -888,8 +1018,6 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-knative-build-templates-build-tests"
     trigger: "(?m)^/test (all|pull-knative-build-templates-build-tests),?(\\s+|$)"
-    labels:
-      preset-test-account: "true"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -906,14 +1034,25 @@ presubmits:
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--build-tests"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-west1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
   - name: pull-knative-build-templates-unit-tests
     agent: kubernetes
     context: pull-knative-build-templates-unit-tests
     always_run: true
     rerun_command: "/test pull-knative-build-templates-unit-tests"
     trigger: "(?m)^/test (all|pull-knative-build-templates-unit-tests),?(\\s+|$)"
-    labels:
-      preset-test-account: "true"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -930,14 +1069,25 @@ presubmits:
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--unit-tests"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-west1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
   - name: pull-knative-build-templates-integration-tests
     agent: kubernetes
     context: pull-knative-build-templates-integration-tests
     always_run: true
     rerun_command: "/test pull-knative-build-templates-integration-tests"
     trigger: "(?m)^/test (all|pull-knative-build-templates-integration-tests),?(\\s+|$)"
-    labels:
-      preset-test-account: "true"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -954,6 +1104,19 @@ presubmits:
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--integration-tests"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-west1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
   knative/pkg:
   - name: pull-knative-pkg-build-tests
     agent: kubernetes
@@ -961,8 +1124,6 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-knative-pkg-build-tests"
     trigger: "(?m)^/test (all|pull-knative-pkg-build-tests),?(\\s+|$)"
-    labels:
-      preset-test-account: "true"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -979,14 +1140,25 @@ presubmits:
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--build-tests"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-west1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
   - name: pull-knative-pkg-unit-tests
     agent: kubernetes
     context: pull-knative-pkg-unit-tests
     always_run: true
     rerun_command: "/test pull-knative-pkg-unit-tests"
     trigger: "(?m)^/test (all|pull-knative-pkg-unit-tests),?(\\s+|$)"
-    labels:
-      preset-test-account: "true"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1003,14 +1175,25 @@ presubmits:
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--unit-tests"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-west1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
   - name: pull-knative-pkg-integration-tests
     agent: kubernetes
     context: pull-knative-pkg-integration-tests
     always_run: true
     rerun_command: "/test pull-knative-pkg-integration-tests"
     trigger: "(?m)^/test (all|pull-knative-pkg-integration-tests),?(\\s+|$)"
-    labels:
-      preset-test-account: "true"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1027,9 +1210,20 @@ presubmits:
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--integration-tests"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-west1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
   - name: pull-knative-pkg-go-coverage
-    labels:
-      preset-test-account: "true"
     agent: kubernetes
     context: pull-knative-pkg-go-coverage
     always_run: true
@@ -1051,13 +1245,13 @@ presubmits:
         - "--profile-name=coverage_profile.txt"
         - "--cov-target=."
         - "--cov-threshold-percentage=50"
-        - "--github-token=/etc/github-token/token"
+        - "--github-token=/etc/covbot-token/token"
         volumeMounts:
-        - name: github-token
-          mountPath: /etc/github-token
+        - name: covbot-token
+          mountPath: /etc/covbot-token
           readOnly: true
       volumes:
-      - name: github-token
+      - name: covbot-token
         secret:
           secretName: covbot-token
   knative/test-infra:
@@ -1067,8 +1261,6 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-knative-test-infra-build-tests"
     trigger: "(?m)^/test (all|pull-knative-test-infra-build-tests),?(\\s+|$)"
-    labels:
-      preset-test-account: "true"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1085,14 +1277,25 @@ presubmits:
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--build-tests"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-west1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
   - name: pull-knative-test-infra-unit-tests
     agent: kubernetes
     context: pull-knative-test-infra-unit-tests
     always_run: true
     rerun_command: "/test pull-knative-test-infra-unit-tests"
     trigger: "(?m)^/test (all|pull-knative-test-infra-unit-tests),?(\\s+|$)"
-    labels:
-      preset-test-account: "true"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1109,14 +1312,25 @@ presubmits:
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--unit-tests"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-west1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
   - name: pull-knative-test-infra-integration-tests
     agent: kubernetes
     context: pull-knative-test-infra-integration-tests
     always_run: true
     rerun_command: "/test pull-knative-test-infra-integration-tests"
     trigger: "(?m)^/test (all|pull-knative-test-infra-integration-tests),?(\\s+|$)"
-    labels:
-      preset-test-account: "true"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1133,6 +1347,19 @@ presubmits:
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--integration-tests"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-west1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
   knative/caching:
   - name: pull-knative-caching-build-tests
     agent: kubernetes
@@ -1140,8 +1367,6 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-knative-caching-build-tests"
     trigger: "(?m)^/test (all|pull-knative-caching-build-tests),?(\\s+|$)"
-    labels:
-      preset-test-account: "true"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1158,14 +1383,25 @@ presubmits:
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--build-tests"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-west1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
   - name: pull-knative-caching-unit-tests
     agent: kubernetes
     context: pull-knative-caching-unit-tests
     always_run: true
     rerun_command: "/test pull-knative-caching-unit-tests"
     trigger: "(?m)^/test (all|pull-knative-caching-unit-tests),?(\\s+|$)"
-    labels:
-      preset-test-account: "true"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1182,14 +1418,25 @@ presubmits:
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--unit-tests"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-west1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
   - name: pull-knative-caching-integration-tests
     agent: kubernetes
     context: pull-knative-caching-integration-tests
     always_run: true
     rerun_command: "/test pull-knative-caching-integration-tests"
     trigger: "(?m)^/test (all|pull-knative-caching-integration-tests),?(\\s+|$)"
-    labels:
-      preset-test-account: "true"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1206,9 +1453,20 @@ presubmits:
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--integration-tests"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-west1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
   - name: pull-knative-caching-go-coverage
-    labels:
-      preset-test-account: "true"
     agent: kubernetes
     context: pull-knative-caching-go-coverage
     always_run: true
@@ -1230,21 +1488,19 @@ presubmits:
         - "--profile-name=coverage_profile.txt"
         - "--cov-target=."
         - "--cov-threshold-percentage=50"
-        - "--github-token=/etc/github-token/token"
+        - "--github-token=/etc/covbot-token/token"
         volumeMounts:
-        - name: github-token
-          mountPath: /etc/github-token
+        - name: covbot-token
+          mountPath: /etc/covbot-token
           readOnly: true
       volumes:
-      - name: github-token
+      - name: covbot-token
         secret:
           secretName: covbot-token
 periodics:
 - cron: "1 */2 * * *"
   name: ci-knative-serving-continuous
   agent: kubernetes
-  labels:
-    preset-test-account: "true"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1263,12 +1519,22 @@ periodics:
       - "./test/presubmit-tests.sh"
       - "--all-tests"
       - "--emit-metrics"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-west1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
 - cron: "15 8 * * *"
   name: ci-knative-serving-0.2-continuous
   agent: kubernetes
-  labels:
-    preset-test-account: "true"
-    preset-dind-enabled: "true"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1289,11 +1555,28 @@ periodics:
       - "--notag-release"
       securityContext:
         privileged: true
+      volumeMounts:
+      - name: docker-graph
+        mountPath: /docker-graph
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-west1
+    volumes:
+    - name: docker-graph
+      emptyDir: {}
+    - name: test-account
+      secret:
+        secretName: test-account
 - cron: "1 8 * * *"
   name: ci-knative-serving-nightly-release
   agent: kubernetes
-  labels:
-    preset-nightly-account: "true"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1312,11 +1595,22 @@ periodics:
       - "./hack/release.sh"
       - "--publish"
       - "--tag-release"
+      volumeMounts:
+      - name: nightly-account
+        mountPath: /etc/nightly-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/nightly-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-west1
+    volumes:
+    - name: nightly-account
+      secret:
+        secretName: nightly-account
 - cron: "1 9 * * 2"
   name: ci-knative-serving-dot-release
   agent: kubernetes
-  labels:
-    preset-release-account: "true"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1337,11 +1631,28 @@ periodics:
       - "--release-gcs knative-releases/serving"
       - "--release-gcr gcr.io/knative-releases"
       - "--github-token /etc/hub-token/token"
+      volumeMounts:
+      - name: hub-token
+        mountPath: /etc/hub-token
+        readOnly: true
+      - name: release-account
+        mountPath: /etc/release-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-west1
+    volumes:
+    - name: hub-token
+      secret:
+        secretName: hub-token
+    - name: release-account
+      secret:
+        secretName: release-account
 - cron: "3 */2 * * *"
   name: ci-knative-serving-auto-release
   agent: kubernetes
-  labels:
-    preset-release-account: "true"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1362,11 +1673,28 @@ periodics:
       - "--release-gcs knative-releases/serving"
       - "--release-gcr gcr.io/knative-releases"
       - "--github-token /etc/hub-token/token"
+      volumeMounts:
+      - name: hub-token
+        mountPath: /etc/hub-token
+        readOnly: true
+      - name: release-account
+        mountPath: /etc/release-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-west1
+    volumes:
+    - name: hub-token
+      secret:
+        secretName: hub-token
+    - name: release-account
+      secret:
+        secretName: release-account
 - cron: "1 9 * * 6"
   name: ci-knative-serving-playground
   agent: kubernetes
-  labels:
-    preset-test-account: "true"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1384,11 +1712,22 @@ periodics:
       - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./hack/deploy.sh"
       - "knative-playground"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-west1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
 - cron: "5 8 * * *"
   name: ci-knative-serving-latency
   agent: kubernetes
-  labels:
-    preset-test-account: "true"
   decorate: true
   extra_refs:
   - org: knative
@@ -1405,11 +1744,22 @@ periodics:
       - "--source-directory=ci-knative-serving-continuous"
       - "--artifacts-dir=$(ARTIFACTS)"
       - "--service-account=/etc/test-account/service-account.json"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-west1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
 - cron: "5 8 * * *"
   name: ci-knative-serving-api-coverage
   agent: kubernetes
-  labels:
-    preset-test-account: "true"
   decorate: true
   extra_refs:
   - org: knative
@@ -1425,11 +1775,22 @@ periodics:
       args:
       - "--artifacts-dir=$(ARTIFACTS)"
       - "--service-account=/etc/test-account/service-account.json"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-west1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
 - cron: "0 1 * * *"
   name: ci-knative-serving-performance
   agent: kubernetes
-  labels:
-    preset-test-account: "true"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1446,6 +1807,19 @@ periodics:
       - "--" # end bootstrap args, scenario args below
       - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./test/performance-tests.sh"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-west1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
 - cron: "0 1 * * *"
   name: ci-knative-serving-go-coverage
   agent: kubernetes
@@ -1469,8 +1843,6 @@ periodics:
 - cron: "15 * * * *"
   name: ci-knative-build-continuous
   agent: kubernetes
-  labels:
-    preset-test-account: "true"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1489,12 +1861,22 @@ periodics:
       - "./test/presubmit-tests.sh"
       - "--all-tests"
       - "--emit-metrics"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-west1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
 - cron: "31 8 * * *"
   name: ci-knative-build-nightly-release
   agent: kubernetes
-  labels:
-    preset-nightly-account: "true"
-    preset-dind-enabled: "true"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1515,12 +1897,28 @@ periodics:
       - "--tag-release"
       securityContext:
         privileged: true
+      volumeMounts:
+      - name: docker-graph
+        mountPath: /docker-graph
+      - name: nightly-account
+        mountPath: /etc/nightly-account
+        readOnly: true
+      env:
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/nightly-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-west1
+    volumes:
+    - name: docker-graph
+      emptyDir: {}
+    - name: nightly-account
+      secret:
+        secretName: nightly-account
 - cron: "7 */2 * * *"
   name: ci-knative-build-auto-release
   agent: kubernetes
-  labels:
-    preset-release-account: "true"
-    preset-dind-enabled: "true"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1543,11 +1941,34 @@ periodics:
       - "--github-token /etc/hub-token/token"
       securityContext:
         privileged: true
+      volumeMounts:
+      - name: docker-graph
+        mountPath: /docker-graph
+      - name: hub-token
+        mountPath: /etc/hub-token
+        readOnly: true
+      - name: release-account
+        mountPath: /etc/release-account
+        readOnly: true
+      env:
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-west1
+    volumes:
+    - name: docker-graph
+      emptyDir: {}
+    - name: hub-token
+      secret:
+        secretName: hub-token
+    - name: release-account
+      secret:
+        secretName: release-account
 - cron: "5 8 * * *"
   name: ci-knative-build-latency
   agent: kubernetes
-  labels:
-    preset-test-account: "true"
   decorate: true
   extra_refs:
   - org: knative
@@ -1564,6 +1985,19 @@ periodics:
       - "--source-directory=ci-knative-build-continuous"
       - "--artifacts-dir=$(ARTIFACTS)"
       - "--service-account=/etc/test-account/service-account.json"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-west1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
 - cron: "0 1 * * *"
   name: ci-knative-build-go-coverage
   agent: kubernetes
@@ -1587,9 +2021,6 @@ periodics:
 - cron: "31 8 * * *"
   name: ci-knative-build-pipeline-nightly-release
   agent: kubernetes
-  labels:
-    preset-nightly-account: "true"
-    preset-dind-enabled: "true"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1610,6 +2041,25 @@ periodics:
       - "--tag-release"
       securityContext:
         privileged: true
+      volumeMounts:
+      - name: docker-graph
+        mountPath: /docker-graph
+      - name: nightly-account
+        mountPath: /etc/nightly-account
+        readOnly: true
+      env:
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/nightly-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-west1
+    volumes:
+    - name: docker-graph
+      emptyDir: {}
+    - name: nightly-account
+      secret:
+        secretName: nightly-account
 - cron: "0 1 * * *"
   name: ci-knative-build-pipeline-go-coverage
   agent: kubernetes
@@ -1633,8 +2083,6 @@ periodics:
 - cron: "50 * * * *"
   name: ci-knative-docs-continuous
   agent: kubernetes
-  labels:
-    preset-test-account: "true"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1653,6 +2101,19 @@ periodics:
       - "./test/presubmit-tests.sh"
       - "--all-tests"
       - "--emit-metrics"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-west1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
 - cron: "0 1 * * *"
   name: ci-knative-docs-go-coverage
   agent: kubernetes
@@ -1676,8 +2137,6 @@ periodics:
 - cron: "30 * * * *"
   name: ci-knative-eventing-continuous
   agent: kubernetes
-  labels:
-    preset-test-account: "true"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1696,11 +2155,22 @@ periodics:
       - "./test/presubmit-tests.sh"
       - "--all-tests"
       - "--emit-metrics"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-west1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
 - cron: "16 9 * * *"
   name: ci-knative-eventing-nightly-release
   agent: kubernetes
-  labels:
-    preset-nightly-account: "true"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1719,11 +2189,22 @@ periodics:
       - "./hack/release.sh"
       - "--publish"
       - "--tag-release"
+      volumeMounts:
+      - name: nightly-account
+        mountPath: /etc/nightly-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/nightly-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-west1
+    volumes:
+    - name: nightly-account
+      secret:
+        secretName: nightly-account
 - cron: "5 */2 * * *"
   name: ci-knative-eventing-auto-release
   agent: kubernetes
-  labels:
-    preset-release-account: "true"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1744,6 +2225,25 @@ periodics:
       - "--release-gcs knative-releases/eventing"
       - "--release-gcr gcr.io/knative-releases"
       - "--github-token /etc/hub-token/token"
+      volumeMounts:
+      - name: hub-token
+        mountPath: /etc/hub-token
+        readOnly: true
+      - name: release-account
+        mountPath: /etc/release-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-west1
+    volumes:
+    - name: hub-token
+      secret:
+        secretName: hub-token
+    - name: release-account
+      secret:
+        secretName: release-account
 - cron: "0 1 * * *"
   name: ci-knative-eventing-go-coverage
   agent: kubernetes
@@ -1767,8 +2267,6 @@ periodics:
 - cron: "30 * * * *"
   name: ci-knative-eventing-sources-continuous
   agent: kubernetes
-  labels:
-    preset-test-account: "true"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1787,11 +2285,22 @@ periodics:
       - "./test/presubmit-tests.sh"
       - "--all-tests"
       - "--emit-metrics"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-west1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
 - cron: "16 9 * * *"
   name: ci-knative-eventing-sources-nightly-release
   agent: kubernetes
-  labels:
-    preset-nightly-account: "true"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1810,6 +2319,19 @@ periodics:
       - "./hack/release.sh"
       - "--publish"
       - "--tag-release"
+      volumeMounts:
+      - name: nightly-account
+        mountPath: /etc/nightly-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/nightly-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-west1
+    volumes:
+    - name: nightly-account
+      secret:
+        secretName: nightly-account
 - cron: "0 1 * * *"
   name: ci-knative-eventing-sources-go-coverage
   agent: kubernetes
@@ -1833,8 +2355,6 @@ periodics:
 - cron: "40 * * * *"
   name: ci-knative-build-templates-continuous
   agent: kubernetes
-  labels:
-    preset-test-account: "true"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1853,11 +2373,22 @@ periodics:
       - "./test/presubmit-tests.sh"
       - "--all-tests"
       - "--emit-metrics"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-west1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
 - cron: "45 * * * *"
   name: ci-knative-pkg-continuous
   agent: kubernetes
-  labels:
-    preset-test-account: "true"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1876,6 +2407,19 @@ periodics:
       - "./test/presubmit-tests.sh"
       - "--all-tests"
       - "--emit-metrics"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-west1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
 - cron: "0 1 * * *"
   name: ci-knative-pkg-go-coverage
   agent: kubernetes
@@ -1899,8 +2443,6 @@ periodics:
 - cron: "30 * * * *"
   name: ci-knative-caching-continuous
   agent: kubernetes
-  labels:
-    preset-test-account: "true"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1919,6 +2461,19 @@ periodics:
       - "./test/presubmit-tests.sh"
       - "--all-tests"
       - "--emit-metrics"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-west1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
 - cron: "0 1 * * *"
   name: ci-knative-caching-go-coverage
   agent: kubernetes
@@ -1942,8 +2497,6 @@ periodics:
 - cron: "0 19 * * 1"
   name: ci-knative-cleanup
   agent: kubernetes
-  labels:
-    preset-test-account: "true"
   decorate: true
   decoration_config:
     timeout: 28800000000000 # 8 hours
@@ -1964,11 +2517,17 @@ periodics:
       - "--days-to-keep 30"
       - "--service-account /etc/test-account/service-account.json"
       - "--artifacts $(ARTIFACTS)"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
 - cron: "15 9 * * *"
   name: ci-knative-backup-artifacts
   agent: kubernetes
-  labels:
-    preset-backup-account: "true"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/backups:latest
@@ -1977,6 +2536,14 @@ periodics:
       - "/backup.sh"
       args:
       - "/etc/backup-account/service-account.json"
+      volumeMounts:
+      - name: backup-account
+        mountPath: /etc/backup-account
+        readOnly: true
+    volumes:
+    - name: backup-account
+      secret:
+        secretName: backup-account
 postsubmits:
   knative/serving:
   - name: post-knative-serving-go-coverage

--- a/ci/prow/make_config.go
+++ b/ci/prow/make_config.go
@@ -834,9 +834,6 @@ func generateGoCoveragePostsubmits() {
 		data.Base.Image = coverageDockerImage
 		data.PostsubmitJobName = fmt.Sprintf("post-%s-go-coverage", data.Base.RepoNameForJob)
 		configureServiceAccountForJob(&data.Base)
-		if jobNameFilter != "" && jobNameFilter != data.PostsubmitJobName && jobNameFilter != "post-knative-serving-go-coverage-dev" {
-			continue
-		}
 		executeJobTemplate("postsubmit go coverage", goCoveragePostsubmitJob, "postsubmits", repo, data.PostsubmitJobName, true, data)
 		// TODO(adrcunha): remove once the coverage-dev job isn't necessary anymore.
 		// Generate config for post-knative-serving-go-coverage-dev right after post-knative-serving-go-coverage

--- a/ci/prow/make_config.go
+++ b/ci/prow/make_config.go
@@ -51,28 +51,28 @@ type repositoryData struct {
 type baseProwJobTemplateData struct {
 	RepoName            string
 	RepoNameForJob      string
+	GcsBucket           string
 	GcsLogDir           string
 	GcsPresubmitLogDir  string
-	GcsBucket           string
 	RepoURI             string
 	RepoBranch          string
 	SecurityContext     []string
-	AccountPresets      []string
 	SkipBranches        []string
 	Command             string
 	Args                []string
+	Env                 []string
+	Volumes             []string
+	VolumeMounts        []string
 	Timeout             int
-	Year                int
+	AlwaysRun           bool
 	LogsDir             string
 	PresubmitLogsDir    string
 	TestAccount         string
-	NightlyAccount      string
-	ReleaseAccount      string
+	ServiceAccount      string
 	ReleaseGcs          string
 	GoCoverageThreshold int
-	ServiceAccount      string
-	AlwaysRun           bool
 	Image               string
+	Year                int
 }
 
 // presubmitJobTemplateData contains data about a presubmit Prow job.
@@ -99,16 +99,12 @@ type postsubmitJobTemplateData struct {
 }
 
 // sectionGenerator is a function that generates Prow job configs given a slice of a yaml file with configs.
-type sectionGenerator func(string, yaml.MapSlice)
+type sectionGenerator func(string, string, yaml.MapSlice)
 
 var (
 	// Array constants used throughout the jobs.
-	allPresubmitTests    = []string{"--all-tests", "--emit-metrics"}
-	releaseNightly       = []string{"--publish", "--tag-release"}
-	presetTestAccount    = []string{"preset-test-account: \"true\""}
-	presetNightlyAccount = []string{"preset-nightly-account: \"true\""}
-	presetReleaseAccount = []string{"preset-release-account: \"true\""}
-	presetDindEnabled    = []string{"preset-dind-enabled: \"true\""}
+	allPresubmitTests = []string{"--all-tests", "--emit-metrics"}
+	releaseNightly    = []string{"--publish", "--tag-release"}
 
 	// Values used in the jobs that can be changed through command-line flags.
 	gcsBucket            string
@@ -122,10 +118,17 @@ var (
 	presubmitScript      string
 	releaseScript        string
 	performanceScript    string
-	repositoryOverride   string
+
+	// Overrides and behavior changes through command-line flags.
+	repositoryOverride string
+	jobNameFilter      string
+	preCommand         string
 
 	// List of Knative repositories.
 	repositories []repositoryData
+
+	// Map which sections of the config.yaml were written to stdout.
+	sectionMap map[string]bool
 )
 
 // Templates for config generation.
@@ -213,88 +216,6 @@ tide:
     knative: squash
     knative/build-pipeline: rebase
   target_url: https://prow.knative.dev/tide
-
-presets:
-# test run service account
-- labels:
-    preset-test-account: "true"
-  env:
-  - name: GOOGLE_APPLICATION_CREDENTIALS
-    value: [[.TestAccount]]
-  - name: E2E_CLUSTER_REGION
-    value: us-west1
-  volumes:
-  - name: account
-    secret:
-      secretName: test-account
-  volumeMounts:
-  - name: account
-    mountPath: /etc/test-account
-    readOnly: true
-# nightly release service account
-- labels:
-    preset-nightly-account: "true"
-  env:
-  - name: GOOGLE_APPLICATION_CREDENTIALS
-    value: [[.NightlyAccount]]
-  - name: E2E_CLUSTER_REGION
-    value: us-west1
-  volumes:
-  - name: account
-    secret:
-      secretName: nightly-account
-  volumeMounts:
-  - name: account
-    mountPath: /etc/nightly-account
-    readOnly: true
-# versioned release service account
-- labels:
-    preset-release-account: "true"
-  env:
-  - name: GOOGLE_APPLICATION_CREDENTIALS
-    value: [[.ReleaseAccount]]
-  - name: E2E_CLUSTER_REGION
-    value: us-west1
-  volumes:
-  - name: account
-    secret:
-      secretName: release-account
-  - name: hub-token
-    secret:
-      secretName: hub-token
-  volumeMounts:
-  - name: account
-    mountPath: /etc/release-account
-    readOnly: true
-  - name: hub-token
-    mountPath: /etc/hub-token
-    readOnly: true
-# backups service account
-- labels:
-    preset-backup-account: "true"
-  env:
-  - name: GOOGLE_APPLICATION_CREDENTIALS
-    value: /etc/backup-account/service-account.json
-  volumes:
-  - name: account
-    secret:
-      secretName: backup-account
-  volumeMounts:
-  - name: account
-    mountPath: /etc/backup-account
-    readOnly: true
-# docker-in-docker presets
-- labels:
-    preset-dind-enabled: "true"
-  env:
-  - name: DOCKER_IN_DOCKER_ENABLED
-    value: "true"
-  volumes:
-  - name: docker-graph
-    emptyDir: {}
-  volumeMounts:
-  - name: docker-graph
-    mountPath: /docker-graph
 `
 
 	// presubmitJob is the template for presubmit jobs.
@@ -305,9 +226,6 @@ presets:
     always_run: [[.Base.AlwaysRun]]
     rerun_command: "/test [[.PresubmitPullJobName]]"
     trigger: "(?m)^/test (all|[[.PresubmitPullJobName]]),?(\\s+|$)"
-    labels:
-      preset-test-account: "true"
-      [[indent_keys 6 .Base.AccountPresets]]
     [[indent_array_section 4 "skip_branches" .Base.SkipBranches]]
     spec:
       containers:
@@ -319,19 +237,20 @@ presets:
         - "--job=$(JOB_NAME)"
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
-        - "--service-account=[[.Base.TestAccount]]"
+        - "--service-account=[[.Base.ServiceAccount]]"
         - "--upload=[[.Base.GcsPresubmitLogDir]]"
         - "--" # end bootstrap args, scenario args below
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         [[indent_array 8 .PresubmitCommand]]
         [[indent_section 10 "securityContext" .Base.SecurityContext]]
+        [[indent_section 8 "volumeMounts" .Base.VolumeMounts]]
+        [[indent_section 8 "env" .Base.Env]]
+      [[indent_section 6 "volumes" .Base.Volumes]]
 `
 
 	// presubmitGoCoverageJob is the template for go coverage presubmit jobs.
 	presubmitGoCoverageJob = `
   - name: [[.PresubmitPullJobName]]
-    labels:
-      preset-test-account: "true"
     agent: kubernetes
     context: [[.PresubmitPullJobName]]
     always_run: [[.Base.AlwaysRun]]
@@ -353,15 +272,10 @@ presets:
         - "--profile-name=coverage_profile.txt"
         - "--cov-target=."
         - "--cov-threshold-percentage=[[.Base.GoCoverageThreshold]]"
-        - "--github-token=/etc/github-token/token"
-        volumeMounts:
-        - name: github-token
-          mountPath: /etc/github-token
-          readOnly: true
-      volumes:
-      - name: github-token
-        secret:
-          secretName: covbot-token
+        - "--github-token=/etc/covbot-token/token"
+        [[indent_section 8 "volumeMounts" .Base.VolumeMounts]]
+        [[indent_section 8 "env" .Base.Env]]
+      [[indent_section 6 "volumes" .Base.Volumes]]
 `
 
 	// presubmitJob is the template for presubmit jobs.
@@ -369,7 +283,6 @@ presets:
 - cron: "[[.CronString]]"
   name: [[.PeriodicJobName]]
   agent: kubernetes
-  [[indent_section 4 "labels" .Base.AccountPresets]]
   spec:
     containers:
     - image: [[.Base.Image]]
@@ -387,6 +300,9 @@ presets:
       - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       [[indent_array 6 .PeriodicCommand]]
       [[indent_section 8 "securityContext" .Base.SecurityContext]]
+      [[indent_section 6 "volumeMounts" .Base.VolumeMounts]]
+      [[indent_section 6 "env" .Base.Env]]
+    [[indent_section 4 "volumes" .Base.Volumes]]
 `
 
 	// latencyJob is the template for latency metrics aggregation jobs.
@@ -394,7 +310,6 @@ presets:
 - cron: "[[.CronString]]"
   name: [[.PeriodicJobName]]
   agent: kubernetes
-  [[indent_section 4 "labels" .Base.AccountPresets]]
   decorate: true
   extra_refs:
   - org: knative
@@ -411,6 +326,9 @@ presets:
       - "--source-directory=ci-[[.Base.RepoNameForJob]]-continuous"
       - "--artifacts-dir=$(ARTIFACTS)"
       - "--service-account=[[.Base.ServiceAccount]]"
+      [[indent_section 6 "volumeMounts" .Base.VolumeMounts]]
+      [[indent_section 6 "env" .Base.Env]]
+    [[indent_section 4 "volumes" .Base.Volumes]]
 `
 
 	// apiCoverageJob is the template for API coverage metrics aggregation jobs.
@@ -418,7 +336,6 @@ presets:
 - cron: "[[.CronString]]"
   name: [[.PeriodicJobName]]
   agent: kubernetes
-  [[indent_section 4 "labels" .Base.AccountPresets]]
   decorate: true
   extra_refs:
   - org: knative
@@ -434,6 +351,9 @@ presets:
       args:
       - "--artifacts-dir=$(ARTIFACTS)"
       - "--service-account=[[.Base.ServiceAccount]]"
+      [[indent_section 6 "volumeMounts" .Base.VolumeMounts]]
+      [[indent_section 6 "env" .Base.Env]]
+    [[indent_section 4 "volumes" .Base.Volumes]]
 `
 
 	// goCoveragePeriodicJob is the template for go coverage periodic jobs.
@@ -458,6 +378,9 @@ presets:
       - "--profile-name=coverage_profile.txt"
       - "--cov-target=."
       - "--cov-threshold-percentage=[[.Base.GoCoverageThreshold]]"
+      [[indent_section 6 "volumeMounts" .Base.VolumeMounts]]
+      [[indent_section 6 "env" .Base.Env]]
+    [[indent_section 4 "volumes" .Base.Volumes]]
 `
 
 	// cleanupPeriodicJob is the template for the cleanup job.
@@ -465,7 +388,6 @@ presets:
 - cron: "[[.CronString]]"
   name: [[.PeriodicJobName]]
   agent: kubernetes
-  [[indent_section 4 "labels" .Base.AccountPresets]]
   decorate: true
   decoration_config:
     timeout: 28800000000000 # 8 hours
@@ -486,6 +408,9 @@ presets:
       - "--days-to-keep 30"
       - "--service-account [[.Base.ServiceAccount]]"
       - "--artifacts $(ARTIFACTS)"
+      [[indent_section 6 "volumeMounts" .Base.VolumeMounts]]
+      [[indent_section 6 "env" .Base.Env]]
+    [[indent_section 4 "volumes" .Base.Volumes]]
 `
 
 	// cleanupPeriodicJob is the template for the cleanup job.
@@ -493,8 +418,6 @@ presets:
 - cron: "[[.CronString]]"
   name: [[.PeriodicJobName]]
   agent: kubernetes
-  labels:
-    preset-backup-account: "true"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/backups:latest
@@ -502,7 +425,10 @@ presets:
       command:
       - "/backup.sh"
       args:
-      - "/etc/backup-account/service-account.json"
+      - "[[.Base.ServiceAccount]]"
+      [[indent_section 6 "volumeMounts" .Base.VolumeMounts]]
+      [[indent_section 6 "env" .Base.Env]]
+    [[indent_section 4 "volumes" .Base.Volumes]]
 `
 
 	// goCoveragePostsubmitJob is the template for the go postsubmit coverage job.
@@ -597,9 +523,6 @@ func getMapSlice(m interface{}) yaml.MapSlice {
 // newbaseProwJobTemplateData returns a baseProwJobTemplateData type with its initial, default values.
 func newbaseProwJobTemplateData(repo string) baseProwJobTemplateData {
 	var data baseProwJobTemplateData
-	data.TestAccount = testAccount
-	data.NightlyAccount = nightlyAccount
-	data.ReleaseAccount = releaseAccount
 	data.Timeout = 50
 	data.RepoName = strings.Replace(repo, "knative/", "", 1)
 	data.RepoNameForJob = strings.Replace(repo, "/", "-", -1)
@@ -613,8 +536,61 @@ func newbaseProwJobTemplateData(repo string) baseProwJobTemplateData {
 	data.ReleaseGcs = strings.Replace(repo, "knative/", "knative-releases/", 1)
 	data.AlwaysRun = true
 	data.Image = prowTestsDockerImage
+	data.ServiceAccount = testAccount
+	data.Command = ""
+	data.Args = make([]string, 0)
+	data.Volumes = make([]string, 0)
+	data.VolumeMounts = make([]string, 0)
+	data.Env = make([]string, 0)
 	return data
 }
+
+// General helpers.
+
+// createCommand returns an array with the command to run and its arguments.
+func createCommand(data baseProwJobTemplateData) []string {
+	c := []string{data.Command}
+	// Prefix the pre-command if present.
+	if preCommand != "" {
+		c = append([]string{preCommand}, c...)
+	}
+	return append(c, data.Args...)
+}
+
+// addEnvToJob adds the given key/pair environment variable to the job.
+func addEnvToJob(data *baseProwJobTemplateData, key, value string) {
+	(*data).Env = append((*data).Env, []string{"- name: " + key, "  value: " + value}...)
+}
+
+// addVolumeToJob adds the given mount path as volume for the job.
+func addVolumeToJob(data *baseProwJobTemplateData, mountPath, name string, isSecret bool) {
+	(*data).VolumeMounts = append((*data).VolumeMounts, []string{"- name: " + name, "  mountPath: " + mountPath}...)
+	if isSecret {
+		(*data).VolumeMounts = append((*data).VolumeMounts, "  readOnly: true")
+	}
+	s := []string{"- name: " + name}
+	if isSecret {
+		s = append(s, []string{"  secret:", "    secretName: " + name}...)
+	} else {
+		s = append(s, "  emptyDir: {}")
+	}
+	(*data).Volumes = append((*data).Volumes, s...)
+}
+
+// configureServiceAccountForJob adds the necessary volumes for the service account for the job.
+func configureServiceAccountForJob(data *baseProwJobTemplateData) {
+	if data.ServiceAccount == "" {
+		return
+	}
+	p := strings.Split(data.ServiceAccount, "/")
+	if len(p) != 4 || p[0] != "" || p[1] != "etc" || p[3] != "service-account.json" {
+		log.Fatalf("Service account path %q is expected to be \"/etc/<name>/service-account.json\"", data.ServiceAccount)
+	}
+	name := p[2]
+	addVolumeToJob(data, "/etc/"+name, name, true)
+}
+
+// Config parsers.
 
 // parseBasicJobConfig populates the given baseProwJobTemplateData with any basic option present in the given config.
 func parseBasicJobConfig(data *baseProwJobTemplateData, config yaml.MapSlice) {
@@ -628,11 +604,10 @@ func parseBasicJobConfig(data *baseProwJobTemplateData, config yaml.MapSlice) {
 			(*data).Timeout = getInt(item.Value)
 		case "command":
 			(*data).Command = getString(item.Value)
-		case "labels":
-			(*data).AccountPresets = append((*data).AccountPresets, getStringArray(item.Value)...)
 		case "needs-dind":
 			if getBool(item.Value) {
-				(*data).AccountPresets = append((*data).AccountPresets, presetDindEnabled...)
+				addVolumeToJob(data, "/docker-graph", "docker-graph", false)
+				addEnvToJob(data, "DOCKER_IN_DOCKER_ENABLED", "\"true\"")
 				(*data).SecurityContext = []string{"privileged: true"}
 			}
 		case "always_run":
@@ -646,14 +621,14 @@ func parseBasicJobConfig(data *baseProwJobTemplateData, config yaml.MapSlice) {
 }
 
 // generatePresubmit generates all presubmit job configs for the given repo and configuration.
-func generatePresubmit(repo string, presubmitConfig yaml.MapSlice) {
+func generatePresubmit(title string, repoName string, presubmitConfig yaml.MapSlice) {
 	var data presubmitJobTemplateData
-	data.Base = newbaseProwJobTemplateData(repo)
+	data.Base = newbaseProwJobTemplateData(repoName)
 	data.Base.Command = presubmitScript
 	data.Base.GoCoverageThreshold = 80
 	parseBasicJobConfig(&data.Base, presubmitConfig)
 	jobTemplate := presubmitJob
-	repoData := repositoryData{Name: repo, EnableGoCoverage: false, GoCoverageThreshold: data.Base.GoCoverageThreshold}
+	repoData := repositoryData{Name: repoName, EnableGoCoverage: false, GoCoverageThreshold: data.Base.GoCoverageThreshold}
 	for _, item := range presubmitConfig {
 		switch item.Key {
 		case "build-tests", "unit-tests", "integration-tests":
@@ -673,7 +648,9 @@ func generatePresubmit(repo string, presubmitConfig yaml.MapSlice) {
 			jobTemplate = presubmitGoCoverageJob
 			data.PresubmitJobName = data.Base.RepoNameForJob + "-go-coverage"
 			data.Base.Image = coverageDockerImage
+			data.Base.ServiceAccount = ""
 			repoData.EnableGoCoverage = true
+			addVolumeToJob(&data.Base, "/etc/covbot-token", "covbot-token", true)
 		case "custom-test":
 			data.PresubmitJobName = data.Base.RepoNameForJob + "-" + getString(item.Value)
 		case "go-coverage-threshold":
@@ -686,10 +663,15 @@ func generatePresubmit(repo string, presubmitConfig yaml.MapSlice) {
 		}
 	}
 	repositories = append(repositories, repoData)
-	data.PresubmitCommand = append([]string{data.Base.Command}, data.Base.Args...)
+	data.PresubmitCommand = createCommand(data.Base)
 	data.PresubmitPullJobName = "pull-" + data.PresubmitJobName
 	data.PresubmitPostJobName = "post-" + data.PresubmitJobName
-	executeTemplate("presubmit", jobTemplate, data)
+        if data.Base.ServiceAccount != "" {
+		addEnvToJob(&data.Base, "GOOGLE_APPLICATION_CREDENTIALS", data.Base.ServiceAccount)
+		addEnvToJob(&data.Base, "E2E_CLUSTER_REGION", "us-west1")
+	}
+	configureServiceAccountForJob(&data.Base)
+	executeJobTemplate("presubmit", jobTemplate, title, repoName, data.PresubmitPullJobName, true, data)
 	// TODO(adrcunha): remove once the coverage-dev job isn't necessary anymore.
 	// Generate config for pull-knative-serving-go-coverage-dev right after pull-knative-serving-go-coverage
 	if data.PresubmitPullJobName == "pull-knative-serving-go-coverage" {
@@ -697,21 +679,17 @@ func generatePresubmit(repo string, presubmitConfig yaml.MapSlice) {
 		data.Base.AlwaysRun = false
 		data.Base.Image = strings.Replace(data.Base.Image, "coverage:latest", "coverage-dev:latest-dev", -1)
 		template := strings.Replace(presubmitGoCoverageJob, "(all|", "(", 1)
-		executeTemplate("presubmit", template, data)
+		executeJobTemplate("presubmit", template, title, repoName, data.PresubmitPullJobName, true, data)
 	}
 }
 
 // generatePeriodic generates all periodic job configs for the given repo and configuration.
-func generatePeriodic(repo string, periodicConfig yaml.MapSlice) {
+func generatePeriodic(title string, repoName string, periodicConfig yaml.MapSlice) {
 	var data periodicJobTemplateData
-	data.Base = newbaseProwJobTemplateData(repo)
-	data.Base.Command = ""
-	data.Base.Args = make([]string, 0)
-	data.Base.ServiceAccount = testAccount
+	data.Base = newbaseProwJobTemplateData(repoName)
 	parseBasicJobConfig(&data.Base, periodicConfig)
 	jobNameSuffix := ""
 	jobTemplate := periodicJob
-	accountPresets := presetTestAccount
 	for _, item := range periodicConfig {
 		switch item.Key {
 		case "continuous":
@@ -732,7 +710,6 @@ func generatePeriodic(repo string, periodicConfig yaml.MapSlice) {
 			}
 			jobNameSuffix = "nightly-release"
 			data.Base.ServiceAccount = nightlyAccount
-			accountPresets = presetNightlyAccount
 			data.Base.Command = releaseScript
 			data.Base.Args = releaseNightly
 			data.Base.Timeout = 90
@@ -742,13 +719,13 @@ func generatePeriodic(repo string, periodicConfig yaml.MapSlice) {
 			}
 			jobNameSuffix = getString(item.Key)
 			data.Base.ServiceAccount = releaseAccount
-			accountPresets = presetReleaseAccount
 			data.Base.Command = releaseScript
 			data.Base.Args = []string{
 				"--" + jobNameSuffix,
 				"--release-gcs " + data.Base.ReleaseGcs,
 				"--release-gcr gcr.io/knative-releases",
 				"--github-token /etc/hub-token/token"}
+			addVolumeToJob(&data.Base, "/etc/hub-token", "hub-token", true)
 			data.Base.Timeout = 90
 		case "performance":
 			if !getBool(item.Value) {
@@ -796,33 +773,38 @@ func generatePeriodic(repo string, periodicConfig yaml.MapSlice) {
 		log.Fatalf("Job %q is missing command", data.PeriodicJobName)
 	}
 	// Generate config itself.
-	data.PeriodicCommand = append([]string{data.Base.Command}, data.Base.Args...)
-	data.Base.AccountPresets = append(accountPresets, data.Base.AccountPresets...)
-	executeTemplate("periodic", jobTemplate, data)
+	data.PeriodicCommand = createCommand(data.Base)
+        if data.Base.ServiceAccount != "" {
+		addEnvToJob(&data.Base, "GOOGLE_APPLICATION_CREDENTIALS", data.Base.ServiceAccount)
+		addEnvToJob(&data.Base, "E2E_CLUSTER_REGION", "us-west1")
+	}
+	configureServiceAccountForJob(&data.Base)
+	executeJobTemplate("periodic", jobTemplate, title, repoName, data.PeriodicJobName, false, data)
 }
 
 // generateCleanupPeriodicJob generates the cleanup job config.
 func generateCleanupPeriodicJob() {
 	var data periodicJobTemplateData
 	data.Base = newbaseProwJobTemplateData("knative/test-infra")
-	data.Base.ServiceAccount = testAccount
-	data.Base.AccountPresets = presetTestAccount
 	data.PeriodicJobName = "ci-knative-cleanup"
 	data.CronString = cleanupPeriodicJobCron
-	executeTemplate("periodic cleanup", cleanupPeriodicJob, data)
+	configureServiceAccountForJob(&data.Base)
+	executeJobTemplate("periodic cleanup", cleanupPeriodicJob, "presubmits", "", data.PeriodicJobName, false, data)
 }
 
 // generateBackupPeriodicJob generates the backup job config.
 func generateBackupPeriodicJob() {
 	var data periodicJobTemplateData
 	data.Base = newbaseProwJobTemplateData("none/unused")
+	data.Base.ServiceAccount = "/etc/backup-account/service-account.json"
 	data.PeriodicJobName = "ci-knative-backup-artifacts"
 	data.CronString = backupPeriodicJobCron
-	executeTemplate("periodic backup", backupPeriodicJob, data)
+	configureServiceAccountForJob(&data.Base)
+	executeJobTemplate("periodic backup", backupPeriodicJob, "presubmits", "", data.PeriodicJobName, false, data)
 }
 
 // generateGoCoveragePeriodic generates the go coverage periodic job config for the given repo (configuration is ignored).
-func generateGoCoveragePeriodic(repoName string, periodicConfig yaml.MapSlice) {
+func generateGoCoveragePeriodic(title string, repoName string, periodicConfig yaml.MapSlice) {
 	for _, repo := range repositories {
 		if repoName != repo.Name || !repo.EnableGoCoverage {
 			continue
@@ -833,55 +815,52 @@ func generateGoCoveragePeriodic(repoName string, periodicConfig yaml.MapSlice) {
 		data.PeriodicJobName = fmt.Sprintf("ci-%s-go-coverage", data.Base.RepoNameForJob)
 		data.CronString = goCoveragePeriodicJobCron
 		data.Base.GoCoverageThreshold = repo.GoCoverageThreshold
-		executeTemplate("periodic go coverage", goCoveragePeriodicJob, data)
+		data.Base.ServiceAccount = ""
+		configureServiceAccountForJob(&data.Base)
+		executeJobTemplate("periodic go coverage", goCoveragePeriodicJob, title, repoName, data.PeriodicJobName, false, data)
 		return
 	}
 }
 
 // generateGoCoveragePostsubmits generates the go coverage postsubmit job configs for all repos.
 func generateGoCoveragePostsubmits() {
-	outputConfig("postsubmits:")
 	for i := range repositories { // Keep order for predictable output.
 		if !repositories[i].EnableGoCoverage {
 			continue
 		}
 		repo := repositories[i].Name
-		outputConfig("  " + repo + ":")
 		var data postsubmitJobTemplateData
 		data.Base = newbaseProwJobTemplateData(repo)
 		data.Base.Image = coverageDockerImage
 		data.PostsubmitJobName = fmt.Sprintf("post-%s-go-coverage", data.Base.RepoNameForJob)
-		executeTemplate("postsubmit go coverage", goCoveragePostsubmitJob, data)
+		configureServiceAccountForJob(&data.Base)
+		if jobNameFilter != "" && jobNameFilter != data.PostsubmitJobName && jobNameFilter != "post-knative-serving-go-coverage-dev" {
+			continue
+		}
+		executeJobTemplate("postsubmit go coverage", goCoveragePostsubmitJob, "postsubmits", repo, data.PostsubmitJobName, true, data)
 		// TODO(adrcunha): remove once the coverage-dev job isn't necessary anymore.
 		// Generate config for post-knative-serving-go-coverage-dev right after post-knative-serving-go-coverage
 		if data.PostsubmitJobName == "post-knative-serving-go-coverage" {
 			data.PostsubmitJobName += "-dev"
 			data.Base.Image = strings.Replace(data.Base.Image, "coverage:latest", "coverage-dev:latest-dev", -1)
-			executeTemplate("presubmit", goCoveragePostsubmitJob, data)
+			executeJobTemplate("presubmit", goCoveragePostsubmitJob, "postsubmits", repo, data.PostsubmitJobName, false, data)
 		}
 	}
 }
 
 // parseSection generate the configs form a given section of the input yaml file.
-func parseSection(config yaml.MapSlice, title string, groupByRepo bool, generate sectionGenerator, finalize sectionGenerator) {
-	if len(config) == 0 {
-		return
-	}
-	outputConfig(title + ":")
+func parseSection(config yaml.MapSlice, title string, generate sectionGenerator, finalize sectionGenerator) {
 	for _, section := range config {
 		if section.Key != title {
 			continue
 		}
 		for _, repo := range getMapSlice(section.Value) {
 			repoName := getString(repo.Key)
-			if groupByRepo {
-				outputConfig(baseIndent + repoName + ":")
-			}
 			for _, jobConfig := range getInterfaceArray(repo.Value) {
-				generate(repoName, getMapSlice(jobConfig))
+				generate(title, repoName, getMapSlice(jobConfig))
 			}
 			if finalize != nil {
-				finalize(repoName, nil)
+				finalize(title, repoName, nil)
 			}
 		}
 	}
@@ -903,7 +882,7 @@ func gitHubRepo(data baseProwJobTemplateData) string {
 
 // quote returns the given string quoted if it's not a key/value pair or already quoted.
 func quote(s string) string {
-	if strings.Contains(s, "\"") || strings.Contains(s, ": ") {
+	if strings.Contains(s, "\"") || strings.Contains(s, ": ") || strings.HasSuffix(s, ":") {
 		return s
 	}
 	return "\"" + s + "\""
@@ -962,6 +941,24 @@ func outputConfig(line string) {
 	}
 }
 
+// executeTemplate outputs the given job template with the given data, respecting any filtering.
+func executeJobTemplate(name, templ, title, repoName, jobName string, groupByRepo bool, data interface{}) {
+	if jobNameFilter != "" && jobNameFilter != jobName {
+		return
+	}
+	if !sectionMap[title] {
+		outputConfig(title + ":")
+		sectionMap[title] = true
+	}
+	if groupByRepo {
+		if !sectionMap[title+repoName] {
+			outputConfig(baseIndent + repoName + ":")
+			sectionMap[title+repoName] = true
+		}
+	}
+	executeTemplate(name, templ, data)
+}
+
 // executeTemplate outputs the given template with the given data.
 func executeTemplate(name, templ string, data interface{}) {
 	var res bytes.Buffer
@@ -997,6 +994,8 @@ func main() {
 	flag.StringVar(&releaseScript, "release-script", "./hack/release.sh", "Executable for creating releases")
 	flag.StringVar(&performanceScript, "performance-script", "./test/performance-tests.sh", "Executable for running performance tests")
 	flag.StringVar(&repositoryOverride, "repo-override", "", "Repository path (github.com/foo/bar[=branch]) to use instead for a job")
+	flag.StringVar(&jobNameFilter, "job-filter", "", "Generate only this job, instead of all jobs")
+	flag.StringVar(&preCommand, "pre-command", "", "Executable for running instead of the real command of a job")
 	flag.Parse()
 	if len(flag.Args()) != 1 {
 		log.Fatal("Pass the config file as parameter")
@@ -1004,6 +1003,7 @@ func main() {
 	// We use MapSlice instead of maps to keep key order and create predictable output.
 	config := yaml.MapSlice{}
 	repositories = make([]repositoryData, 0)
+	sectionMap = make(map[string]bool)
 
 	// Read input config.
 	name := flag.Arg(0)
@@ -1019,9 +1019,10 @@ func main() {
 	if *includeConfig {
 		executeTemplate("general config", generalConfig, newbaseProwJobTemplateData(""))
 	}
-	parseSection(config, "presubmits", true, generatePresubmit, nil)
-	parseSection(config, "periodics", false, generatePeriodic, generateGoCoveragePeriodic)
+	parseSection(config, "presubmits", generatePresubmit, nil)
+	parseSection(config, "periodics", generatePeriodic, generateGoCoveragePeriodic)
 	generateCleanupPeriodicJob()
 	generateBackupPeriodicJob()
 	generateGoCoveragePostsubmits()
 }
+


### PR DESCRIPTION
* move account presets to the jobs, making them self-contained
* allow filtering config by job name
* allow adding a wrapper command to a job