### PR TITLE
Remove usage of K8S_CLUSTER_OVERRIDE

### DIFF
--- a/tools/webhook-apicoverage/tools/README.md
+++ b/tools/webhook-apicoverage/tools/README.md
@@ -4,15 +4,13 @@ Tools package is intended to contain types and public helper methods that provid
 utilities to solves common requirements across repos. It currently contains following
 helper methods:
 
-1. `GetDefaultClusterName`: Helper method to fetch cluster name from the env variable
- K8S_CLUSTER_OVERRIDE
 1. `GetDefaultKubePath`: Helper method to retrieve the path for Kubeconfig inside
- users home directory.
+   users home directory.
 1. `GetWebhookServiceIP`: Helper method to retrieve the public IP address for the
- webhook service. The service is setup as part of the apicoverage-webhook
- setup.
+   webhook service. The service is setup as part of the apicoverage-webhook
+   setup.
 1. `GetResourceCoverage`: Helper method to retrieve Coverage data for a resource
- passed as parameter. The coverage data is retrieved from the API that is exposed
- by the HTTP server in [Webhook Setup](../webhook/webhook.go)
+   passed as parameter. The coverage data is retrieved from the API that is exposed
+   by the HTTP server in [Webhook Setup](../webhook/webhook.go)
 1. `GetAndWriteResourceCoverage`: Helper method that uses `GetResourceCoverage`
- to retrieve resource coverage and writes output to a file.
+   to retrieve resource coverage and writes output to a file.

--- a/tools/webhook-apicoverage/tools/tools.go
+++ b/tools/webhook-apicoverage/tools/tools.go
@@ -42,17 +42,6 @@ const (
 	WebhookResourceCoverageEndPoint = "https://%s:443/resourcecoverage?resource=%s"
 )
 
-// GetDefaultClusterName helper method to fetch cluster name from the env variable K8S_CLUSTER_OVERRIDE
-func GetDefaultClusterName() (string, error) {
-	envName := "K8S_CLUSTER_OVERRIDE"
-	var clusterName string
-	if clusterName = os.Getenv(envName); len(clusterName) == 0 {
-		return "", fmt.Errorf("cluster name not set. Method expects the cluster to be set as an environment variable: %s", envName)
-	}
-
-	return clusterName, nil
-}
-
 // GetDefaultKubePath helper method to fetch kubeconfig path.
 func GetDefaultKubePath() (string, error) {
 	var (

--- a/tools/webhook-apicoverage/tools/tools.go
+++ b/tools/webhook-apicoverage/tools/tools.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"os/user"
 	"path"
 


### PR DESCRIPTION
1. It was removed in #481.
1. This is a dupe of a flag in pkg/test/e2e_flags.go, we should have a single approach for such helpers.