### PR TITLE
Run serving tests hourly

### DIFF
--- a/ci/prow/config_knative.yaml
+++ b/ci/prow/config_knative.yaml
@@ -99,8 +99,8 @@ presubmits:
 periodics:
   knative/serving:
     - continuous: true
-      cron: "1 */2 * * *" # Run every other hour and one minute
-      timeout: 100
+      cron: "1 * * * *" # Run every other hour and one minute
+      timeout: 55
     - continuous: true
       release: "0.2"
       needs-dind: true


### PR DESCRIPTION
Recent improvements caused tests to run in ~40 minutes.