### PR TITLE
Run serving tests hourly

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -1498,7 +1498,7 @@ presubmits:
         secret:
           secretName: covbot-token
 periodics:
-- cron: "1 */2 * * *"
+- cron: "1 * * * *"
   name: ci-knative-serving-continuous
   agent: kubernetes
   spec:
@@ -1513,7 +1513,7 @@ periodics:
       - "--root=/go/src"
       - "--service-account=/etc/test-account/service-account.json"
       - "--upload=gs://knative-prow/logs"
-      - "--timeout=100" # Avoid overrun
+      - "--timeout=55" # Avoid overrun
       - "--" # end bootstrap args, scenario args below
       - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./test/presubmit-tests.sh"

--- a/ci/prow/config_knative.yaml
+++ b/ci/prow/config_knative.yaml
@@ -99,8 +99,8 @@ presubmits:
 periodics:
   knative/serving:
     - continuous: true
-      cron: "1 */2 * * *" # Run every other hour and one minute
-      timeout: 100
+      cron: "1 * * * *" # Run every other hour and one minute
+      timeout: 55
     - continuous: true
       release: "0.2"
       needs-dind: true


### PR DESCRIPTION
Recent improvements caused tests to run in ~40 minutes.