### PR TITLE
webhook-apicoverage: Add support for total coverage API and display

### DIFF
--- a/tools/webhook-apicoverage/tools/README.md
+++ b/tools/webhook-apicoverage/tools/README.md
@@ -13,4 +13,9 @@ helper methods:
    passed as parameter. The coverage data is retrieved from the API that is exposed
    by the HTTP server in [Webhook Setup](../webhook/webhook.go)
 1. `GetAndWriteResourceCoverage`: Helper method that uses `GetResourceCoverage`
-   to retrieve resource coverage and writes output to a file.
+ to retrieve resource coverage and writes output to a file.
+1. `GetTotalCoverage`: Helper method to retrieve total coverage data for a repo.
+ The coverage data is retrieved from the API that is exposed by the HTTP server
+ in [Webhook Setup](../webhook/webhook.go)
+1. `GetAndWriteTotalCoverage`: Helper method that uses `GetTotalCoverage` to
+ retrieve total coverage and writes output to a file.

--- a/tools/webhook-apicoverage/view/README.md
+++ b/tools/webhook-apicoverage/view/README.md
@@ -22,3 +22,16 @@ Type: <TypeName>
     ....
 }
 ```
+
+`GetCoverageValuesDisplay()` is a utility method that can be used by repos to produce
+coverage values display. The method takes as input [CoverageValue](../coveragecalculator/calculator.go)
+and produces a display in the format:
+
+```
+CoverageValues:
+
+Total Fields:  <Number of total fields>
+Covered Fields: <Number of fields covered>
+Ignored Fields: <Number of fields ignored>
+Coverage Percentage: <Percentage value of coverage>
+```

--- a/tools/webhook-apicoverage/view/coverage_display.go
+++ b/tools/webhook-apicoverage/view/coverage_display.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package view
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/knative/test-infra/tools/webhook-apicoverage/coveragecalculator"
+)
+
+// GetCoverageValuesDisplay builds the string display for coveragecalculator.CoverageValues
+func GetCoverageValuesDisplay(coverageValues *coveragecalculator.CoverageValues) string {
+	var buffer strings.Builder
+	buffer.WriteString("\nCoverage Values:\n")
+	buffer.WriteString(fmt.Sprintf("Total Fields : %d\n", coverageValues.TotalFields))
+	buffer.WriteString(fmt.Sprintf("Covered Fields : %d\n", coverageValues.CoveredFields))
+	buffer.WriteString(fmt.Sprintf("Ignored Fields : %d\n", coverageValues.IgnoredFields))
+
+	percentCoverage := 0.0
+	if coverageValues.CoveredFields > 0 {
+		percentCoverage = (float64(coverageValues.CoveredFields) / float64(coverageValues.TotalFields - coverageValues.IgnoredFields)) * 100
+	}
+	buffer.WriteString(fmt.Sprintf("Coverage Percentage : %f\n", percentCoverage))
+	return buffer.String()
+}

--- a/tools/webhook-apicoverage/view/jsontype_display.go
+++ b/tools/webhook-apicoverage/view/jsontype_display.go
@@ -63,7 +63,7 @@ func defaultTypeDisplay(field *coveragecalculator.FieldCoverage) string {
 	} else {
 		buffer.WriteString("\tCovered: " + strconv.FormatBool(field.Coverage))
 		if len(field.Values) > 0 {
-			buffer.WriteString("\tValues: [" + strings.Join(field.GetValues(), ",") + "]")
+			buffer.WriteString("\tValues: [" + strings.Join(field.GetValues(), ", ") + "]")
 		}
 	}
 	buffer.WriteString("\n")


### PR DESCRIPTION
This change adds a API and display support to retrieve total API coverage for a repo. This would act as summary across all resources in a repo to get the coverage percentage.

The change also includes some refactoring around coverage value display.