### PR TITLE
Allow listing prow builds in gcs without precompute start/finish time

### DIFF
--- a/tools/flaky-test-reporter/result.go
+++ b/tools/flaky-test-reporter/result.go
@@ -26,6 +26,7 @@ import (
 	"io/ioutil"
 	"path"
 	"path/filepath"
+	"sort"
 
 	"github.com/knative/test-infra/shared/prow"
 	"github.com/knative/test-infra/shared/junit"
@@ -144,7 +145,7 @@ func collectTestResultsForRepo(jc *JobConfig) (*RepoData, error) {
 	if !job.PathExists() {
 		return rd, fmt.Errorf("job path not exist '%s'", jc.Name)
 	}
-	builds := job.GetLatestBuilds(buildsCount)
+	builds := getLatestFinishedBuilds(job, buildsCount)
 	
 	log.Printf("latest builds: ")
 	for i, build := range builds {
@@ -164,4 +165,24 @@ func collectTestResultsForRepo(jc *JobConfig) (*RepoData, error) {
 		}
 	}
 	return rd, nil
+}
+
+// getLatestFinishedBuilds is an inexpensive way of listing latest finished builds, in comparing to
+// the GetLatestBuilds function from prow package, as it doesn't precompute start/finish time before sorting.
+// This function takes the assumption that build IDs are always incremental integers
+func getLatestFinishedBuilds(job *prow.Job, count int) []prow.Build {
+	var builds []prow.Build
+	buildIDs := job.GetBuildIDs()
+	fmt.Println(len(buildIDs))
+	sort.Sort(sort.Reverse(sort.IntSlice(buildIDs)))
+	for _, buildID := range buildIDs {
+		if len(builds) >= count {
+			break
+		}
+		build := job.NewBuild(buildID)
+		if nil != build.FinishTime {
+			builds = append(builds, *build)
+		}
+	}
+	return builds
 }


### PR DESCRIPTION
The current implementation of listing prow builds in gcs always precomputes start/finish time, by parsing `Started.json` and `Finished.json` on gcs, this is very expensive for listing latest N runs, especially when there are large number of builds, i.e. >5000 builds for serving continuous job. This PR adds a function for listing builds without precomputing start/finish time

Part of: #132 
