### PR TITLE
Fix failing release when `build_release` fails.

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -388,7 +388,11 @@ function main() {
 
   run_validation_tests ${VALIDATION_TESTS}
   banner "Building the release"
-  build_release || abort "error building the release"
+  build_release
+  # Do not use `||` above or any error will be swallowed.
+  if [[ $? -ne 0 ]]; then
+    abort "error building the release"
+  fi
   [[ -z "${YAMLS_TO_PUBLISH}" ]] && abort "no manifests were generated"
   echo "New release built successfully"
   if (( PUBLISH_RELEASE )); then


### PR DESCRIPTION
Addresses #513.

This now correctly fails for cases like:

```
$ ./hack/release.sh --notag-release --nopublish --skip-tests
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@@@@ Release configuration @@@@
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
- Destination GCR: ko.local
- Tests will NOT be run
- Artifacts WILL NOT be tagged
- Release will not be published
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@@@@ Building the release @@@@
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
Sending build context to Docker daemon  2.048kB
Step 1/2 : FROM alpine:latest
 ---> 3f53bb00af94
Step 2/2 : RUN apk add --update git openssh-client
 ---> Using cache
 ---> 23cd03203998
Successfully built 23cd03203998
Successfully tagged ko.local/github.com/knative/build/build-base:latest
Building build-crd
2019/02/25 10:16:08 Building github.com/knative/build/cmd/nop
2019/02/25 10:16:08 Building github.com/knative/build/cmd/creds-init
2019/02/25 10:16:08 Building github.com/knative/build/cmd/controller
2019/02/25 10:16:08 Building github.com/knative/build/cmd/git-init
2019/02/25 10:16:08 Building github.com/knative/build/cmd/webhook
2019/02/25 10:16:08 Using base gcr.io/distroless/base:latest for github.com/knative/build/cmd/nop
2019/02/25 10:16:09 Loading ko.local/github.com/knative/build/cmd/nop:6e695d74051c21edd8645afd051abf23486a51f1f5b4cfcf26173493c4ca5463
2019/02/25 10:16:10 Using base gcr.io/knative-nightlya/github.com/knative/build/build-base:latest for github.com/knative/build/cmd/creds-init
2019/02/25 10:16:10 Using base gcr.io/knative-nightlya/github.com/knative/build/build-base:latest for github.com/knative/build/cmd/git-init
2019/02/25 10:16:10 Loaded ko.local/github.com/knative/build/cmd/nop:6e695d74051c21edd8645afd051abf23486a51f1f5b4cfcf26173493c4ca5463
2019/02/25 10:16:10 error processing import paths in "config/999-cache.yaml": UNKNOWN: Project 'projects/knative-nightlya' not found or deleted.
$
```