### PR TITLE
Always store the logs in `go_test_e2e`

### DIFF
--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -203,6 +203,7 @@ function create_test_cluster() {
     gcloud compute http-health-checks delete -q --project=${gcloud_project} ${http_health_checks}
   fi
   local result="$(cat ${TEST_RESULT_FILE})"
+  echo "Artifacts were written to ${ARTIFACTS}"
   echo "Test result code is ${result}"
 
   exit ${result}


### PR DESCRIPTION
Addresses #527.

So it's easy to check them when running E2E tests locally.

`e2e-tests.sh` now displays where the artifacts were written once it finishes. For local runs, this is a new temporary directory and will contain both the JUnit XML file and the full go test log.