### PR TITLE
Adding webhook API Coverage prow job

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -1905,6 +1905,38 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
+- cron: "5 9 * * *"
+  name: ci-knative-serving-webhook-apicoverage
+  agent: kubernetes
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      args:
+      - "--scenario=kubernetes_execute_bazel"
+      - "--clean"
+      - "--job=$(JOB_NAME)"
+      - "--repo=github.com/knative/serving"
+      - "--root=/go/src"
+      - "--service-account=/etc/test-account/service-account.json"
+      - "--upload=gs://knative-prow/logs"
+      - "--timeout=50" # Avoid overrun
+      - "--" # end bootstrap args, scenario args below
+      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
+      - "./test/apicoverage.sh"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-west1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
 - cron: "0 1 * * *"
   name: ci-knative-serving-go-coverage
   agent: kubernetes

--- a/ci/prow/config_knative.yaml
+++ b/ci/prow/config_knative.yaml
@@ -147,6 +147,8 @@ periodics:
       cron: "5 8 * * *" # Run at 01:05PST every day (08:05 UTC)
     - performance: true
       cron: "0 1 * * *" # Run at 01:00 every day
+    - webhook-apicoverage: true
+      cron: "5 9 * * *" # Run at 02:05PST every day (09:05 UTC)
 
   knative/build:
     - continuous: true

--- a/ci/prow/make_config.go
+++ b/ci/prow/make_config.go
@@ -121,6 +121,7 @@ var (
 	presubmitScript      string
 	releaseScript        string
 	performanceScript    string
+	webhookAPICoverageScript string
 
 	// Overrides and behavior changes through command-line flags.
 	repositoryOverride string
@@ -772,6 +773,12 @@ func generatePeriodic(title string, repoName string, periodicConfig yaml.MapSlic
 			version := getString(item.Value)
 			jobNameSuffix = version + "-" + jobNameSuffix
 			data.Base.RepoBranch = "release-" + version
+		case "webhook-apicoverage":
+			if !getBool(item.Value) {
+				return
+			}
+			jobNameSuffix = "webhook-apicoverage"
+			data.Base.Command = webhookAPICoverageScript
 		case nil: // already processed by parseBasicJobConfig
 			continue
 		default:
@@ -1023,6 +1030,7 @@ func main() {
 	flag.StringVar(&presubmitScript, "presubmit-script", "./test/presubmit-tests.sh", "Executable for running presubmit tests")
 	flag.StringVar(&releaseScript, "release-script", "./hack/release.sh", "Executable for creating releases")
 	flag.StringVar(&performanceScript, "performance-script", "./test/performance-tests.sh", "Executable for running performance tests")
+	flag.StringVar(&webhookAPICoverageScript, "webhookAPICoverageScript", "./test/apicoverage.sh", "Executable for running webhook apicoverage tool")
 	flag.StringVar(&repositoryOverride, "repo-override", "", "Repository path (github.com/foo/bar[=branch]) to use instead for a job")
 	flag.StringVar(&jobNameFilter, "job-filter", "", "Generate only this job, instead of all jobs")
 	flag.StringVar(&preCommand, "pre-command", "", "Executable for running instead of the real command of a job")


### PR DESCRIPTION
This changeset adds the prow job to the webhook apicoverage tool on a periodic basis. The job is set to Run at 02:05PST every day (09:05 UTC)
