### PR TITLE
Simplify defining a continuous build for previous releases

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -1548,7 +1548,7 @@ periodics:
       - "--root=/go/src"
       - "--service-account=/etc/test-account/service-account.json"
       - "--upload=gs://knative-prow/logs"
-      - "--timeout=50" # Avoid overrun
+      - "--timeout=90" # Avoid overrun
       - "--" # end bootstrap args, scenario args below
       - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./hack/release.sh"
@@ -1590,7 +1590,7 @@ periodics:
       - "--root=/go/src"
       - "--service-account=/etc/test-account/service-account.json"
       - "--upload=gs://knative-prow/logs"
-      - "--timeout=50" # Avoid overrun
+      - "--timeout=90" # Avoid overrun
       - "--" # end bootstrap args, scenario args below
       - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./hack/release.sh"
@@ -1632,7 +1632,7 @@ periodics:
       - "--root=/go/src"
       - "--service-account=/etc/test-account/service-account.json"
       - "--upload=gs://knative-prow/logs"
-      - "--timeout=50" # Avoid overrun
+      - "--timeout=90" # Avoid overrun
       - "--" # end bootstrap args, scenario args below
       - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./hack/release.sh"

--- a/ci/prow/config_knative.yaml
+++ b/ci/prow/config_knative.yaml
@@ -101,33 +101,15 @@ periodics:
     - continuous: true
       cron: "1 * * * *" # Run every other hour and one minute
       timeout: 55
-    - continuous: true
+    - branch-ci: true
       release: "0.2"
-      needs-dind: true
       cron: "15 8 * * *" # Run at 01:15PST every day (08:15 UTC)
-      command:
-      - "./hack/release.sh"
-      args:
-      - "--nopublish"
-      - "--notag-release"
-    - continuous: true
+    - branch-ci: true
       release: "0.3"
-      needs-dind: true
       cron: "20 8 * * *" # Run at 01:20PST every day (08:20 UTC)
-      command:
-      - "./hack/release.sh"
-      args:
-      - "--nopublish"
-      - "--notag-release"
-    - continuous: true
+    - branch-ci: true
       release: "0.4"
-      needs-dind: true
       cron: "25 8 * * *" # Run at 01:25PST every day (08:25 UTC)
-      command:
-      - "./hack/release.sh"
-      args:
-      - "--nopublish"
-      - "--notag-release"
     - nightly: true
       cron: "1 8 * * *" # Run at 01:01PST every day (08:01 UTC)
     - dot-release: true

--- a/ci/prow/make_config.go
+++ b/ci/prow/make_config.go
@@ -108,6 +108,7 @@ var (
 	// Array constants used throughout the jobs.
 	allPresubmitTests = []string{"--all-tests", "--emit-metrics"}
 	releaseNightly    = []string{"--publish", "--tag-release"}
+	releaseLocal      = []string{"--nopublish", "--notag-release"}
 
 	// Values used in the jobs that can be changed through command-line flags.
 	gcsBucket            string
@@ -606,6 +607,13 @@ func addExtraEnvVarsToJob(data *baseProwJobTemplateData) {
 	}
 }
 
+// setupDockerInDockerForJob enables docker-in-docker for the given job.
+func setupDockerInDockerForJob(data *baseProwJobTemplateData) {
+	addVolumeToJob(data, "/docker-graph", "docker-graph", false)
+	addEnvToJob(data, "DOCKER_IN_DOCKER_ENABLED", "\"true\"")
+	(*data).SecurityContext = []string{"privileged: true"}
+}
+
 // Config parsers.
 
 // parseBasicJobConfig populates the given baseProwJobTemplateData with any basic option present in the given config.
@@ -622,9 +630,7 @@ func parseBasicJobConfig(data *baseProwJobTemplateData, config yaml.MapSlice) {
 			(*data).Command = getString(item.Value)
 		case "needs-dind":
 			if getBool(item.Value) {
-				addVolumeToJob(data, "/docker-graph", "docker-graph", false)
-				addEnvToJob(data, "DOCKER_IN_DOCKER_ENABLED", "\"true\"")
-				(*data).SecurityContext = []string{"privileged: true"}
+				setupDockerInDockerForJob(data)
 			}
 		case "always_run":
 			(*data).AlwaysRun = getBool(item.Value)
@@ -707,12 +713,14 @@ func generatePeriodic(title string, repoName string, periodicConfig yaml.MapSlic
 	parseBasicJobConfig(&data.Base, periodicConfig)
 	jobNameSuffix := ""
 	jobTemplate := periodicJob
+	jobType := ""
 	for _, item := range periodicConfig {
 		switch item.Key {
 		case "continuous":
 			if !getBool(item.Value) {
 				return
 			}
+			jobType = getString(item.Key)
 			jobNameSuffix = "continuous"
 			// Use default command and arguments if none given.
 			if data.Base.Command == "" {
@@ -725,15 +733,27 @@ func generatePeriodic(title string, repoName string, periodicConfig yaml.MapSlic
 			if !getBool(item.Value) {
 				return
 			}
+			jobType = getString(item.Key)
 			jobNameSuffix = "nightly-release"
 			data.Base.ServiceAccount = nightlyAccount
 			data.Base.Command = releaseScript
 			data.Base.Args = releaseNightly
 			data.Base.Timeout = 90
+		case "branch-ci":
+			if !getBool(item.Value) {
+				return
+			}
+			jobType = getString(item.Key)
+			jobNameSuffix = "continuous"
+			data.Base.Command = releaseScript
+			data.Base.Args = releaseLocal
+			setupDockerInDockerForJob(&data.Base)
+			data.Base.Timeout = 90
 		case "dot-release", "auto-release":
 			if !getBool(item.Value) {
 				return
 			}
+			jobType = getString(item.Key)
 			jobNameSuffix = getString(item.Key)
 			data.Base.ServiceAccount = releaseAccount
 			data.Base.Command = releaseScript
@@ -748,12 +768,14 @@ func generatePeriodic(title string, repoName string, periodicConfig yaml.MapSlic
 			if !getBool(item.Value) {
 				return
 			}
+			jobType = getString(item.Key)
 			jobNameSuffix = "performance"
 			data.Base.Command = performanceScript
 		case "latency":
 			if !getBool(item.Value) {
 				return
 			}
+			jobType = getString(item.Key)
 			jobTemplate = latencyJob
 			jobNameSuffix = "latency"
 			data.Base.Command = "unused"
@@ -761,10 +783,12 @@ func generatePeriodic(title string, repoName string, periodicConfig yaml.MapSlic
 			if !getBool(item.Value) {
 				return
 			}
+			jobType = getString(item.Key)
 			jobTemplate = apiCoverageJob
 			jobNameSuffix = "api-coverage"
 			data.Base.Command = "unused"
 		case "custom-job":
+			jobType = getString(item.Key)
 			jobNameSuffix = getString(item.Value)
 		case "cron":
 			data.CronString = getString(item.Value)
@@ -788,6 +812,9 @@ func generatePeriodic(title string, repoName string, periodicConfig yaml.MapSlic
 	}
 	if len(data.Base.Args) == 0 && data.Base.Command == "" {
 		log.Fatalf("Job %q is missing command", data.PeriodicJobName)
+	}
+	if jobType == "branch-ci" && data.Base.RepoBranch == "" {
+		log.Fatalf("%q jobs are intended to be used on release branches", jobType)
 	}
 	// Generate config itself.
 	data.PeriodicCommand = createCommand(data.Base)


### PR DESCRIPTION
Instead of customizing a continuous job, use a "branch-ci" job definition.