### PR TITLE
Handling parellel request to the webhook apicoverage tool

### DIFF
--- a/tools/webhook-apicoverage/resourcetree/basictypekindnode.go
+++ b/tools/webhook-apicoverage/resourcetree/basictypekindnode.go
@@ -68,7 +68,7 @@ func (b *BasicTypeKindNode) string(v reflect.Value) string {
 		if v.Int() != 0 {
 			return strconv.Itoa(int(v.Int()))
 		}
-	case reflect.Uint, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 		if v.Uint() != 0 {
 			return strconv.FormatUint(v.Uint(), 10)
 		}

--- a/tools/webhook-apicoverage/resourcetree/resourcetree.go
+++ b/tools/webhook-apicoverage/resourcetree/resourcetree.go
@@ -40,8 +40,8 @@ func (r *ResourceTree) createNode(field string, parent NodeInterface, t reflect.
 	case reflect.Ptr, reflect.UnsafePointer, reflect.Uintptr:
 		n = new(PtrKindNode)
 	case reflect.Bool, reflect.String, reflect.Float32, reflect.Float64,
-		reflect.Int, reflect.Int16, reflect.Int32, reflect.Int64,
-		reflect.Uint, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		reflect.Int, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint,
+		reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 		n = new(BasicTypeKindNode)
 	default:
 		n = new(OtherKindNode) // Maps, interfaces, etc


### PR DESCRIPTION
Webhook based API Coverage tool didn't support concurrent updates for data structures maintained by the resource tree. This causes issues for tests that run in parallel. This change introduces queue based resource coverage update by using go routines and channel.

The change also fixes a missed case for uint8 type in the resource tree.
