### PR TITLE
Enable the verify-owners plugin for Prow

### DIFF
--- a/ci/prow/plugins.yaml
+++ b/ci/prow/plugins.yaml
@@ -47,5 +47,6 @@ plugins:
   - size
   - skip
   - trigger
+  - verify-owners
   - wip
   - yuks


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Enable the verify-owners plugin for Prow 

Github issue: https://github.com/knative/test-infra/issues/324