### PR TITLE
Webhook-APICoverage: Prow job env variable fix

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -1929,6 +1929,8 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
+      - name: SYSTEM_NAMESPACE
+        value: knative-serving
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION

--- a/ci/prow/make_config.go
+++ b/ci/prow/make_config.go
@@ -714,6 +714,7 @@ func generatePeriodic(title string, repoName string, periodicConfig yaml.MapSlic
 			}
 			jobNameSuffix = "webhook-apicoverage"
 			data.Base.Command = webhookAPICoverageScript
+			addEnvToJob(&data.Base, "SYSTEM_NAMESPACE", data.Base.RepoNameForJob)
 		default:
 			continue
 		}


### PR DESCRIPTION
This change adds an environment variable into the Webhook API Coverage job that is required by the tool.
