### PR TITLE
Fix typo doc

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -132,7 +132,7 @@ This is a helper script for Knative E2E test scripts. To use it:
 
 1. [optional] Write the `dump_extra_cluster_state()` function. It will be
    called when a test fails, and can dump extra information about the current state
-   of the cluster (tipically using `kubectl`).
+   of the cluster (typically using `kubectl`).
 
 1. [optional] Write the `parse_flags()` function. It will be called whenever an
    unrecognized flag is passed to the script, allowing you to define your own flags.

--- a/tools/apicoverage/README.md
+++ b/tools/apicoverage/README.md
@@ -2,7 +2,7 @@
 This tool is designed to show the field level coverage exercised by the conformance tests.
 
 ## Read from GCS
-This tool reads the logs from the latest continuous build of knative/serving. The logs have the information of which CRD objects are being created and which fields are being set for the testing.
+This tool reads the logs from the latest continous build of knative/serving. The logs have the information of which CRD objects are being created and which fields are being set for the testing.
 It uses the service account passed in or by default will use the GOOGLE_APPLICATION_CREDENTIALS variable to get the logs. 
 
 ## Creating Output

--- a/tools/apicoverage/README.md
+++ b/tools/apicoverage/README.md
@@ -2,7 +2,7 @@
 This tool is designed to show the field level coverage exercised by the conformance tests.
 
 ## Read from GCS
-This tool reads the logs from the latest continous build of knative/serving. The logs have the information of which CRD objects are being created and which fields are being set for the testing.
+This tool reads the logs from the latest continuous build of knative/serving. The logs have the information of which CRD objects are being created and which fields are being set for the testing.
 It uses the service account passed in or by default will use the GOOGLE_APPLICATION_CREDENTIALS variable to get the logs. 
 
 ## Creating Output


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes a typo in `scripts/README.md`.