### PR TITLE
Enable auto and dot releases for eventing-sources

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -2451,6 +2451,90 @@ periodics:
     - name: nightly-account
       secret:
         secretName: nightly-account
+- cron: "17 9 * * 2"
+  name: ci-knative-eventing-sources-dot-release
+  agent: kubernetes
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      args:
+      - "--scenario=kubernetes_execute_bazel"
+      - "--clean"
+      - "--job=$(JOB_NAME)"
+      - "--repo=github.com/knative/eventing-sources"
+      - "--root=/go/src"
+      - "--service-account=/etc/release-account/service-account.json"
+      - "--upload=gs://knative-prow/logs"
+      - "--timeout=90" # Avoid overrun
+      - "--" # end bootstrap args, scenario args below
+      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
+      - "./hack/release.sh"
+      - "--dot-release"
+      - "--release-gcs knative-releases/eventing-sources"
+      - "--release-gcr gcr.io/knative-releases"
+      - "--github-token /etc/hub-token/token"
+      volumeMounts:
+      - name: hub-token
+        mountPath: /etc/hub-token
+        readOnly: true
+      - name: release-account
+        mountPath: /etc/release-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-west1
+    volumes:
+    - name: hub-token
+      secret:
+        secretName: hub-token
+    - name: release-account
+      secret:
+        secretName: release-account
+- cron: "5 */2 * * *"
+  name: ci-knative-eventing-sources-auto-release
+  agent: kubernetes
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      args:
+      - "--scenario=kubernetes_execute_bazel"
+      - "--clean"
+      - "--job=$(JOB_NAME)"
+      - "--repo=github.com/knative/eventing-sources"
+      - "--root=/go/src"
+      - "--service-account=/etc/release-account/service-account.json"
+      - "--upload=gs://knative-prow/logs"
+      - "--timeout=90" # Avoid overrun
+      - "--" # end bootstrap args, scenario args below
+      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
+      - "./hack/release.sh"
+      - "--auto-release"
+      - "--release-gcs knative-releases/eventing-sources"
+      - "--release-gcr gcr.io/knative-releases"
+      - "--github-token /etc/hub-token/token"
+      volumeMounts:
+      - name: hub-token
+        mountPath: /etc/hub-token
+        readOnly: true
+      - name: release-account
+        mountPath: /etc/release-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-west1
+    volumes:
+    - name: hub-token
+      secret:
+        secretName: hub-token
+    - name: release-account
+      secret:
+        secretName: release-account
 - cron: "0 1 * * *"
   name: ci-knative-eventing-sources-go-coverage
   agent: kubernetes

--- a/ci/prow/config_knative.yaml
+++ b/ci/prow/config_knative.yaml
@@ -166,6 +166,10 @@ periodics:
       cron: "30 * * * *" # Run every hour and 30 minutes
     - nightly: true
       cron: "16 9 * * *" # Run at 02:16PST every day (09:16 UTC)
+    - dot-release: true
+      cron: "17 9 * * 2" # Run at 02:17PST every Tuesday (09:17 UTC)
+    - auto-release: true
+      cron: "5 */2 * * *" # Run every two hours and five minutes
 
   knative/build-templates:
     - continuous: true


### PR DESCRIPTION
* Every Tuesday 2:17PST, if the latest eventing-sources release branch contains any new PRs, a new release will be built and published to GitHub automatically (as of today that will start with 0.4.2).
* Whenever a new release branch is created on GitHub (as of today that will start with release-0.5), within 3 hours a new release will be built and published to GitHub automatically.

Fixes https://github.com/knative/eventing-sources/issues/237

/hold
Requires https://github.com/knative/eventing-sources/pull/238 to be merged first.