### PR TITLE
flaky tests reporter: assorted fixes

### DIFF
--- a/tools/flaky-test-reporter/config.go
+++ b/tools/flaky-test-reporter/config.go
@@ -31,12 +31,15 @@ const (
 	threshold     = 0.01
 
 	org           = "knative"
-	// Temporarily creating issues under "test-infra" for better management
-	// TODO(chaodaiG): repo for issue same as the src of the test
-	repoForIssue  = "test-infra"
 )
 
-// jobConfigs defines which job to be monitored for giving repo
-var jobConfigs = []JobConfig{
-	{"ci-knative-serving-continuous", "serving", prow.PostsubmitJob}, // CI flow for serving repo
-}
+var (
+	jobConfigs = []JobConfig{
+		{"ci-knative-serving-continuous", "serving", prow.PostsubmitJob}, // CI flow for serving repo
+	}
+	// Temporarily creating issues under "test-infra" for better management
+	// TODO(chaodaiG): repo for issue same as the src of the test
+	repoIssueMap = map[string]string{
+		"serving": "test-infra",
+	}
+)

--- a/tools/flaky-test-reporter/ghutil/ghutil.go
+++ b/tools/flaky-test-reporter/ghutil/ghutil.go
@@ -60,7 +60,7 @@ type GithubClientInterface interface {
 	ReopenIssue(org, repo string, issueNumber int) error
 	ListComments(org, repo string, issueNumber int) ([]*github.IssueComment, error)
 	GetComment(org, repo string, commentID int64) (*github.IssueComment, error)
-	CreateComment(org, repo string, issueNumber int, commentBody string) error
+	CreateComment(org, repo string, issueNumber int, commentBody string) (*github.IssueComment, error)
 	EditComment(org, repo string, commentID int64, commentBody string) error
 	AddLabelsToIssue(org, repo string, issueNumber int, labels []string) error
 	RemoveLabelForIssue(org, repo string, issueNumber int, label string) error
@@ -231,7 +231,8 @@ func (gc *GithubClient) GetComment(org, repo string, commentID int64) (*github.I
 }
 
 // CreateComment adds comment to issue
-func (gc *GithubClient) CreateComment(org, repo string, issueNumber int, commentBody string) error {
+func (gc *GithubClient) CreateComment(org, repo string, issueNumber int, commentBody string) (*github.IssueComment, error) {
+	var res *github.IssueComment
 	comment := &github.IssueComment{
 		Body: &commentBody,
 	}
@@ -239,11 +240,13 @@ func (gc *GithubClient) CreateComment(org, repo string, issueNumber int, comment
 		fmt.Sprintf("commenting issue '%s %s %d'", org, repo, issueNumber),
 		maxRetryCount,
 		func() (*github.Response, error) {
-			_, resp, err := gc.Client.Issues.CreateComment(ctx, org, repo, issueNumber, comment)
+			var resp *github.Response
+			var err error
+			res, resp, err = gc.Client.Issues.CreateComment(ctx, org, repo, issueNumber, comment)
 			return resp, err
 		},
 	)
-	return err
+	return res, err
 }
 
 // EditComment edits comment by replacing with provided comment

--- a/tools/flaky-test-reporter/main.go
+++ b/tools/flaky-test-reporter/main.go
@@ -30,7 +30,7 @@ import (
 
 func main() {
 	serviceAccount := flag.String("service-account", os.Getenv("GOOGLE_APPLICATION_CREDENTIALS"), "JSON key file for GCS service account")
-	githubToken := flag.String("github-token", "", "Token file for Github authentication")
+	githubAccount := flag.String("github-account", "", "Token file for Github authentication")
 	slackAccount := flag.String("slack-account", "", "slack secret file for authenticating with Slack")
 	dryrun := flag.Bool("dry-run", false, "dry run switch")
 	flag.Parse()
@@ -42,7 +42,7 @@ func main() {
 	if err := prow.Initialize(*serviceAccount); nil != err { // Explicit authenticate with gcs Client
 		log.Fatalf("Failed authenticating GCS: '%v'", err)
 	}
-	ghi, err := Setup(*githubToken)
+	ghi, err := Setup(*githubAccount)
 	if err != nil {
 		log.Fatalf("Cannot setup github: %v", err)
 	}


### PR DESCRIPTION
Assorted fixes for flaky tests reporter, includes:
- When updating Github issues, derive repo name from issue struct instead of using where its was originally created
- CreateComment returns both comment and error, so that it's consistent with CreateIssue
- Add more fields to fake Github data for unit testing

Part of #132
