### PR TITLE
updating plank to v20190311

### DIFF
--- a/ci/prow/cluster.yaml
+++ b/ci/prow/cluster.yaml
@@ -148,7 +148,7 @@ spec:
       serviceAccountName: "plank"
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:v20190109-716fe27
+        image: gcr.io/k8s-prow/plank:v20190311-a967141
         args:
         - --dry-run=false
         volumeMounts:

--- a/ci/prow/cluster.yaml
+++ b/ci/prow/cluster.yaml
@@ -148,6 +148,7 @@ spec:
       serviceAccountName: "plank"
       containers:
       - name: plank
+        # Update plank utility_images versions in config.yaml when updating this version
         image: gcr.io/k8s-prow/plank:v20190311-a967141
         args:
         - --dry-run=false

--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -25,10 +25,10 @@ plank:
     timeout: 7200000000000 # 2h
     grace_period: 15000000000 # 15s
     utility_images:
-      clonerefs: "gcr.io/k8s-prow/clonerefs@sha256:b62ba1f379ac19c5ec9ee7bcab14d3f0b3c31cea9cdd4bc491e98e2c5f346c07"
-      initupload: "gcr.io/k8s-prow/initupload@sha256:58f89f2aae68f7dc46aaf05c7e8204c4f26b53ec9ce30353d1c27ce44a60d121"
-      entrypoint: "gcr.io/k8s-prow/entrypoint:v20180512-0255926d1"
-      sidecar: "gcr.io/k8s-prow/sidecar@sha256:8807b2565f4d2699920542fcf890878824b1ede4198d7ff46bca53feb064ed44"
+      clonerefs: "gcr.io/k8s-prow/clonerefs:v20190311-a967141"
+      initupload: "gcr.io/k8s-prow/initupload:v20190311-a967141"
+      entrypoint: "gcr.io/k8s-prow/entrypoint:v20190311-a967141"
+      sidecar: "gcr.io/k8s-prow/sidecar:v20190311-a967141"
     gcs_configuration:
       bucket: "knative-prow"
       path_strategy: "explicit"

--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -25,6 +25,7 @@ plank:
     timeout: 7200000000000 # 2h
     grace_period: 15000000000 # 15s
     utility_images:
+      # Update these versions when updating plank version in cluster.yaml
       clonerefs: "gcr.io/k8s-prow/clonerefs:v20190311-a967141"
       initupload: "gcr.io/k8s-prow/initupload:v20190311-a967141"
       entrypoint: "gcr.io/k8s-prow/entrypoint:v20190311-a967141"

--- a/ci/prow/make_config.go
+++ b/ci/prow/make_config.go
@@ -23,12 +23,13 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"log"
 	"strings"
 	"text/template"
 	"time"
+
+	"gopkg.in/yaml.v2"
 )
 
 const (
@@ -177,6 +178,7 @@ plank:
     timeout: 7200000000000 # 2h
     grace_period: 15000000000 # 15s
     utility_images:
+      # Update these versions when updating plank version in cluster.yaml
       clonerefs: "gcr.io/k8s-prow/clonerefs:v20190311-a967141"
       initupload: "gcr.io/k8s-prow/initupload:v20190311-a967141"
       entrypoint: "gcr.io/k8s-prow/entrypoint:v20190311-a967141"

--- a/ci/prow/make_config.go
+++ b/ci/prow/make_config.go
@@ -177,10 +177,10 @@ plank:
     timeout: 7200000000000 # 2h
     grace_period: 15000000000 # 15s
     utility_images:
-      clonerefs: "gcr.io/k8s-prow/clonerefs@sha256:b62ba1f379ac19c5ec9ee7bcab14d3f0b3c31cea9cdd4bc491e98e2c5f346c07"
-      initupload: "gcr.io/k8s-prow/initupload@sha256:58f89f2aae68f7dc46aaf05c7e8204c4f26b53ec9ce30353d1c27ce44a60d121"
-      entrypoint: "gcr.io/k8s-prow/entrypoint:v20180512-0255926d1"
-      sidecar: "gcr.io/k8s-prow/sidecar@sha256:8807b2565f4d2699920542fcf890878824b1ede4198d7ff46bca53feb064ed44"
+      clonerefs: "gcr.io/k8s-prow/clonerefs:v20190311-a967141"
+      initupload: "gcr.io/k8s-prow/initupload:v20190311-a967141"
+      entrypoint: "gcr.io/k8s-prow/entrypoint:v20190311-a967141"
+      sidecar: "gcr.io/k8s-prow/sidecar:v20190311-a967141"
     gcs_configuration:
       bucket: "[[.GcsBucket]]"
       path_strategy: "explicit"


### PR DESCRIPTION
plank was recently updated to v20190109 but not it's utilities images, which makes us missing some features, for example `decoration_config` for overriding default timeout, which is required by currently failing images cleanup job due to timeout.