### PR TITLE
Be more verbose about a release being published

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -388,7 +388,7 @@ function main() {
     tag_images_in_yamls ${YAMLS_TO_PUBLISH}
     publish_yamls ${YAMLS_TO_PUBLISH}
     publish_to_github ${YAMLS_TO_PUBLISH}
-    echo "New release published successfully"
+    banner "New release published successfully"
   fi
 }
 


### PR DESCRIPTION
Use a banner instead of just a message, it's easier to spot it in the (huge) Prow log.