### PR TITLE
hard code E2E_CLUSTER_ZONE to a

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -106,6 +106,8 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
+        - name: E2E_CLUSTER_ZONE
+          value: a
       volumes:
       - name: test-account
         secret:
@@ -141,6 +143,8 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
+        - name: E2E_CLUSTER_ZONE
+          value: a
       volumes:
       - name: test-account
         secret:
@@ -177,6 +181,8 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
+        - name: E2E_CLUSTER_ZONE
+          value: a
       volumes:
       - name: test-account
         secret:
@@ -216,6 +222,8 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
+        - name: E2E_CLUSTER_ZONE
+          value: a
       volumes:
       - name: test-account
         secret:
@@ -316,6 +324,8 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
+        - name: E2E_CLUSTER_ZONE
+          value: a
       volumes:
       - name: test-account
         secret:
@@ -352,6 +362,8 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
+        - name: E2E_CLUSTER_ZONE
+          value: a
       volumes:
       - name: test-account
         secret:
@@ -387,6 +399,8 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
+        - name: E2E_CLUSTER_ZONE
+          value: a
       volumes:
       - name: test-account
         secret:
@@ -428,6 +442,8 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
+        - name: E2E_CLUSTER_ZONE
+          value: a
       volumes:
       - name: docker-graph
         emptyDir: {}
@@ -497,6 +513,8 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
+        - name: E2E_CLUSTER_ZONE
+          value: a
       volumes:
       - name: test-account
         secret:
@@ -532,6 +550,8 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
+        - name: E2E_CLUSTER_ZONE
+          value: a
       volumes:
       - name: test-account
         secret:
@@ -567,6 +587,8 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
+        - name: E2E_CLUSTER_ZONE
+          value: a
       volumes:
       - name: test-account
         secret:
@@ -634,6 +656,8 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
+        - name: E2E_CLUSTER_ZONE
+          value: a
       volumes:
       - name: test-account
         secret:
@@ -669,6 +693,8 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
+        - name: E2E_CLUSTER_ZONE
+          value: a
       volumes:
       - name: test-account
         secret:
@@ -704,6 +730,8 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
+        - name: E2E_CLUSTER_ZONE
+          value: a
       volumes:
       - name: test-account
         secret:
@@ -771,6 +799,8 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
+        - name: E2E_CLUSTER_ZONE
+          value: a
       volumes:
       - name: test-account
         secret:
@@ -806,6 +836,8 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
+        - name: E2E_CLUSTER_ZONE
+          value: a
       volumes:
       - name: test-account
         secret:
@@ -841,6 +873,8 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
+        - name: E2E_CLUSTER_ZONE
+          value: a
       volumes:
       - name: test-account
         secret:
@@ -908,6 +942,8 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
+        - name: E2E_CLUSTER_ZONE
+          value: a
       volumes:
       - name: test-account
         secret:
@@ -943,6 +979,8 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
+        - name: E2E_CLUSTER_ZONE
+          value: a
       volumes:
       - name: test-account
         secret:
@@ -978,6 +1016,8 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
+        - name: E2E_CLUSTER_ZONE
+          value: a
       volumes:
       - name: test-account
         secret:
@@ -1045,6 +1085,8 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
+        - name: E2E_CLUSTER_ZONE
+          value: a
       volumes:
       - name: test-account
         secret:
@@ -1080,6 +1122,8 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
+        - name: E2E_CLUSTER_ZONE
+          value: a
       volumes:
       - name: test-account
         secret:
@@ -1115,6 +1159,8 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
+        - name: E2E_CLUSTER_ZONE
+          value: a
       volumes:
       - name: test-account
         secret:
@@ -1151,6 +1197,8 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
+        - name: E2E_CLUSTER_ZONE
+          value: a
       volumes:
       - name: test-account
         secret:
@@ -1186,6 +1234,8 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
+        - name: E2E_CLUSTER_ZONE
+          value: a
       volumes:
       - name: test-account
         secret:
@@ -1221,6 +1271,8 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
+        - name: E2E_CLUSTER_ZONE
+          value: a
       volumes:
       - name: test-account
         secret:
@@ -1288,6 +1340,8 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
+        - name: E2E_CLUSTER_ZONE
+          value: a
       volumes:
       - name: test-account
         secret:
@@ -1323,6 +1377,8 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
+        - name: E2E_CLUSTER_ZONE
+          value: a
       volumes:
       - name: test-account
         secret:
@@ -1358,6 +1414,8 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
+        - name: E2E_CLUSTER_ZONE
+          value: a
       volumes:
       - name: test-account
         secret:
@@ -1394,6 +1452,8 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
+        - name: E2E_CLUSTER_ZONE
+          value: a
       volumes:
       - name: test-account
         secret:
@@ -1429,6 +1489,8 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
+        - name: E2E_CLUSTER_ZONE
+          value: a
       volumes:
       - name: test-account
         secret:
@@ -1464,6 +1526,8 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
+        - name: E2E_CLUSTER_ZONE
+          value: a
       volumes:
       - name: test-account
         secret:

--- a/ci/prow/make_config.go
+++ b/ci/prow/make_config.go
@@ -597,6 +597,7 @@ func generatePresubmit(title string, repoName string, presubmitConfig yaml.MapSl
 	if data.Base.ServiceAccount != "" {
 		addEnvToJob(&data.Base, "GOOGLE_APPLICATION_CREDENTIALS", data.Base.ServiceAccount)
 		addEnvToJob(&data.Base, "E2E_CLUSTER_REGION", "us-west1")
+		addEnvToJob(&data.Base, "E2E_CLUSTER_ZONE", "a")
 	}
 	addExtraEnvVarsToJob(&data.Base)
 	configureServiceAccountForJob(&data.Base)


### PR DESCRIPTION
Seems like automatic cluster zone selection could also run into problem of picking zone that has not enough resource. Hard code zone to "a" so that it's easier to manage
Fixes #571 
