### PR TITLE
flaky test reporter: add new comment explaining closing/reopening reasons

### DIFF
--- a/tools/flaky-test-reporter/github_issue.go
+++ b/tools/flaky-test-reporter/github_issue.go
@@ -226,7 +226,12 @@ func (gi *GithubIssue) updateIssue(fi *flakyIssue, newComment string, ts *TestSt
 				if err := run(
 					"closing issue",
 					func() error {
-						return gi.client.CloseIssue(org, getRepoFromIssue(issue), *issue.Number)
+						closeErr := gi.client.CloseIssue(org, getRepoFromIssue(issue), *issue.Number)
+						if nil == closeErr {
+							closeComment := "Closing issue: this test has passed in latest 2 scans"
+							_, closeErr = gi.client.CreateComment(org, getRepoFromIssue(issue), *issue.Number, closeComment)
+						}
+						return closeErr
 					},
 					dryrun); nil != err {
 					return fmt.Errorf("failed closing issue '%s': '%v'", *issue.URL, err)
@@ -238,7 +243,12 @@ func (gi *GithubIssue) updateIssue(fi *flakyIssue, newComment string, ts *TestSt
 			if err := run(
 				"reopening issue",
 				func() error {
-					return gi.client.ReopenIssue(org, getRepoFromIssue(issue), *issue.Number)
+					openErr := gi.client.ReopenIssue(org, getRepoFromIssue(issue), *issue.Number)
+					if nil == openErr {
+						openComment := "Reopening issue: this test is flaky"
+						_, openErr = gi.client.CreateComment(org, getRepoFromIssue(issue), *issue.Number, openComment)
+					}
+					return openErr
 				},
 				dryrun); nil != err {
 				return fmt.Errorf("failed reopen issue: '%s'", *issue.URL)


### PR DESCRIPTION
For automatically closing/reopening actions done by flaky test reporter, add a comment explaining the action and reasons.
