### PR TITLE
Increase serving test timeouts

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -1419,7 +1419,7 @@ presubmits:
         secret:
           secretName: covbot-token
 periodics:
-- cron: "1 * * * *"
+- cron: "1 */2 * * *"
   name: ci-knative-serving-continuous
   agent: kubernetes
   spec:
@@ -1434,7 +1434,7 @@ periodics:
       - "--root=/go/src"
       - "--service-account=/etc/test-account/service-account.json"
       - "--upload=gs://knative-prow/logs"
-      - "--timeout=55" # Avoid overrun
+      - "--timeout=100" # Avoid overrun
       - "--" # end bootstrap args, scenario args below
       - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./test/presubmit-tests.sh"

--- a/ci/prow/config_knative.yaml
+++ b/ci/prow/config_knative.yaml
@@ -92,8 +92,8 @@ presubmits:
 periodics:
   knative/serving:
     - continuous: true
-      cron: "1 * * * *" # Run every other hour and one minute
-      timeout: 55
+      cron: "1 */2 * * *" # Run every other hour and one minute
+      timeout: 100
     - branch-ci: true
       release: "0.2"
       cron: "15 8 * * *" # Run at 01:15PST every day (08:15 UTC)


### PR DESCRIPTION
Per [testgrid](https://testgrid.knative.dev/knative-serving#continuous), the serving test suite is timing out. This changes back the timeout and run frequency configs of serving tests to address these timeouts.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
