### PR TITLE
Flaky test reporter: fixes for Prow job config and Docker file

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -2744,9 +2744,9 @@ periodics:
       command:
       - "/flaky-test-reporter"
       args:
-      - "--service-account /etc/test-account/service-account.json"
-      - "--github-account /etc/flaky-test-reporter-github-token/token"
-      - "--slack-account /etc/flaky-test-reporter-slack-token/token"
+      - "--service-account=/etc/test-account/service-account.json"
+      - "--github-account=/etc/flaky-test-reporter-github-token/token"
+      - "--slack-account=/etc/flaky-test-reporter-slack-token/token"
       volumeMounts:
       - name: test-account
         mountPath: /etc/test-account

--- a/ci/prow/make_config.go
+++ b/ci/prow/make_config.go
@@ -779,9 +779,9 @@ func generateFlakytoolPeriodicJob() {
 	data.CronString = flakesreporterPeriodicJobCron
 	data.Base.Command = "/flaky-test-reporter"
 	data.Base.Args = []string{
-		"--service-account " + data.Base.ServiceAccount,
-		"--github-account /etc/flaky-test-reporter-github-token/token",
-		"--slack-account /etc/flaky-test-reporter-slack-token/token"}
+		"--service-account=" + data.Base.ServiceAccount,
+		"--github-account=/etc/flaky-test-reporter-github-token/token",
+		"--slack-account=/etc/flaky-test-reporter-slack-token/token"}
 	addExtraEnvVarsToJob(&data.Base)
 	configureServiceAccountForJob(&data.Base)
 	addVolumeToJob(&data.Base, "/etc/flaky-test-reporter-github-token", "flaky-test-reporter-github-token", true)

--- a/images/flaky-test-reporter/Dockerfile
+++ b/images/flaky-test-reporter/Dockerfile
@@ -24,7 +24,7 @@ ADD . $TEMP_REPO_DIR
 
 # Build flaky test reporter tool in the container
 RUN make -C $TEMP_REPO_DIR/tools/$TOOL_NAME/
-RUN cp $TEMP_REPO_DIR/tools/$TOOL_NAME/$TOOL_NAME .
+RUN cp $TEMP_REPO_DIR/tools/$TOOL_NAME/$TOOL_NAME /$TOOL_NAME
 
 # Remove test-infra from the container
 RUN rm -fr $TEMP_REPO_DIR


### PR DESCRIPTION
Assorted fixes in Prow jobs and Docker file for flaky test reporter to make it work:
- Parameters names and values joined by `=` instead of space
- Copy exec directly under `/` in Docker file