### PR TITLE
Flaky test reporter: consider test as flaky even with not enough runs

### DIFF
--- a/tools/flaky-test-reporter/github_issue.go
+++ b/tools/flaky-test-reporter/github_issue.go
@@ -441,7 +441,7 @@ func (gi *GithubIssue) processGithubIssueForRepo(rd *RepoData, flakyIssuesMap ma
 
 	// Update/Create issues for flaky/used-to-be-flaky tests
 	for testFullName, ts := range rd.TestStats {
-		if !ts.hasEnoughRuns() || (!ts.isFlaky() && !ts.isPassed()) {
+		if !ts.isFlaky() && !ts.isPassed() {
 			continue
 		}
 		identity := getIdentityForTest(testFullName, rd.Config.Repo)


### PR DESCRIPTION
Currently for a test to be considered flaky, there needs to be enough runs, i.e. 8 valid runs(passed/failed) out of 10 runs. This can be inconsistent with Testgrid. For example there are 10 runs, 1 passed, 6 failed, and 3 skipped, current flaky test reporter would consider it not enough runs and skip reporting it. This PR covers this case by allowing test being considered flaky even with not enough runs