### PR TITLE
Revert Hardcoding cluster zones

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -104,8 +104,6 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
-        - name: E2E_CLUSTER_ZONE
-          value: a
       volumes:
       - name: test-account
         secret:
@@ -141,8 +139,6 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
-        - name: E2E_CLUSTER_ZONE
-          value: a
       volumes:
       - name: test-account
         secret:
@@ -179,8 +175,6 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
-        - name: E2E_CLUSTER_ZONE
-          value: a
       volumes:
       - name: test-account
         secret:
@@ -220,8 +214,6 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
-        - name: E2E_CLUSTER_ZONE
-          value: a
       volumes:
       - name: test-account
         secret:
@@ -322,8 +314,6 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
-        - name: E2E_CLUSTER_ZONE
-          value: a
       volumes:
       - name: test-account
         secret:
@@ -360,8 +350,6 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
-        - name: E2E_CLUSTER_ZONE
-          value: a
       volumes:
       - name: test-account
         secret:
@@ -397,8 +385,6 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
-        - name: E2E_CLUSTER_ZONE
-          value: a
       volumes:
       - name: test-account
         secret:
@@ -440,8 +426,6 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
-        - name: E2E_CLUSTER_ZONE
-          value: a
       volumes:
       - name: docker-graph
         emptyDir: {}
@@ -511,8 +495,6 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
-        - name: E2E_CLUSTER_ZONE
-          value: a
       volumes:
       - name: test-account
         secret:
@@ -548,8 +530,6 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
-        - name: E2E_CLUSTER_ZONE
-          value: a
       volumes:
       - name: test-account
         secret:
@@ -585,8 +565,6 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
-        - name: E2E_CLUSTER_ZONE
-          value: a
       volumes:
       - name: test-account
         secret:
@@ -654,8 +632,6 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
-        - name: E2E_CLUSTER_ZONE
-          value: a
       volumes:
       - name: test-account
         secret:
@@ -691,8 +667,6 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
-        - name: E2E_CLUSTER_ZONE
-          value: a
       volumes:
       - name: test-account
         secret:
@@ -728,8 +702,6 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
-        - name: E2E_CLUSTER_ZONE
-          value: a
       volumes:
       - name: test-account
         secret:
@@ -797,8 +769,6 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
-        - name: E2E_CLUSTER_ZONE
-          value: a
       volumes:
       - name: test-account
         secret:
@@ -834,8 +804,6 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
-        - name: E2E_CLUSTER_ZONE
-          value: a
       volumes:
       - name: test-account
         secret:
@@ -871,8 +839,6 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
-        - name: E2E_CLUSTER_ZONE
-          value: a
       volumes:
       - name: test-account
         secret:
@@ -940,8 +906,6 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
-        - name: E2E_CLUSTER_ZONE
-          value: a
       volumes:
       - name: test-account
         secret:
@@ -977,8 +941,6 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
-        - name: E2E_CLUSTER_ZONE
-          value: a
       volumes:
       - name: test-account
         secret:
@@ -1014,8 +976,6 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
-        - name: E2E_CLUSTER_ZONE
-          value: a
       volumes:
       - name: test-account
         secret:
@@ -1052,8 +1012,6 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
-        - name: E2E_CLUSTER_ZONE
-          value: a
       volumes:
       - name: test-account
         secret:
@@ -1089,8 +1047,6 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
-        - name: E2E_CLUSTER_ZONE
-          value: a
       volumes:
       - name: test-account
         secret:
@@ -1126,8 +1082,6 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
-        - name: E2E_CLUSTER_ZONE
-          value: a
       volumes:
       - name: test-account
         secret:
@@ -1195,8 +1149,6 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
-        - name: E2E_CLUSTER_ZONE
-          value: a
       volumes:
       - name: test-account
         secret:
@@ -1232,8 +1184,6 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
-        - name: E2E_CLUSTER_ZONE
-          value: a
       volumes:
       - name: test-account
         secret:
@@ -1269,8 +1219,6 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
-        - name: E2E_CLUSTER_ZONE
-          value: a
       volumes:
       - name: test-account
         secret:
@@ -1307,8 +1255,6 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
-        - name: E2E_CLUSTER_ZONE
-          value: a
       volumes:
       - name: test-account
         secret:
@@ -1344,8 +1290,6 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
-        - name: E2E_CLUSTER_ZONE
-          value: a
       volumes:
       - name: test-account
         secret:
@@ -1381,8 +1325,6 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-west1
-        - name: E2E_CLUSTER_ZONE
-          value: a
       volumes:
       - name: test-account
         secret:
@@ -1449,8 +1391,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-west1
-      - name: E2E_CLUSTER_ZONE
-        value: a
     volumes:
     - name: test-account
       secret:
@@ -1491,8 +1431,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-west1
-      - name: E2E_CLUSTER_ZONE
-        value: a
     volumes:
     - name: docker-graph
       emptyDir: {}
@@ -1535,8 +1473,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-west1
-      - name: E2E_CLUSTER_ZONE
-        value: a
     volumes:
     - name: docker-graph
       emptyDir: {}
@@ -1579,8 +1515,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-west1
-      - name: E2E_CLUSTER_ZONE
-        value: a
     volumes:
     - name: docker-graph
       emptyDir: {}
@@ -1617,8 +1551,6 @@ periodics:
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-west1
-      - name: E2E_CLUSTER_ZONE
-        value: a
     volumes:
     - name: nightly-account
       secret:
@@ -1658,8 +1590,6 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-west1
-      - name: E2E_CLUSTER_ZONE
-        value: a
     volumes:
     - name: hub-token
       secret:
@@ -1702,8 +1632,6 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-west1
-      - name: E2E_CLUSTER_ZONE
-        value: a
     volumes:
     - name: hub-token
       secret:
@@ -1740,8 +1668,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-west1
-      - name: E2E_CLUSTER_ZONE
-        value: a
     volumes:
     - name: test-account
       secret:
@@ -1774,8 +1700,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-west1
-      - name: E2E_CLUSTER_ZONE
-        value: a
     volumes:
     - name: test-account
       secret:
@@ -1807,8 +1731,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-west1
-      - name: E2E_CLUSTER_ZONE
-        value: a
     volumes:
     - name: test-account
       secret:
@@ -1841,8 +1763,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-west1
-      - name: E2E_CLUSTER_ZONE
-        value: a
     volumes:
     - name: test-account
       secret:
@@ -1877,8 +1797,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-west1
-      - name: E2E_CLUSTER_ZONE
-        value: a
     volumes:
     - name: test-account
       secret:
@@ -1933,8 +1851,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-west1
-      - name: E2E_CLUSTER_ZONE
-        value: a
     volumes:
     - name: test-account
       secret:
@@ -1975,8 +1891,6 @@ periodics:
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-west1
-      - name: E2E_CLUSTER_ZONE
-        value: a
     volumes:
     - name: docker-graph
       emptyDir: {}
@@ -2018,8 +1932,6 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-west1
-      - name: E2E_CLUSTER_ZONE
-        value: a
     volumes:
     - name: hub-token
       secret:
@@ -2068,8 +1980,6 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-west1
-      - name: E2E_CLUSTER_ZONE
-        value: a
     volumes:
     - name: hub-token
       secret:
@@ -2107,8 +2017,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-west1
-      - name: E2E_CLUSTER_ZONE
-        value: a
     volumes:
     - name: test-account
       secret:
@@ -2163,8 +2071,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-west1
-      - name: E2E_CLUSTER_ZONE
-        value: a
     volumes:
     - name: test-account
       secret:
@@ -2219,8 +2125,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-west1
-      - name: E2E_CLUSTER_ZONE
-        value: a
     volumes:
     - name: test-account
       secret:
@@ -2255,8 +2159,6 @@ periodics:
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-west1
-      - name: E2E_CLUSTER_ZONE
-        value: a
     volumes:
     - name: nightly-account
       secret:
@@ -2296,8 +2198,6 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-west1
-      - name: E2E_CLUSTER_ZONE
-        value: a
     volumes:
     - name: hub-token
       secret:
@@ -2340,8 +2240,6 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-west1
-      - name: E2E_CLUSTER_ZONE
-        value: a
     volumes:
     - name: hub-token
       secret:
@@ -2399,8 +2297,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-west1
-      - name: E2E_CLUSTER_ZONE
-        value: a
     volumes:
     - name: test-account
       secret:
@@ -2435,8 +2331,6 @@ periodics:
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-west1
-      - name: E2E_CLUSTER_ZONE
-        value: a
     volumes:
     - name: nightly-account
       secret:
@@ -2476,8 +2370,6 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-west1
-      - name: E2E_CLUSTER_ZONE
-        value: a
     volumes:
     - name: hub-token
       secret:
@@ -2520,8 +2412,6 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-west1
-      - name: E2E_CLUSTER_ZONE
-        value: a
     volumes:
     - name: hub-token
       secret:
@@ -2579,8 +2469,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-west1
-      - name: E2E_CLUSTER_ZONE
-        value: a
     volumes:
     - name: test-account
       secret:
@@ -2615,8 +2503,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-west1
-      - name: E2E_CLUSTER_ZONE
-        value: a
     volumes:
     - name: test-account
       secret:
@@ -2671,8 +2557,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-west1
-      - name: E2E_CLUSTER_ZONE
-        value: a
     volumes:
     - name: test-account
       secret:

--- a/ci/prow/make_config.go
+++ b/ci/prow/make_config.go
@@ -597,7 +597,6 @@ func generatePresubmit(title string, repoName string, presubmitConfig yaml.MapSl
 	if data.Base.ServiceAccount != "" {
 		addEnvToJob(&data.Base, "GOOGLE_APPLICATION_CREDENTIALS", data.Base.ServiceAccount)
 		addEnvToJob(&data.Base, "E2E_CLUSTER_REGION", "us-west1")
-		addEnvToJob(&data.Base, "E2E_CLUSTER_ZONE", "a")
 	}
 	addExtraEnvVarsToJob(&data.Base)
 	configureServiceAccountForJob(&data.Base)
@@ -744,7 +743,6 @@ func generatePeriodic(title string, repoName string, periodicConfig yaml.MapSlic
 	if data.Base.ServiceAccount != "" {
 		addEnvToJob(&data.Base, "GOOGLE_APPLICATION_CREDENTIALS", data.Base.ServiceAccount)
 		addEnvToJob(&data.Base, "E2E_CLUSTER_REGION", "us-west1")
-		addEnvToJob(&data.Base, "E2E_CLUSTER_ZONE", "a")
 	}
 	addExtraEnvVarsToJob(&data.Base)
 	configureServiceAccountForJob(&data.Base)


### PR DESCRIPTION
This reverts the commits which added the cluster zone configuration, which caused a regression due to clusters not being Highly Available. 

These configurations were added to address a stockout issue we had. I filed [an issue](https://github.com/knative/test-infra/issues/592) to better address stockouts in the future. 

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
