### PR TITLE
Fix docs link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 # Contribution guidelines
 
-So you want to hack on Knative Test Infrastructure? Yay! Please refer to Knative's overall [contribution guidelines](https://github.com/knative/docs/blob/master/community/CONTRIBUTING.md) to find out how you can help.
+So you want to hack on Knative Test Infrastructure? Yay! Please refer to Knative's overall [contribution guidelines](https://github.com/knative/docs/blob/master/contributing/CONTRIBUTING.md) to find out how you can help.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

A recent commit in the docs repo, https://github.com/knative/docs/commit/3c04f86ad7b7f937ae552a1b93eca97a5d312449, has moved the `CONTRIBUTING.md` to a different directly resulting in a broken link.
