### PR TITLE
Flaky test reporter: don't list individual test in Slack if flaky rate too high 

### DIFF
--- a/tools/flaky-test-reporter/github_issue.go
+++ b/tools/flaky-test-reporter/github_issue.go
@@ -102,7 +102,7 @@ func getIdentityForTest(testFullName, repoName string) string {
 	return fmt.Sprintf("'%s' in repo '%s'", testFullName, repoName)
 }
 
-// getBulkIssueIdentity creates a unique identify for bulk issue when flaky rate above threshold
+// getBulkIssueIdentity creates a unique identity for a bulk issue when the flaky rate is above a threshold
 func getBulkIssueIdentity(rd *RepoData, flakyRate float32) string {
 	return fmt.Sprintf("%.2f%% tests failed in repo %s on %s",
 		flakyRate*100, rd.Config.Repo, time.Unix(*rd.LastBuildStartTime, 0).String())

--- a/tools/flaky-test-reporter/slack_notification.go
+++ b/tools/flaky-test-reporter/slack_notification.go
@@ -113,6 +113,8 @@ func createSlackMessageForRepo(rd *RepoData, flakyIssuesMap map[string][]*flakyI
 	if flakyRate > threshold { // Don't list each test as this can be huge
 		message += fmt.Sprintf("\n>- skip displaying all tests as flaky rate above '%0.2f%%'", threshold)
 		if flakyIssues, ok := flakyIssuesMap[getBulkIssueIdentity(rd, flakyRate)]; ok {
+			// When flaky rate is above threthold, there is only one issue created,
+			// so there is only one element in flakyIssues
 			for _, fi := range flakyIssues {
 				message += fmt.Sprintf("\t%s", fi.issue.GetHTMLURL())
 			}


### PR DESCRIPTION
When the ratio of flaky tests is above certain threshold, there is only 1 issue created to avoid flooding github. Apply the same logic to Slack notification, so that we will not get a message with thousand lines