### PR TITLE
Point to new ko repo

### DIFF
--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -38,7 +38,7 @@ RUN rm -rf /usr/local/go && \
     rm "${GO_TARBALL}"
 
 # Extra tools through go get
-RUN go get -u github.com/google/go-containerregistry/cmd/ko
+RUN go get -u github.com/google/ko/cmd/ko
 RUN go get -u github.com/golang/dep/cmd/dep
 RUN go get -u github.com/google/licenseclassifier
 RUN go get -u github.com/jstemmer/go-junit-report


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

`ko` now has its own repo at https://github.com/google/ko
