### PR TITLE
Cleanup Testgrid a bit

### DIFF
--- a/ci/prow/Makefile
+++ b/ci/prow/Makefile
@@ -48,5 +48,8 @@ test:
 	go run make_config.go --prow-config-output="$(TMP_YAML_PROW)" --testgrid-config-output="$(TMP_YAML_TESTGRID)" config_knative.yaml
 	diff config.yaml $(TMP_YAML_PROW)
 	diff $(TESTGRID_DIR)/config.yaml $(TMP_YAML_TESTGRID)
-	@echo "*** Checking config validity"
+	@echo "*** Checking configs validity"
 	bazel run @k8s//prow/cmd/checkconfig -- --plugin-config=$(PROW_DIR)/plugins.yaml --config-path=$(PROW_DIR)/config.yaml
+	bazel run @k8s//testgrid/cmd/configurator -- \
+		--yaml=$(TESTGRID_DIR)/config.yaml \
+		--validate-config-file

--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -1704,37 +1704,6 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "5 8 * * *"
-  name: ci-knative-serving-api-coverage
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: knative
-    repo: serving
-    base_ref: master
-    clone_uri: "https://github.com/knative/serving.git"
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/apicoverage:latest
-      imagePullPolicy: Always
-      command:
-      - "/apicoverage"
-      args:
-      - "--artifacts-dir=$(ARTIFACTS)"
-      - "--service-account=/etc/test-account/service-account.json"
-      volumeMounts:
-      - name: test-account
-        mountPath: /etc/test-account
-        readOnly: true
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/test-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-    volumes:
-    - name: test-account
-      secret:
-        secretName: test-account
 - cron: "0 1 * * *"
   name: ci-knative-serving-performance
   agent: kubernetes

--- a/ci/prow/config_knative.yaml
+++ b/ci/prow/config_knative.yaml
@@ -118,8 +118,6 @@ periodics:
       timeout: 90
     - latency: true
       cron: "5 8 * * *" # Run at 01:05PST every day (08:05 UTC)
-    - api-coverage: true
-      cron: "5 8 * * *" # Run at 01:05PST every day (08:05 UTC)
     - performance: true
       cron: "0 1 * * *" # Run at 01:00 every day
     - webhook-apicoverage: true

--- a/ci/prow/make_config.go
+++ b/ci/prow/make_config.go
@@ -852,18 +852,6 @@ func generatePeriodic(title string, repoName string, periodicConfig yaml.MapSlic
 				fmt.Sprintf("--source-directory=ci-%s-continuous", data.Base.RepoNameForJob),
 				"--artifacts-dir=$(ARTIFACTS)",
 				"--service-account=" + data.Base.ServiceAccount}
-		case "api-coverage":
-			if !getBool(item.Value) {
-				return
-			}
-			jobType = getString(item.Key)
-			jobTemplate = periodicCustomJob
-			jobNameSuffix = "api-coverage"
-			data.Base.Image = "gcr.io/knative-tests/test-infra/apicoverage:latest"
-			data.Base.Command = "/apicoverage"
-			data.Base.Args = []string{
-				"--artifacts-dir=$(ARTIFACTS)",
-				"--service-account=" + data.Base.ServiceAccount}
 		case "custom-job":
 			jobType = getString(item.Key)
 			jobNameSuffix = getString(item.Value)
@@ -1230,7 +1218,7 @@ func collectMetaData(periodicJob yaml.MapSlice) {
 			releaseVersion := ""
 			for _, item := range jobConfig {
 				switch item.Key {
-				case "continuous", "dot-release", "auto-release", "performance", "latency", "api-coverage", "nightly":
+				case "continuous", "dot-release", "auto-release", "performance", "latency", "nightly":
 					if getBool(item.Value) {
 						enabled = true
 						jobName = getString(item.Key)
@@ -1314,7 +1302,7 @@ func generateTestGroup(repoName string, jobNames []string) {
 		gcsLogDir := fmt.Sprintf("%s/%s/%s", gcsBucket, logsDir, testGroupName)
 		extras := make(map[string]string)
 		switch jobName {
-		case "continuous", "dot-release", "auto-release", "performance", "latency", "api-coverage", "playground", "nightly":
+		case "continuous", "dot-release", "auto-release", "performance", "latency", "playground", "nightly":
 			if jobName == "playground" {
 				// TODO(Fredy-Z): this value should be derived from the cron string
 				extras["alert_stale_results_hours"] = "168"
@@ -1322,9 +1310,6 @@ func generateTestGroup(repoName string, jobNames []string) {
 
 			if jobName == "latency" {
 				extras["short_text_metric"] = "latency"
-			}
-			if jobName == "api-coverage" {
-				extras["short_text_metric"] = "api_coverage"
 			}
 			if jobName == "performance" {
 				extras["short_text_metric"] = "perf_latency"
@@ -1361,7 +1346,7 @@ func generateDashboard(repoName string, jobNames []string) {
 			if repoName == "knative-serving" {
 				executeDashboardTabTemplate("conformance-tests", testGroupName, "include-filter-by-regex=test/conformance\\\\.&sort-by-name=", noExtras)
 			}
-		case "dot-release", "auto-release", "performance", "latency", "api-coverage", "playground":
+		case "dot-release", "auto-release", "performance", "latency", "playground":
 			extras := make(map[string]string)
 			baseOptions := testgridTabSortByName
 			switch jobName {
@@ -1370,9 +1355,6 @@ func generateDashboard(repoName string, jobNames []string) {
 			case "latency":
 				baseOptions = testgridTabGroupByDir
 				extras["description"] = "95% latency in ms"
-			case "api-coverage":
-				baseOptions = testgridTabGroupByDir
-				extras["description"] = "Conformance tests API coverage."
 			}
 			executeDashboardTabTemplate(jobName, testGroupName, baseOptions, extras)
 		case "nightly":
@@ -1398,7 +1380,7 @@ func executeDashboardTabTemplate(dashboardTabName string, testGroupName string, 
 // getTestGroupName get the testGroupName from the given repoName and jobName
 func getTestGroupName(repoName string, jobName string) string {
 	switch jobName {
-	case "continuous", "dot-release", "auto-release", "performance", "latency", "api-coverage", "playground":
+	case "continuous", "dot-release", "auto-release", "performance", "latency", "playground":
 		return fmt.Sprintf("ci-%s-%s", repoName, jobName)
 	case "nightly":
 		return fmt.Sprintf("ci-%s-%s-release", repoName, jobName)

--- a/ci/testgrid/config.yaml
+++ b/ci/testgrid/config.yaml
@@ -70,9 +70,6 @@ test_groups:
 - name: ci-knative-serving-latency
   gcs_prefix: knative-prow/logs/ci-knative-serving-latency
   short_text_metric: "latency"
-- name: ci-knative-serving-api-coverage
-  gcs_prefix: knative-prow/logs/ci-knative-serving-api-coverage
-  short_text_metric: "api_coverage"
 - name: ci-knative-serving-performance
   gcs_prefix: knative-prow/logs/ci-knative-serving-performance
   short_text_metric: "perf_latency"
@@ -163,10 +160,6 @@ dashboards:
     test_group_name: ci-knative-serving-latency
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
     description: "95% latency in ms"
-  - name: api-coverage
-    test_group_name: ci-knative-serving-api-coverage
-    base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
-    description: "Conformance tests API coverage."
   - name: performance
     test_group_name: ci-knative-serving-performance
     base_options: "exclude-filter-by-regex=Overall$&group-by-target=&expand-groups=&sort-by-name="

--- a/ci/testgrid/config.yaml
+++ b/ci/testgrid/config.yaml
@@ -147,7 +147,7 @@ dashboards:
   - name: conformance-tests
     test_group_name: ci-knative-serving-continuous
     base_options: "include-filter-by-regex=test/conformance\\.&sort-by-name="
-  - name: release
+  - name: nightly
     test_group_name: ci-knative-serving-nightly-release
     base_options: "sort-by-name="
   - name: dot-release
@@ -178,7 +178,7 @@ dashboards:
   - name: continuous
     test_group_name: ci-knative-build-continuous
     base_options: "sort-by-name="
-  - name: release
+  - name: nightly
     test_group_name: ci-knative-build-nightly-release
     base_options: "sort-by-name="
   - name: dot-release
@@ -207,7 +207,7 @@ dashboards:
   - name: continuous
     test_group_name: ci-knative-eventing-continuous
     base_options: "sort-by-name="
-  - name: release
+  - name: nightly
     test_group_name: ci-knative-eventing-nightly-release
     base_options: "sort-by-name="
   - name: dot-release
@@ -224,7 +224,7 @@ dashboards:
   - name: continuous
     test_group_name: ci-knative-eventing-sources-continuous
     base_options: "sort-by-name="
-  - name: release
+  - name: nightly
     test_group_name: ci-knative-eventing-sources-nightly-release
     base_options: "sort-by-name="
   - name: dot-release


### PR DESCRIPTION
* rename "release" tab to "nightly" (this is a more appropriate and clear name)
* add back Testgrid config test that was dropped by mistake in #583
* remove the now unused api-coverage job (and tab)