### PR TITLE
Enable dind for integration test in docs repo

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -968,16 +968,24 @@ presubmits:
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--integration-tests"
+        securityContext:
+          privileged: true
         volumeMounts:
+        - name: docker-graph
+          mountPath: /docker-graph
         - name: test-account
           mountPath: /etc/test-account
           readOnly: true
         env:
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: "true"
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-central1
       volumes:
+      - name: docker-graph
+        emptyDir: {}
       - name: test-account
         secret:
           secretName: test-account
@@ -2169,16 +2177,24 @@ periodics:
       - "./test/presubmit-tests.sh"
       - "--all-tests"
       - "--emit-metrics"
+      securityContext:
+        privileged: true
       volumeMounts:
+      - name: docker-graph
+        mountPath: /docker-graph
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
       env:
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
     volumes:
+    - name: docker-graph
+      emptyDir: {}
     - name: test-account
       secret:
         secretName: test-account

--- a/ci/prow/config_knative.yaml
+++ b/ci/prow/config_knative.yaml
@@ -69,6 +69,7 @@ presubmits:
     - build-tests: true
     - unit-tests: true
     - integration-tests: true
+      needs-dind: true
     - go-coverage: true
       go-coverage-threshold: 50
 
@@ -146,6 +147,7 @@ periodics:
 
   knative/docs:
     - continuous: true
+      needs-dind: true
       cron: "50 * * * *" # Run every hour and 50 minutes
 
   knative/eventing:


### PR DESCRIPTION
Enable docker in docker for integration test in docs repo, as docker is needed for running e2e tests while testing sample apps deployment. For example: https://github.com/knative/docs/tree/master/docs/serving/samples/hello-world/helloworld-java