### PR TITLE
sending slack notification to api channel

### DIFF
--- a/tools/flaky-test-reporter/slack_notification.go
+++ b/tools/flaky-test-reporter/slack_notification.go
@@ -42,7 +42,7 @@ const (
 
 // slackChannelsMap defines mapping of repo: slack channels
 var slackChannelsMap = map[string][]slackChannel{
-	"serving": []slackChannel{{"test", "CA1DTGZ2N"}},
+	"serving": []slackChannel{{"api", "CA4DNJ9A4"}},
 }
 
 // SlackClient contains Slack bot related information


### PR DESCRIPTION
Sending Slack notification to # api channel for flaky tests discovered in serving repo