### PR TITLE
remove post-knative-serving-go-coverage as defaultPostSubmitJobName

### DIFF
--- a/tools/coverage/main.go
+++ b/tools/coverage/main.go
@@ -33,7 +33,7 @@ const (
 	defaultStdoutRedirect    = "stdout.txt"
 	defaultCoverageTargetDir = "./pkg/"
 	defaultGcsBucket         = "knative-prow"
-	defaultPostSubmitJobName = "post-knative-serving-go-coverage"
+	defaultPostSubmitJobName = ""
 	defaultCovThreshold      = 80
 )
 


### PR DESCRIPTION
We are running code coverage on multiple repos and we are running it not only in pre-submit.
Periodical jobs and post-submit jobs do not need the flag and it is distracting to set the defaultPostSubmitJobName, as it would be printed in logs.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes https://github.com/knative/test-infra/issues/645
