### PR TITLE
Allow running a setup function before starting the test cluster

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -132,6 +132,12 @@ This is a helper script for Knative E2E test scripts. To use it:
 1. [optional] Write the `test_teardown()` function, which will tear down the test
    resources.
 
+1. [optional] Write the `cluster_setup()` function, which will set up any resources
+   before the test cluster is created.
+
+1. [optional] Write the `cluster_teardown()` function, which will tear down any
+   resources after the test cluster is destroyed.
+
 1. [optional] Write the `dump_extra_cluster_state()` function. It will be
    called when a test fails, and can dump extra information about the current state
    of the cluster (typically using `kubectl`).

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -150,6 +150,10 @@ function create_test_cluster() {
   set -o errexit
   set -o pipefail
 
+  if function_exists cluster_setup; then
+    cluster_setup || fail_test "cluster setup failed"
+  fi
+
   header "Creating test cluster"
 
   echo "Cluster will have a minimum of ${E2E_MIN_CLUSTER_NODES} and a maximum of ${E2E_MAX_CLUSTER_NODES} nodes."
@@ -209,6 +213,7 @@ function create_test_cluster() {
   echo "Test subprocess exited with code $?"
   # Ignore any errors below, this is a best-effort cleanup and shouldn't affect the test result.
   set +o errexit
+  function_exists cluster_teardown && cluster_teardown
   delete_leaked_network_resources
   local result="$(cat ${TEST_RESULT_FILE})"
   echo "Artifacts were written to ${ARTIFACTS}"


### PR DESCRIPTION
Also allow running the counterpart teardown function.

Fixes #666.