### PR TITLE
Increase timeout of branch CI tests

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -1556,7 +1556,7 @@ periodics:
       - "--root=/go/src"
       - "--service-account=/etc/test-account/service-account.json"
       - "--upload=gs://knative-prow/logs"
-      - "--timeout=90" # Avoid overrun
+      - "--timeout=180" # Avoid overrun
       - "--" # end bootstrap args, scenario args below
       - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./hack/release.sh"

--- a/ci/prow/make_config.go
+++ b/ci/prow/make_config.go
@@ -829,7 +829,8 @@ func generatePeriodic(title string, repoName string, periodicConfig yaml.MapSlic
 			data.Base.Command = releaseScript
 			data.Base.Args = releaseLocal
 			setupDockerInDockerForJob(&data.Base)
-			data.Base.Timeout = 90
+			// TODO(adrcunha): Consider reducing the timeout in the future.
+			data.Base.Timeout = 180
 		case "dot-release", "auto-release":
 			if !getBool(item.Value) {
 				return


### PR DESCRIPTION
It's not unusual that release-0.4 CI takes more than 90 minutes to finish. With 0.5 released, this won't be addressed so timeout failures provides no valuable signals.