### PR TITLE
E2E clusters creation retry different regions/zones

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -108,8 +108,10 @@ This is a helper script for Knative E2E test scripts. To use it:
    if the default values don't fit your needs:
 
    - `E2E_CLUSTER_REGION`: Cluster region, defaults to `us-central1`.
+   - `E2E_CLUSTER_BACKUP_REGION`: Backup cluster regions for retry, defaults to `us-west1 us-east1`. (Retry is only triggered when there is a stockout)
    - `E2E_CLUSTER_ZONE`: Cluster zone (e.g., `a`), defaults to none (i.e. use a regional
      cluster).
+   - `E2E_CLUSTER_BACKUP_ZONE`: Backup cluster zone for retry, defaults to none. If defined `E2E_CLUSTER_BACKUP_REGION` will be ignored.
    - `E2E_CLUSTER_MACHINE`: Cluster node machine type, defaults to `n1-standard-4}`.
    - `E2E_MIN_CLUSTER_NODES`: Minimum number of nodes in the cluster when autoscaling,
      defaults to 1.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -108,10 +108,10 @@ This is a helper script for Knative E2E test scripts. To use it:
    if the default values don't fit your needs:
 
    - `E2E_CLUSTER_REGION`: Cluster region, defaults to `us-central1`.
-   - `E2E_CLUSTER_BACKUP_REGION`: Backup cluster regions for retry, defaults to `us-west1 us-east1`. (Retry is only triggered when there is a stockout)
+   - `E2E_CLUSTER_BACKUP_REGIONS`: Space-separated list of regions to retry test cluster creation in case of stockout. Defaults to `us-west1 us-east1`.
    - `E2E_CLUSTER_ZONE`: Cluster zone (e.g., `a`), defaults to none (i.e. use a regional
      cluster).
-   - `E2E_CLUSTER_BACKUP_ZONE`: Backup cluster zone for retry, defaults to none. If defined `E2E_CLUSTER_BACKUP_REGION` will be ignored.
+   - `E2E_CLUSTER_BACKUP_ZONES`: Space-separated list of zones to retry test cluster creation in case of stockout. If defined, `E2E_CLUSTER_BACKUP_REGION` will be ignored thus it defaults to none.
    - `E2E_CLUSTER_MACHINE`: Cluster node machine type, defaults to `n1-standard-4}`.
    - `E2E_MIN_CLUSTER_NODES`: Minimum number of nodes in the cluster when autoscaling,
      defaults to 1.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -111,7 +111,7 @@ This is a helper script for Knative E2E test scripts. To use it:
    - `E2E_CLUSTER_BACKUP_REGIONS`: Space-separated list of regions to retry test cluster creation in case of stockout. Defaults to `us-west1 us-east1`.
    - `E2E_CLUSTER_ZONE`: Cluster zone (e.g., `a`), defaults to none (i.e. use a regional
      cluster).
-   - `E2E_CLUSTER_BACKUP_ZONES`: Space-separated list of zones to retry test cluster creation in case of stockout. If defined, `E2E_CLUSTER_BACKUP_REGION` will be ignored thus it defaults to none.
+   - `E2E_CLUSTER_BACKUP_ZONES`: Space-separated list of zones to retry test cluster creation in case of stockout. If defined, `E2E_CLUSTER_BACKUP_REGIONS` will be ignored thus it defaults to none.
    - `E2E_CLUSTER_MACHINE`: Cluster node machine type, defaults to `n1-standard-4}`.
    - `E2E_MIN_CLUSTER_NODES`: Minimum number of nodes in the cluster when autoscaling,
      defaults to 1.

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -37,7 +37,7 @@ function build_resource_name() {
 
 # Test cluster parameters
 
-# export E2E_CLUSTER_REGION and E2E_CLUSTER_ZONE to make save_metadata work
+# export E2E_CLUSTER_REGION and E2E_CLUSTER_ZONE as they're used in the cluster setup subprocess
 # Configurable parameters
 export E2E_CLUSTER_REGION=${E2E_CLUSTER_REGION:-us-central1}
 # By default we use regional clusters.


### PR DESCRIPTION
E2E test jobs sometimes fail due to stockout in certain regions/zones, current strategy is manually switch to different regions/zones. This PR provides a solution of automatically retrying different regions/zones when stockout happens.

Fixes #592 
