### PR TITLE
refactor mkdir into a common function

### DIFF
--- a/shared/common/common.go
+++ b/shared/common/common.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"fmt"
+	"os"
+)
+
+const allUsersFullPermission = 0777
+
+// CreateDir creates dir if does not exist.
+// The created dir will have the permission bits as 0777, which means everyone can read/write/execute it.
+func CreateDir(dirPath string) error {
+	return CreateDirWithFileMode(dirPath, allUsersFullPermission)
+}
+
+// CreateDirWithFileMode creates dir if does not exist.
+// The created dir will have the permission bits as perm, which is the standard Unix rwxrwxrwx permissions.
+func CreateDirWithFileMode(dirPath string, perm os.FileMode) error {
+	if _, err := os.Stat(dirPath); os.IsNotExist(err) {
+		if err = os.MkdirAll(dirPath, perm); err != nil {
+			return fmt.Errorf("Failed to create directory: %v", err)
+		}
+	}
+	return nil
+}

--- a/shared/loadgenerator/loadgenerator.go
+++ b/shared/loadgenerator/loadgenerator.go
@@ -27,7 +27,7 @@ import (
 
 	"fortio.org/fortio/fhttp"
 	"fortio.org/fortio/periodic"
-	"github.com/knative/pkg/test/helpers"
+	"github.com/knative/test-infra/shared/common"
 	"github.com/knative/test-infra/shared/prow"
 )
 
@@ -110,7 +110,7 @@ func (g *GeneratorOptions) RunLoadTest(resolvableDomain bool) (*GeneratorResults
 // SaveJSON saves the results as Json in the artifacts directory
 func (gr *GeneratorResults) SaveJSON(testName string) error {
 	dir := prow.GetLocalArtifactsDir()
-	if err := helpers.CreateDir(dir); err != nil {
+	if err := common.CreateDir(dir); err != nil {
 		return err
 	}
 

--- a/shared/loadgenerator/loadgenerator.go
+++ b/shared/loadgenerator/loadgenerator.go
@@ -27,6 +27,7 @@ import (
 
 	"fortio.org/fortio/fhttp"
 	"fortio.org/fortio/periodic"
+	"github.com/knative/pkg/test/helpers"
 	"github.com/knative/test-infra/shared/prow"
 )
 
@@ -109,10 +110,8 @@ func (g *GeneratorOptions) RunLoadTest(resolvableDomain bool) (*GeneratorResults
 // SaveJSON saves the results as Json in the artifacts directory
 func (gr *GeneratorResults) SaveJSON(testName string) error {
 	dir := prow.GetLocalArtifactsDir()
-	if _, err := os.Stat(dir); os.IsNotExist(err) {
-		if err = os.MkdirAll(dir, 0777); err != nil {
-			return fmt.Errorf("Failed to create dir: %v", err)
-		}
+	if err := helpers.CreateDir(dir); err != nil {
+		return err
 	}
 
 	outputFile := dir + "/" + testName + jsonExt

--- a/shared/testgrid/testgrid.go
+++ b/shared/testgrid/testgrid.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path"
 
+	"github.com/knative/pkg/test/helpers"
 	"github.com/knative/test-infra/shared/junit"
 	"github.com/knative/test-infra/shared/prow"
 )
@@ -38,16 +39,6 @@ const (
 // jobNameTestgridURLMap contains harded coded mapping of job name: Testgrid tab URL relative to base URL
 var jobNameTestgridURLMap = map[string]string{
 	"ci-knative-serving-continuous": "knative-serving#continuous",
-}
-
-// createDir creates dir if does not exist.
-func createDir(dirPath string) error {
-	if _, err := os.Stat(dirPath); os.IsNotExist(err) {
-		if err = os.MkdirAll(dirPath, 0777); err != nil {
-			return fmt.Errorf("Failed to create directory: %v", err)
-		}
-	}
-	return nil
 }
 
 // GetTestgridTabURL gets Testgrid URL for giving job and filters for Testgrid
@@ -69,7 +60,7 @@ func CreateXMLOutput(tc []junit.TestCase, testName string) error {
 
 	// ensure artifactsDir exist, in case not invoked from this script
 	artifactsDir := prow.GetLocalArtifactsDir()
-	if err := createDir(artifactsDir); nil != err {
+	if err := helpers.CreateDir(artifactsDir); nil != err {
 		return err
 	}
 	op, err := ts.ToBytes("", "  ")

--- a/shared/testgrid/testgrid.go
+++ b/shared/testgrid/testgrid.go
@@ -24,7 +24,7 @@ import (
 	"os"
 	"path"
 
-	"github.com/knative/pkg/test/helpers"
+	"github.com/knative/test-infra/shared/common"
 	"github.com/knative/test-infra/shared/junit"
 	"github.com/knative/test-infra/shared/prow"
 )
@@ -60,7 +60,7 @@ func CreateXMLOutput(tc []junit.TestCase, testName string) error {
 
 	// ensure artifactsDir exist, in case not invoked from this script
 	artifactsDir := prow.GetLocalArtifactsDir()
-	if err := helpers.CreateDir(artifactsDir); nil != err {
+	if err := common.CreateDir(artifactsDir); nil != err {
 		return err
 	}
 	op, err := ts.ToBytes("", "  ")

--- a/tools/flaky-test-reporter/main.go
+++ b/tools/flaky-test-reporter/main.go
@@ -25,7 +25,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/knative/pkg/test/helpers"
+	"github.com/knative/test-infra/shared/common"
 	"github.com/knative/test-infra/shared/prow"
 )
 
@@ -56,7 +56,7 @@ func main() {
 	// Clean up local artifacts directory, this will be used later for artifacts uploads
 	err = os.RemoveAll(prow.GetLocalArtifactsDir()) // this function returns nil if path not found
 	if nil == err {
-		err = helpers.CreateDir(prow.GetLocalArtifactsDir())
+		err = common.CreateDir(prow.GetLocalArtifactsDir())
 	}
 	if nil != err {
 		log.Fatalf("Failed preparing local artifacts directory: %v", err)

--- a/tools/flaky-test-reporter/main.go
+++ b/tools/flaky-test-reporter/main.go
@@ -25,6 +25,7 @@ import (
 	"log"
 	"os"
 
+	"github.com/knative/pkg/test/helpers"
 	"github.com/knative/test-infra/shared/prow"
 )
 
@@ -55,9 +56,7 @@ func main() {
 	// Clean up local artifacts directory, this will be used later for artifacts uploads
 	err = os.RemoveAll(prow.GetLocalArtifactsDir()) // this function returns nil if path not found
 	if nil == err {
-		if _, err = os.Stat(prow.GetLocalArtifactsDir()); os.IsNotExist(err) {
-			err = os.MkdirAll(prow.GetLocalArtifactsDir(), 0777)
-		}
+		err = helpers.CreateDir(prow.GetLocalArtifactsDir())
 	}
 	if nil != err {
 		log.Fatalf("Failed preparing local artifacts directory: %v", err)
@@ -77,7 +76,7 @@ func main() {
 
 	// Errors that could result in inaccuracy reporting would be treated with fast fail by processGithubIssues,
 	// so any errors returned are github opeations error, which in most cases wouldn't happend, but in case it
-	// happens, it should fail the job after Slack notification 
+	// happens, it should fail the job after Slack notification
 	githubErr := ghi.processGithubIssues(repoDataAll, *dryrun)
 	slackErr := sendSlackNotifications(repoDataAll, slackClient, ghi, *dryrun)
 	if nil != githubErr {


### PR DESCRIPTION
#656 
Create `test-infra/shared/common/common.go` to hold the `CreateDir` function, and use it to replace the duplicate code.

We can continuously add common functions used by multiple components in this file.