### PR TITLE
Fix batch job wait logic.

### DIFF
--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -153,7 +153,7 @@ function wait_until_batch_job_complete() {
   for i in {1..150}; do  # timeout after 5 minutes
     local pods="$(kubectl get pods --selector=job-name --no-headers -n $1 2>/dev/null | grep -v '^[[:space:]]*$')"
     # All pods must be complete
-    local not_complete=$(echo "${pods}" | grep -v Completed | wc -l)
+    local not_complete=$(echo "${pods}" | grep -v Completed | grep -v "^[[:space:]]*$" | wc -l)
     if [[ ${not_complete} -eq 0 ]]; then
       echo -e "\nAll pods are complete:\n${pods}"
       return 0

--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -151,7 +151,7 @@ function wait_until_pods_running() {
 function wait_until_batch_job_complete() {
   echo -n "Waiting until all batch jobs in namespace $1 run to completion."
   for i in {1..150}; do  # timeout after 5 minutes
-    local jobs=$(kubectl get jobs -n $1 --no-headers
+    local jobs=$(kubectl get jobs -n $1 --no-headers \
                  -ocustom-columns='n:{.metadata.name},c:{.spec.completions},s:{.status.succeeded}')
     # All jobs must be complete
     local not_complete=$(echo "${jobs}" | awk '{if ($2!=$3) print $0}' | wc -l)

--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -151,7 +151,8 @@ function wait_until_pods_running() {
 function wait_until_batch_job_complete() {
   echo -n "Waiting until all batch jobs in namespace $1 run to completion."
   for i in {1..150}; do  # timeout after 5 minutes
-    local jobs=$(kubectl get jobs -n $1 --no-headers)
+    local jobs=$(kubectl get jobs -n $1 --no-headers
+                 -ocustom-columns='n:{.metadata.name},c:{.spec.completions},s:{.status.succeeded}')
     # All jobs must be complete
     local not_complete=$(echo "${jobs}" | awk '{if ($2!=$3) print $0}' | wc -l)
     if [[ ${not_complete} -eq 0 ]]; then

--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -146,22 +146,22 @@ function wait_until_pods_running() {
   return 1
 }
 
-# Waits until all batch job pods are running in the given namespace.
+# Waits until all batch jobs complete in the given namespace.
 # Parameters: $1 - namespace.
 function wait_until_batch_job_complete() {
-  echo -n "Waiting until all batch job pods in namespace $1 run to completion."
+  echo -n "Waiting until all batch jobs in namespace $1 run to completion."
   for i in {1..150}; do  # timeout after 5 minutes
-    local pods="$(kubectl get pods --selector=job-name --no-headers -n $1 2>/dev/null | grep -v '^[[:space:]]*$')"
-    # All pods must be complete
-    local not_complete=$(echo "${pods}" | grep -v Completed | grep -v "^[[:space:]]*$" | wc -l)
+    local jobs=$(kubectl get jobs -n $1 --no-headers)
+    # All jobs must be complete
+    local not_complete=$(echo "${jobs}" | awk '{if ($2!=$3) print $0}' | wc -l)
     if [[ ${not_complete} -eq 0 ]]; then
-      echo -e "\nAll pods are complete:\n${pods}"
+      echo -e "\nAll jobs are complete:\n${jobs}"
       return 0
     fi
     echo -n "."
     sleep 2
   done
-  echo -e "\n\nERROR: timeout waiting for pods to complete\n${pods}"
+  echo -e "\n\nERROR: timeout waiting for jobs to complete\n${jobs}"
   return 1
 }
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

In older version of Istio there are no batch jobs.  Changing this wait to succeed when there are no batch job running so we can run tests with Istio 1.0.x.