### PR TITLE
Use 6 janitors for Boskos cleanup

### DIFF
--- a/ci/prow/boskos/config.yaml
+++ b/ci/prow/boskos/config.yaml
@@ -104,7 +104,7 @@ metadata:
     app: boskos-janitor
   namespace: test-pods
 spec:
-  replicas: 3  # 3 distributed janitor instances
+  replicas: 6  # 6 distributed janitor instances
   template:
     metadata:
       labels:


### PR DESCRIPTION
Boskos projects cleanup is significantly slower than it's being used since moving the clusters cleaning up part to Boskos. Up janitors count to make it catch up