### PR TITLE
make E2E_CLUSTER_PROJECT globally available

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -155,8 +155,9 @@ This is a helper script for Knative E2E test scripts. To use it:
 1. Write logic for the end-to-end tests. Run all go tests using `go_test_e2e()`
    (or `report_go_test()` if you need a more fine-grained control) and call
    `fail_test()` or `success()` if any of them failed. The environment variable
-   `KO_DOCKER_REPO` will be set according to the test cluster. You can also use
-   the following boolean (0 is false, 1 is true) environment variables for the logic:
+   `KO_DOCKER_REPO` and `E2E_PROJECT_ID` will be set according to the test cluster.
+   You can also use the following boolean (0 is false, 1 is true) environment
+   variables for the logic:
 
    - `EMIT_METRICS`: true if `--emit-metrics` was passed.
 

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -273,6 +273,7 @@ function setup_test_cluster() {
 
   header "Setting up test cluster"
 
+  # Set the actual project the test cluster resides in
   E2E_CLUSTER_PROJECT="$(gcloud config get-value project)"
   readonly E2E_CLUSTER_PROJECT
 

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -113,7 +113,7 @@ function save_metadata() {
     geo_key="Zone"
     geo_value="${E2E_CLUSTER_REGION}-${E2E_CLUSTER_ZONE}"
   fi
-  local cluster_version="$(gcloud container clusters list --project=${E2E_CLUSTER_PROJECT} --format='value(currentMasterVersion)')"
+  local cluster_version="$(gcloud container clusters list --project=${E2E_PROJECT_ID} --format='value(currentMasterVersion)')"
   cat << EOF > ${ARTIFACTS}/metadata.json
 {
   "E2E:${geo_key}": "${geo_value}",
@@ -271,7 +271,7 @@ function setup_test_cluster() {
   # Set the actual project the test cluster resides in
   # It will be a project assigned by Boskos if test is running on Prow, 
   # otherwise will be ${GCP_PROJECT} set up by user.
-  export E2E_CLUSTER_PROJECT="$(gcloud config get-value project)"
+  readonly export E2E_PROJECT_ID="$(gcloud config get-value project)"
 
   # Save some metadata about cluster creation for using in prow and testgrid
   save_metadata
@@ -284,15 +284,15 @@ function setup_test_cluster() {
   if [[ -z "$(kubectl get clusterrolebinding cluster-admin-binding 2> /dev/null)" ]]; then
     acquire_cluster_admin_role ${k8s_user} ${E2E_CLUSTER_NAME} ${E2E_CLUSTER_REGION} ${E2E_CLUSTER_ZONE}
     kubectl config set-context ${k8s_cluster} --namespace=default
-    export KO_DOCKER_REPO=gcr.io/${E2E_CLUSTER_PROJECT}/${E2E_BASE_NAME}-e2e-img
+    readonly export KO_DOCKER_REPO=gcr.io/${E2E_PROJECT_ID}/${E2E_BASE_NAME}-e2e-img
   fi
 
-  echo "- Project is ${E2E_CLUSTER_PROJECT}"
+  echo "- Project is ${E2E_PROJECT_ID}"
   echo "- Cluster is ${k8s_cluster}"
   echo "- User is ${k8s_user}"
   echo "- Docker is ${KO_DOCKER_REPO}"
 
-  export KO_DATA_PATH="${REPO_ROOT_DIR}/.git"
+  readonly export KO_DATA_PATH="${REPO_ROOT_DIR}/.git"
 
   trap teardown_test_resources EXIT
 

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -284,7 +284,7 @@ function setup_test_cluster() {
   if [[ -z "$(kubectl get clusterrolebinding cluster-admin-binding 2> /dev/null)" ]]; then
     acquire_cluster_admin_role ${k8s_user} ${E2E_CLUSTER_NAME} ${E2E_CLUSTER_REGION} ${E2E_CLUSTER_ZONE}
     kubectl config set-context ${k8s_cluster} --namespace=default
-    readonly export KO_DOCKER_REPO=gcr.io/${E2E_PROJECT_ID}/${E2E_BASE_NAME}-e2e-img
+    export KO_DOCKER_REPO=gcr.io/${E2E_PROJECT_ID}/${E2E_BASE_NAME}-e2e-img
   fi
 
   echo "- Project is ${E2E_PROJECT_ID}"
@@ -292,7 +292,7 @@ function setup_test_cluster() {
   echo "- User is ${k8s_user}"
   echo "- Docker is ${KO_DOCKER_REPO}"
 
-  readonly export KO_DATA_PATH="${REPO_ROOT_DIR}/.git"
+  export KO_DATA_PATH="${REPO_ROOT_DIR}/.git"
 
   trap teardown_test_resources EXIT
 

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -260,11 +260,6 @@ function create_test_cluster_with_retries() {
   done
 }
 
-# Flag which project holds the actual e2e test cluster.
-# It will be a project assigned by Boskos if test is running on Prow, 
-# otherwise will be ${GCP_PROJECT} set up by user.
-E2E_CLUSTER_PROJECT=""
-
 # Setup the test cluster for running the tests.
 function setup_test_cluster() {
   # Fail fast during setup.
@@ -274,8 +269,9 @@ function setup_test_cluster() {
   header "Setting up test cluster"
 
   # Set the actual project the test cluster resides in
-  E2E_CLUSTER_PROJECT="$(gcloud config get-value project)"
-  readonly E2E_CLUSTER_PROJECT
+  # It will be a project assigned by Boskos if test is running on Prow, 
+  # otherwise will be ${GCP_PROJECT} set up by user.
+  export E2E_CLUSTER_PROJECT="$(gcloud config get-value project)"
 
   # Save some metadata about cluster creation for using in prow and testgrid
   save_metadata


### PR DESCRIPTION
As an enhancement for the [PR in Eventing](https://github.com/knative/eventing/pull/1066#discussion_r276495895), add a flag `E2E_CLUSTER_PROJECT` that saves the actual project the `E2E_CLUSTER` resides in, and make it globally available.