### PR TITLE
Add defaults before using the values

### DIFF
--- a/shared/loadgenerator/loadgenerator.go
+++ b/shared/loadgenerator/loadgenerator.go
@@ -88,9 +88,7 @@ func (g *GeneratorOptions) addDefaults() {
 
 // CreateRunnerOptions sets up the fortio client with the knobs needed to run the load test
 func (g *GeneratorOptions) CreateRunnerOptions(resolvableDomain bool) *fhttp.HTTPRunnerOptions {
-	g.addDefaults()
 	o := fhttp.NewHTTPOptions(g.URL)
-
 	o.NumConnections = g.NumConnections
 	o.HTTPReqTimeOut = g.RequestTimeout
 
@@ -125,6 +123,7 @@ For LoadFactors=[1,2,4], baseQPS=q, duration=d
             1       2       3  <--- factors
 */
 func (g *GeneratorOptions) RunLoadTest(resolvableDomain bool) (*GeneratorResults, error) {
+	g.addDefaults()
 	res := make([]*fhttp.HTTPRunnerResults, len(g.LoadFactors))
 
 	for i, f := range g.LoadFactors {

--- a/shared/loadgenerator/loadgenerator_test.go
+++ b/shared/loadgenerator/loadgenerator_test.go
@@ -19,58 +19,10 @@ package loadgenerator_test
 import (
 	"os"
 	"testing"
-	"time"
 
 	"github.com/knative/test-infra/shared/loadgenerator"
 	"github.com/knative/test-infra/shared/prow"
 )
-
-const (
-	testTime = 1 * time.Minute
-	testNum  = 5
-	testUrl  = "http://example.com"
-	testQPS  = 100.0
-)
-
-func getOptions() *loadgenerator.GeneratorOptions {
-	return &loadgenerator.GeneratorOptions{
-		Duration:       testTime,
-		NumThreads:     testNum,
-		NumConnections: testNum,
-		URL:            testUrl,
-		Domain:         testUrl,
-		BaseQPS:        testQPS,
-	}
-}
-
-func TestCreateRunnerOptions(t *testing.T) {
-	o := getOptions()
-	opts := o.CreateRunnerOptions(false)
-
-	if opts.RunnerOptions.Duration != testTime {
-		t.Fatalf("Duration is %v. Expected %v", opts.RunnerOptions.Duration, testTime)
-	}
-
-	if opts.RunnerOptions.NumThreads != testNum {
-		t.Fatalf("Number of threads is %d. Expected %d", opts.RunnerOptions.NumThreads, testNum)
-	}
-
-	if opts.RunnerOptions.QPS != testQPS {
-		t.Fatalf("QPS is %f. Expected %f", opts.RunnerOptions.QPS, testQPS)
-	}
-
-	if opts.HTTPOptions.NumConnections != testNum {
-		t.Fatalf("Number of connections is %d. Expected %d", opts.HTTPOptions.NumConnections, testNum)
-	}
-
-	if opts.HTTPOptions.HTTPReqTimeOut != testTime {
-		t.Fatalf("Request timeout is %v. Expected %v", opts.HTTPOptions.HTTPReqTimeOut, testTime)
-	}
-
-	if opts.HTTPOptions.URL != testUrl {
-		t.Fatalf("Url is %s. Expected %s", opts.HTTPOptions.URL, testUrl)
-	}
-}
 
 func TestSaveJSON(t *testing.T) {
 	res := &loadgenerator.GeneratorResults{}


### PR DESCRIPTION
We were updating the default values when we were creating the fortio options. But, we were using some generator option values before setting them up correctly. This PR updates the place where we add the default options at the start before using the values. 

Also, remove an unnecessary UT as this was just testing if the fortio assignment was working correctly and does not really help in testing our wrapper. We now have an e2e that tests this functionality making this UT moot.

Fixes https://github.com/knative/serving/issues/3812