### PR TITLE
E2E test allow arbitrary cluster name

### DIFF
--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -282,7 +282,7 @@ function setup_test_cluster() {
   # If cluster admin role isn't set, this is a brand new cluster
   # Setup the admin role and also KO_DOCKER_REPO
   if [[ -z "$(kubectl get clusterrolebinding cluster-admin-binding 2> /dev/null)" ]]; then
-    acquire_cluster_admin_role ${k8s_user} ${E2E_CLUSTER_NAME} ${E2E_CLUSTER_REGION} ${E2E_CLUSTER_ZONE}
+    acquire_cluster_admin_role ${k8s_user} ${k8s_cluster} ${E2E_CLUSTER_REGION} ${E2E_CLUSTER_ZONE}
     kubectl config set-context ${k8s_cluster} --namespace=default
     export KO_DOCKER_REPO=gcr.io/${E2E_PROJECT_ID}/${E2E_BASE_NAME}-e2e-img
   fi


### PR DESCRIPTION
In `setup_cluster` we dynamically set GCP cloud project, user, and cluster context, but not cluster name, as `E2E_CLUSTER_NAME` is a hard coded value. This PR enables arbitrary cluster name based on context.