### PR TITLE
Increase timeout for perf job to 2 hrs

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -1823,7 +1823,7 @@ periodics:
       - "--root=/go/src"
       - "--service-account=/etc/test-account/service-account.json"
       - "--upload=gs://knative-prow/logs"
-      - "--timeout=50" # Avoid overrun
+      - "--timeout=120" # Avoid overrun
       - "--" # end bootstrap args, scenario args below
       - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./test/performance-tests.sh"

--- a/ci/prow/make_config.go
+++ b/ci/prow/make_config.go
@@ -856,6 +856,7 @@ func generatePeriodic(title string, repoName string, periodicConfig yaml.MapSlic
 			// We need a larger cluster of at least 16 nodes for perf tests
 			addEnvToJob(&data.Base, "E2E_MIN_CLUSTER_NODES", "16")
 			addEnvToJob(&data.Base, "E2E_MAX_CLUSTER_NODES", "16")
+			data.Base.Timeout = 120
 		case "latency":
 			if !getBool(item.Value) {
 				return


### PR DESCRIPTION
The perf tests run more than the allotted 50m and we are adding more tests here. We had a higher timeout to run all these tests