### PR TITLE
Add ability to add cpu and memory profile with loadgenerator

### DIFF
--- a/shared/loadgenerator/loadgenerator.go
+++ b/shared/loadgenerator/loadgenerator.go
@@ -118,7 +118,12 @@ func (g *GeneratorOptions) CreateRunnerOptions(resolvableDomain bool) *fhttp.HTT
 	}
 
 	if len(g.FileNamePrefix) != 0 {
-		ro.Profiler = g.FileNamePrefix
+		dir := prow.GetLocalArtifactsDir()
+		if err := common.CreateDir(dir); err != nil {
+			return nil
+		}
+
+		ro.Profiler = path.Join(dir, g.FileNamePrefix)
 	}
 
 	return &ro

--- a/shared/loadgenerator/loadgenerator.go
+++ b/shared/loadgenerator/loadgenerator.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path"
 	"time"
 
 	"fortio.org/fortio/fhttp"
@@ -64,11 +65,19 @@ type GeneratorOptions struct {
 	// LoadFactors defines the multiplier for baseQPS.
 	// Len(loadfactors) defines the number of QPS changes.
 	LoadFactors []float64
+	// FileNamePrefix is the prefix used to identify the stored files in artifacts.
+	// If not empty, this can be used to store cpu/mem profile from loadgenerator.
+	// Typically, we can use t.Name() to differentiate between the tests.
+	FileNamePrefix string
 }
 
 // GeneratorResults contains the results of running the per test
 type GeneratorResults struct {
 	Result []*fhttp.HTTPRunnerResults
+	// FileNamePrefix is the prefix used to identify the stored files in artifacts.
+	// This will be used to store the JSON output from loadgenerator.
+	// Typically, we can use t.Name() to differentiate between the tests.
+	FileNamePrefix string
 }
 
 // addDefaults adds default values to non mandatory params
@@ -97,7 +106,7 @@ func (g *GeneratorOptions) CreateRunnerOptions(resolvableDomain bool) *fhttp.HTT
 		o.AddAndValidateExtraHeader(fmt.Sprintf("Host: %s", g.Domain))
 	}
 
-	return &fhttp.HTTPRunnerOptions{
+	ro := fhttp.HTTPRunnerOptions{
 		RunnerOptions: periodic.RunnerOptions{
 			Duration:    g.Duration,
 			NumThreads:  g.NumThreads,
@@ -107,6 +116,12 @@ func (g *GeneratorOptions) CreateRunnerOptions(resolvableDomain bool) *fhttp.HTT
 		HTTPOptions:        *o,
 		AllowInitialErrors: g.AllowInitialErrors,
 	}
+
+	if len(g.FileNamePrefix) != 0 {
+		ro.Profiler = g.FileNamePrefix
+	}
+
+	return &ro
 }
 
 /*
@@ -115,8 +130,8 @@ By default, LoadFactors = [1] => test full load directly with no intermediate st
 
 For LoadFactors=[1,2,4], baseQPS=q, duration=d
 	QPS
-	|		|---d---|
-	|		|   |	|
+	|               |---d---|
+	|               |   |   |
 	|       |---d---|   |4q	|
 	|---d---|   |2q	    |	|
 	|___|q______|_______|___|____duration(time)
@@ -139,13 +154,13 @@ func (g *GeneratorOptions) RunLoadTest(resolvableDomain bool) (*GeneratorResults
 }
 
 // SaveJSON saves the results as Json in the artifacts directory
-func (gr *GeneratorResults) SaveJSON(testName string) error {
+func (gr *GeneratorResults) SaveJSON() error {
 	dir := prow.GetLocalArtifactsDir()
 	if err := common.CreateDir(dir); err != nil {
 		return err
 	}
 
-	outputFile := dir + "/" + testName + jsonExt
+	outputFile := path.Join(dir, gr.FileNamePrefix+jsonExt)
 	log.Printf("Storing json output in %s", outputFile)
 	f, err := os.OpenFile(outputFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {

--- a/shared/loadgenerator/loadgenerator.go
+++ b/shared/loadgenerator/loadgenerator.go
@@ -155,7 +155,7 @@ func (g *GeneratorOptions) RunLoadTest(resolvableDomain bool) (*GeneratorResults
 		res[i] = r
 	}
 
-	return &GeneratorResults{Result: res}, nil
+	return &GeneratorResults{Result: res, FileNamePrefix: g.FileNamePrefix}, nil
 }
 
 // SaveJSON saves the results as Json in the artifacts directory

--- a/shared/loadgenerator/loadgenerator_test.go
+++ b/shared/loadgenerator/loadgenerator_test.go
@@ -25,8 +25,8 @@ import (
 )
 
 func TestSaveJSON(t *testing.T) {
-	res := &loadgenerator.GeneratorResults{}
-	err := res.SaveJSON("TestSaveJSON")
+	res := &loadgenerator.GeneratorResults{FileNamePrefix: t.Name()}
+	err := res.SaveJSON()
 	if err != nil {
 		t.Fatalf("Cannot save JSON: %v", err)
 	}

--- a/test/e2e/load_generator_test.go
+++ b/test/e2e/load_generator_test.go
@@ -49,7 +49,7 @@ func loadTest(t *testing.T, factors bool, profiler bool) {
 	}
 
 	if factors && len(res.Result) != 3 {
-		t.Logf("got:%d, want: 3", len(res.Result))
+		t.Fatalf("got:%d, want: 3", len(res.Result))
 	}
 }
 func TestFullLoad(t *testing.T) {

--- a/test/e2e/load_generator_test.go
+++ b/test/e2e/load_generator_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/knative/test-infra/shared/loadgenerator"
 )
 
-func loadTest(t *testing.T, factors []float64) {
+func loadTest(t *testing.T, factors bool, profiler bool) {
 	opts := loadgenerator.GeneratorOptions{
 		URL:            "http://www.google.com",
 		Duration:       10 * time.Second,
@@ -33,7 +33,14 @@ func loadTest(t *testing.T, factors []float64) {
 		NumThreads:     1,
 		NumConnections: 1,
 		RequestTimeout: 10 * time.Second,
-		LoadFactors:    factors,
+	}
+
+	if factors {
+		opts.LoadFactors = []float64{1, 2, 4}
+	}
+
+	if profiler {
+		opts.FileNamePrefix = t.Name()
 	}
 
 	res, err := opts.RunLoadTest(true)
@@ -41,14 +48,18 @@ func loadTest(t *testing.T, factors []float64) {
 		t.Fatalf("Error performing load test: %v", err)
 	}
 
-	if len(res.Result) != len(factors) {
-		t.Logf("got:%d, want: %d", len(res.Result), len(factors))
+	if factors && len(res.Result) != 3 {
+		t.Logf("got:%d, want: 3", len(res.Result))
 	}
 }
-func TestLoadGeneratorFullLoad(t *testing.T) {
-	loadTest(t, []float64{1})
+func TestFullLoad(t *testing.T) {
+	loadTest(t, false, false)
 }
 
-func TestLoadGeneratorStepLoad(t *testing.T) {
-	loadTest(t, []float64{1, 2, 4})
+func TestStepLoad(t *testing.T) {
+	loadTest(t, true, false)
+}
+
+func TestProfiler(t *testing.T) {
+	loadTest(t, false, true)
 }


### PR DESCRIPTION
Fixes https://github.com/knative/test-infra/issues/520

the load generator library provides ability to create cpu and memory profiles. Add that capability to the load generator as well. Performance tests should be able to use them if possible.

Also, add a new var to generator options `FileNamePrefix` that will be used to store the profiles in artifacts

The profiles are generated using [pprof](https://github.com/google/pprof/blob/master/README.md) and can be read using the tool like `pprof -web TestProfiler.mem`