### PR TITLE
Don't tear down test environment on boskos

### DIFF
--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -67,6 +67,7 @@ IS_BOSKOS=0
 
 # Tear down the test resources.
 function teardown_test_resources() {
+  (( IS_BOSKOS )) && return
   header "Tearing down test environment"
   function_exists test_teardown && test_teardown
   (( ! SKIP_KNATIVE_SETUP )) && function_exists knative_teardown && knative_teardown

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -67,6 +67,7 @@ IS_BOSKOS=0
 
 # Tear down the test resources.
 function teardown_test_resources() {
+  # On boskos, save time and don't teardown as the cluster will be destroyed anyway.
   (( IS_BOSKOS )) && return
   header "Tearing down test environment"
   function_exists test_teardown && test_teardown
@@ -130,6 +131,7 @@ EOF
 # See https://github.com/knative/serving/issues/959 for details.
 # TODO(adrcunha): Remove once the leak issue is resolved.
 function delete_leaked_network_resources() {
+  # On boskos, don't bother with leaks as the janitor will delete everything in the project.
   (( IS_BOSKOS )) && return
   # Ensure we're using the GCP project used by kubetest
   local gcloud_project="$(gcloud config get-value project)"


### PR DESCRIPTION
The test cluster will be deleted by boskos, an with that all test resources and Knative. Deleting them after the test finishes is just wasting time and resources.

Fixes #702.

/assign @dushyanthsc 