### PR TITLE
Add CI support for istio version and istio mesh

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -1625,6 +1625,146 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
+- cron: "7 */2 * * *"
+  name: ci-knative-serving-istio-1.0.7-mesh
+  agent: kubernetes
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      args:
+      - "--scenario=kubernetes_execute_bazel"
+      - "--clean"
+      - "--job=$(JOB_NAME)"
+      - "--repo=github.com/knative/serving"
+      - "--root=/go/src"
+      - "--service-account=/etc/test-account/service-account.json"
+      - "--upload=gs://knative-prow/logs"
+      - "--timeout=100" # Avoid overrun
+      - "--" # end bootstrap args, scenario args below
+      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
+      - "./test/e2e-tests.sh"
+      - "--istio-version"
+      - "1.0.7"
+      - "--mesh"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "22 */2 * * *"
+  name: ci-knative-serving-istio-1.0.7-no-mesh
+  agent: kubernetes
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      args:
+      - "--scenario=kubernetes_execute_bazel"
+      - "--clean"
+      - "--job=$(JOB_NAME)"
+      - "--repo=github.com/knative/serving"
+      - "--root=/go/src"
+      - "--service-account=/etc/test-account/service-account.json"
+      - "--upload=gs://knative-prow/logs"
+      - "--timeout=100" # Avoid overrun
+      - "--" # end bootstrap args, scenario args below
+      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
+      - "./test/e2e-tests.sh"
+      - "--istio-version"
+      - "1.0.7"
+      - "--no-mesh"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "37 */2 * * *"
+  name: ci-knative-serving-istio-1.1.2-mesh
+  agent: kubernetes
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      args:
+      - "--scenario=kubernetes_execute_bazel"
+      - "--clean"
+      - "--job=$(JOB_NAME)"
+      - "--repo=github.com/knative/serving"
+      - "--root=/go/src"
+      - "--service-account=/etc/test-account/service-account.json"
+      - "--upload=gs://knative-prow/logs"
+      - "--timeout=100" # Avoid overrun
+      - "--" # end bootstrap args, scenario args below
+      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
+      - "./test/e2e-tests.sh"
+      - "--istio-version"
+      - "1.1.2"
+      - "--mesh"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "52 */2 * * *"
+  name: ci-knative-serving-istio-1.1.2-no-mesh
+  agent: kubernetes
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      args:
+      - "--scenario=kubernetes_execute_bazel"
+      - "--clean"
+      - "--job=$(JOB_NAME)"
+      - "--repo=github.com/knative/serving"
+      - "--root=/go/src"
+      - "--service-account=/etc/test-account/service-account.json"
+      - "--upload=gs://knative-prow/logs"
+      - "--timeout=100" # Avoid overrun
+      - "--" # end bootstrap args, scenario args below
+      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
+      - "./test/e2e-tests.sh"
+      - "--istio-version"
+      - "1.1.2"
+      - "--no-mesh"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
 - cron: "1 8 * * *"
   name: ci-knative-serving-nightly-release
   agent: kubernetes

--- a/ci/prow/config_knative.yaml
+++ b/ci/prow/config_knative.yaml
@@ -108,6 +108,42 @@ periodics:
     - branch-ci: true
       release: "0.5"
       cron: "35 8 * * *" # Run at 01:35PST every day (08:35 UTC)
+    - custom-job: istio-1.0.7-mesh
+      cron: "7 */2 * * *" # Run every other hour and seven minute
+      command:
+      - "./test/e2e-tests.sh"
+      args:
+      - "--istio-version"
+      - "1.0.7"
+      - "--mesh"
+      timeout: 100
+    - custom-job: istio-1.0.7-no-mesh
+      cron: "22 */2 * * *" # Run every other hour and twenty-two minute
+      command:
+      - "./test/e2e-tests.sh"
+      args:
+      - "--istio-version"
+      - "1.0.7"
+      - "--no-mesh"
+      timeout: 100
+    - custom-job: istio-1.1.2-mesh
+      cron: "37 */2 * * *" # Run every other hour and thirty-seven minute
+      command:
+      - "./test/e2e-tests.sh"
+      args:
+      - "--istio-version"
+      - "1.1.2"
+      - "--mesh"
+      timeout: 100
+    - custom-job: istio-1.1.2-no-mesh
+      cron: "52 */2 * * *" # Run every other hour and fifty-two minute
+      command:
+      - "./test/e2e-tests.sh"
+      args:
+      - "--istio-version"
+      - "1.1.2"
+      - "--no-mesh"
+      timeout: 100
     - nightly: true
       cron: "1 8 * * *" # Run at 01:01PST every day (08:01 UTC)
     - dot-release: true

--- a/ci/prow/make_config.go
+++ b/ci/prow/make_config.go
@@ -1355,8 +1355,11 @@ func generateTestGroup(repoName string, jobNames []string) {
 			extras["short_text_metric"] = "coverage"
 			// Do not alert on coverage failures (i.e., coverage below threshold)
 			extras["num_failures_to_alert"] = "9999"
+		case "istio-1.0.7-mesh", "istio-1.0.7-no-mesh", "istio-1.1.2-mesh", "istio-1.1.2-no-mesh":
+			extras["alert_stale_results_hours"] = "3"
+			extras["num_failures_to_alert"] = "3"
 		default:
-			log.Fatalf("Unknown jobName: %s", jobName)
+			log.Fatalf("Unknown jobName for generateTestGroup: %s", jobName)
 		}
 		executeTestGroupTemplate(testGroupName, gcsLogDir, extras)
 	}
@@ -1399,6 +1402,8 @@ func generateDashboard(repoName string, jobNames []string) {
 			executeDashboardTabTemplate("nightly", testGroupName, testgridTabSortByName, noExtras)
 		case "test-coverage":
 			executeDashboardTabTemplate("coverage", testGroupName, testgridTabGroupByDir, noExtras)
+		case "istio-1.0.7-mesh", "istio-1.0.7-no-mesh", "istio-1.1.2-mesh", "istio-1.1.2-no-mesh":
+			executeDashboardTabTemplate(jobName, testGroupName, testgridTabSortByName, noExtras)
 		default:
 			log.Fatalf("Unknown job name %q", jobName)
 		}
@@ -1424,8 +1429,10 @@ func getTestGroupName(repoName string, jobName string) string {
 		return fmt.Sprintf("ci-%s-%s-release", repoName, jobName)
 	case "test-coverage":
 		return fmt.Sprintf("pull-%s-%s", repoName, jobName)
+	case "istio-1.0.7-mesh", "istio-1.0.7-no-mesh", "istio-1.1.2-mesh", "istio-1.1.2-no-mesh":
+		return fmt.Sprintf("ci-%s-%s", repoName, jobName)
 	}
-	log.Fatalf("Unknown jobName: %s", jobName)
+	log.Fatalf("Unknown jobName for getTestGroupName: %s", jobName)
 	return ""
 }
 

--- a/ci/testgrid/config.yaml
+++ b/ci/testgrid/config.yaml
@@ -60,6 +60,22 @@ test_groups:
   gcs_prefix: knative-prow/logs/ci-knative-serving-continuous
   alert_stale_results_hours: 3
   num_failures_to_alert: 3
+- name: ci-knative-serving-istio-1.0.7-mesh
+  gcs_prefix: knative-prow/logs/ci-knative-serving-istio-1.0.7-mesh
+  alert_stale_results_hours: 3
+  num_failures_to_alert: 3
+- name: ci-knative-serving-istio-1.0.7-no-mesh
+  gcs_prefix: knative-prow/logs/ci-knative-serving-istio-1.0.7-no-mesh
+  alert_stale_results_hours: 3
+  num_failures_to_alert: 3
+- name: ci-knative-serving-istio-1.1.2-mesh
+  gcs_prefix: knative-prow/logs/ci-knative-serving-istio-1.1.2-mesh
+  alert_stale_results_hours: 3
+  num_failures_to_alert: 3
+- name: ci-knative-serving-istio-1.1.2-no-mesh
+  gcs_prefix: knative-prow/logs/ci-knative-serving-istio-1.1.2-no-mesh
+  alert_stale_results_hours: 3
+  num_failures_to_alert: 3
 - name: ci-knative-serving-nightly-release
   gcs_prefix: knative-prow/logs/ci-knative-serving-nightly-release
 - name: ci-knative-serving-dot-release
@@ -183,6 +199,18 @@ dashboards:
   - name: conformance-tests
     test_group_name: ci-knative-serving-continuous
     base_options: "include-filter-by-regex=test/conformance\\.&sort-by-name="
+  - name: istio-1.0.7-mesh
+    test_group_name: ci-knative-serving-istio-1.0.7-mesh
+    base_options: "sort-by-name="
+  - name: istio-1.0.7-no-mesh
+    test_group_name: ci-knative-serving-istio-1.0.7-no-mesh
+    base_options: "sort-by-name="
+  - name: istio-1.1.2-mesh
+    test_group_name: ci-knative-serving-istio-1.1.2-mesh
+    base_options: "sort-by-name="
+  - name: istio-1.1.2-no-mesh
+    test_group_name: ci-knative-serving-istio-1.1.2-no-mesh
+    base_options: "sort-by-name="
   - name: nightly
     test_group_name: ci-knative-serving-nightly-release
     base_options: "sort-by-name="


### PR DESCRIPTION
This allows CI system to specify what version of istio to use and
whether to use istio mesh or not.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #
