### PR TITLE
Fix latency aggregation tool for E2E tests

### DIFF
--- a/tools/latency/main.go
+++ b/tools/latency/main.go
@@ -240,7 +240,8 @@ func parseLog(dir string, dateRestriction time.Time, metrics MetricsMap) {
 			startedE2ETests = true
 		}
 		// I0911 16:05:43.464] ==== CREATING TEST CLUSTER ====
-		if len(fields) == 7 && fields[3] == "CREATING" && fields[4] == "TEST" && fields[5] == "CLUSTER" {
+		// I0424 14:10:56.870] ==== CREATING TEST CLUSTER IN US-CENTRAL1 ====
+		if len(fields) >= 7 && fields[3] == "CREATING" && fields[4] == "TEST" && fields[5] == "CLUSTER" {
 			startedE2ETests = true
 		}
 		// I0711 22:23:20.729] --- PASS: TestHelloWorldFromShell (36.85s)


### PR DESCRIPTION
The E2E tests banner changed with PR 671.

Fix #706.