### PR TITLE
Add some missing labels to Prow config

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -69,9 +69,15 @@ tide:
     missingLabels:
     - do-not-merge/hold
     - do-not-merge/work-in-progress
+    - do-not-merge/invalid-owners-file
   merge_method:
     knative: squash
   target_url: https://prow.knative.dev/tide
+  pr_status_base_url: https://prow.knative.dev/pr
+  blocker_label: tide/merge-blocker
+  squash_label: tide/merge-method-squash
+  rebase_label: tide/merge-method-rebase
+  merge_label: tide/merge-method-merge
 presubmits:
   knative/serving:
   - name: pull-knative-serving-build-tests

--- a/ci/prow/make_config.go
+++ b/ci/prow/make_config.go
@@ -295,9 +295,15 @@ tide:
     missingLabels:
     - do-not-merge/hold
     - do-not-merge/work-in-progress
+    - do-not-merge/invalid-owners-file
   merge_method:
     knative: squash
   target_url: https://prow.knative.dev/tide
+  pr_status_base_url: https://prow.knative.dev/pr
+  blocker_label: tide/merge-blocker
+  squash_label: tide/merge-method-squash
+  rebase_label: tide/merge-method-rebase
+  merge_label: tide/merge-method-merge
 `
 
 	// presubmitJob is the template for presubmit jobs.


### PR DESCRIPTION
* block automerge when OWNERS file is invalid
* add allowed tide labels (currently not used)
* set PR status base URL (to be used by 709)