### PR TITLE
Correct expression for catching stockouts in retrying cluster creation

### DIFF
--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -258,7 +258,7 @@ function create_test_cluster_with_retries() {
       # Exit if test succeeded
       [[ "$(get_test_return_code)" == "0" ]] && return
       # If test failed not because of cluster creation stockout, return
-      [[ -z "$(grep -Eio 'does not have enough resources to fulfill the request' ${cluster_creation_log})" ]] && return
+      [[ -z "$(grep -Eio 'does not have enough resources available to fulfill the request' ${cluster_creation_log})" ]] && return
     done
   done
 }


### PR DESCRIPTION
Fixing expression for catching stockouts. Not sure why the previous commit missed a word in the middle.

Reference:
https://storage.googleapis.com/knative-prow/pr-logs/pull/knative_serving/3353/pull-knative-serving-integration-tests/1105982603938238464/build-log.txt