### PR TITLE
Rename and reorganize TestGrid tab names

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -74,12 +74,12 @@ tide:
   target_url: https://prow.knative.dev/tide
 presubmits:
   knative/serving:
-  - name: pull-knative-serving-build-tests
+  - name: pull-serving-build-tests
     agent: kubernetes
-    context: pull-knative-serving-build-tests
+    context: pull-serving-build-tests
     always_run: true
-    rerun_command: "/test pull-knative-serving-build-tests"
-    trigger: "(?m)^/test (all|pull-knative-serving-build-tests),?(\\s+|$)"
+    rerun_command: "/test pull-serving-build-tests"
+    trigger: "(?m)^/test (all|pull-serving-build-tests),?(\\s+|$)"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -109,12 +109,12 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-serving-unit-tests
+  - name: pull-serving-unit-tests
     agent: kubernetes
-    context: pull-knative-serving-unit-tests
+    context: pull-serving-unit-tests
     always_run: true
-    rerun_command: "/test pull-knative-serving-unit-tests"
-    trigger: "(?m)^/test (all|pull-knative-serving-unit-tests),?(\\s+|$)"
+    rerun_command: "/test pull-serving-unit-tests"
+    trigger: "(?m)^/test (all|pull-serving-unit-tests),?(\\s+|$)"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -144,12 +144,12 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-serving-integration-tests
+  - name: pull-serving-integration-tests
     agent: kubernetes
-    context: pull-knative-serving-integration-tests
+    context: pull-serving-integration-tests
     always_run: true
-    rerun_command: "/test pull-knative-serving-integration-tests"
-    trigger: "(?m)^/test (all|pull-knative-serving-integration-tests),?(\\s+|$)"
+    rerun_command: "/test pull-serving-integration-tests"
+    trigger: "(?m)^/test (all|pull-serving-integration-tests),?(\\s+|$)"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -180,12 +180,12 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-serving-upgrade-tests
+  - name: pull-serving-upgrade-tests
     agent: kubernetes
-    context: pull-knative-serving-upgrade-tests
+    context: pull-serving-upgrade-tests
     always_run: true
-    rerun_command: "/test pull-knative-serving-upgrade-tests"
-    trigger: "(?m)^/test (all|pull-knative-serving-upgrade-tests),?(\\s+|$)"
+    rerun_command: "/test pull-serving-upgrade-tests"
+    trigger: "(?m)^/test (all|pull-serving-upgrade-tests),?(\\s+|$)"
     skip_branches:
     - "release-0.1"
     - "release-0.2"
@@ -219,12 +219,12 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-serving-go-coverage
+  - name: pull-serving-go-coverage
     agent: kubernetes
-    context: pull-knative-serving-go-coverage
+    context: pull-serving-go-coverage
     always_run: true
-    rerun_command: "/test pull-knative-serving-go-coverage"
-    trigger: "(?m)^/test (all|pull-knative-serving-go-coverage),?(\\s+|$)"
+    rerun_command: "/test pull-serving-go-coverage"
+    trigger: "(?m)^/test (all|pull-serving-go-coverage),?(\\s+|$)"
     optional: true
     decorate: true
     clone_uri: "https://github.com/knative/serving.git"
@@ -236,7 +236,7 @@ presubmits:
         - "/coverage"
         args:
         - "--postsubmit-gcs-bucket=knative-prow"
-        - "--postsubmit-job-name=post-knative-serving-go-coverage"
+        - "--postsubmit-job-name=post-serving-go-coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--profile-name=coverage_profile.txt"
         - "--cov-target=."
@@ -250,12 +250,12 @@ presubmits:
       - name: covbot-token
         secret:
           secretName: covbot-token
-  - name: pull-knative-serving-go-coverage-dev
+  - name: pull-serving-go-coverage-dev
     agent: kubernetes
-    context: pull-knative-serving-go-coverage-dev
+    context: pull-serving-go-coverage-dev
     always_run: false
-    rerun_command: "/test pull-knative-serving-go-coverage-dev"
-    trigger: "(?m)^/test (pull-knative-serving-go-coverage-dev),?(\\s+|$)"
+    rerun_command: "/test pull-serving-go-coverage-dev"
+    trigger: "(?m)^/test (pull-serving-go-coverage-dev),?(\\s+|$)"
     optional: true
     decorate: true
     clone_uri: "https://github.com/knative/serving.git"
@@ -267,7 +267,7 @@ presubmits:
         - "/coverage"
         args:
         - "--postsubmit-gcs-bucket=knative-prow"
-        - "--postsubmit-job-name=post-knative-serving-go-coverage"
+        - "--postsubmit-job-name=post-serving-go-coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--profile-name=coverage_profile.txt"
         - "--cov-target=."
@@ -281,12 +281,12 @@ presubmits:
       - name: covbot-token
         secret:
           secretName: covbot-token
-  - name: pull-knative-serving-perf-tests
+  - name: pull-serving-perf-tests
     agent: kubernetes
-    context: pull-knative-serving-perf-tests
+    context: pull-serving-perf-tests
     always_run: false
-    rerun_command: "/test pull-knative-serving-perf-tests"
-    trigger: "(?m)^/test (all|pull-knative-serving-perf-tests),?(\\s+|$)"
+    rerun_command: "/test pull-serving-perf-tests"
+    trigger: "(?m)^/test (all|pull-serving-perf-tests),?(\\s+|$)"
     skip_branches:
     - "release-0.1"
     - "release-0.2"
@@ -320,12 +320,12 @@ presubmits:
         secret:
           secretName: test-account
   knative/build:
-  - name: pull-knative-build-build-tests
+  - name: pull-build-build-tests
     agent: kubernetes
-    context: pull-knative-build-build-tests
+    context: pull-build-build-tests
     always_run: true
-    rerun_command: "/test pull-knative-build-build-tests"
-    trigger: "(?m)^/test (all|pull-knative-build-build-tests),?(\\s+|$)"
+    rerun_command: "/test pull-build-build-tests"
+    trigger: "(?m)^/test (all|pull-build-build-tests),?(\\s+|$)"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -355,12 +355,12 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-build-unit-tests
+  - name: pull-build-unit-tests
     agent: kubernetes
-    context: pull-knative-build-unit-tests
+    context: pull-build-unit-tests
     always_run: true
-    rerun_command: "/test pull-knative-build-unit-tests"
-    trigger: "(?m)^/test (all|pull-knative-build-unit-tests),?(\\s+|$)"
+    rerun_command: "/test pull-build-unit-tests"
+    trigger: "(?m)^/test (all|pull-build-unit-tests),?(\\s+|$)"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -390,12 +390,12 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-build-integration-tests
+  - name: pull-build-integration-tests
     agent: kubernetes
-    context: pull-knative-build-integration-tests
+    context: pull-build-integration-tests
     always_run: true
-    rerun_command: "/test pull-knative-build-integration-tests"
-    trigger: "(?m)^/test (all|pull-knative-build-integration-tests),?(\\s+|$)"
+    rerun_command: "/test pull-build-integration-tests"
+    trigger: "(?m)^/test (all|pull-build-integration-tests),?(\\s+|$)"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -433,12 +433,12 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-build-go-coverage
+  - name: pull-build-go-coverage
     agent: kubernetes
-    context: pull-knative-build-go-coverage
+    context: pull-build-go-coverage
     always_run: true
-    rerun_command: "/test pull-knative-build-go-coverage"
-    trigger: "(?m)^/test (all|pull-knative-build-go-coverage),?(\\s+|$)"
+    rerun_command: "/test pull-build-go-coverage"
+    trigger: "(?m)^/test (all|pull-build-go-coverage),?(\\s+|$)"
     optional: true
     decorate: true
     clone_uri: "https://github.com/knative/build.git"
@@ -450,7 +450,7 @@ presubmits:
         - "/coverage"
         args:
         - "--postsubmit-gcs-bucket=knative-prow"
-        - "--postsubmit-job-name=post-knative-build-go-coverage"
+        - "--postsubmit-job-name=post-build-go-coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--profile-name=coverage_profile.txt"
         - "--cov-target=."
@@ -465,12 +465,12 @@ presubmits:
         secret:
           secretName: covbot-token
   knative/client:
-  - name: pull-knative-client-build-tests
+  - name: pull-client-build-tests
     agent: kubernetes
-    context: pull-knative-client-build-tests
+    context: pull-client-build-tests
     always_run: true
-    rerun_command: "/test pull-knative-client-build-tests"
-    trigger: "(?m)^/test (all|pull-knative-client-build-tests),?(\\s+|$)"
+    rerun_command: "/test pull-client-build-tests"
+    trigger: "(?m)^/test (all|pull-client-build-tests),?(\\s+|$)"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -500,12 +500,12 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-client-unit-tests
+  - name: pull-client-unit-tests
     agent: kubernetes
-    context: pull-knative-client-unit-tests
+    context: pull-client-unit-tests
     always_run: true
-    rerun_command: "/test pull-knative-client-unit-tests"
-    trigger: "(?m)^/test (all|pull-knative-client-unit-tests),?(\\s+|$)"
+    rerun_command: "/test pull-client-unit-tests"
+    trigger: "(?m)^/test (all|pull-client-unit-tests),?(\\s+|$)"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -535,12 +535,12 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-client-integration-tests
+  - name: pull-client-integration-tests
     agent: kubernetes
-    context: pull-knative-client-integration-tests
+    context: pull-client-integration-tests
     always_run: true
-    rerun_command: "/test pull-knative-client-integration-tests"
-    trigger: "(?m)^/test (all|pull-knative-client-integration-tests),?(\\s+|$)"
+    rerun_command: "/test pull-client-integration-tests"
+    trigger: "(?m)^/test (all|pull-client-integration-tests),?(\\s+|$)"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -570,12 +570,12 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-client-go-coverage
+  - name: pull-client-go-coverage
     agent: kubernetes
-    context: pull-knative-client-go-coverage
+    context: pull-client-go-coverage
     always_run: true
-    rerun_command: "/test pull-knative-client-go-coverage"
-    trigger: "(?m)^/test (all|pull-knative-client-go-coverage),?(\\s+|$)"
+    rerun_command: "/test pull-client-go-coverage"
+    trigger: "(?m)^/test (all|pull-client-go-coverage),?(\\s+|$)"
     optional: true
     decorate: true
     clone_uri: "https://github.com/knative/client.git"
@@ -587,7 +587,7 @@ presubmits:
         - "/coverage"
         args:
         - "--postsubmit-gcs-bucket=knative-prow"
-        - "--postsubmit-job-name=post-knative-client-go-coverage"
+        - "--postsubmit-job-name=post-client-go-coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--profile-name=coverage_profile.txt"
         - "--cov-target=."
@@ -602,12 +602,12 @@ presubmits:
         secret:
           secretName: covbot-token
   knative/eventing:
-  - name: pull-knative-eventing-build-tests
+  - name: pull-eventing-build-tests
     agent: kubernetes
-    context: pull-knative-eventing-build-tests
+    context: pull-eventing-build-tests
     always_run: true
-    rerun_command: "/test pull-knative-eventing-build-tests"
-    trigger: "(?m)^/test (all|pull-knative-eventing-build-tests),?(\\s+|$)"
+    rerun_command: "/test pull-eventing-build-tests"
+    trigger: "(?m)^/test (all|pull-eventing-build-tests),?(\\s+|$)"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -637,12 +637,12 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-eventing-unit-tests
+  - name: pull-eventing-unit-tests
     agent: kubernetes
-    context: pull-knative-eventing-unit-tests
+    context: pull-eventing-unit-tests
     always_run: true
-    rerun_command: "/test pull-knative-eventing-unit-tests"
-    trigger: "(?m)^/test (all|pull-knative-eventing-unit-tests),?(\\s+|$)"
+    rerun_command: "/test pull-eventing-unit-tests"
+    trigger: "(?m)^/test (all|pull-eventing-unit-tests),?(\\s+|$)"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -672,12 +672,12 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-eventing-integration-tests
+  - name: pull-eventing-integration-tests
     agent: kubernetes
-    context: pull-knative-eventing-integration-tests
+    context: pull-eventing-integration-tests
     always_run: true
-    rerun_command: "/test pull-knative-eventing-integration-tests"
-    trigger: "(?m)^/test (all|pull-knative-eventing-integration-tests),?(\\s+|$)"
+    rerun_command: "/test pull-eventing-integration-tests"
+    trigger: "(?m)^/test (all|pull-eventing-integration-tests),?(\\s+|$)"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -707,12 +707,12 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-eventing-go-coverage
+  - name: pull-eventing-go-coverage
     agent: kubernetes
-    context: pull-knative-eventing-go-coverage
+    context: pull-eventing-go-coverage
     always_run: true
-    rerun_command: "/test pull-knative-eventing-go-coverage"
-    trigger: "(?m)^/test (all|pull-knative-eventing-go-coverage),?(\\s+|$)"
+    rerun_command: "/test pull-eventing-go-coverage"
+    trigger: "(?m)^/test (all|pull-eventing-go-coverage),?(\\s+|$)"
     optional: true
     decorate: true
     clone_uri: "https://github.com/knative/eventing.git"
@@ -724,7 +724,7 @@ presubmits:
         - "/coverage"
         args:
         - "--postsubmit-gcs-bucket=knative-prow"
-        - "--postsubmit-job-name=post-knative-eventing-go-coverage"
+        - "--postsubmit-job-name=post-eventing-go-coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--profile-name=coverage_profile.txt"
         - "--cov-target=."
@@ -739,12 +739,12 @@ presubmits:
         secret:
           secretName: covbot-token
   knative/eventing-sources:
-  - name: pull-knative-eventing-sources-build-tests
+  - name: pull-eventing-sources-build-tests
     agent: kubernetes
-    context: pull-knative-eventing-sources-build-tests
+    context: pull-eventing-sources-build-tests
     always_run: true
-    rerun_command: "/test pull-knative-eventing-sources-build-tests"
-    trigger: "(?m)^/test (all|pull-knative-eventing-sources-build-tests),?(\\s+|$)"
+    rerun_command: "/test pull-eventing-sources-build-tests"
+    trigger: "(?m)^/test (all|pull-eventing-sources-build-tests),?(\\s+|$)"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -774,12 +774,12 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-eventing-sources-unit-tests
+  - name: pull-eventing-sources-unit-tests
     agent: kubernetes
-    context: pull-knative-eventing-sources-unit-tests
+    context: pull-eventing-sources-unit-tests
     always_run: true
-    rerun_command: "/test pull-knative-eventing-sources-unit-tests"
-    trigger: "(?m)^/test (all|pull-knative-eventing-sources-unit-tests),?(\\s+|$)"
+    rerun_command: "/test pull-eventing-sources-unit-tests"
+    trigger: "(?m)^/test (all|pull-eventing-sources-unit-tests),?(\\s+|$)"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -809,12 +809,12 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-eventing-sources-integration-tests
+  - name: pull-eventing-sources-integration-tests
     agent: kubernetes
-    context: pull-knative-eventing-sources-integration-tests
+    context: pull-eventing-sources-integration-tests
     always_run: true
-    rerun_command: "/test pull-knative-eventing-sources-integration-tests"
-    trigger: "(?m)^/test (all|pull-knative-eventing-sources-integration-tests),?(\\s+|$)"
+    rerun_command: "/test pull-eventing-sources-integration-tests"
+    trigger: "(?m)^/test (all|pull-eventing-sources-integration-tests),?(\\s+|$)"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -844,12 +844,12 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-eventing-sources-go-coverage
+  - name: pull-eventing-sources-go-coverage
     agent: kubernetes
-    context: pull-knative-eventing-sources-go-coverage
+    context: pull-eventing-sources-go-coverage
     always_run: true
-    rerun_command: "/test pull-knative-eventing-sources-go-coverage"
-    trigger: "(?m)^/test (all|pull-knative-eventing-sources-go-coverage),?(\\s+|$)"
+    rerun_command: "/test pull-eventing-sources-go-coverage"
+    trigger: "(?m)^/test (all|pull-eventing-sources-go-coverage),?(\\s+|$)"
     optional: true
     decorate: true
     clone_uri: "https://github.com/knative/eventing-sources.git"
@@ -861,7 +861,7 @@ presubmits:
         - "/coverage"
         args:
         - "--postsubmit-gcs-bucket=knative-prow"
-        - "--postsubmit-job-name=post-knative-eventing-sources-go-coverage"
+        - "--postsubmit-job-name=post-eventing-sources-go-coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--profile-name=coverage_profile.txt"
         - "--cov-target=."
@@ -876,12 +876,12 @@ presubmits:
         secret:
           secretName: covbot-token
   knative/docs:
-  - name: pull-knative-docs-build-tests
+  - name: pull-docs-build-tests
     agent: kubernetes
-    context: pull-knative-docs-build-tests
+    context: pull-docs-build-tests
     always_run: true
-    rerun_command: "/test pull-knative-docs-build-tests"
-    trigger: "(?m)^/test (all|pull-knative-docs-build-tests),?(\\s+|$)"
+    rerun_command: "/test pull-docs-build-tests"
+    trigger: "(?m)^/test (all|pull-docs-build-tests),?(\\s+|$)"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -911,12 +911,12 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-docs-unit-tests
+  - name: pull-docs-unit-tests
     agent: kubernetes
-    context: pull-knative-docs-unit-tests
+    context: pull-docs-unit-tests
     always_run: true
-    rerun_command: "/test pull-knative-docs-unit-tests"
-    trigger: "(?m)^/test (all|pull-knative-docs-unit-tests),?(\\s+|$)"
+    rerun_command: "/test pull-docs-unit-tests"
+    trigger: "(?m)^/test (all|pull-docs-unit-tests),?(\\s+|$)"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -946,12 +946,12 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-docs-integration-tests
+  - name: pull-docs-integration-tests
     agent: kubernetes
-    context: pull-knative-docs-integration-tests
+    context: pull-docs-integration-tests
     always_run: true
-    rerun_command: "/test pull-knative-docs-integration-tests"
-    trigger: "(?m)^/test (all|pull-knative-docs-integration-tests),?(\\s+|$)"
+    rerun_command: "/test pull-docs-integration-tests"
+    trigger: "(?m)^/test (all|pull-docs-integration-tests),?(\\s+|$)"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -989,12 +989,12 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-docs-go-coverage
+  - name: pull-docs-go-coverage
     agent: kubernetes
-    context: pull-knative-docs-go-coverage
+    context: pull-docs-go-coverage
     always_run: true
-    rerun_command: "/test pull-knative-docs-go-coverage"
-    trigger: "(?m)^/test (all|pull-knative-docs-go-coverage),?(\\s+|$)"
+    rerun_command: "/test pull-docs-go-coverage"
+    trigger: "(?m)^/test (all|pull-docs-go-coverage),?(\\s+|$)"
     optional: true
     decorate: true
     clone_uri: "https://github.com/knative/docs.git"
@@ -1006,7 +1006,7 @@ presubmits:
         - "/coverage"
         args:
         - "--postsubmit-gcs-bucket=knative-prow"
-        - "--postsubmit-job-name=post-knative-docs-go-coverage"
+        - "--postsubmit-job-name=post-docs-go-coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--profile-name=coverage_profile.txt"
         - "--cov-target=."
@@ -1021,12 +1021,12 @@ presubmits:
         secret:
           secretName: covbot-token
   knative/build-templates:
-  - name: pull-knative-build-templates-build-tests
+  - name: pull-build-templates-build-tests
     agent: kubernetes
-    context: pull-knative-build-templates-build-tests
+    context: pull-build-templates-build-tests
     always_run: true
-    rerun_command: "/test pull-knative-build-templates-build-tests"
-    trigger: "(?m)^/test (all|pull-knative-build-templates-build-tests),?(\\s+|$)"
+    rerun_command: "/test pull-build-templates-build-tests"
+    trigger: "(?m)^/test (all|pull-build-templates-build-tests),?(\\s+|$)"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1056,12 +1056,12 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-build-templates-unit-tests
+  - name: pull-build-templates-unit-tests
     agent: kubernetes
-    context: pull-knative-build-templates-unit-tests
+    context: pull-build-templates-unit-tests
     always_run: true
-    rerun_command: "/test pull-knative-build-templates-unit-tests"
-    trigger: "(?m)^/test (all|pull-knative-build-templates-unit-tests),?(\\s+|$)"
+    rerun_command: "/test pull-build-templates-unit-tests"
+    trigger: "(?m)^/test (all|pull-build-templates-unit-tests),?(\\s+|$)"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1091,12 +1091,12 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-build-templates-integration-tests
+  - name: pull-build-templates-integration-tests
     agent: kubernetes
-    context: pull-knative-build-templates-integration-tests
+    context: pull-build-templates-integration-tests
     always_run: true
-    rerun_command: "/test pull-knative-build-templates-integration-tests"
-    trigger: "(?m)^/test (all|pull-knative-build-templates-integration-tests),?(\\s+|$)"
+    rerun_command: "/test pull-build-templates-integration-tests"
+    trigger: "(?m)^/test (all|pull-build-templates-integration-tests),?(\\s+|$)"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1127,12 +1127,12 @@ presubmits:
         secret:
           secretName: test-account
   knative/pkg:
-  - name: pull-knative-pkg-build-tests
+  - name: pull-pkg-build-tests
     agent: kubernetes
-    context: pull-knative-pkg-build-tests
+    context: pull-pkg-build-tests
     always_run: true
-    rerun_command: "/test pull-knative-pkg-build-tests"
-    trigger: "(?m)^/test (all|pull-knative-pkg-build-tests),?(\\s+|$)"
+    rerun_command: "/test pull-pkg-build-tests"
+    trigger: "(?m)^/test (all|pull-pkg-build-tests),?(\\s+|$)"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1162,12 +1162,12 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-pkg-unit-tests
+  - name: pull-pkg-unit-tests
     agent: kubernetes
-    context: pull-knative-pkg-unit-tests
+    context: pull-pkg-unit-tests
     always_run: true
-    rerun_command: "/test pull-knative-pkg-unit-tests"
-    trigger: "(?m)^/test (all|pull-knative-pkg-unit-tests),?(\\s+|$)"
+    rerun_command: "/test pull-pkg-unit-tests"
+    trigger: "(?m)^/test (all|pull-pkg-unit-tests),?(\\s+|$)"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1197,12 +1197,12 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-pkg-integration-tests
+  - name: pull-pkg-integration-tests
     agent: kubernetes
-    context: pull-knative-pkg-integration-tests
+    context: pull-pkg-integration-tests
     always_run: true
-    rerun_command: "/test pull-knative-pkg-integration-tests"
-    trigger: "(?m)^/test (all|pull-knative-pkg-integration-tests),?(\\s+|$)"
+    rerun_command: "/test pull-pkg-integration-tests"
+    trigger: "(?m)^/test (all|pull-pkg-integration-tests),?(\\s+|$)"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1232,12 +1232,12 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-pkg-go-coverage
+  - name: pull-pkg-go-coverage
     agent: kubernetes
-    context: pull-knative-pkg-go-coverage
+    context: pull-pkg-go-coverage
     always_run: true
-    rerun_command: "/test pull-knative-pkg-go-coverage"
-    trigger: "(?m)^/test (all|pull-knative-pkg-go-coverage),?(\\s+|$)"
+    rerun_command: "/test pull-pkg-go-coverage"
+    trigger: "(?m)^/test (all|pull-pkg-go-coverage),?(\\s+|$)"
     optional: true
     decorate: true
     clone_uri: "https://github.com/knative/pkg.git"
@@ -1249,7 +1249,7 @@ presubmits:
         - "/coverage"
         args:
         - "--postsubmit-gcs-bucket=knative-prow"
-        - "--postsubmit-job-name=post-knative-pkg-go-coverage"
+        - "--postsubmit-job-name=post-pkg-go-coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--profile-name=coverage_profile.txt"
         - "--cov-target=."
@@ -1264,12 +1264,12 @@ presubmits:
         secret:
           secretName: covbot-token
   knative/test-infra:
-  - name: pull-knative-test-infra-build-tests
+  - name: pull-test-infra-build-tests
     agent: kubernetes
-    context: pull-knative-test-infra-build-tests
+    context: pull-test-infra-build-tests
     always_run: true
-    rerun_command: "/test pull-knative-test-infra-build-tests"
-    trigger: "(?m)^/test (all|pull-knative-test-infra-build-tests),?(\\s+|$)"
+    rerun_command: "/test pull-test-infra-build-tests"
+    trigger: "(?m)^/test (all|pull-test-infra-build-tests),?(\\s+|$)"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1299,12 +1299,12 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-test-infra-unit-tests
+  - name: pull-test-infra-unit-tests
     agent: kubernetes
-    context: pull-knative-test-infra-unit-tests
+    context: pull-test-infra-unit-tests
     always_run: true
-    rerun_command: "/test pull-knative-test-infra-unit-tests"
-    trigger: "(?m)^/test (all|pull-knative-test-infra-unit-tests),?(\\s+|$)"
+    rerun_command: "/test pull-test-infra-unit-tests"
+    trigger: "(?m)^/test (all|pull-test-infra-unit-tests),?(\\s+|$)"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1334,12 +1334,12 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-test-infra-integration-tests
+  - name: pull-test-infra-integration-tests
     agent: kubernetes
-    context: pull-knative-test-infra-integration-tests
+    context: pull-test-infra-integration-tests
     always_run: true
-    rerun_command: "/test pull-knative-test-infra-integration-tests"
-    trigger: "(?m)^/test (all|pull-knative-test-infra-integration-tests),?(\\s+|$)"
+    rerun_command: "/test pull-test-infra-integration-tests"
+    trigger: "(?m)^/test (all|pull-test-infra-integration-tests),?(\\s+|$)"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1370,12 +1370,12 @@ presubmits:
         secret:
           secretName: test-account
   knative/caching:
-  - name: pull-knative-caching-build-tests
+  - name: pull-caching-build-tests
     agent: kubernetes
-    context: pull-knative-caching-build-tests
+    context: pull-caching-build-tests
     always_run: true
-    rerun_command: "/test pull-knative-caching-build-tests"
-    trigger: "(?m)^/test (all|pull-knative-caching-build-tests),?(\\s+|$)"
+    rerun_command: "/test pull-caching-build-tests"
+    trigger: "(?m)^/test (all|pull-caching-build-tests),?(\\s+|$)"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1405,12 +1405,12 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-caching-unit-tests
+  - name: pull-caching-unit-tests
     agent: kubernetes
-    context: pull-knative-caching-unit-tests
+    context: pull-caching-unit-tests
     always_run: true
-    rerun_command: "/test pull-knative-caching-unit-tests"
-    trigger: "(?m)^/test (all|pull-knative-caching-unit-tests),?(\\s+|$)"
+    rerun_command: "/test pull-caching-unit-tests"
+    trigger: "(?m)^/test (all|pull-caching-unit-tests),?(\\s+|$)"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1440,12 +1440,12 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-caching-integration-tests
+  - name: pull-caching-integration-tests
     agent: kubernetes
-    context: pull-knative-caching-integration-tests
+    context: pull-caching-integration-tests
     always_run: true
-    rerun_command: "/test pull-knative-caching-integration-tests"
-    trigger: "(?m)^/test (all|pull-knative-caching-integration-tests),?(\\s+|$)"
+    rerun_command: "/test pull-caching-integration-tests"
+    trigger: "(?m)^/test (all|pull-caching-integration-tests),?(\\s+|$)"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1475,12 +1475,12 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-caching-go-coverage
+  - name: pull-caching-go-coverage
     agent: kubernetes
-    context: pull-knative-caching-go-coverage
+    context: pull-caching-go-coverage
     always_run: true
-    rerun_command: "/test pull-knative-caching-go-coverage"
-    trigger: "(?m)^/test (all|pull-knative-caching-go-coverage),?(\\s+|$)"
+    rerun_command: "/test pull-caching-go-coverage"
+    trigger: "(?m)^/test (all|pull-caching-go-coverage),?(\\s+|$)"
     optional: true
     decorate: true
     clone_uri: "https://github.com/knative/caching.git"
@@ -1492,7 +1492,7 @@ presubmits:
         - "/coverage"
         args:
         - "--postsubmit-gcs-bucket=knative-prow"
-        - "--postsubmit-job-name=post-knative-caching-go-coverage"
+        - "--postsubmit-job-name=post-caching-go-coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--profile-name=coverage_profile.txt"
         - "--cov-target=."
@@ -1932,7 +1932,7 @@ periodics:
       command:
       - "/metrics"
       args:
-      - "--source-directory=ci-knative-serving-continuous"
+      - "--source-directory=ci-serving-continuous"
       - "--artifacts-dir=$(ARTIFACTS)"
       - "--service-account=/etc/test-account/service-account.json"
       volumeMounts:
@@ -2009,7 +2009,7 @@ periodics:
         readOnly: true
       env:
       - name: SYSTEM_NAMESPACE
-        value: knative-serving
+        value: serving
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -2019,7 +2019,7 @@ periodics:
       secret:
         secretName: test-account
 - cron: "0 1 * * *"
-  name: ci-knative-serving-go-coverage
+  name: ci-serving-go-coverage
   agent: kubernetes
   decorate: true
   extra_refs:
@@ -2264,7 +2264,7 @@ periodics:
       command:
       - "/metrics"
       args:
-      - "--source-directory=ci-knative-build-continuous"
+      - "--source-directory=ci-build-continuous"
       - "--artifacts-dir=$(ARTIFACTS)"
       - "--service-account=/etc/test-account/service-account.json"
       volumeMounts:
@@ -2281,7 +2281,7 @@ periodics:
       secret:
         secretName: test-account
 - cron: "0 1 * * *"
-  name: ci-knative-build-go-coverage
+  name: ci-build-go-coverage
   agent: kubernetes
   decorate: true
   extra_refs:
@@ -2343,7 +2343,7 @@ periodics:
       secret:
         secretName: test-account
 - cron: "0 1 * * *"
-  name: ci-knative-docs-go-coverage
+  name: ci-docs-go-coverage
   agent: kubernetes
   decorate: true
   extra_refs:
@@ -2557,7 +2557,7 @@ periodics:
       secret:
         secretName: release-account
 - cron: "0 1 * * *"
-  name: ci-knative-eventing-go-coverage
+  name: ci-eventing-go-coverage
   agent: kubernetes
   decorate: true
   extra_refs:
@@ -2771,7 +2771,7 @@ periodics:
       secret:
         secretName: release-account
 - cron: "0 1 * * *"
-  name: ci-knative-eventing-sources-go-coverage
+  name: ci-eventing-sources-go-coverage
   agent: kubernetes
   decorate: true
   extra_refs:
@@ -2859,7 +2859,7 @@ periodics:
       secret:
         secretName: test-account
 - cron: "0 1 * * *"
-  name: ci-knative-pkg-go-coverage
+  name: ci-pkg-go-coverage
   agent: kubernetes
   decorate: true
   extra_refs:
@@ -2913,7 +2913,7 @@ periodics:
       secret:
         secretName: test-account
 - cron: "0 1 * * *"
-  name: ci-knative-caching-go-coverage
+  name: ci-caching-go-coverage
   agent: kubernetes
   decorate: true
   extra_refs:
@@ -2933,7 +2933,7 @@ periodics:
       - "--cov-target=."
       - "--cov-threshold-percentage=50"
 - cron: "0 1 * * *"
-  name: ci-knative-client-go-coverage
+  name: ci-client-go-coverage
   agent: kubernetes
   decorate: true
   extra_refs:
@@ -3044,7 +3044,7 @@ periodics:
         secretName: backup-account
 postsubmits:
   knative/serving:
-  - name: post-knative-serving-go-coverage
+  - name: post-serving-go-coverage
     branches:
     - master
     agent: kubernetes
@@ -3061,25 +3061,8 @@ postsubmits:
         - "--profile-name=coverage_profile.txt"
         - "--cov-target=."
         - "--cov-threshold-percentage=0"
-  - name: post-knative-serving-go-coverage-dev
-    branches:
-    - master
-    agent: kubernetes
-    decorate: true
-    clone_uri: "https://github.com/knative/serving.git"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/coverage-dev:latest-dev
-        imagePullPolicy: Always
-        command:
-        - "/coverage"
-        args:
-        - "--artifacts=$(ARTIFACTS)"
-        - "--profile-name=coverage_profile.txt"
-        - "--cov-target=."
-        - "--cov-threshold-percentage=0"
   knative/build:
-  - name: post-knative-build-go-coverage
+  - name: post-build-go-coverage
     branches:
     - master
     agent: kubernetes
@@ -3097,7 +3080,7 @@ postsubmits:
         - "--cov-target=."
         - "--cov-threshold-percentage=0"
   knative/client:
-  - name: post-knative-client-go-coverage
+  - name: post-client-go-coverage
     branches:
     - master
     agent: kubernetes
@@ -3115,7 +3098,7 @@ postsubmits:
         - "--cov-target=."
         - "--cov-threshold-percentage=0"
   knative/eventing:
-  - name: post-knative-eventing-go-coverage
+  - name: post-eventing-go-coverage
     branches:
     - master
     agent: kubernetes
@@ -3133,7 +3116,7 @@ postsubmits:
         - "--cov-target=."
         - "--cov-threshold-percentage=0"
   knative/eventing-sources:
-  - name: post-knative-eventing-sources-go-coverage
+  - name: post-eventing-sources-go-coverage
     branches:
     - master
     agent: kubernetes
@@ -3151,7 +3134,7 @@ postsubmits:
         - "--cov-target=."
         - "--cov-threshold-percentage=0"
   knative/docs:
-  - name: post-knative-docs-go-coverage
+  - name: post-docs-go-coverage
     branches:
     - master
     agent: kubernetes
@@ -3169,7 +3152,7 @@ postsubmits:
         - "--cov-target=."
         - "--cov-threshold-percentage=0"
   knative/pkg:
-  - name: post-knative-pkg-go-coverage
+  - name: post-pkg-go-coverage
     branches:
     - master
     agent: kubernetes
@@ -3187,7 +3170,7 @@ postsubmits:
         - "--cov-target=."
         - "--cov-threshold-percentage=0"
   knative/caching:
-  - name: post-knative-caching-go-coverage
+  - name: post-caching-go-coverage
     branches:
     - master
     agent: kubernetes

--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -1932,7 +1932,7 @@ periodics:
       command:
       - "/metrics"
       args:
-      - "--source-directory=ci-serving-continuous"
+      - "--source-directory=ci-serving"
       - "--artifacts-dir=$(ARTIFACTS)"
       - "--service-account=/etc/test-account/service-account.json"
       volumeMounts:
@@ -2019,7 +2019,7 @@ periodics:
       secret:
         secretName: test-account
 - cron: "0 1 * * *"
-  name: ci-serving-go-coverage
+  name: go-coverage-serving
   agent: kubernetes
   decorate: true
   extra_refs:
@@ -2264,7 +2264,7 @@ periodics:
       command:
       - "/metrics"
       args:
-      - "--source-directory=ci-build-continuous"
+      - "--source-directory=ci-build"
       - "--artifacts-dir=$(ARTIFACTS)"
       - "--service-account=/etc/test-account/service-account.json"
       volumeMounts:
@@ -2281,7 +2281,7 @@ periodics:
       secret:
         secretName: test-account
 - cron: "0 1 * * *"
-  name: ci-build-go-coverage
+  name: go-coverage-build
   agent: kubernetes
   decorate: true
   extra_refs:
@@ -2343,7 +2343,7 @@ periodics:
       secret:
         secretName: test-account
 - cron: "0 1 * * *"
-  name: ci-docs-go-coverage
+  name: go-coverage-docs
   agent: kubernetes
   decorate: true
   extra_refs:
@@ -2557,7 +2557,7 @@ periodics:
       secret:
         secretName: release-account
 - cron: "0 1 * * *"
-  name: ci-eventing-go-coverage
+  name: go-coverage-eventing
   agent: kubernetes
   decorate: true
   extra_refs:
@@ -2771,7 +2771,7 @@ periodics:
       secret:
         secretName: release-account
 - cron: "0 1 * * *"
-  name: ci-eventing-sources-go-coverage
+  name: go-coverage-eventing-sources
   agent: kubernetes
   decorate: true
   extra_refs:
@@ -2859,7 +2859,7 @@ periodics:
       secret:
         secretName: test-account
 - cron: "0 1 * * *"
-  name: ci-pkg-go-coverage
+  name: go-coverage-pkg
   agent: kubernetes
   decorate: true
   extra_refs:
@@ -2913,7 +2913,7 @@ periodics:
       secret:
         secretName: test-account
 - cron: "0 1 * * *"
-  name: ci-caching-go-coverage
+  name: go-coverage-caching
   agent: kubernetes
   decorate: true
   extra_refs:
@@ -2933,7 +2933,7 @@ periodics:
       - "--cov-target=."
       - "--cov-threshold-percentage=50"
 - cron: "0 1 * * *"
-  name: ci-client-go-coverage
+  name: go-coverage-client
   agent: kubernetes
   decorate: true
   extra_refs:
@@ -2953,7 +2953,7 @@ periodics:
       - "--cov-target=."
       - "--cov-threshold-percentage=50"
 - cron: "0 19 * * 1"
-  name: ci-knative-cleanup
+  name: cleanup
   agent: kubernetes
   decorate: true
   decoration_config:
@@ -2984,7 +2984,7 @@ periodics:
       secret:
         secretName: test-account
 - cron: "0 12 * * *"
-  name: ci-knative-flakes-reporter
+  name: flakes-reporter
   agent: kubernetes
   decorate: true
   extra_refs:
@@ -3023,7 +3023,7 @@ periodics:
       secret:
         secretName: flaky-test-reporter-slack-token
 - cron: "15 9 * * *"
-  name: ci-knative-backup-artifacts
+  name: backup-artifacts
   agent: kubernetes
   decorate: true
   spec:

--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -1508,7 +1508,7 @@ presubmits:
           secretName: covbot-token
 periodics:
 - cron: "1 */2 * * *"
-  name: ci-knative-serving-continuous
+  name: ci-serving
   agent: kubernetes
   spec:
     containers:
@@ -1542,7 +1542,7 @@ periodics:
       secret:
         secretName: test-account
 - cron: "25 8 * * *"
-  name: ci-knative-serving-0.4-continuous
+  name: ci-serving-0.4
   agent: kubernetes
   spec:
     containers:
@@ -1584,7 +1584,7 @@ periodics:
       secret:
         secretName: test-account
 - cron: "35 8 * * *"
-  name: ci-knative-serving-0.5-continuous
+  name: ci-serving-0.5
   agent: kubernetes
   spec:
     containers:
@@ -1626,7 +1626,7 @@ periodics:
       secret:
         secretName: test-account
 - cron: "7 */2 * * *"
-  name: ci-knative-serving-istio-1.0.7-mesh
+  name: ci-serving-istio-1.0.7-mesh
   agent: kubernetes
   spec:
     containers:
@@ -1661,7 +1661,7 @@ periodics:
       secret:
         secretName: test-account
 - cron: "22 */2 * * *"
-  name: ci-knative-serving-istio-1.0.7-no-mesh
+  name: ci-serving-istio-1.0.7-nomesh
   agent: kubernetes
   spec:
     containers:
@@ -1696,7 +1696,7 @@ periodics:
       secret:
         secretName: test-account
 - cron: "37 */2 * * *"
-  name: ci-knative-serving-istio-1.1.2-mesh
+  name: ci-serving-istio-1.1.2-mesh
   agent: kubernetes
   spec:
     containers:
@@ -1731,7 +1731,7 @@ periodics:
       secret:
         secretName: test-account
 - cron: "52 */2 * * *"
-  name: ci-knative-serving-istio-1.1.2-no-mesh
+  name: ci-serving-istio-1.1.2-nomesh
   agent: kubernetes
   spec:
     containers:
@@ -1766,7 +1766,7 @@ periodics:
       secret:
         secretName: test-account
 - cron: "1 8 * * *"
-  name: ci-knative-serving-nightly-release
+  name: nightly-release-serving
   agent: kubernetes
   spec:
     containers:
@@ -1800,7 +1800,7 @@ periodics:
       secret:
         secretName: nightly-account
 - cron: "1 9 * * 2"
-  name: ci-knative-serving-dot-release
+  name: dot-release-serving
   agent: kubernetes
   spec:
     containers:
@@ -1842,7 +1842,7 @@ periodics:
       secret:
         secretName: release-account
 - cron: "3 */2 * * *"
-  name: ci-knative-serving-auto-release
+  name: auto-release-serving
   agent: kubernetes
   spec:
     containers:
@@ -1884,7 +1884,7 @@ periodics:
       secret:
         secretName: release-account
 - cron: "1 9 * * 6"
-  name: ci-knative-serving-playground
+  name: playground-serving
   agent: kubernetes
   spec:
     containers:
@@ -1917,7 +1917,7 @@ periodics:
       secret:
         secretName: test-account
 - cron: "5 8 * * *"
-  name: ci-knative-serving-latency
+  name: latency-serving
   agent: kubernetes
   decorate: true
   extra_refs:
@@ -1949,7 +1949,7 @@ periodics:
       secret:
         secretName: test-account
 - cron: "0 1 * * *"
-  name: ci-knative-serving-performance
+  name: performance-serving
   agent: kubernetes
   spec:
     containers:
@@ -1985,7 +1985,7 @@ periodics:
       secret:
         secretName: test-account
 - cron: "5 9 * * *"
-  name: ci-knative-serving-webhook-apicoverage
+  name: webhook-apicoverage-serving
   agent: kubernetes
   spec:
     containers:
@@ -2039,7 +2039,7 @@ periodics:
       - "--cov-target=."
       - "--cov-threshold-percentage=80"
 - cron: "15 * * * *"
-  name: ci-knative-build-continuous
+  name: ci-build
   agent: kubernetes
   spec:
     containers:
@@ -2073,7 +2073,7 @@ periodics:
       secret:
         secretName: test-account
 - cron: "45 8 * * *"
-  name: ci-knative-build-0.5-continuous
+  name: ci-build-0.5
   agent: kubernetes
   spec:
     containers:
@@ -2115,7 +2115,7 @@ periodics:
       secret:
         secretName: test-account
 - cron: "31 8 * * *"
-  name: ci-knative-build-nightly-release
+  name: nightly-release-build
   agent: kubernetes
   spec:
     containers:
@@ -2157,7 +2157,7 @@ periodics:
       secret:
         secretName: nightly-account
 - cron: "11 9 * * 2"
-  name: ci-knative-build-dot-release
+  name: dot-release-build
   agent: kubernetes
   spec:
     containers:
@@ -2199,7 +2199,7 @@ periodics:
       secret:
         secretName: release-account
 - cron: "7 */2 * * *"
-  name: ci-knative-build-auto-release
+  name: auto-release-build
   agent: kubernetes
   spec:
     containers:
@@ -2249,7 +2249,7 @@ periodics:
       secret:
         secretName: release-account
 - cron: "5 8 * * *"
-  name: ci-knative-build-latency
+  name: latency-build
   agent: kubernetes
   decorate: true
   extra_refs:
@@ -2301,7 +2301,7 @@ periodics:
       - "--cov-target=."
       - "--cov-threshold-percentage=80"
 - cron: "50 * * * *"
-  name: ci-knative-docs-continuous
+  name: ci-docs
   agent: kubernetes
   spec:
     containers:
@@ -2363,7 +2363,7 @@ periodics:
       - "--cov-target=."
       - "--cov-threshold-percentage=50"
 - cron: "30 * * * *"
-  name: ci-knative-eventing-continuous
+  name: ci-eventing
   agent: kubernetes
   spec:
     containers:
@@ -2397,7 +2397,7 @@ periodics:
       secret:
         secretName: test-account
 - cron: "40 8 * * *"
-  name: ci-knative-eventing-0.5-continuous
+  name: ci-eventing-0.5
   agent: kubernetes
   spec:
     containers:
@@ -2439,7 +2439,7 @@ periodics:
       secret:
         secretName: test-account
 - cron: "16 9 * * *"
-  name: ci-knative-eventing-nightly-release
+  name: nightly-release-eventing
   agent: kubernetes
   spec:
     containers:
@@ -2473,7 +2473,7 @@ periodics:
       secret:
         secretName: nightly-account
 - cron: "19 9 * * 2"
-  name: ci-knative-eventing-dot-release
+  name: dot-release-eventing
   agent: kubernetes
   spec:
     containers:
@@ -2515,7 +2515,7 @@ periodics:
       secret:
         secretName: release-account
 - cron: "5 */2 * * *"
-  name: ci-knative-eventing-auto-release
+  name: auto-release-eventing
   agent: kubernetes
   spec:
     containers:
@@ -2577,7 +2577,7 @@ periodics:
       - "--cov-target=."
       - "--cov-threshold-percentage=50"
 - cron: "30 * * * *"
-  name: ci-knative-eventing-sources-continuous
+  name: ci-eventing-sources
   agent: kubernetes
   spec:
     containers:
@@ -2611,7 +2611,7 @@ periodics:
       secret:
         secretName: test-account
 - cron: "50 8 * * *"
-  name: ci-knative-eventing-sources-0.5-continuous
+  name: ci-eventing-sources-0.5
   agent: kubernetes
   spec:
     containers:
@@ -2653,7 +2653,7 @@ periodics:
       secret:
         secretName: test-account
 - cron: "16 9 * * *"
-  name: ci-knative-eventing-sources-nightly-release
+  name: nightly-release-eventing-sources
   agent: kubernetes
   spec:
     containers:
@@ -2687,7 +2687,7 @@ periodics:
       secret:
         secretName: nightly-account
 - cron: "17 9 * * 2"
-  name: ci-knative-eventing-sources-dot-release
+  name: dot-release-eventing-sources
   agent: kubernetes
   spec:
     containers:
@@ -2729,7 +2729,7 @@ periodics:
       secret:
         secretName: release-account
 - cron: "5 */2 * * *"
-  name: ci-knative-eventing-sources-auto-release
+  name: auto-release-eventing-sources
   agent: kubernetes
   spec:
     containers:
@@ -2791,7 +2791,7 @@ periodics:
       - "--cov-target=."
       - "--cov-threshold-percentage=50"
 - cron: "40 * * * *"
-  name: ci-knative-build-templates-continuous
+  name: ci-build-templates
   agent: kubernetes
   spec:
     containers:
@@ -2825,7 +2825,7 @@ periodics:
       secret:
         secretName: test-account
 - cron: "45 * * * *"
-  name: ci-knative-pkg-continuous
+  name: ci-pkg
   agent: kubernetes
   spec:
     containers:
@@ -2879,7 +2879,7 @@ periodics:
       - "--cov-target=."
       - "--cov-threshold-percentage=50"
 - cron: "30 * * * *"
-  name: ci-knative-caching-continuous
+  name: ci-caching
   agent: kubernetes
   spec:
     containers:

--- a/ci/prow/config_knative.yaml
+++ b/ci/prow/config_knative.yaml
@@ -117,7 +117,7 @@ periodics:
       - "1.0.7"
       - "--mesh"
       timeout: 100
-    - custom-job: istio-1.0.7-no-mesh
+    - custom-job: istio-1.0.7-nomesh
       cron: "22 */2 * * *" # Run every other hour and twenty-two minute
       command:
       - "./test/e2e-tests.sh"
@@ -135,7 +135,7 @@ periodics:
       - "1.1.2"
       - "--mesh"
       timeout: 100
-    - custom-job: istio-1.1.2-no-mesh
+    - custom-job: istio-1.1.2-nomesh
       cron: "52 */2 * * *" # Run every other hour and fifty-two minute
       command:
       - "./test/e2e-tests.sh"

--- a/ci/prow/make_config.go
+++ b/ci/prow/make_config.go
@@ -1376,7 +1376,9 @@ func executeTestGroupTemplate(testGroupName string, gcsLogDir string, extras map
 
 // generateDashboard generates the dashboard configuration
 func generateDashboard(repoName string, jobNames []string) {
-	outputConfig("- name: " + repoName + "\n" + baseIndent + "dashboard_tab:")
+	dashboardName := getDashboardName(repoName)
+	outputConfig("- name: " + dashboardName + "\n" + baseIndent + "dashboard_tab:")
+
 	noExtras := make(map[string]string)
 	for _, jobName := range jobNames {
 		testGroupName := getTestGroupName(repoName, jobName)
@@ -1458,14 +1460,21 @@ func generateDashboardGroups() {
 	outputConfig("dashboard_groups:")
 	for _, projName := range projNames {
 		repos := metaData[projName]
-		dashboardRepoNames := make([]string, 0)
+		dashboardNames := make([]string, 0)
 		for _, repoName := range repoNames {
 			if _, exists := repos[repoName]; exists {
-				dashboardRepoNames = append(dashboardRepoNames, buildProjRepoStr(projName, repoName))
+				repoName := buildProjRepoStr(projName, repoName)
+				dashboardName := getDashboardName(repoName)
+				dashboardNames = append(dashboardNames, dashboardName)
 			}
 		}
-		executeDashboardGroupTemplate(projName, dashboardRepoNames)
+		executeDashboardGroupTemplate(projName, dashboardNames)
 	}
+}
+
+// getDashboardName gets the dashboardName from the repoName by removing the prefixed "knative-"
+func getDashboardName(repoName string) string {
+	return strings.TrimPrefix(repoName, "knative-")
 }
 
 // executeDashboardGroupTemplate outputs the given dashboard group config template with the given data

--- a/ci/prow/make_config.go
+++ b/ci/prow/make_config.go
@@ -591,7 +591,7 @@ func newbaseProwJobTemplateData(repo string) baseProwJobTemplateData {
 	var data baseProwJobTemplateData
 	data.Timeout = 50
 	data.RepoName = strings.Replace(repo, "knative/", "", 1)
-	data.RepoNameForJob = strings.Replace(repo, "/", "-", -1)
+	data.RepoNameForJob = data.RepoName
 	data.GcsBucket = gcsBucket
 	data.RepoURI = "github.com/" + repo
 	data.CloneURI = fmt.Sprintf("\"https://%s.git\"", data.RepoURI)
@@ -778,8 +778,8 @@ func generatePresubmit(title string, repoName string, presubmitConfig yaml.MapSl
 	configureServiceAccountForJob(&data.Base)
 	executeJobTemplate("presubmit", jobTemplate, title, repoName, data.PresubmitPullJobName, true, data)
 	// TODO(adrcunha): remove once the coverage-dev job isn't necessary anymore.
-	// Generate config for pull-knative-serving-go-coverage-dev right after pull-knative-serving-go-coverage
-	if data.PresubmitPullJobName == "pull-knative-serving-go-coverage" {
+	// Generate config for pull-serving-go-coverage-dev right after pull-serving-go-coverage
+	if data.PresubmitPullJobName == "pull-serving-go-coverage" {
 		data.PresubmitPullJobName += "-dev"
 		data.Base.AlwaysRun = false
 		data.Base.Image = strings.Replace(data.Base.Image, "coverage:latest", "coverage-dev:latest-dev", -1)

--- a/ci/prow/make_config.go
+++ b/ci/prow/make_config.go
@@ -1385,9 +1385,9 @@ func generateDashboard(repoName string, jobNames []string) {
 		switch jobName {
 		case "continuous":
 			executeDashboardTabTemplate("continuous", testGroupName, testgridTabSortByName, noExtras)
-			// This is a special case for knative/serving, as conformance-tests tab is just a filtered view of the continuous tab.
+			// This is a special case for knative/serving, as conformance tab is just a filtered view of the continuous tab.
 			if repoName == "knative-serving" {
-				executeDashboardTabTemplate("conformance-tests", testGroupName, "include-filter-by-regex=test/conformance\\\\.&sort-by-name=", noExtras)
+				executeDashboardTabTemplate("conformance", testGroupName, "include-filter-by-regex=test/conformance\\\\.&sort-by-name=", noExtras)
 			}
 		case "dot-release", "auto-release", "performance", "latency", "playground":
 			extras := make(map[string]string)

--- a/ci/testgrid/config.yaml
+++ b/ci/testgrid/config.yaml
@@ -56,296 +56,296 @@ default_dashboard_tab:
   alert_options:
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
 test_groups:
-- name: ci-knative-serving-continuous
-  gcs_prefix: knative-prow/logs/ci-knative-serving-continuous
+- name: ci-serving
+  gcs_prefix: knative-prow/logs/ci-serving
   alert_stale_results_hours: 3
   num_failures_to_alert: 3
-- name: ci-knative-serving-istio-1.0.7-mesh
-  gcs_prefix: knative-prow/logs/ci-knative-serving-istio-1.0.7-mesh
+- name: ci-serving-istio-1.0.7-mesh
+  gcs_prefix: knative-prow/logs/ci-serving-istio-1.0.7-mesh
   alert_stale_results_hours: 3
   num_failures_to_alert: 3
-- name: ci-knative-serving-istio-1.0.7-no-mesh
-  gcs_prefix: knative-prow/logs/ci-knative-serving-istio-1.0.7-no-mesh
+- name: ci-serving-istio-1.0.7-nomesh
+  gcs_prefix: knative-prow/logs/ci-serving-istio-1.0.7-nomesh
   alert_stale_results_hours: 3
   num_failures_to_alert: 3
-- name: ci-knative-serving-istio-1.1.2-mesh
-  gcs_prefix: knative-prow/logs/ci-knative-serving-istio-1.1.2-mesh
+- name: ci-serving-istio-1.1.2-mesh
+  gcs_prefix: knative-prow/logs/ci-serving-istio-1.1.2-mesh
   alert_stale_results_hours: 3
   num_failures_to_alert: 3
-- name: ci-knative-serving-istio-1.1.2-no-mesh
-  gcs_prefix: knative-prow/logs/ci-knative-serving-istio-1.1.2-no-mesh
+- name: ci-serving-istio-1.1.2-nomesh
+  gcs_prefix: knative-prow/logs/ci-serving-istio-1.1.2-nomesh
   alert_stale_results_hours: 3
   num_failures_to_alert: 3
-- name: ci-knative-serving-nightly-release
-  gcs_prefix: knative-prow/logs/ci-knative-serving-nightly-release
-- name: ci-knative-serving-dot-release
-  gcs_prefix: knative-prow/logs/ci-knative-serving-dot-release
+- name: nightly-release-serving
+  gcs_prefix: knative-prow/logs/nightly-release-serving
+- name: dot-release-serving
+  gcs_prefix: knative-prow/logs/dot-release-serving
   alert_stale_results_hours: 170
-- name: ci-knative-serving-auto-release
-  gcs_prefix: knative-prow/logs/ci-knative-serving-auto-release
+- name: auto-release-serving
+  gcs_prefix: knative-prow/logs/auto-release-serving
   alert_stale_results_hours: 3
-- name: ci-knative-serving-playground
-  gcs_prefix: knative-prow/logs/ci-knative-serving-playground
+- name: playground-serving
+  gcs_prefix: knative-prow/logs/playground-serving
   alert_stale_results_hours: 170
-- name: ci-knative-serving-latency
-  gcs_prefix: knative-prow/logs/ci-knative-serving-latency
+- name: latency-serving
+  gcs_prefix: knative-prow/logs/latency-serving
   short_text_metric: "latency"
-- name: ci-knative-serving-performance
-  gcs_prefix: knative-prow/logs/ci-knative-serving-performance
+- name: performance-serving
+  gcs_prefix: knative-prow/logs/performance-serving
   short_text_metric: "perf_latency"
-- name: pull-knative-serving-test-coverage
+- name: pull-serving-test-coverage
   gcs_prefix: knative-prow/logs/ci-knative-serving-go-coverage
   num_failures_to_alert: 9999
   short_text_metric: "coverage"
-- name: ci-knative-build-continuous
-  gcs_prefix: knative-prow/logs/ci-knative-build-continuous
+- name: ci-build
+  gcs_prefix: knative-prow/logs/ci-build
   alert_stale_results_hours: 3
   num_failures_to_alert: 3
-- name: ci-knative-build-nightly-release
-  gcs_prefix: knative-prow/logs/ci-knative-build-nightly-release
-- name: ci-knative-build-dot-release
-  gcs_prefix: knative-prow/logs/ci-knative-build-dot-release
+- name: nightly-release-build
+  gcs_prefix: knative-prow/logs/nightly-release-build
+- name: dot-release-build
+  gcs_prefix: knative-prow/logs/dot-release-build
   alert_stale_results_hours: 170
-- name: ci-knative-build-auto-release
-  gcs_prefix: knative-prow/logs/ci-knative-build-auto-release
+- name: auto-release-build
+  gcs_prefix: knative-prow/logs/auto-release-build
   alert_stale_results_hours: 3
-- name: ci-knative-build-latency
-  gcs_prefix: knative-prow/logs/ci-knative-build-latency
+- name: latency-build
+  gcs_prefix: knative-prow/logs/latency-build
   short_text_metric: "latency"
-- name: pull-knative-build-test-coverage
+- name: pull-build-test-coverage
   gcs_prefix: knative-prow/logs/ci-knative-build-go-coverage
   num_failures_to_alert: 9999
   short_text_metric: "coverage"
-- name: ci-knative-docs-continuous
-  gcs_prefix: knative-prow/logs/ci-knative-docs-continuous
+- name: ci-docs
+  gcs_prefix: knative-prow/logs/ci-docs
   alert_stale_results_hours: 3
   num_failures_to_alert: 3
-- name: pull-knative-docs-test-coverage
+- name: pull-docs-test-coverage
   gcs_prefix: knative-prow/logs/ci-knative-docs-go-coverage
   num_failures_to_alert: 9999
   short_text_metric: "coverage"
-- name: ci-knative-eventing-continuous
-  gcs_prefix: knative-prow/logs/ci-knative-eventing-continuous
+- name: ci-eventing
+  gcs_prefix: knative-prow/logs/ci-eventing
   alert_stale_results_hours: 3
   num_failures_to_alert: 3
-- name: ci-knative-eventing-nightly-release
-  gcs_prefix: knative-prow/logs/ci-knative-eventing-nightly-release
-- name: ci-knative-eventing-dot-release
-  gcs_prefix: knative-prow/logs/ci-knative-eventing-dot-release
+- name: nightly-release-eventing
+  gcs_prefix: knative-prow/logs/nightly-release-eventing
+- name: dot-release-eventing
+  gcs_prefix: knative-prow/logs/dot-release-eventing
   alert_stale_results_hours: 170
-- name: ci-knative-eventing-auto-release
-  gcs_prefix: knative-prow/logs/ci-knative-eventing-auto-release
+- name: auto-release-eventing
+  gcs_prefix: knative-prow/logs/auto-release-eventing
   alert_stale_results_hours: 3
-- name: pull-knative-eventing-test-coverage
+- name: pull-eventing-test-coverage
   gcs_prefix: knative-prow/logs/ci-knative-eventing-go-coverage
   num_failures_to_alert: 9999
   short_text_metric: "coverage"
-- name: ci-knative-eventing-sources-continuous
-  gcs_prefix: knative-prow/logs/ci-knative-eventing-sources-continuous
+- name: ci-eventing-sources
+  gcs_prefix: knative-prow/logs/ci-eventing-sources
   alert_stale_results_hours: 3
   num_failures_to_alert: 3
-- name: ci-knative-eventing-sources-nightly-release
-  gcs_prefix: knative-prow/logs/ci-knative-eventing-sources-nightly-release
-- name: ci-knative-eventing-sources-dot-release
-  gcs_prefix: knative-prow/logs/ci-knative-eventing-sources-dot-release
+- name: nightly-release-eventing-sources
+  gcs_prefix: knative-prow/logs/nightly-release-eventing-sources
+- name: dot-release-eventing-sources
+  gcs_prefix: knative-prow/logs/dot-release-eventing-sources
   alert_stale_results_hours: 170
-- name: ci-knative-eventing-sources-auto-release
-  gcs_prefix: knative-prow/logs/ci-knative-eventing-sources-auto-release
+- name: auto-release-eventing-sources
+  gcs_prefix: knative-prow/logs/auto-release-eventing-sources
   alert_stale_results_hours: 3
-- name: pull-knative-eventing-sources-test-coverage
+- name: pull-eventing-sources-test-coverage
   gcs_prefix: knative-prow/logs/ci-knative-eventing-sources-go-coverage
   num_failures_to_alert: 9999
   short_text_metric: "coverage"
-- name: ci-knative-build-templates-continuous
-  gcs_prefix: knative-prow/logs/ci-knative-build-templates-continuous
+- name: ci-build-templates
+  gcs_prefix: knative-prow/logs/ci-build-templates
   alert_stale_results_hours: 3
   num_failures_to_alert: 3
-- name: ci-knative-pkg-continuous
-  gcs_prefix: knative-prow/logs/ci-knative-pkg-continuous
+- name: ci-pkg
+  gcs_prefix: knative-prow/logs/ci-pkg
   alert_stale_results_hours: 3
   num_failures_to_alert: 3
-- name: pull-knative-pkg-test-coverage
+- name: pull-pkg-test-coverage
   gcs_prefix: knative-prow/logs/ci-knative-pkg-go-coverage
   num_failures_to_alert: 9999
   short_text_metric: "coverage"
-- name: ci-knative-caching-continuous
-  gcs_prefix: knative-prow/logs/ci-knative-caching-continuous
+- name: ci-caching
+  gcs_prefix: knative-prow/logs/ci-caching
   alert_stale_results_hours: 3
   num_failures_to_alert: 3
-- name: pull-knative-caching-test-coverage
+- name: pull-caching-test-coverage
   gcs_prefix: knative-prow/logs/ci-knative-caching-go-coverage
   num_failures_to_alert: 9999
   short_text_metric: "coverage"
-- name: pull-knative-client-test-coverage
+- name: pull-client-test-coverage
   gcs_prefix: knative-prow/logs/ci-knative-client-go-coverage
   num_failures_to_alert: 9999
   short_text_metric: "coverage"
-- name: ci-knative-serving-0.4-continuous
-  gcs_prefix: knative-prow/logs/ci-knative-serving-0.4-continuous
-- name: ci-knative-serving-0.5-continuous
-  gcs_prefix: knative-prow/logs/ci-knative-serving-0.5-continuous
-- name: ci-knative-build-0.5-continuous
-  gcs_prefix: knative-prow/logs/ci-knative-build-0.5-continuous
-- name: ci-knative-eventing-0.5-continuous
-  gcs_prefix: knative-prow/logs/ci-knative-eventing-0.5-continuous
-- name: ci-knative-eventing-sources-0.5-continuous
-  gcs_prefix: knative-prow/logs/ci-knative-eventing-sources-0.5-continuous
+- name: ci-serving-0.4
+  gcs_prefix: knative-prow/logs/ci-serving-0.4
+- name: ci-serving-0.5
+  gcs_prefix: knative-prow/logs/ci-serving-0.5
+- name: ci-build-0.5
+  gcs_prefix: knative-prow/logs/ci-build-0.5
+- name: ci-eventing-0.5
+  gcs_prefix: knative-prow/logs/ci-eventing-0.5
+- name: ci-eventing-sources-0.5
+  gcs_prefix: knative-prow/logs/ci-eventing-sources-0.5
 dashboards:
 - name: serving
   dashboard_tab:
   - name: continuous
-    test_group_name: ci-knative-serving-continuous
+    test_group_name: ci-serving
     base_options: "sort-by-name="
   - name: conformance
-    test_group_name: ci-knative-serving-continuous
+    test_group_name: ci-serving
     base_options: "include-filter-by-regex=test/conformance\\.&sort-by-name="
   - name: istio-1.0.7-mesh
-    test_group_name: ci-knative-serving-istio-1.0.7-mesh
+    test_group_name: ci-serving-istio-1.0.7-mesh
     base_options: "sort-by-name="
-  - name: istio-1.0.7-no-mesh
-    test_group_name: ci-knative-serving-istio-1.0.7-no-mesh
+  - name: istio-1.0.7-nomesh
+    test_group_name: ci-serving-istio-1.0.7-nomesh
     base_options: "sort-by-name="
   - name: istio-1.1.2-mesh
-    test_group_name: ci-knative-serving-istio-1.1.2-mesh
+    test_group_name: ci-serving-istio-1.1.2-mesh
     base_options: "sort-by-name="
-  - name: istio-1.1.2-no-mesh
-    test_group_name: ci-knative-serving-istio-1.1.2-no-mesh
+  - name: istio-1.1.2-nomesh
+    test_group_name: ci-serving-istio-1.1.2-nomesh
     base_options: "sort-by-name="
   - name: nightly
-    test_group_name: ci-knative-serving-nightly-release
+    test_group_name: nightly-release-serving
     base_options: "sort-by-name="
   - name: dot-release
-    test_group_name: ci-knative-serving-dot-release
+    test_group_name: dot-release-serving
     base_options: "sort-by-name="
   - name: auto-release
-    test_group_name: ci-knative-serving-auto-release
+    test_group_name: auto-release-serving
     base_options: "sort-by-name="
   - name: playground
-    test_group_name: ci-knative-serving-playground
+    test_group_name: playground-serving
     base_options: "sort-by-name="
   - name: latency
-    test_group_name: ci-knative-serving-latency
+    test_group_name: latency-serving
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
     description: "95% latency in ms"
   - name: performance
-    test_group_name: ci-knative-serving-performance
+    test_group_name: performance-serving
     base_options: "exclude-filter-by-regex=Overall$&group-by-target=&expand-groups=&sort-by-name="
   - name: coverage
-    test_group_name: pull-knative-serving-test-coverage
+    test_group_name: pull-serving-test-coverage
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
 - name: build
   dashboard_tab:
   - name: continuous
-    test_group_name: ci-knative-build-continuous
+    test_group_name: ci-build
     base_options: "sort-by-name="
   - name: nightly
-    test_group_name: ci-knative-build-nightly-release
+    test_group_name: nightly-release-build
     base_options: "sort-by-name="
   - name: dot-release
-    test_group_name: ci-knative-build-dot-release
+    test_group_name: dot-release-build
     base_options: "sort-by-name="
   - name: auto-release
-    test_group_name: ci-knative-build-auto-release
+    test_group_name: auto-release-build
     base_options: "sort-by-name="
   - name: latency
-    test_group_name: ci-knative-build-latency
+    test_group_name: latency-build
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
     description: "95% latency in ms"
   - name: coverage
-    test_group_name: pull-knative-build-test-coverage
+    test_group_name: pull-build-test-coverage
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
 - name: docs
   dashboard_tab:
   - name: continuous
-    test_group_name: ci-knative-docs-continuous
+    test_group_name: ci-docs
     base_options: "sort-by-name="
   - name: coverage
-    test_group_name: pull-knative-docs-test-coverage
+    test_group_name: pull-docs-test-coverage
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
 - name: eventing
   dashboard_tab:
   - name: continuous
-    test_group_name: ci-knative-eventing-continuous
+    test_group_name: ci-eventing
     base_options: "sort-by-name="
   - name: nightly
-    test_group_name: ci-knative-eventing-nightly-release
+    test_group_name: nightly-release-eventing
     base_options: "sort-by-name="
   - name: dot-release
-    test_group_name: ci-knative-eventing-dot-release
+    test_group_name: dot-release-eventing
     base_options: "sort-by-name="
   - name: auto-release
-    test_group_name: ci-knative-eventing-auto-release
+    test_group_name: auto-release-eventing
     base_options: "sort-by-name="
   - name: coverage
-    test_group_name: pull-knative-eventing-test-coverage
+    test_group_name: pull-eventing-test-coverage
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
 - name: eventing-sources
   dashboard_tab:
   - name: continuous
-    test_group_name: ci-knative-eventing-sources-continuous
+    test_group_name: ci-eventing-sources
     base_options: "sort-by-name="
   - name: nightly
-    test_group_name: ci-knative-eventing-sources-nightly-release
+    test_group_name: nightly-release-eventing-sources
     base_options: "sort-by-name="
   - name: dot-release
-    test_group_name: ci-knative-eventing-sources-dot-release
+    test_group_name: dot-release-eventing-sources
     base_options: "sort-by-name="
   - name: auto-release
-    test_group_name: ci-knative-eventing-sources-auto-release
+    test_group_name: auto-release-eventing-sources
     base_options: "sort-by-name="
   - name: coverage
-    test_group_name: pull-knative-eventing-sources-test-coverage
+    test_group_name: pull-eventing-sources-test-coverage
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
 - name: build-templates
   dashboard_tab:
   - name: continuous
-    test_group_name: ci-knative-build-templates-continuous
+    test_group_name: ci-build-templates
     base_options: "sort-by-name="
 - name: pkg
   dashboard_tab:
   - name: continuous
-    test_group_name: ci-knative-pkg-continuous
+    test_group_name: ci-pkg
     base_options: "sort-by-name="
   - name: coverage
-    test_group_name: pull-knative-pkg-test-coverage
+    test_group_name: pull-pkg-test-coverage
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
 - name: caching
   dashboard_tab:
   - name: continuous
-    test_group_name: ci-knative-caching-continuous
+    test_group_name: ci-caching
     base_options: "sort-by-name="
   - name: coverage
-    test_group_name: pull-knative-caching-test-coverage
+    test_group_name: pull-caching-test-coverage
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
 - name: client
   dashboard_tab:
   - name: coverage
-    test_group_name: pull-knative-client-test-coverage
+    test_group_name: pull-client-test-coverage
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
 - name: serving-0.4
   dashboard_tab:
   - name: continuous
-    test_group_name: ci-knative-serving-0.4-continuous
+    test_group_name: ci-serving-0.4
     base_options: "sort-by-name="
 - name: serving-0.5
   dashboard_tab:
   - name: continuous
-    test_group_name: ci-knative-serving-0.5-continuous
+    test_group_name: ci-serving-0.5
     base_options: "sort-by-name="
 - name: build-0.5
   dashboard_tab:
   - name: continuous
-    test_group_name: ci-knative-build-0.5-continuous
+    test_group_name: ci-build-0.5
     base_options: "sort-by-name="
 - name: eventing-0.5
   dashboard_tab:
   - name: continuous
-    test_group_name: ci-knative-eventing-0.5-continuous
+    test_group_name: ci-eventing-0.5
     base_options: "sort-by-name="
 - name: eventing-sources-0.5
   dashboard_tab:
   - name: continuous
-    test_group_name: ci-knative-eventing-sources-0.5-continuous
+    test_group_name: ci-eventing-sources-0.5
     base_options: "sort-by-name="
 dashboard_groups:
 - name: knative

--- a/ci/testgrid/config.yaml
+++ b/ci/testgrid/config.yaml
@@ -191,12 +191,12 @@ test_groups:
 - name: ci-knative-eventing-sources-0.5-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-sources-0.5-continuous
 dashboards:
-- name: knative-serving
+- name: serving
   dashboard_tab:
   - name: continuous
     test_group_name: ci-knative-serving-continuous
     base_options: "sort-by-name="
-  - name: conformance-tests
+  - name: conformance
     test_group_name: ci-knative-serving-continuous
     base_options: "include-filter-by-regex=test/conformance\\.&sort-by-name="
   - name: istio-1.0.7-mesh
@@ -233,7 +233,7 @@ dashboards:
   - name: coverage
     test_group_name: pull-knative-serving-test-coverage
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
-- name: knative-build
+- name: build
   dashboard_tab:
   - name: continuous
     test_group_name: ci-knative-build-continuous
@@ -254,7 +254,7 @@ dashboards:
   - name: coverage
     test_group_name: pull-knative-build-test-coverage
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
-- name: knative-docs
+- name: docs
   dashboard_tab:
   - name: continuous
     test_group_name: ci-knative-docs-continuous
@@ -262,7 +262,7 @@ dashboards:
   - name: coverage
     test_group_name: pull-knative-docs-test-coverage
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
-- name: knative-eventing
+- name: eventing
   dashboard_tab:
   - name: continuous
     test_group_name: ci-knative-eventing-continuous
@@ -279,7 +279,7 @@ dashboards:
   - name: coverage
     test_group_name: pull-knative-eventing-test-coverage
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
-- name: knative-eventing-sources
+- name: eventing-sources
   dashboard_tab:
   - name: continuous
     test_group_name: ci-knative-eventing-sources-continuous
@@ -296,12 +296,12 @@ dashboards:
   - name: coverage
     test_group_name: pull-knative-eventing-sources-test-coverage
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
-- name: knative-build-templates
+- name: build-templates
   dashboard_tab:
   - name: continuous
     test_group_name: ci-knative-build-templates-continuous
     base_options: "sort-by-name="
-- name: knative-pkg
+- name: pkg
   dashboard_tab:
   - name: continuous
     test_group_name: ci-knative-pkg-continuous
@@ -309,7 +309,7 @@ dashboards:
   - name: coverage
     test_group_name: pull-knative-pkg-test-coverage
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
-- name: knative-caching
+- name: caching
   dashboard_tab:
   - name: continuous
     test_group_name: ci-knative-caching-continuous
@@ -317,32 +317,32 @@ dashboards:
   - name: coverage
     test_group_name: pull-knative-caching-test-coverage
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
-- name: knative-client
+- name: client
   dashboard_tab:
   - name: coverage
     test_group_name: pull-knative-client-test-coverage
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
-- name: knative-serving-0.4
+- name: serving-0.4
   dashboard_tab:
   - name: continuous
     test_group_name: ci-knative-serving-0.4-continuous
     base_options: "sort-by-name="
-- name: knative-serving-0.5
+- name: serving-0.5
   dashboard_tab:
   - name: continuous
     test_group_name: ci-knative-serving-0.5-continuous
     base_options: "sort-by-name="
-- name: knative-build-0.5
+- name: build-0.5
   dashboard_tab:
   - name: continuous
     test_group_name: ci-knative-build-0.5-continuous
     base_options: "sort-by-name="
-- name: knative-eventing-0.5
+- name: eventing-0.5
   dashboard_tab:
   - name: continuous
     test_group_name: ci-knative-eventing-0.5-continuous
     base_options: "sort-by-name="
-- name: knative-eventing-sources-0.5
+- name: eventing-sources-0.5
   dashboard_tab:
   - name: continuous
     test_group_name: ci-knative-eventing-sources-0.5-continuous
@@ -350,21 +350,21 @@ dashboards:
 dashboard_groups:
 - name: knative
   dashboard_names:
-  - "knative-serving"
-  - "knative-build"
-  - "knative-docs"
-  - "knative-eventing"
-  - "knative-eventing-sources"
-  - "knative-build-templates"
-  - "knative-pkg"
-  - "knative-caching"
-  - "knative-client"
+  - "serving"
+  - "build"
+  - "docs"
+  - "eventing"
+  - "eventing-sources"
+  - "build-templates"
+  - "pkg"
+  - "caching"
+  - "client"
 - name: knative-0.4
   dashboard_names:
-  - "knative-serving-0.4"
+  - "serving-0.4"
 - name: knative-0.5
   dashboard_names:
-  - "knative-serving-0.5"
-  - "knative-build-0.5"
-  - "knative-eventing-0.5"
-  - "knative-eventing-sources-0.5"
+  - "serving-0.5"
+  - "build-0.5"
+  - "eventing-0.5"
+  - "eventing-sources-0.5"

--- a/ci/testgrid/config.yaml
+++ b/ci/testgrid/config.yaml
@@ -94,7 +94,7 @@ test_groups:
   gcs_prefix: knative-prow/logs/performance-serving
   short_text_metric: "perf_latency"
 - name: pull-serving-test-coverage
-  gcs_prefix: knative-prow/logs/ci-serving-go-coverage
+  gcs_prefix: knative-prow/logs/go-coverage-serving
   num_failures_to_alert: 9999
   short_text_metric: "coverage"
 - name: ci-build
@@ -113,7 +113,7 @@ test_groups:
   gcs_prefix: knative-prow/logs/latency-build
   short_text_metric: "latency"
 - name: pull-build-test-coverage
-  gcs_prefix: knative-prow/logs/ci-build-go-coverage
+  gcs_prefix: knative-prow/logs/go-coverage-build
   num_failures_to_alert: 9999
   short_text_metric: "coverage"
 - name: ci-docs
@@ -121,7 +121,7 @@ test_groups:
   alert_stale_results_hours: 3
   num_failures_to_alert: 3
 - name: pull-docs-test-coverage
-  gcs_prefix: knative-prow/logs/ci-docs-go-coverage
+  gcs_prefix: knative-prow/logs/go-coverage-docs
   num_failures_to_alert: 9999
   short_text_metric: "coverage"
 - name: ci-eventing
@@ -137,7 +137,7 @@ test_groups:
   gcs_prefix: knative-prow/logs/auto-release-eventing
   alert_stale_results_hours: 3
 - name: pull-eventing-test-coverage
-  gcs_prefix: knative-prow/logs/ci-eventing-go-coverage
+  gcs_prefix: knative-prow/logs/go-coverage-eventing
   num_failures_to_alert: 9999
   short_text_metric: "coverage"
 - name: ci-eventing-sources
@@ -153,7 +153,7 @@ test_groups:
   gcs_prefix: knative-prow/logs/auto-release-eventing-sources
   alert_stale_results_hours: 3
 - name: pull-eventing-sources-test-coverage
-  gcs_prefix: knative-prow/logs/ci-eventing-sources-go-coverage
+  gcs_prefix: knative-prow/logs/go-coverage-eventing-sources
   num_failures_to_alert: 9999
   short_text_metric: "coverage"
 - name: ci-build-templates
@@ -165,7 +165,7 @@ test_groups:
   alert_stale_results_hours: 3
   num_failures_to_alert: 3
 - name: pull-pkg-test-coverage
-  gcs_prefix: knative-prow/logs/ci-pkg-go-coverage
+  gcs_prefix: knative-prow/logs/go-coverage-pkg
   num_failures_to_alert: 9999
   short_text_metric: "coverage"
 - name: ci-caching
@@ -173,11 +173,11 @@ test_groups:
   alert_stale_results_hours: 3
   num_failures_to_alert: 3
 - name: pull-caching-test-coverage
-  gcs_prefix: knative-prow/logs/ci-caching-go-coverage
+  gcs_prefix: knative-prow/logs/go-coverage-caching
   num_failures_to_alert: 9999
   short_text_metric: "coverage"
 - name: pull-client-test-coverage
-  gcs_prefix: knative-prow/logs/ci-client-go-coverage
+  gcs_prefix: knative-prow/logs/go-coverage-client
   num_failures_to_alert: 9999
   short_text_metric: "coverage"
 - name: ci-serving-0.4

--- a/ci/testgrid/config.yaml
+++ b/ci/testgrid/config.yaml
@@ -94,7 +94,7 @@ test_groups:
   gcs_prefix: knative-prow/logs/performance-serving
   short_text_metric: "perf_latency"
 - name: pull-serving-test-coverage
-  gcs_prefix: knative-prow/logs/ci-knative-serving-go-coverage
+  gcs_prefix: knative-prow/logs/ci-serving-go-coverage
   num_failures_to_alert: 9999
   short_text_metric: "coverage"
 - name: ci-build
@@ -113,7 +113,7 @@ test_groups:
   gcs_prefix: knative-prow/logs/latency-build
   short_text_metric: "latency"
 - name: pull-build-test-coverage
-  gcs_prefix: knative-prow/logs/ci-knative-build-go-coverage
+  gcs_prefix: knative-prow/logs/ci-build-go-coverage
   num_failures_to_alert: 9999
   short_text_metric: "coverage"
 - name: ci-docs
@@ -121,7 +121,7 @@ test_groups:
   alert_stale_results_hours: 3
   num_failures_to_alert: 3
 - name: pull-docs-test-coverage
-  gcs_prefix: knative-prow/logs/ci-knative-docs-go-coverage
+  gcs_prefix: knative-prow/logs/ci-docs-go-coverage
   num_failures_to_alert: 9999
   short_text_metric: "coverage"
 - name: ci-eventing
@@ -137,7 +137,7 @@ test_groups:
   gcs_prefix: knative-prow/logs/auto-release-eventing
   alert_stale_results_hours: 3
 - name: pull-eventing-test-coverage
-  gcs_prefix: knative-prow/logs/ci-knative-eventing-go-coverage
+  gcs_prefix: knative-prow/logs/ci-eventing-go-coverage
   num_failures_to_alert: 9999
   short_text_metric: "coverage"
 - name: ci-eventing-sources
@@ -153,7 +153,7 @@ test_groups:
   gcs_prefix: knative-prow/logs/auto-release-eventing-sources
   alert_stale_results_hours: 3
 - name: pull-eventing-sources-test-coverage
-  gcs_prefix: knative-prow/logs/ci-knative-eventing-sources-go-coverage
+  gcs_prefix: knative-prow/logs/ci-eventing-sources-go-coverage
   num_failures_to_alert: 9999
   short_text_metric: "coverage"
 - name: ci-build-templates
@@ -165,7 +165,7 @@ test_groups:
   alert_stale_results_hours: 3
   num_failures_to_alert: 3
 - name: pull-pkg-test-coverage
-  gcs_prefix: knative-prow/logs/ci-knative-pkg-go-coverage
+  gcs_prefix: knative-prow/logs/ci-pkg-go-coverage
   num_failures_to_alert: 9999
   short_text_metric: "coverage"
 - name: ci-caching
@@ -173,11 +173,11 @@ test_groups:
   alert_stale_results_hours: 3
   num_failures_to_alert: 3
 - name: pull-caching-test-coverage
-  gcs_prefix: knative-prow/logs/ci-knative-caching-go-coverage
+  gcs_prefix: knative-prow/logs/ci-caching-go-coverage
   num_failures_to_alert: 9999
   short_text_metric: "coverage"
 - name: pull-client-test-coverage
-  gcs_prefix: knative-prow/logs/ci-knative-client-go-coverage
+  gcs_prefix: knative-prow/logs/ci-client-go-coverage
   num_failures_to_alert: 9999
   short_text_metric: "coverage"
 - name: ci-serving-0.4


### PR DESCRIPTION
### Proposed changes:
1. Remove "knative-" from dashboard names.
2. Change "conformance-tests" to "conformance".
3. Change prefix of periodic job names to be the actual job types.
4. Shorten a lot of names by removing the unnecessary "knative-"