### PR TITLE
Cleanup job timeout extends to 24 hours

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -2963,7 +2963,7 @@ periodics:
   agent: kubernetes
   decorate: true
   decoration_config:
-    timeout: 28800000000000
+    timeout: 86400000000000
   extra_refs:
   - org: knative
     repo: test-infra

--- a/ci/prow/make_config.go
+++ b/ci/prow/make_config.go
@@ -930,7 +930,7 @@ func generateCleanupPeriodicJob() {
 	data.Base = newbaseProwJobTemplateData("knative/test-infra")
 	data.PeriodicJobName = "ci-knative-cleanup"
 	data.CronString = cleanupPeriodicJobCron
-	data.Base.DecorationConfig = []string{"timeout: 28800000000000"} // 8 hours
+	data.Base.DecorationConfig = []string{"timeout: 86400000000000"} // 24 hours
 	data.Base.Command = cleanupScript
 	data.Base.Args = []string{
 		"--project-resource-yaml ci/prow/boskos/resources.yaml",


### PR DESCRIPTION
Cleanup job is responsible for cleaning up stale test images and clusters from all Boskos gcr/projects. Current timeout is 8 hours, and last run timed out with 17 out of 40 finished. Extends timeout to 24 hours to make it work