### PR TITLE
Add crier and pubsub reporter to prow config

### DIFF
--- a/ci/prow/cluster.yaml
+++ b/ci/prow/cluster.yaml
@@ -348,4 +348,41 @@ spec:
       - name: config
         configMap:
           name: config
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: crier
+  labels:
+    app: crier
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: crier
+    spec:
+      serviceAccountName: crier
+      terminationGracePeriodSeconds: 30
+      containers:
+      - name: crier
+        image: gcr.io/k8s-prow/crier:v20190415-c700e7878
+        args:
+        - --pubsub-workers=1
+        - --report-agent=knative-build
+        - --config-path=/etc/config/config.yaml
+        volumeMounts:
+        - name: config
+          mountPath: /etc/config
+          readOnly: true
+        - name: oauth
+          mountPath: /etc/github
+          readOnly: true
+      volumes:
+      - name: config
+        configMap:
+          name: config
+      - name: oauth
+        secret:
+          secretName: oauth-token
 

--- a/ci/prow/config_start.yaml
+++ b/ci/prow/config_start.yaml
@@ -337,3 +337,37 @@ subjects:
 - kind: ServiceAccount
   name: "tide"
   namespace: default
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: "crier"
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  # "namespace" omitted since ClusterRoles are not namespaced
+  name: crier
+rules:
+- apiGroups:
+    - "prow.k8s.io"
+  resources:
+    - "prowjobs"
+  verbs:
+    - "get"
+    - "watch"
+    - "list"
+    - "patch"
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: "crier"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: "crier"
+subjects:
+- kind: ServiceAccount
+  name: "crier"
+  namespace: default


### PR DESCRIPTION
This PR allows us to use crier pubsub reporter to listen for prow status changes on our pubsub channel. We also need to decorate the individual prow jobs we are interested to report as mentioned in https://github.com/kubernetes/test-infra/tree/master/prow/crier#pubsub-reporter

I will update the config once this is merged.