### PR TITLE
Wait until all containers in pods are running too.

### DIFF
--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -133,7 +133,7 @@ function wait_until_pods_running() {
         [[ ${status[0]} -lt 1 ]] && all_ready=0 && break
         [[ ${status[1]} -lt 1 ]] && all_ready=0 && break
         [[ ${status[0]} -ne ${status[1]} ]] && all_ready=0 && break
-      done <<< $(echo "${pods}" | grep -v Completed)
+      done <<< "$(echo "${pods}" | grep -v Completed)"
       if (( all_ready )); then
         echo -e "\nAll pods are up:\n${pods}"
         return 0


### PR DESCRIPTION
The two missing quotes cause the output from kubectl to being read in one go (rather than line by line). The container check logic therefore only checks the very first pod's containers.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
