### PR TITLE
Add CI flow and testgrid dashboards for eventing, eventing-sources and build 0.6 release

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -2313,6 +2313,8 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.6
     volumes:
     - name: docker-graph
       emptyDir: {}
@@ -2681,6 +2683,8 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.6
     volumes:
     - name: docker-graph
       emptyDir: {}
@@ -2939,6 +2943,8 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.6
     volumes:
     - name: docker-graph
       emptyDir: {}

--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -2269,6 +2269,48 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
+- cron: "55 8 * * *"
+  name: ci-knative-build-0.6-continuous
+  agent: kubernetes
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      args:
+      - "--scenario=kubernetes_execute_bazel"
+      - "--clean"
+      - "--job=$(JOB_NAME)"
+      - "--repo=github.com/knative/build=release-0.6"
+      - "--root=/go/src"
+      - "--service-account=/etc/test-account/service-account.json"
+      - "--upload=gs://knative-prow/logs"
+      - "--timeout=180" # Avoid overrun
+      - "--" # end bootstrap args, scenario args below
+      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
+      - "./hack/release.sh"
+      - "--nopublish"
+      - "--notag-release"
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - name: docker-graph
+        mountPath: /docker-graph
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: docker-graph
+      emptyDir: {}
+    - name: test-account
+      secret:
+        secretName: test-account
 - cron: "31 8 * * *"
   name: ci-knative-build-nightly-release
   agent: kubernetes
@@ -2593,6 +2635,48 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
+- cron: "50 8 * * *"
+  name: ci-knative-eventing-0.6-continuous
+  agent: kubernetes
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      args:
+      - "--scenario=kubernetes_execute_bazel"
+      - "--clean"
+      - "--job=$(JOB_NAME)"
+      - "--repo=github.com/knative/eventing=release-0.6"
+      - "--root=/go/src"
+      - "--service-account=/etc/test-account/service-account.json"
+      - "--upload=gs://knative-prow/logs"
+      - "--timeout=180" # Avoid overrun
+      - "--" # end bootstrap args, scenario args below
+      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
+      - "./hack/release.sh"
+      - "--nopublish"
+      - "--notag-release"
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - name: docker-graph
+        mountPath: /docker-graph
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: docker-graph
+      emptyDir: {}
+    - name: test-account
+      secret:
+        secretName: test-account
 - cron: "16 9 * * *"
   name: ci-knative-eventing-nightly-release
   agent: kubernetes
@@ -2777,6 +2861,48 @@ periodics:
       - "--clean"
       - "--job=$(JOB_NAME)"
       - "--repo=github.com/knative/eventing-sources=release-0.5"
+      - "--root=/go/src"
+      - "--service-account=/etc/test-account/service-account.json"
+      - "--upload=gs://knative-prow/logs"
+      - "--timeout=180" # Avoid overrun
+      - "--" # end bootstrap args, scenario args below
+      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
+      - "./hack/release.sh"
+      - "--nopublish"
+      - "--notag-release"
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - name: docker-graph
+        mountPath: /docker-graph
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: docker-graph
+      emptyDir: {}
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "0 9 * * *"
+  name: ci-knative-eventing-sources-0.6-continuous
+  agent: kubernetes
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      args:
+      - "--scenario=kubernetes_execute_bazel"
+      - "--clean"
+      - "--job=$(JOB_NAME)"
+      - "--repo=github.com/knative/eventing-sources=release-0.6"
       - "--root=/go/src"
       - "--service-account=/etc/test-account/service-account.json"
       - "--upload=gs://knative-prow/logs"

--- a/ci/prow/config_knative.yaml
+++ b/ci/prow/config_knative.yaml
@@ -178,6 +178,9 @@ periodics:
     - branch-ci: true
       release: "0.5"
       cron: "45 8 * * *" # Run at 01:45PST every day (08:45 UTC)
+    - branch-ci: true
+      release: "0.6"
+      cron: "55 8 * * *" # Run at 01:55PST every day (08:55 UTC)
     - nightly: true
       cron: "31 8 * * *" # Run at 01:31PST every day (08:31 UTC)
       needs-dind: true
@@ -200,6 +203,9 @@ periodics:
     - branch-ci: true
       release: "0.5"
       cron: "40 8 * * *" # Run at 01:40PST every day (08:40 UTC)
+    - branch-ci: true
+      release: "0.6"
+      cron: "50 8 * * *" # Run at 01:50 PST every day (08:50 UTC)
     - nightly: true
       cron: "16 9 * * *" # Run at 02:16PST every day (09:16 UTC)
     - dot-release: true
@@ -213,6 +219,9 @@ periodics:
     - branch-ci: true
       release: "0.5"
       cron: "50 8 * * *" # Run at 01:50PST every day (08:50 UTC)
+    - branch-ci: true
+      release: "0.6"
+      cron: "0 9 * * *" # Run at 02:00 PST every day (09:00 UTC)
     - nightly: true
       cron: "16 9 * * *" # Run at 02:16PST every day (09:16 UTC)
     - dot-release: true

--- a/ci/testgrid/config.yaml
+++ b/ci/testgrid/config.yaml
@@ -196,6 +196,12 @@ test_groups:
   gcs_prefix: knative-prow/logs/ci-knative-eventing-sources-0.5-continuous
 - name: ci-knative-serving-0.6-continuous
   gcs_prefix: knative-prow/logs/ci-knative-serving-0.6-continuous
+- name: ci-knative-build-0.6-continuous
+  gcs_prefix: knative-prow/logs/ci-knative-build-0.6-continuous
+- name: ci-knative-eventing-0.6-continuous
+  gcs_prefix: knative-prow/logs/ci-knative-eventing-0.6-continuous
+- name: ci-knative-eventing-sources-0.6-continuous
+  gcs_prefix: knative-prow/logs/ci-knative-eventing-sources-0.6-continuous
 dashboards:
 - name: knative-serving
   dashboard_tab:
@@ -356,6 +362,15 @@ dashboards:
   dashboard_tab:
   - name: serving
     test_group_name: ci-knative-serving-0.6-continuous
+    base_options: "sort-by-name="
+  - name: build
+    test_group_name: ci-knative-build-0.6-continuous
+    base_options: "sort-by-name="
+  - name: eventing
+    test_group_name: ci-knative-eventing-0.6-continuous
+    base_options: "sort-by-name="
+  - name: eventing-sources
+    test_group_name: ci-knative-eventing-sources-0.6-continuous
     base_options: "sort-by-name="
 dashboard_groups:
 - name: knative


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Eventing, eventing-sources and build have also cut the 0.6 release. Add CI flow and testgrid dashboards for them as well.
