### PR TITLE
Install the correct version of component for all prow jobs

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -1690,6 +1690,8 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
+      - name: RELEASE_VERSION
+        value: "0.4"
     volumes:
     - name: docker-graph
       emptyDir: {}
@@ -1732,6 +1734,8 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
+      - name: RELEASE_VERSION
+        value: "0.5"
     volumes:
     - name: docker-graph
       emptyDir: {}
@@ -1774,6 +1778,8 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
+      - name: RELEASE_VERSION
+        value: "0.6"
     volumes:
     - name: docker-graph
       emptyDir: {}
@@ -2263,6 +2269,8 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
+      - name: RELEASE_VERSION
+        value: "0.5"
     volumes:
     - name: docker-graph
       emptyDir: {}
@@ -2587,6 +2595,8 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
+      - name: RELEASE_VERSION
+        value: "0.5"
     volumes:
     - name: docker-graph
       emptyDir: {}
@@ -2801,6 +2811,8 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
+      - name: RELEASE_VERSION
+        value: "0.5"
     volumes:
     - name: docker-graph
       emptyDir: {}

--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -1690,8 +1690,8 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: RELEASE_VERSION
-        value: "0.4"
+      - name: PULL_BASE_REF
+        value: release-0.4
     volumes:
     - name: docker-graph
       emptyDir: {}
@@ -1734,8 +1734,8 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: RELEASE_VERSION
-        value: "0.5"
+      - name: PULL_BASE_REF
+        value: release-0.5
     volumes:
     - name: docker-graph
       emptyDir: {}
@@ -1778,8 +1778,8 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: RELEASE_VERSION
-        value: "0.6"
+      - name: PULL_BASE_REF
+        value: release-0.6
     volumes:
     - name: docker-graph
       emptyDir: {}
@@ -2269,8 +2269,8 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: RELEASE_VERSION
-        value: "0.5"
+      - name: PULL_BASE_REF
+        value: release-0.5
     volumes:
     - name: docker-graph
       emptyDir: {}
@@ -2595,8 +2595,8 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: RELEASE_VERSION
-        value: "0.5"
+      - name: PULL_BASE_REF
+        value: release-0.5
     volumes:
     - name: docker-graph
       emptyDir: {}
@@ -2811,8 +2811,8 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: RELEASE_VERSION
-        value: "0.5"
+      - name: PULL_BASE_REF
+        value: release-0.5
     volumes:
     - name: docker-graph
       emptyDir: {}

--- a/ci/prow/make_config.go
+++ b/ci/prow/make_config.go
@@ -806,6 +806,7 @@ func generatePeriodic(title string, repoName string, periodicConfig yaml.MapSlic
 	jobNameSuffix := ""
 	jobTemplate := periodicTestJob
 	jobType := ""
+	version := ""
 	for i, item := range periodicConfig {
 		switch item.Key {
 		case "continuous":
@@ -887,7 +888,7 @@ func generatePeriodic(title string, repoName string, periodicConfig yaml.MapSlic
 		case "cron":
 			data.CronString = getString(item.Value)
 		case "release":
-			version := getString(item.Value)
+			version = getString(item.Value)
 			jobNameSuffix = version + "-" + jobNameSuffix
 			data.Base.RepoBranch = "release-" + version
 		case "webhook-apicoverage":
@@ -923,6 +924,9 @@ func generatePeriodic(title string, repoName string, periodicConfig yaml.MapSlic
 	if data.Base.ServiceAccount != "" {
 		addEnvToJob(&data.Base, "GOOGLE_APPLICATION_CREDENTIALS", data.Base.ServiceAccount)
 		addEnvToJob(&data.Base, "E2E_CLUSTER_REGION", "us-central1")
+	}
+	if version != "" {
+		addEnvToJob(&data.Base, "RELEASE_VERSION", version)
 	}
 	addExtraEnvVarsToJob(&data.Base)
 	configureServiceAccountForJob(&data.Base)

--- a/ci/prow/make_config.go
+++ b/ci/prow/make_config.go
@@ -926,7 +926,11 @@ func generatePeriodic(title string, repoName string, periodicConfig yaml.MapSlic
 		addEnvToJob(&data.Base, "E2E_CLUSTER_REGION", "us-central1")
 	}
 	if version != "" {
-		addEnvToJob(&data.Base, "RELEASE_VERSION", version)
+		// If it's a release version, add env var PULL_BASE_REF as ref name of the base branch.
+		// NOTE:
+		// This serves as a workaround since Prow does not have PULL_BASE_REF set for periodic jobs - https://github.com/kubernetes/test-infra/blob/abcd35c4dbfb0feadd09fc452b533222e3a16b29/prow/jobs.md.
+		// We are checking with Kubernetes test-infra team. If we can actually add this env var for all periodic jobs, we can safely delete it here.
+		addEnvToJob(&data.Base, "PULL_BASE_REF", "release-"+version)
 	}
 	addExtraEnvVarsToJob(&data.Base)
 	configureServiceAccountForJob(&data.Base)

--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -447,13 +447,12 @@ function get_knative_base_yaml_source() {
   local knative_base_yaml_source="https://storage.googleapis.com/knative-nightly/@/latest"
   local branch_name=""
   # For non-periodic jobs, we get the branch name from env var set by Prow - https://github.com/kubernetes/test-infra/blob/abcd35c4dbfb0feadd09fc452b533222e3a16b29/prow/jobs.md
-  if [[ -n "${PULL_BASE_REF}" ]]; then
-    branch_name="${PULL_BASE_REF}"
-  fi
-  # For periodic jobs, we only care if it's running against a release branch.
-  # If RELEASE_VERSION is set, branch_name will be the actual release version, like 0.5. Otherwise it will still be an empty string.
-  if [[ -n "${RELEASE_VERSION}" ]]; then
-    branch_name="${RELEASE_VERSION}"
+  # For peroidic jobs, we get the branch name from env var set on our Prow jobs.
+  # The two env vars have the same name to keep consistence. Check `make_config.go` for more information.
+  branch_name="${PULL_BASE_REF}"
+  if (( ! IS_PROW )); then
+    # If the test job is not running on Prow, we get the branch name directly via git command.
+    branch_name="$(git rev-parse --abbrev-ref HEAD)"
   fi
   # If it's a release branch, we should have a different knative_base_yaml_source.
   if [[ $branch_name =~ ^release-[0-9\.]+$ ]]; then

--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -445,11 +445,8 @@ function get_canonical_path() {
 # Return the base url we use to build the actual knative yaml sources.
 function get_knative_base_yaml_source() {
   local knative_base_yaml_source="https://storage.googleapis.com/knative-nightly/@/latest"
-  local branch_name=""
-  # For non-periodic jobs, we get the branch name from env var set by Prow - https://github.com/kubernetes/test-infra/blob/abcd35c4dbfb0feadd09fc452b533222e3a16b29/prow/jobs.md
-  # For peroidic jobs, we get the branch name from env var set on our Prow jobs.
-  # The two env vars have the same name to keep consistence. Check `make_config.go` for more information.
-  branch_name="${PULL_BASE_REF}"
+  # Get the branch name from Prow's env var by default, see https://github.com/kubernetes/test-infra/blob/master/prow/jobs.md.
+  local branch_name="${PULL_BASE_REF}"
   if (( ! IS_PROW )); then
     # If the test job is not running on Prow, we get the branch name directly via git command.
     branch_name="$(git rev-parse --abbrev-ref HEAD)"

--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -445,7 +445,16 @@ function get_canonical_path() {
 # Return the base url we use to build the actual knative yaml sources.
 function get_knative_base_yaml_source() {
   local knative_base_yaml_source="https://storage.googleapis.com/knative-nightly/@/latest"
-  local branch_name="$(git rev-parse --abbrev-ref HEAD)"
+  local branch_name=""
+  # For non-periodic jobs, we get the branch name from env var set by Prow - https://github.com/kubernetes/test-infra/blob/abcd35c4dbfb0feadd09fc452b533222e3a16b29/prow/jobs.md
+  if [[ -n "${PULL_BASE_REF}" ]]; then
+    branch_name="${PULL_BASE_REF}"
+  fi
+  # For periodic jobs, we only care if it's running against a release branch.
+  # If RELEASE_VERSION is set, branch_name will be the actual release version, like 0.5. Otherwise it will still be an empty string.
+  if [[ -n "${RELEASE_VERSION}" ]]; then
+    branch_name="${RELEASE_VERSION}"
+  fi
   # If it's a release branch, we should have a different knative_base_yaml_source.
   if [[ $branch_name =~ ^release-[0-9\.]+$ ]]; then
     # Get the latest tag name for the current branch, which is likely formatted as v0.5.0


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #721 
1. For periodic jobs, set `PULL_BASE_REF` env var to keep consistent with Prow;
2. Use `PULL_BASE_REF` as the branch name for Prow jobs, and `git rev-parse --abbrev-ref HEAD` for non-Prow jobs;
3. I have double checked that `git describe --tags` can get the correct tag from our script.

/cc @adrcunha 
/cc @chaodaiG 