### PR TITLE
Make using profiler optional when using loadgenerator

### DIFF
--- a/test/e2e/load_generator_test.go
+++ b/test/e2e/load_generator_test.go
@@ -43,7 +43,7 @@ func loadTest(t *testing.T, factors bool, profiler bool) {
 		opts.FileNamePrefix = t.Name()
 	}
 
-	res, err := opts.RunLoadTest(true)
+	res, err := opts.RunLoadTest()
 	if err != nil {
 		t.Fatalf("Error performing load test: %v", err)
 	}


### PR DESCRIPTION
This CR also updates the bool options into const, so its easier and more readable when setting up the load generator.