### PR TITLE
Fix the tag name in some situation

### DIFF
--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -454,7 +454,7 @@ function get_knative_base_yaml_source() {
   # If it's a release branch, we should have a different knative_base_yaml_source.
   if [[ $branch_name =~ ^release-[0-9\.]+$ ]]; then
     # Get the latest tag name for the current branch, which is likely formatted as v0.5.0
-    local tag_name="$(git describe --abbrev=0)"
+    local tag_name="$(git describe --tags --abbrev=0)"
     knative_base_yaml_source="https://storage.googleapis.com/knative-releases/@/previous/${tag_name}"
   fi
   echo "${knative_base_yaml_source}"

--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -454,7 +454,7 @@ function get_knative_base_yaml_source() {
   # If it's a release branch, we should have a different knative_base_yaml_source.
   if [[ $branch_name =~ ^release-[0-9\.]+$ ]]; then
     # Get the latest tag name for the current branch, which is likely formatted as v0.5.0
-    local tag_name="$(git describe --tags)"
+    local tag_name="$(git describe --abbrev=0)"
     knative_base_yaml_source="https://storage.googleapis.com/knative-releases/@/previous/${tag_name}"
   fi
   echo "${knative_base_yaml_source}"


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Add `--abbrev=0` to use the closest tag.

According to https://linux.die.net/man/1/git-describe, if the current branch is based on one tag, e.g. v1.0.4, but it has a few commits on top of that, describe will add the number of additional commits ("14") and an abbreviated object name for the commit itself ("2414721") at the end. So when we run `git describe --tags` will get us `v1.0.4-14-g2414721`.

And with `--abbrev` set to 0, the command can be used to find the closest tagname without any suffix, so `git describe --tags --abbrev` will get us `v1.0.4`.