### PR TITLE
update cluster creation retry logic for 2 different error messages

### DIFF
--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -259,7 +259,7 @@ function create_test_cluster_with_retries() {
       # Exit if test succeeded
       [[ "$(get_test_return_code)" == "0" ]] && return
       # If test failed not because of cluster creation stockout, return
-      [[ -z "$(grep -Eio 'does not have enough resources available to fulfill the request' ${cluster_creation_log})" ]] && return
+      [[ -z "$(grep -Eio 'does not have enough resources available to fulfill' ${cluster_creation_log})" ]] && return
     done
   done
 }


### PR DESCRIPTION
A new stock out error message came up, update regex to accommodate both error messages.

Reference:
new: https://gubernator.knative.dev/build/knative-prow/logs/ci-knative-docs-continuous/1128870325379928064/
old: https://storage.googleapis.com/knative-prow/pr-logs/pull/knative_serving/3353/pull-knative-serving-integration-tests/1105982603938238464/build-log.txt
