### PR TITLE
Export build date, tag and hash properties for release

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -108,10 +108,13 @@ This is a helper script for Knative E2E test scripts. To use it:
    if the default values don't fit your needs:
 
    - `E2E_CLUSTER_REGION`: Cluster region, defaults to `us-central1`.
-   - `E2E_CLUSTER_BACKUP_REGIONS`: Space-separated list of regions to retry test cluster creation in case of stockout. Defaults to `us-west1 us-east1`.
+   - `E2E_CLUSTER_BACKUP_REGIONS`: Space-separated list of regions to retry test
+     cluster creation in case of stockout. Defaults to `us-west1 us-east1`.
    - `E2E_CLUSTER_ZONE`: Cluster zone (e.g., `a`), defaults to none (i.e. use a regional
      cluster).
-   - `E2E_CLUSTER_BACKUP_ZONES`: Space-separated list of zones to retry test cluster creation in case of stockout. If defined, `E2E_CLUSTER_BACKUP_REGIONS` will be ignored thus it defaults to none.
+   - `E2E_CLUSTER_BACKUP_ZONES`: Space-separated list of zones to retry test cluster 
+     creation in case of stockout. If defined, `E2E_CLUSTER_BACKUP_REGIONS` will be
+     ignored thus it defaults to none.
    - `E2E_CLUSTER_MACHINE`: Cluster node machine type, defaults to `n1-standard-4}`.
    - `E2E_MIN_CLUSTER_NODES`: Minimum number of nodes in the cluster when autoscaling,
      defaults to 1.
@@ -241,14 +244,20 @@ This is a helper script for Knative release scripts. To use it:
    - `RELEASE_GCS_BUCKET`: contains the GCS bucket name to store the manifests if
      `--release-gcs` was passed, otherwise the default value `knative-nightly/<repo>`
      will be used. It is empty if `--publish` was not passed.
+   - `BUILD_COMMIT_HASH`: the commit short hash for the current repo. If the current
+     git tree is dirty, it will have `-dirty` appended to it.
+   - `BUILD_YYYYMMDD`: current UTC date in `YYYYMMDD` format.
+   - `BUILD_TIMESTAMP`: human-readable UTC timestamp in `YYYY-MM-DD HH:MM:SS` format.
+   - `BUILD_TAG`: a tag in the form `v$BUILD_YYYYMMDD-$BUILD_COMMIT_HASH`.
    - `KO_DOCKER_REPO`: contains the GCR to store the images if `--release-gcr` was
      passed, otherwise the default value `gcr.io/knative-nightly` will be used. It
      is set to `ko.local` if `--publish` was not passed.
    - `SKIP_TESTS`: true if `--skip-tests` was passed. This is handled automatically.
    - `TAG_RELEASE`: true if `--tag-release` was passed. In this case, the environment
-     variable `TAG` will contain the release tag in the form `vYYYYMMDD-<commit_short_hash>`.
+     variable `TAG` will contain the release tag in the form `v$BUILD_TAG`.
    - `PUBLISH_RELEASE`: true if `--publish` was passed. In this case, the environment
-     variable `KO_FLAGS` will be updated with the `-L` option.
+     variable `KO_FLAGS` will be updated with the `-L` option and `TAG` will contain
+     the release tag in the form `v$RELEASE_VERSION`.
    - `PUBLISH_TO_GITHUB`: true if `--version`, `--branch` and `--publish-release`
      were passed.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -112,7 +112,7 @@ This is a helper script for Knative E2E test scripts. To use it:
      cluster creation in case of stockout. Defaults to `us-west1 us-east1`.
    - `E2E_CLUSTER_ZONE`: Cluster zone (e.g., `a`), defaults to none (i.e. use a regional
      cluster).
-   - `E2E_CLUSTER_BACKUP_ZONES`: Space-separated list of zones to retry test cluster 
+   - `E2E_CLUSTER_BACKUP_ZONES`: Space-separated list of zones to retry test cluster
      creation in case of stockout. If defined, `E2E_CLUSTER_BACKUP_REGIONS` will be
      ignored thus it defaults to none.
    - `E2E_CLUSTER_MACHINE`: Cluster node machine type, defaults to `n1-standard-4}`.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -82,17 +82,21 @@ TAG_RELEASE=0
 PUBLISH_RELEASE=0
 PUBLISH_TO_GITHUB=0
 TAG=""
+BUILD_COMMIT_HASH=""
+BUILD_YYYYMMDD=""
+BUILD_TIMESTAMP=""
+BUILD_TAG=""
 RELEASE_VERSION=""
 RELEASE_NOTES=""
 RELEASE_BRANCH=""
-RELEASE_GCS_BUCKET=""
-KO_FLAGS=""
+RELEASE_GCS_BUCKET="knative-nightly/${REPO_NAME}"
+KO_FLAGS="-P"
 VALIDATION_TESTS="./test/presubmit-tests.sh"
 YAMLS_TO_PUBLISH=""
 ARTIFACTS_TO_PUBLISH=""
 FROM_NIGHTLY_RELEASE=""
 FROM_NIGHTLY_RELEASE_GCS=""
-export KO_DOCKER_REPO=""
+export KO_DOCKER_REPO="gcr.io/knative-nightly"
 export GITHUB_TOKEN=""
 
 # Convenience function to run the hub tool.
@@ -319,15 +323,6 @@ function find_latest_nightly() {
 
 # Parses flags and sets environment variables accordingly.
 function parse_flags() {
-  TAG=""
-  RELEASE_VERSION=""
-  RELEASE_NOTES=""
-  RELEASE_BRANCH=""
-  KO_FLAGS="-P"
-  KO_DOCKER_REPO="gcr.io/knative-nightly"
-  RELEASE_GCS_BUCKET="knative-nightly/${REPO_NAME}"
-  GITHUB_TOKEN=""
-  FROM_NIGHTLY_RELEASE=""
   local has_gcr_flag=0
   local has_gcs_flag=0
   local is_dot_release=0
@@ -422,20 +417,21 @@ function parse_flags() {
     RELEASE_GCS_BUCKET=""
   fi
 
-  if (( TAG_RELEASE )); then
-    # Get the commit, excluding any tags but keeping the "dirty" flag
-    local commit="$(git describe --always --dirty --match '^$')"
-    [[ -n "${commit}" ]] || abort "error getting the current commit"
-    # Like kubernetes, image tag is vYYYYMMDD-commit
-    TAG="v$(date +%Y%m%d)-${commit}"
-  fi
+  # Get the commit, excluding any tags but keeping the "dirty" flag
+  BUILD_COMMIT_HASH="$(git describe --always --dirty --match '^$')"
+  [[ -n "${BUILD_COMMIT_HASH}" ]] || abort "error getting the current commit"
+  BUILD_YYYYMMDD="$(date -u +%Y%m%d)"
+  BUILD_TIMESTAMP="$(date -u '+%Y-%m-%d %H:%M:%S')"
+  BUILD_TAG="v${BUILD_YYYYMMDD}-${BUILD_COMMIT_HASH}"
 
-  if [[ -n "${RELEASE_VERSION}" ]]; then
-    TAG="v${RELEASE_VERSION}"
-  fi
-
+  (( TAG_RELEASE )) && TAG="${BUILD_TAG}"
+  [[ -n "${RELEASE_VERSION}" ]] && TAG="v${RELEASE_VERSION}"
   [[ -n "${RELEASE_VERSION}" && -n "${RELEASE_BRANCH}" ]] && (( PUBLISH_RELEASE )) && PUBLISH_TO_GITHUB=1
 
+  readonly BUILD_COMMIT_HASH
+  readonly BUILD_YYYYMMDD
+  readonly BUILD_TIMESTAMP
+  readonly BUILD_TAG
   readonly SKIP_TESTS
   readonly TAG_RELEASE
   readonly PUBLISH_RELEASE


### PR DESCRIPTION
* use UTC time for dates for consistency
* remove double initialization of parameters