### PR TITLE
Remove pointer to JobConfig in RepoData struct to fix memory bug

### DIFF
--- a/tools/flaky-test-reporter/github_issue_test.go
+++ b/tools/flaky-test-reporter/github_issue_test.go
@@ -80,7 +80,7 @@ func createNewIssue(fgi *GithubIssue, title, body, testStat string) (*github.Iss
 }
 
 func createRepoData(passed, flaky, failed, notenoughdata int, startTime int64) *RepoData {
-	config := &JobConfig{
+	config := JobConfig{
 		Repo: fakeRepo,
 	}
 	tss := map[string]*TestStat{}

--- a/tools/flaky-test-reporter/main.go
+++ b/tools/flaky-test-reporter/main.go
@@ -64,7 +64,7 @@ func main() {
 
 	for _, jc := range jobConfigs {
 		log.Printf("collecting results for repo '%s'\n", jc.Repo)
-		rd, err := collectTestResultsForRepo(&jc)
+		rd, err := collectTestResultsForRepo(jc)
 		if nil != err {
 			log.Fatalf("Error collecting results for repo '%s': %v", jc.Repo, err)
 		}

--- a/tools/flaky-test-reporter/result.go
+++ b/tools/flaky-test-reporter/result.go
@@ -41,7 +41,7 @@ const (
 
 // RepoData struct contains all configurations and test results for a repo
 type RepoData struct {
-	Config             *JobConfig
+	Config             JobConfig
 	TestStats          map[string]*TestStat // key is test full name
 	BuildIDs           []int                // all build IDs scanned in this run
 	LastBuildStartTime *int64               // timestamp, determines how fresh the data is
@@ -169,7 +169,7 @@ func getCombinedResultsForBuild(build *prow.Build) ([]*junit.TestSuites, error) 
 
 // collectTestResultsForRepo collects test results, build IDs from all builds,
 // as well as LastBuildStartTime, and stores them in RepoData
-func collectTestResultsForRepo(jc *JobConfig) (*RepoData, error) {
+func collectTestResultsForRepo(jc JobConfig) (*RepoData, error) {
 	rd := &RepoData{Config: jc}
 	job := prow.NewJob(jc.Name, jc.Type, jc.Repo, 0)
 	if !job.PathExists() {


### PR DESCRIPTION
### Bug:
There seems to be a quirk with Go loops, where the local variable used is actually a copy of the current list item, with the same memory address across iterations. When adding multiple JobConfigs to run, the RepoData structs created referenced this memory address, thus making them all reference the last JobConfig when the loop exited, even though they ran the correct configuration on their iteration.
### Fix:
Remove pointers entirely. Seems similar to a quirk with [Goroutines](https://github.com/golang/go/wiki/CommonMistakes#using-goroutines-on-loop-iterator-variables), though I haven't found any documentation on this case specifically.

This was discovered while working on a fix for #736 