### PR TITLE
Don't assume PULL_BASE_REF exists in get_knative_base_yaml_source()

### DIFF
--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -459,14 +459,13 @@ function get_canonical_path() {
 # Return the base url we use to build the actual knative yaml sources.
 function get_knative_base_yaml_source() {
   local knative_base_yaml_source="https://storage.googleapis.com/knative-nightly/@/latest"
-  # Get the branch name from Prow's env var by default, see https://github.com/kubernetes/test-infra/blob/master/prow/jobs.md.
-  local branch_name="${PULL_BASE_REF}"
-  if (( ! IS_PROW )); then
-    # If the test job is not running on Prow, we get the branch name directly via git command.
-    branch_name="$(git rev-parse --abbrev-ref HEAD)"
-  fi
-  # If it's a release branch, we should have a different knative_base_yaml_source.
-  if [[ $branch_name =~ ^release-[0-9\.]+$ ]]; then
+  local branch_name=""
+  # Get the branch name from Prow's env var, see https://github.com/kubernetes/test-infra/blob/master/prow/jobs.md.
+  # Otherwise, try getting the current branch from git.
+  (( IS_PROW )) && branch_name="${PULL_BASE_REF:-}"
+  [[ -z "${branch_name}" ]] && branch_name="$(git rev-parse --abbrev-ref HEAD)"
+  # If it's a release branch, base URL should point to a specific version.
+  if [[ ${branch_name} =~ ^release-[0-9\.]+$ ]]; then
     # Get the latest tag name for the current branch, which is likely formatted as v0.5.0
     local tag_name="$(git describe --tags --abbrev=0)"
     knative_base_yaml_source="https://storage.googleapis.com/knative-releases/@/previous/${tag_name}"


### PR DESCRIPTION
It's not set for master branches.

Example: https://prow.knative.dev/log?job=ci-knative-client-auto-release&id=1129534956536598528