### PR TITLE
Prevents e2e test from running on prow cluster

### DIFF
--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -283,6 +283,9 @@ function setup_test_cluster() {
   local k8s_user=$(gcloud config get-value core/account)
   local k8s_cluster=$(kubectl config current-context)
 
+  is_protected_cluster ${k8s_cluster} && \
+    abort "\$Kubeconfig context set to ${k8s_cluster}, which is forbidden"
+
   # If cluster admin role isn't set, this is a brand new cluster
   # Setup the admin role and also KO_DOCKER_REPO
   if [[ -z "$(kubectl get clusterrolebinding cluster-admin-binding 2> /dev/null)" ]]; then

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -284,7 +284,7 @@ function setup_test_cluster() {
   local k8s_cluster=$(kubectl config current-context)
 
   is_protected_cluster ${k8s_cluster} && \
-    abort "\$Kubeconfig context set to ${k8s_cluster}, which is forbidden"
+    abort "kubeconfig context set to ${k8s_cluster}, which is forbidden"
 
   # If cluster admin role isn't set, this is a brand new cluster
   # Setup the admin role and also KO_DOCKER_REPO

--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -18,6 +18,9 @@
 # to be used in test scripts and the like. It doesn't do anything when
 # called from command line.
 
+# GCP project where all tests releate resources live
+readonly KNATIVE_TESTS_PROJECT=knative-tests
+
 # Default GKE version to be used with Knative Serving
 readonly SERVING_GKE_VERSION=gke-latest
 readonly SERVING_GKE_IMAGE=cos
@@ -415,13 +418,20 @@ function is_int() {
 # Return whether the given parameter is the knative release/nightly GCF.
 # Parameters: $1 - full GCR name, e.g. gcr.io/knative-foo-bar
 function is_protected_gcr() {
-  [[ -n $1 && "$1" =~ "^gcr.io/knative-(releases|nightly)/?$" ]]
+  [[ -n $1 && $1 =~ ^gcr.io/knative-(releases|nightly)/?$ ]]
 }
 
-# Return whether the given parameter is the knative-prow cluster.
+# Return whether the given parameter is the knative prow cluster.
 # Parameters: $1 - Kubernetes cluster context (output of kubectl config current-context)
 function is_protected_cluster() {
-  [[ -n $1 && "$1" = "gke_knative-tests_us-central1-f_prow" ]]
+  # Example: gke_knative-tests_us-central1-f_prow
+  [[ -n $1 && $1 =~ ^gke_${KNATIVE_TESTS_PROJECT}_us\-[a-zA-Z0-9]+\-[a-z]+_prow$ ]]
+}
+
+# Return whether the given parameter is ${KNATIVE_TESTS_PROJECT}.
+# Parameters: $1 - project name
+function is_protected_project() {
+  [[ -n $1 && "$1" == "${KNATIVE_TESTS_PROJECT}" ]]
 }
 
 # Remove symlinks in a path that are broken or lead outside the repo.
@@ -443,12 +453,6 @@ function remove_broken_symlinks() {
       continue
     fi
   done
-}
-
-# Return whether the given parameter is knative-tests.
-# Parameters: $1 - project name
-function is_protected_project() {
-  [[ -n "$1" && "$1" == "knative-tests" ]]
 }
 
 # Returns the canonical path of a filesystem object.

--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -418,6 +418,12 @@ function is_protected_gcr() {
   [[ -n $1 && "$1" =~ "^gcr.io/knative-(releases|nightly)/?$" ]]
 }
 
+# Return whether the given parameter is the knative-prow cluster.
+# Parameters: $1 - Kubernetes cluster context (output of kubectl config current-context)
+function is_protected_cluster() {
+  [[ -n $1 && "$1" = "gke_knative-tests_us-central1-f_prow" ]]
+}
+
 # Remove symlinks in a path that are broken or lead outside the repo.
 # Parameters: $1 - path name, e.g. vendor
 function remove_broken_symlinks() {

--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -421,11 +421,11 @@ function is_protected_gcr() {
   [[ -n $1 && $1 =~ ^gcr.io/knative-(releases|nightly)/?$ ]]
 }
 
-# Return whether the given parameter is the knative prow cluster.
+# Return whether the given parameter is any cluster under ${KNATIVE_TESTS_PROJECT}.
 # Parameters: $1 - Kubernetes cluster context (output of kubectl config current-context)
 function is_protected_cluster() {
   # Example: gke_knative-tests_us-central1-f_prow
-  [[ -n $1 && $1 =~ ^gke_${KNATIVE_TESTS_PROJECT}_us\-[a-zA-Z0-9]+\-[a-z]+_prow$ ]]
+  [[ -n $1 && $1 =~ ^gke_${KNATIVE_TESTS_PROJECT}_us\-[a-zA-Z0-9]+\-[a-z]+_[a-z0-9\-]+$ ]]
 }
 
 # Return whether the given parameter is ${KNATIVE_TESTS_PROJECT}.

--- a/test/unit/library-tests.sh
+++ b/test/unit/library-tests.sh
@@ -50,6 +50,24 @@ test_function ${SUCCESS} "${REPO_ROOT_DIR}/test/unit/library-tests.sh" get_canon
 test_function ${SUCCESS} "Foo Bar" capitalize "foo bar"
 test_function ${SUCCESS} ">>> Knative Testinfra controller logs:" mock_kubectl_function dump_app_logs "controller" "test-infra"
 
+test_function ${SUCCESS} "" is_protected_gcr "gcr.io/knative-releases"
+test_function ${SUCCESS} "" is_protected_gcr "gcr.io/knative-nightly"
+test_function ${FAILURE} "" is_protected_gcr "gcr.io/knative-foobar"
+test_function ${FAILURE} "" is_protected_gcr "gcr.io/foobar-releases"
+test_function ${FAILURE} "" is_protected_gcr "gcr.io/foobar-nightly"
+test_function ${FAILURE} "" is_protected_gcr ""
+
+test_function ${SUCCESS} "" is_protected_cluster "gke_knative-tests_us-central1-f_prow"
+test_function ${SUCCESS} "" is_protected_cluster "gke_knative-tests_us-west2-a_prow"
+test_function ${SUCCESS} "" is_protected_cluster "gke_knative-tests_us-west2-a_foobar"
+test_function ${FAILURE} "" is_protected_cluster "gke_knative-foobar_us-west2-a_prow"
+test_function ${FAILURE} "" is_protected_cluster ""
+
+test_function ${SUCCESS} "" is_protected_project "knative-tests"
+test_function ${FAILURE} "" is_protected_project "knative-foobar"
+test_function ${FAILURE} "" is_protected_project "foobar-tests"
+test_function ${FAILURE} "" is_protected_project ""
+
 echo ">> Testing report_go_test()"
 
 test_report TestSucceeds "^--- PASS: TestSucceeds"


### PR DESCRIPTION
For debugging e2e tests on existing cluster, the cluster is determined by `kubectl config current-context`, and there is no guard against running on important cluster, such as prow. Add a guard here for safety concern

Fixes: #804 