### PR TITLE
Add flaky test reporting for various istio/mesh combinations

### DIFF
--- a/shared/prow/prow.go
+++ b/shared/prow/prow.go
@@ -38,8 +38,7 @@ const (
 	OrgName = "knative"
 
 	// BucketName is the gcs bucket for all knative builds
-	// TODO: change back to default before PR
-	BucketName = "trevorfarrelly-knative-2019" // "knative-prow"
+	BucketName = "knative-prow"
 	// Latest is the filename storing latest build number
 	Latest = "latest-build.txt"
 	// BuildLog is the filename for build log

--- a/shared/prow/prow.go
+++ b/shared/prow/prow.go
@@ -38,7 +38,8 @@ const (
 	OrgName = "knative"
 
 	// BucketName is the gcs bucket for all knative builds
-	BucketName = "knative-prow"
+	// TODO: change back to default before PR
+	BucketName = "trevorfarrelly-knative-2019" // "knative-prow"
 	// Latest is the filename storing latest build number
 	Latest = "latest-build.txt"
 	// BuildLog is the filename for build log

--- a/tools/flaky-test-reporter/config.go
+++ b/tools/flaky-test-reporter/config.go
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 // config.go contains configurations for flaky tests reporting
+// TODO: change testing customizations back to default before PR
 
 package main
 
@@ -30,14 +31,32 @@ const (
 	// Don't do anything if found more than 1% tests flaky, this is an arbitrary number
 	threshold = 0.01
 
-	org = "knative"
+	org = "TrevorFarrelly"
 )
 
 var (
-	jobConfigs = []JobConfig{
-		{"ci-knative-serving-continuous", "serving", prow.PostsubmitJob}, // CI flow for serving repo
+	// jobConfigs lists all repos and jobs to run within those repos
+	jobConfigs = map[string][]JobConfig{
+		// CI flows for serving repo
+		"serving": {{Name: "ci-knative-serving-continuous", Type: prow.PostsubmitJob},
+			{Name: "ci-knative-serving-istio-1.0.7-mesh", Type: prow.PostsubmitJob},
+			{Name: "ci-knative-serving-istio-1.0.7-no-mesh", Type: prow.PostsubmitJob},
+			{Name: "ci-knative-serving-istio-1.1.2-mesh", Type: prow.PostsubmitJob},
+			{Name: "ci-knative-serving-istio-1.1.2-no-mesh", Type: prow.PostsubmitJo},
+		},
 	}
-	repoIssueMap = map[string]string{
-		"serving": "serving",
+	// slackChannelsMap lists which slack channel to post results in for each job in repo
+	slackChannelsMap = map[string]map[string][]slackChannel{
+		// channel mapping for serving repo
+		"serving": {"default": {{"api", "CJEQ0MB50" /*"CA4DNJ9A4"*/}},
+			"ci-knative-serving-istio-1.0.7-mesh":    {{"networking", "CJS634MKP"}},
+			"ci-knative-serving-istio-1.0.7-no-mesh": {{"networking", "CJS634MKP"}},
+			"ci-knative-serving-istio-1.1.2-mesh":    {{"networking", "CJS634MKP"}},
+			"ci-knative-serving-istio-1.1.2-no-mesh": {{"networking", "CJS634MKP"}},
+		},
+	}
+
+	githubIssueMap = map[string]string{
+		"serving": "knative-testing",
 	}
 )

--- a/tools/flaky-test-reporter/config.go
+++ b/tools/flaky-test-reporter/config.go
@@ -38,11 +38,11 @@ var (
 	// jobConfigs lists all repos and jobs to run within those repos
 	jobConfigs = map[string][]JobConfig{
 		// CI flows for serving repo
-		"serving": {{Name: "ci-knative-serving-continuous", Type: prow.PostsubmitJob},
-			{Name: "ci-knative-serving-istio-1.0.7-mesh", Type: prow.PostsubmitJob},
-			{Name: "ci-knative-serving-istio-1.0.7-no-mesh", Type: prow.PostsubmitJob},
-			{Name: "ci-knative-serving-istio-1.1.2-mesh", Type: prow.PostsubmitJob},
-			{Name: "ci-knative-serving-istio-1.1.2-no-mesh", Type: prow.PostsubmitJo},
+		"serving": {{Name: "ci-knative-serving-continuous", Type: prow.PostsubmitJob, PostIssue: true},
+			{Name: "ci-knative-serving-istio-1.0.7-mesh", Type: prow.PostsubmitJob, PostIssue: true},
+			{Name: "ci-knative-serving-istio-1.0.7-no-mesh", Type: prow.PostsubmitJob, PostIssue: false},
+			{Name: "ci-knative-serving-istio-1.1.2-mesh", Type: prow.PostsubmitJob, PostIssue: false},
+			{Name: "ci-knative-serving-istio-1.1.2-no-mesh", Type: prow.PostsubmitJob, PostIssue: false},
 		},
 	}
 	// slackChannelsMap lists which slack channel to post results in for each job in repo

--- a/tools/flaky-test-reporter/config.go
+++ b/tools/flaky-test-reporter/config.go
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 // config.go contains configurations for flaky tests reporting
-// TODO: change testing customizations back to default before PR
 
 package main
 
@@ -31,7 +30,7 @@ const (
 	// Don't do anything if found more than 1% tests flaky, this is an arbitrary number
 	threshold = 0.01
 
-	org = "TrevorFarrelly"
+	org = "knative"
 )
 
 var (
@@ -48,15 +47,15 @@ var (
 	// slackChannelsMap lists which slack channel to post results in for each job in repo
 	slackChannelsMap = map[string]map[string][]slackChannel{
 		// channel mapping for serving repo
-		"serving": {"default": {{"api", "CJEQ0MB50" /*"CA4DNJ9A4"*/}},
-			"ci-knative-serving-istio-1.0.7-mesh":    {{"networking", "CJS634MKP"}},
-			"ci-knative-serving-istio-1.0.7-no-mesh": {{"networking", "CJS634MKP"}},
-			"ci-knative-serving-istio-1.1.2-mesh":    {{"networking", "CJS634MKP"}},
-			"ci-knative-serving-istio-1.1.2-no-mesh": {{"networking", "CJS634MKP"}},
+		"serving": {"default": {{"api", "CA4DNJ9A4"}},
+			"ci-knative-serving-istio-1.0.7-mesh":    {{"networking", ""}},
+			"ci-knative-serving-istio-1.0.7-no-mesh": {{"networking", ""}},
+			"ci-knative-serving-istio-1.1.2-mesh":    {{"networking", ""}},
+			"ci-knative-serving-istio-1.1.2-no-mesh": {{"networking", ""}},
 		},
 	}
 
 	githubIssueMap = map[string]string{
-		"serving": "knative-testing",
+		"serving": "serving",
 	}
 )

--- a/tools/flaky-test-reporter/config.go
+++ b/tools/flaky-test-reporter/config.go
@@ -44,10 +44,10 @@ var (
 			{Name: "ci-knative-serving-istio-1.1.2-no-mesh", Type: prow.PostsubmitJob, PostIssue: false},
 		},
 	}
-	// slackChannelsMap lists which slack channel to post results in for each job in repo
+	// slackChannelsMap lists which Slack channel to post results in for each job in repo
 	slackChannelsMap = map[string]map[string][]slackChannel{
 		// channel mapping for serving repo
-		"serving": {"default": {{"api", "CA4DNJ9A4"}},
+		"serving": {"ci-knative-serving-continuous": {{"api", "CA4DNJ9A4"}},
 			"ci-knative-serving-istio-1.0.7-mesh":    {{"networking", "CA9RHBGJX"}},
 			"ci-knative-serving-istio-1.0.7-no-mesh": {{"networking", "CA9RHBGJX"}},
 			"ci-knative-serving-istio-1.1.2-mesh":    {{"networking", "CA9RHBGJX"}},

--- a/tools/flaky-test-reporter/config.go
+++ b/tools/flaky-test-reporter/config.go
@@ -47,6 +47,8 @@ var (
 	// slackChannelsMap lists which Slack channel to post results in for each job in repo
 	slackChannelsMap = map[string]map[string][]slackChannel{
 		// channel mapping for serving repo
+		// "CA4DNJ9A4" => serving-api
+		// "CA9RHBGJX" => networking
 		"serving": {"ci-knative-serving-continuous": {{"api", "CA4DNJ9A4"}},
 			"ci-knative-serving-istio-1.0.7-mesh":    {{"networking", "CA9RHBGJX"}},
 			"ci-knative-serving-istio-1.0.7-no-mesh": {{"networking", "CA9RHBGJX"}},

--- a/tools/flaky-test-reporter/config.go
+++ b/tools/flaky-test-reporter/config.go
@@ -34,11 +34,11 @@ const (
 )
 
 var (
-	// jobConfigs lists all repos and jobs to run within those repos
+	// jobConfigs lists all repos and jobs to analyze within those repos
 	jobConfigs = map[string][]JobConfig{
 		// CI flows for serving repo
 		"serving": {{Name: "ci-knative-serving-continuous", Type: prow.PostsubmitJob, PostIssue: true},
-			{Name: "ci-knative-serving-istio-1.0.7-mesh", Type: prow.PostsubmitJob, PostIssue: true},
+			{Name: "ci-knative-serving-istio-1.0.7-mesh", Type: prow.PostsubmitJob, PostIssue: false},
 			{Name: "ci-knative-serving-istio-1.0.7-no-mesh", Type: prow.PostsubmitJob, PostIssue: false},
 			{Name: "ci-knative-serving-istio-1.1.2-mesh", Type: prow.PostsubmitJob, PostIssue: false},
 			{Name: "ci-knative-serving-istio-1.1.2-no-mesh", Type: prow.PostsubmitJob, PostIssue: false},
@@ -48,10 +48,10 @@ var (
 	slackChannelsMap = map[string]map[string][]slackChannel{
 		// channel mapping for serving repo
 		"serving": {"default": {{"api", "CA4DNJ9A4"}},
-			"ci-knative-serving-istio-1.0.7-mesh":    {{"networking", ""}},
-			"ci-knative-serving-istio-1.0.7-no-mesh": {{"networking", ""}},
-			"ci-knative-serving-istio-1.1.2-mesh":    {{"networking", ""}},
-			"ci-knative-serving-istio-1.1.2-no-mesh": {{"networking", ""}},
+			"ci-knative-serving-istio-1.0.7-mesh":    {{"networking", "CA9RHBGJX"}},
+			"ci-knative-serving-istio-1.0.7-no-mesh": {{"networking", "CA9RHBGJX"}},
+			"ci-knative-serving-istio-1.1.2-mesh":    {{"networking", "CA9RHBGJX"}},
+			"ci-knative-serving-istio-1.1.2-no-mesh": {{"networking", "CA9RHBGJX"}},
 		},
 	}
 

--- a/tools/flaky-test-reporter/github_issue.go
+++ b/tools/flaky-test-reporter/github_issue.go
@@ -499,7 +499,7 @@ func (gi *GithubIssue) processGithubIssues(repoDataAll []*RepoData, dryrun bool)
 	}
 
 	for _, rd := range repoDataAll {
-		messages, err := gi.processGithubIssueForRepo(rd, flakyGHIssuesMap, repoIssueMap[rd.Config.Repo], dryrun)
+		messages, err := gi.processGithubIssueForRepo(rd, flakyGHIssuesMap, githubIssueMap[rd.Config.Repo], dryrun)
 		messagesMap[rd.Config.Repo] = messages
 		if nil != err {
 			errMap[rd.Config.Repo] = append(errMap[rd.Config.Repo], err)

--- a/tools/flaky-test-reporter/github_issue.go
+++ b/tools/flaky-test-reporter/github_issue.go
@@ -499,6 +499,10 @@ func (gi *GithubIssue) processGithubIssues(repoDataAll []*RepoData, dryrun bool)
 	}
 
 	for _, rd := range repoDataAll {
+		if !rd.Config.PostIssue {
+			log.Printf("Job '%s' is marked to not create GitHub issues, skipping", rd.Config.Name)
+			continue
+		}
 		messages, err := gi.processGithubIssueForRepo(rd, flakyGHIssuesMap, githubIssueMap[rd.Config.Repo], dryrun)
 		messagesMap[rd.Config.Repo] = messages
 		if nil != err {

--- a/tools/flaky-test-reporter/main.go
+++ b/tools/flaky-test-reporter/main.go
@@ -62,16 +62,19 @@ func main() {
 		log.Fatalf("Failed preparing local artifacts directory: %v", err)
 	}
 
-	for _, jc := range jobConfigs {
-		log.Printf("collecting results for repo '%s'\n", jc.Repo)
-		rd, err := collectTestResultsForRepo(jc)
-		if nil != err {
-			log.Fatalf("Error collecting results for repo '%s': %v", jc.Repo, err)
+	for repoName, jobList := range jobConfigs {
+		for _, jc := range jobList {
+			jc.Repo = repoName
+			log.Printf("collecting results for job '%s' in repo '%s'\n", jc.Name, jc.Repo)
+			rd, err := collectTestResultsForRepo(jc)
+			if nil != err {
+				log.Fatalf("Error collecting results for job '%s' in repo '%s': %v", jc.Name, jc.Repo, err)
+			}
+			if err = createArtifactForRepo(rd); nil != err {
+				log.Fatalf("Error creating artifacts for job '%s' in repo '%s': %v", jc.Name, jc.Repo, err)
+			}
+			repoDataAll = append(repoDataAll, rd)
 		}
-		if err = createArtifactForRepo(rd); nil != err {
-			log.Fatalf("Error creating artifacts for repo '%s': %v", jc.Repo, err)
-		}
-		repoDataAll = append(repoDataAll, rd)
 	}
 
 	// Errors that could result in inaccuracy reporting would be treated with fast fail by processGithubIssues,

--- a/tools/flaky-test-reporter/result.go
+++ b/tools/flaky-test-reporter/result.go
@@ -51,8 +51,8 @@ type RepoData struct {
 type JobConfig struct {
 	Name      string // name of job to analyze
 	Repo      string // repository to test job on
-	Type      string 
-	PostIssue bool	 // flag to set if we want to create a GitHub issue
+	Type      string
+	PostIssue bool // flag to set if we want to create a GitHub issue
 }
 
 // TestStat represents test results of a single testcase across all builds,

--- a/tools/flaky-test-reporter/result.go
+++ b/tools/flaky-test-reporter/result.go
@@ -49,9 +49,9 @@ type RepoData struct {
 
 // JobConfig is initial configuration for a given repo, defines which job to scan
 type JobConfig struct {
-	Name string
-	Repo string
-	Type string
+	Name      string
+	Repo      string
+	Type      string
 }
 
 // TestStat represents test results of a single testcase across all builds,

--- a/tools/flaky-test-reporter/result.go
+++ b/tools/flaky-test-reporter/result.go
@@ -52,6 +52,7 @@ type JobConfig struct {
 	Name      string
 	Repo      string
 	Type      string
+	PostIssue bool
 }
 
 // TestStat represents test results of a single testcase across all builds,

--- a/tools/flaky-test-reporter/result.go
+++ b/tools/flaky-test-reporter/result.go
@@ -49,10 +49,10 @@ type RepoData struct {
 
 // JobConfig is initial configuration for a given repo, defines which job to scan
 type JobConfig struct {
-	Name      string
-	Repo      string
-	Type      string
-	PostIssue bool
+	Name      string // name of job to analyze
+	Repo      string // repository to test job on
+	Type      string 
+	PostIssue bool	 // flag to set if we want to create a GitHub issue
 }
 
 // TestStat represents test results of a single testcase across all builds,

--- a/tools/flaky-test-reporter/slack_notification.go
+++ b/tools/flaky-test-reporter/slack_notification.go
@@ -141,6 +141,7 @@ func getSlackChannel(repo string, name string) []slackChannel {
 	jobMap, ok := slackChannelsMap[repo]
 	if !ok {
 		log.Printf("cannot find Slack channel mapping for repo '%s', skipping Slack notification", repo)
+		return nil
 	}
 	channels, ok := jobMap[name]
 	if !ok {

--- a/tools/flaky-test-reporter/slack_notification.go
+++ b/tools/flaky-test-reporter/slack_notification.go
@@ -34,16 +34,12 @@ import (
 )
 
 const (
-	knativeBotName          = "Knative Testgrid Robot"
+	// TODO: revert
+	knativeBotName          = "knative-bot" // "Knative Testgrid Robot"
 	slackChatPostMessageURL = "https://slack.com/api/chat.postMessage"
 	// default filter for testgrid link
 	testgridFilter = "exclude-non-failed-tests=20"
 )
-
-// slackChannelsMap defines mapping of repo: slack channels
-var slackChannelsMap = map[string][]slackChannel{
-	"serving": {{"api", "CA4DNJ9A4"}},
-}
 
 // SlackClient contains Slack bot related information
 type SlackClient struct {
@@ -107,13 +103,13 @@ func (c *SlackClient) writeSlackMessage(text, channel string) error {
 // createSlackMessageForRepo creates slack message layout from RepoData
 func createSlackMessageForRepo(rd *RepoData, flakyIssuesMap map[string][]*flakyIssue) string {
 	flakyTests := getFlakyTests(rd)
-	message := fmt.Sprintf("As of %s, there are %d flaky tests in '%s'",
-		time.Unix(*rd.LastBuildStartTime, 0).String(), len(flakyTests), rd.Config.Repo)
+	message := fmt.Sprintf("As of %s, there are %d flaky tests in '%s' from repo '%s'",
+		time.Unix(*rd.LastBuildStartTime, 0).String(), len(flakyTests), rd.Config.Name, rd.Config.Repo)
 	flakyRate := getFlakyRate(rd)
 	if flakyRate > threshold { // Don't list each test as this can be huge
 		message += fmt.Sprintf("\n>- skip displaying all tests as flaky rate above '%0.2f%%'", threshold)
 		if flakyIssues, ok := flakyIssuesMap[getBulkIssueIdentity(rd, flakyRate)]; ok {
-			// When flaky rate is above threthold, there is only one issue created,
+			// When flaky rate is above threshold, there is only one issue created,
 			// so there is only one element in flakyIssues
 			for _, fi := range flakyIssues {
 				message += fmt.Sprintf("\t%s", fi.issue.GetHTMLURL())
@@ -145,10 +141,15 @@ func sendSlackNotifications(repoDataAll []*RepoData, c *SlackClient, ghi *Github
 		log.Println("Warning: cannot get flaky Github issues: ", err)
 	}
 	for _, rd := range repoDataAll {
-		channels, ok := slackChannelsMap[rd.Config.Repo]
+		testMap, ok := slackChannelsMap[rd.Config.Repo]
 		if !ok {
-			log.Printf("cannot find Slack channel for repo '%s', skipping Slack notification", rd.Config.Repo)
+			log.Printf("cannot find Slack channel mapping for repo '%s', skipping Slack notification", rd.Config.Repo)
 			continue
+		}
+		channels, ok := testMap[rd.Config.Name]
+		if !ok {
+			log.Printf("cannot find Slack channel for job '%s' in repo '%s', using default channel", rd.Config.Name, rd.Config.Repo)
+			channels = slackChannelsMap[rd.Config.Repo]["default"]
 		}
 
 		ch := make(chan bool, len(channels))
@@ -158,7 +159,7 @@ func sendSlackNotifications(repoDataAll []*RepoData, c *SlackClient, ghi *Github
 			go func(wg *sync.WaitGroup) {
 				message := createSlackMessageForRepo(rd, flakyIssuesMap)
 				if err := run(
-					fmt.Sprintf("post Slack message for repo '%s' in channel '%s'", rd.Config.Repo, channel.name),
+					fmt.Sprintf("post Slack message for job '%s' from repo '%s' in channel '%s'", rd.Config.Name, rd.Config.Repo, channel.name),
 					func() error {
 						return c.writeSlackMessage(message, channel.identity)
 					},

--- a/tools/flaky-test-reporter/slack_notification.go
+++ b/tools/flaky-test-reporter/slack_notification.go
@@ -104,29 +104,28 @@ func createSlackMessageForRepo(rd *RepoData, flakyIssuesMap map[string][]*flakyI
 	flakyTests := getFlakyTests(rd)
 	message := fmt.Sprintf("As of %s, there are %d flaky tests in '%s' from repo '%s'",
 		time.Unix(*rd.LastBuildStartTime, 0).String(), len(flakyTests), rd.Config.Name, rd.Config.Repo)
+	if !rd.Config.PostIssue {
+			message += fmt.Sprintf("\n(Job is marked to not create GitHub issues)")
+	}
 	flakyRate := getFlakyRate(rd)
-	if rd.Config.PostIssue {
-		if flakyRate > threshold { // Don't list each test as this can be huge
-			message += fmt.Sprintf("\n>- skip displaying all tests as flaky rate above '%0.2f%%'", threshold)
-			if flakyIssues, ok := flakyIssuesMap[getBulkIssueIdentity(rd, flakyRate)]; ok && rd.Config.PostIssue {
-				// When flaky rate is above threshold, there is only one issue created,
-				// so there is only one element in flakyIssues
+	if flakyRate > threshold { // Don't list each test as this can be huge
+		message += fmt.Sprintf("\n>- skip displaying all tests as flaky rate above '%0.2f%%'", threshold)
+		if flakyIssues, ok := flakyIssuesMap[getBulkIssueIdentity(rd, flakyRate)]; ok && rd.Config.PostIssue {
+			// When flaky rate is above threshold, there is only one issue created,
+			// so there is only one element in flakyIssues
+			for _, fi := range flakyIssues {
+				message += fmt.Sprintf("\t%s", fi.issue.GetHTMLURL())
+			}
+		}
+	} else {
+		for _, testFullName := range flakyTests {
+			message += fmt.Sprintf("\n>- %s", testFullName)
+			if flakyIssues, ok := flakyIssuesMap[getIdentityForTest(testFullName, rd.Config.Repo)]; ok && rd.Config.PostIssue {
 				for _, fi := range flakyIssues {
 					message += fmt.Sprintf("\t%s", fi.issue.GetHTMLURL())
 				}
 			}
-		} else {
-			for _, testFullName := range flakyTests {
-				message += fmt.Sprintf("\n>- %s", testFullName)
-				if flakyIssues, ok := flakyIssuesMap[getIdentityForTest(testFullName, rd.Config.Repo)]; ok && rd.Config.PostIssue {
-					for _, fi := range flakyIssues {
-						message += fmt.Sprintf("\t%s", fi.issue.GetHTMLURL())
-					}
-				}
-			}
 		}
-	} else {
-		message += fmt.Sprintf("\t Job is marked to not create GitHub issues")
 	}
 
 	if testgridTabURL, err := testgrid.GetTestgridTabURL(rd.Config.Name, []string{testgridFilter}); nil != err {

--- a/tools/flaky-test-reporter/slack_notification.go
+++ b/tools/flaky-test-reporter/slack_notification.go
@@ -34,8 +34,7 @@ import (
 )
 
 const (
-	// TODO: revert
-	knativeBotName          = "knative-bot" // "Knative Testgrid Robot"
+	knativeBotName          = "Knative Testgrid Robot"
 	slackChatPostMessageURL = "https://slack.com/api/chat.postMessage"
 	// default filter for testgrid link
 	testgridFilter = "exclude-non-failed-tests=20"

--- a/tools/flaky-test-reporter/slack_notification.go
+++ b/tools/flaky-test-reporter/slack_notification.go
@@ -108,20 +108,24 @@ func createSlackMessageForRepo(rd *RepoData, flakyIssuesMap map[string][]*flakyI
 	flakyRate := getFlakyRate(rd)
 	if flakyRate > threshold { // Don't list each test as this can be huge
 		message += fmt.Sprintf("\n>- skip displaying all tests as flaky rate above '%0.2f%%'", threshold)
-		if flakyIssues, ok := flakyIssuesMap[getBulkIssueIdentity(rd, flakyRate)]; ok {
+		if flakyIssues, ok := flakyIssuesMap[getBulkIssueIdentity(rd, flakyRate)]; ok && rd.Config.PostIssue {
 			// When flaky rate is above threshold, there is only one issue created,
 			// so there is only one element in flakyIssues
 			for _, fi := range flakyIssues {
 				message += fmt.Sprintf("\t%s", fi.issue.GetHTMLURL())
 			}
+		} else {
+			message += fmt.Sprintf("\t Job is marked to not create GitHub issues")
 		}
 	} else {
 		for _, testFullName := range flakyTests {
 			message += fmt.Sprintf("\n>- %s", testFullName)
-			if flakyIssues, ok := flakyIssuesMap[getIdentityForTest(testFullName, rd.Config.Repo)]; ok {
+			if flakyIssues, ok := flakyIssuesMap[getIdentityForTest(testFullName, rd.Config.Repo)]; ok && rd.Config.PostIssue {
 				for _, fi := range flakyIssues {
 					message += fmt.Sprintf("\t%s", fi.issue.GetHTMLURL())
 				}
+			} else {
+				message += fmt.Sprintf("\t Job is marked to not create GitHub issues")
 			}
 		}
 	}

--- a/tools/flaky-test-reporter/slack_notification.go
+++ b/tools/flaky-test-reporter/slack_notification.go
@@ -137,18 +137,18 @@ func createSlackMessageForRepo(rd *RepoData, flakyIssuesMap map[string][]*flakyI
 }
 
 // getSlackChannel gets the channel(s) to send messages to for a given job configuration
-func getSlackChannel(rd *RepoData) ([]slackChannel, bool) {
-	jobMap, ok := slackChannelsMap[rd.Config.Repo]
+func getSlackChannel(repo string, name string) []slackChannel {
+	jobMap, ok := slackChannelsMap[repo]
 	if !ok {
-		log.Printf("cannot find Slack channel mapping for repo '%s', skipping Slack notification", rd.Config.Repo)
-		return nil, ok
+		log.Printf("cannot find Slack channel mapping for repo '%s', skipping Slack notification", repo)
+		return nil
 	}
-	channels, ok := jobMap[rd.Config.Name]
+	channels, ok := jobMap[name]
 	if !ok {
-		log.Printf("cannot find Slack channel for job '%s' in repo '%s', skipping Slack notification", rd.Config.Name, rd.Config.Repo)
-		return nil, ok
+		log.Printf("cannot find Slack channel for job '%s' in repo '%s', skipping Slack notification", name, repo)
+		return nil
 	}
-	return channels, ok
+	return channels
 }
 
 func sendSlackNotifications(repoDataAll []*RepoData, c *SlackClient, ghi *GithubIssue, dryrun bool) error {
@@ -159,8 +159,8 @@ func sendSlackNotifications(repoDataAll []*RepoData, c *SlackClient, ghi *Github
 		log.Println("Warning: cannot get flaky Github issues: ", err)
 	}
 	for _, rd := range repoDataAll {
-		channels, ok := getSlackChannel(rd)
-		if !ok {
+		channels := getSlackChannel(rd.Config.Repo, rd.Config.Name)
+		if nil == channels {
 			continue
 		}
 		ch := make(chan bool, len(channels))


### PR DESCRIPTION
Refactored JobConfigs data structure to be more extensible in the future, and added a flag for GitHub issue creation if one does not want issues to be created for a specific job, as specified in #736.

Blocked on the Slack networking channel ID, as I do not have access to the team Slack. Once I have that, this change should be good to go.

If someone would like documentation on how to add test configurations for other jobs/repositories, I'd be happy to add it to the README.

/hold

Fixes #736 
