### PR TITLE
Build Log Parser

### DIFF
--- a/tools/monitoring/logs.go
+++ b/tools/monitoring/logs.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"log"
+	"regexp"
+)
+
+// ErrorInLog stores the error pattern and the corresponding error message found in the log
+type ErrorInLog struct {
+	ErrorPattern string
+	ErrorMsg     string
+}
+
+func compilePatterns(patterns []string) ([]regexp.Regexp, []string) {
+	var regexps []regexp.Regexp
+	var badPatterns []string // patterns that cannot be compiled into regex
+
+	for _, pattern := range patterns {
+		r, err := regexp.Compile(pattern)
+		if err != nil {
+			log.Printf("Error compiling pattern [%s]: %v", pattern, err)
+			badPatterns = append(badPatterns, pattern)
+		} else {
+			regexps = append(regexps, *r)
+		}
+	}
+	return regexps, badPatterns
+}
+
+func findMatches(regexps []regexp.Regexp, text []byte) []ErrorInLog {
+	var errorLogs []ErrorInLog
+	for _, r := range regexps {
+		found := r.Find(text)
+		if found != nil {
+			errorLogs = append(errorLogs, ErrorInLog{
+				ErrorPattern: r.String(),
+				ErrorMsg:     string(found),
+			})
+		}
+	}
+	return errorLogs
+}
+
+// ParseLog fetches build log from given url and checks it against given error patterns. Return
+// all found error patterns and error messages in pairs.
+func ParseLog(url string, patterns []string) ([]ErrorInLog, error) {
+	content, err := getFileBytes(url)
+	if err != nil {
+		return nil, err
+	}
+	regexps, badPatterns := compilePatterns(patterns)
+	if len(badPatterns) != 0 {
+		log.Printf("The following pattern cannot be compiled: %v", badPatterns)
+		// TODO: after email feature is done, send an email to oncall about the pattern issues
+	}
+
+	return findMatches(regexps, content), nil
+}

--- a/tools/monitoring/logs_test.go
+++ b/tools/monitoring/logs_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"reflect"
+	"regexp"
+	"testing"
+)
+
+const (
+	sampleLog = `I0515 00:00:32.675] ***************************************
+I0515 00:00:32.675] ***         E2E TEST FAILED         ***
+I0515 00:00:32.675] ***     End of information dump     ***
+I0515 00:00:32.675] ***************************************
+I0515 00:00:32.676] 2019/05/15 00:00:32 process.go:155: Step '/go/src/github.com/knative/docs/test/e2e-tests.sh --run-tests --emit-metrics' finished in 4m12.254697081s
+I0515 00:00:32.676] 2019/05/15 00:00:32 main.go:312: Something went wrong: encountered 1 errors: [error during /go/src/github.com/knative/docs/test/e2e-tests.sh --run-tests --emit-metrics: exit status 1]
+I0515 00:00:32.676] Test subprocess exited with code 0
+I0515 00:00:32.676] Artifacts were written to /workspace/_artifacts
+I0515 00:00:32.676] Test result code is 1
+I0515 00:00:32.676] ==================================
+I0515 00:00:32.676] ==== INTEGRATION TESTS FAILED ====
+I0515 00:00:32.677] ==================================
+W0515 00:00:32.677] Run: ('/workspace/./test-infra/jenkins/../scenarios/../hack/coalesce.py',)
+E0515 00:00:32.677] Command failed`
+)
+
+func Test_compilePatterns(t *testing.T) {
+	type args struct {
+		patterns []string
+	}
+	tests := []struct {
+		name              string
+		args              args
+		wantedRegexps     []regexp.Regexp
+		wantedBadPatterns []string
+	}{
+		{
+			name: "compile patterns",
+			args: args{
+				[]string{
+					"Something went wrong: starting e2e cluster: error creating cluster",
+					"sample*error2",
+					"[0",
+					"Something went wrong:.*\n",
+				},
+			},
+			wantedRegexps: []regexp.Regexp{
+				*regexp.MustCompile("Something went wrong: starting e2e cluster: error creating cluster"),
+				*regexp.MustCompile("sample*error2"),
+				*regexp.MustCompile("Something went wrong:.*\n"),
+			},
+			wantedBadPatterns: []string{
+				"[0",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1 := compilePatterns(tt.args.patterns)
+			if !reflect.DeepEqual(got, tt.wantedRegexps) {
+				t.Errorf("all compiled patterns: got = %v, want %v", got, tt.wantedRegexps)
+			}
+			if !reflect.DeepEqual(got1, tt.wantedBadPatterns) {
+				t.Errorf("all bad patterns: got = %v, want %v", got1, tt.wantedBadPatterns)
+			}
+		})
+	}
+}
+
+func Test_findMatches(t *testing.T) {
+	type args struct {
+		regexps []regexp.Regexp
+		text    []byte
+	}
+	tests := []struct {
+		name string
+		args args
+		want []ErrorInLog
+	}{
+		{
+			name: "single match",
+			args: args{
+				regexps: []regexp.Regexp{
+					*regexp.MustCompile("Something went wrong: starting e2e cluster: error creating cluster"),
+					*regexp.MustCompile("sample*error2"),
+					*regexp.MustCompile("Something went wrong:.*\n"),
+				},
+				text: []byte(sampleLog),
+			},
+			want: []ErrorInLog{
+				{
+					ErrorPattern: "Something went wrong:.*\n",
+					ErrorMsg:     "Something went wrong: encountered 1 errors: [error during /go/src/github.com/knative/docs/test/e2e-tests.sh --run-tests --emit-metrics: exit status 1]\n",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := findMatches(tt.args.regexps, tt.args.text); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("find all matching errors: got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/tools/monitoring/logs_test.go
+++ b/tools/monitoring/logs_test.go
@@ -71,12 +71,12 @@ func Test_compilePatterns(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, got1 := compilePatterns(tt.args.patterns)
-			if !reflect.DeepEqual(got, tt.wantedRegexps) {
-				t.Errorf("all compiled patterns: got = %v, want %v", got, tt.wantedRegexps)
+			compiledPatterns, badPatterns := compilePatterns(tt.args.patterns)
+			if !reflect.DeepEqual(compiledPatterns, tt.wantedRegexps) {
+				t.Errorf("all compiled patterns: compiledPatterns = %v, want %v", compiledPatterns, tt.wantedRegexps)
 			}
-			if !reflect.DeepEqual(got1, tt.wantedBadPatterns) {
-				t.Errorf("all bad patterns: got = %v, want %v", got1, tt.wantedBadPatterns)
+			if !reflect.DeepEqual(badPatterns, tt.wantedBadPatterns) {
+				t.Errorf("all bad patterns: compiledPatterns = %v, want %v", badPatterns, tt.wantedBadPatterns)
 			}
 		})
 	}
@@ -90,7 +90,7 @@ func Test_findMatches(t *testing.T) {
 	tests := []struct {
 		name string
 		args args
-		want []ErrorInLog
+		want []ErrorLog
 	}{
 		{
 			name: "single match",
@@ -102,17 +102,17 @@ func Test_findMatches(t *testing.T) {
 				},
 				text: []byte(sampleLog),
 			},
-			want: []ErrorInLog{
+			want: []ErrorLog{
 				{
-					ErrorPattern: "Something went wrong:.*\n",
-					ErrorMsg:     "Something went wrong: encountered 1 errors: [error during /go/src/github.com/knative/docs/test/e2e-tests.sh --run-tests --emit-metrics: exit status 1]\n",
+					Pattern: "Something went wrong:.*\n",
+					Msg:     "Something went wrong: encountered 1 errors: [error during /go/src/github.com/knative/docs/test/e2e-tests.sh --run-tests --emit-metrics: exit status 1]\n",
 				},
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := findMatches(tt.args.regexps, tt.args.text); !reflect.DeepEqual(got, tt.want) {
+			if got := collectMatches(tt.args.regexps, tt.args.text); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("find all matching errors: got = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
Fetch build log from given url and check it against given error patterns.
Return all found error patterns and error messages in pairs.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #762
