### PR TITLE
flaky-test-reporter: refactor logging to better support new job/repo mapping format

### DIFF
--- a/tools/flaky-test-reporter/config.go
+++ b/tools/flaky-test-reporter/config.go
@@ -37,11 +37,11 @@ var (
 	// jobConfigs lists all repos and jobs to analyze within those repos
 	jobConfigs = map[string][]JobConfig{
 		// CI flows for serving repo
-		"serving": {{Name: "ci-knative-serving-continuous", Type: prow.PostsubmitJob, PostIssue: true},
-			{Name: "ci-knative-serving-istio-1.0.7-mesh", Type: prow.PostsubmitJob, PostIssue: false},
-			{Name: "ci-knative-serving-istio-1.0.7-no-mesh", Type: prow.PostsubmitJob, PostIssue: false},
-			{Name: "ci-knative-serving-istio-1.1.2-mesh", Type: prow.PostsubmitJob, PostIssue: false},
-			{Name: "ci-knative-serving-istio-1.1.2-no-mesh", Type: prow.PostsubmitJob, PostIssue: false},
+		"serving": {{Name: "ci-knative-serving-continuous", Type: prow.PostsubmitJob, SkipGithubIssue: false},
+			{Name: "ci-knative-serving-istio-1.0.7-mesh", Type: prow.PostsubmitJob, SkipGithubIssue: true},
+			{Name: "ci-knative-serving-istio-1.0.7-no-mesh", Type: prow.PostsubmitJob, SkipGithubIssue: true},
+			{Name: "ci-knative-serving-istio-1.1.2-mesh", Type: prow.PostsubmitJob, SkipGithubIssue: true},
+			{Name: "ci-knative-serving-istio-1.1.2-no-mesh", Type: prow.PostsubmitJob, SkipGithubIssue: true},
 		},
 	}
 	// slackChannelsMap lists which Slack channel to post results in for each job in repo

--- a/tools/flaky-test-reporter/github_issue.go
+++ b/tools/flaky-test-reporter/github_issue.go
@@ -428,7 +428,7 @@ func (gi *GithubIssue) processGithubIssueForRepo(rd *RepoData, flakyIssuesMap ma
 	var errs []error
 
 	// if flag is not set, do not create an issue at all
-	if !rd.Config.PostIssue {
+	if rd.Config.SkipGithubIssue {
 		messages = append(messages, "skip creating/updating issues, job is marked to not create GitHub issues\n")
 		return messages, combineErrors(errs)
 	}
@@ -507,12 +507,12 @@ func (gi *GithubIssue) processGithubIssues(repoDataAll []*RepoData, dryrun bool)
 	for _, rd := range repoDataAll {
 		messages, err := gi.processGithubIssueForRepo(rd, flakyGHIssuesMap, githubIssueMap[rd.Config.Repo], dryrun)
 		if _, ok := messagesMap[rd.Config.Repo]; !ok {
-		 	messagesMap[rd.Config.Repo] = make(map[string][]string)
+			messagesMap[rd.Config.Repo] = make(map[string][]string)
 		}
 		messagesMap[rd.Config.Repo][rd.Config.Name] = messages
 		if nil != err {
 			if _, ok := errMap[rd.Config.Repo]; !ok {
-			 	errMap[rd.Config.Repo] = make(map[string][]error)
+				errMap[rd.Config.Repo] = make(map[string][]error)
 			}
 			errMap[rd.Config.Repo][rd.Config.Name] = append(errMap[rd.Config.Repo][rd.Config.Name], err)
 		}

--- a/tools/flaky-test-reporter/github_issue.go
+++ b/tools/flaky-test-reporter/github_issue.go
@@ -494,7 +494,9 @@ func (gi *GithubIssue) processGithubIssueForRepo(rd *RepoData, flakyIssuesMap ma
 
 // analyze all results, figure out flaky tests and processing existing auto:flaky issues
 func (gi *GithubIssue) processGithubIssues(repoDataAll []*RepoData, dryrun bool) error {
+	// map repo to jobs, and jobs to messages
 	messagesMap := make(map[string]map[string][]string)
+	// map repo to jobs, and jobs to errors
 	errMap := make(map[string]map[string][]error)
 
 	// Collect all flaky test issues from all knative repos, in case issues are moved around

--- a/tools/flaky-test-reporter/github_issue.go
+++ b/tools/flaky-test-reporter/github_issue.go
@@ -427,6 +427,12 @@ func (gi *GithubIssue) processGithubIssueForRepo(rd *RepoData, flakyIssuesMap ma
 	var messages []string
 	var errs []error
 
+	// if flag is not set, do not create an issue at all
+	if !rd.Config.PostIssue {
+		messages = append(messages, "skip creating/updating issues, job is marked to not create GitHub issues\n")
+		return messages, combineErrors(errs)
+	}
+
 	// If there are too many failures, create a single issue tracking it.
 	flakyRate := getFlakyRate(rd)
 	if flakyRate > threshold {
@@ -488,8 +494,8 @@ func (gi *GithubIssue) processGithubIssueForRepo(rd *RepoData, flakyIssuesMap ma
 
 // analyze all results, figure out flaky tests and processing existing auto:flaky issues
 func (gi *GithubIssue) processGithubIssues(repoDataAll []*RepoData, dryrun bool) error {
-	messagesMap := make(map[string][]string)
-	errMap := make(map[string][]error)
+	messagesMap := make(map[string]map[string][]string)
+	errMap := make(map[string]map[string][]error)
 
 	// Collect all flaky test issues from all knative repos, in case issues are moved around
 	// Fail this job if data collection failed
@@ -499,26 +505,28 @@ func (gi *GithubIssue) processGithubIssues(repoDataAll []*RepoData, dryrun bool)
 	}
 
 	for _, rd := range repoDataAll {
-		if !rd.Config.PostIssue {
-			log.Printf("Job '%s' is marked to not create GitHub issues, skipping", rd.Config.Name)
-			continue
-		}
 		messages, err := gi.processGithubIssueForRepo(rd, flakyGHIssuesMap, githubIssueMap[rd.Config.Repo], dryrun)
-		messagesMap[rd.Config.Repo] = messages
+		if _, ok := messagesMap[rd.Config.Repo]; !ok {
+		 	messagesMap[rd.Config.Repo] = make(map[string][]string)
+		}
+		messagesMap[rd.Config.Repo][rd.Config.Name] = messages
 		if nil != err {
-			errMap[rd.Config.Repo] = append(errMap[rd.Config.Repo], err)
+			if _, ok := errMap[rd.Config.Repo]; !ok {
+			 	errMap[rd.Config.Repo] = make(map[string][]error)
+			}
+			errMap[rd.Config.Repo][rd.Config.Name] = append(errMap[rd.Config.Repo][rd.Config.Name], err)
 		}
 	}
 
 	// Print summaries
 	summary := "Summary:\n"
 	for _, rd := range repoDataAll {
-		if messages, ok := messagesMap[rd.Config.Repo]; ok {
-			summary += fmt.Sprintf("Summary of repo '%s':\n", rd.Config.Repo)
+		if messages, ok := messagesMap[rd.Config.Repo][rd.Config.Name]; ok {
+			summary += fmt.Sprintf("Summary of job '%s' in repo '%s':\n", rd.Config.Name, rd.Config.Repo)
 			summary += strings.Join(messages, "\n")
 		}
-		if errs, ok := errMap[rd.Config.Repo]; ok {
-			summary += fmt.Sprintf("Errors in repo '%s':\n%v", rd.Config.Repo, combineErrors(errs))
+		if errs, ok := errMap[rd.Config.Repo][rd.Config.Name]; ok {
+			summary += fmt.Sprintf("Errors in job '%s' in repo '%s':\n%v", rd.Config.Name, rd.Config.Repo, combineErrors(errs))
 		}
 	}
 

--- a/tools/flaky-test-reporter/result.go
+++ b/tools/flaky-test-reporter/result.go
@@ -49,10 +49,10 @@ type RepoData struct {
 
 // JobConfig is initial configuration for a given repo, defines which job to scan
 type JobConfig struct {
-	Name      string // name of job to analyze
-	Repo      string // repository to test job on
-	Type      string
-	PostIssue bool // flag to set if we want to create a GitHub issue
+	Name            string // name of job to analyze
+	Repo            string // repository to test job on
+	Type            string
+	SkipGithubIssue bool // flag to set if we want to create a GitHub issue
 }
 
 // TestStat represents test results of a single testcase across all builds,

--- a/tools/flaky-test-reporter/slack_notification.go
+++ b/tools/flaky-test-reporter/slack_notification.go
@@ -104,13 +104,13 @@ func createSlackMessageForRepo(rd *RepoData, flakyIssuesMap map[string][]*flakyI
 	flakyTests := getFlakyTests(rd)
 	message := fmt.Sprintf("As of %s, there are %d flaky tests in '%s' from repo '%s'",
 		time.Unix(*rd.LastBuildStartTime, 0).String(), len(flakyTests), rd.Config.Name, rd.Config.Repo)
-	if !rd.Config.PostIssue {
-			message += fmt.Sprintf("\n(Job is marked to not create GitHub issues)")
+	if rd.Config.SkipGithubIssue {
+		message += fmt.Sprintf("\n(Job is marked to not create GitHub issues)")
 	}
 	flakyRate := getFlakyRate(rd)
 	if flakyRate > threshold { // Don't list each test as this can be huge
 		message += fmt.Sprintf("\n>- skip displaying all tests as flaky rate above '%0.2f%%'", threshold)
-		if flakyIssues, ok := flakyIssuesMap[getBulkIssueIdentity(rd, flakyRate)]; ok && rd.Config.PostIssue {
+		if flakyIssues, ok := flakyIssuesMap[getBulkIssueIdentity(rd, flakyRate)]; ok && !rd.Config.SkipGithubIssue {
 			// When flaky rate is above threshold, there is only one issue created,
 			// so there is only one element in flakyIssues
 			for _, fi := range flakyIssues {
@@ -120,7 +120,7 @@ func createSlackMessageForRepo(rd *RepoData, flakyIssuesMap map[string][]*flakyI
 	} else {
 		for _, testFullName := range flakyTests {
 			message += fmt.Sprintf("\n>- %s", testFullName)
-			if flakyIssues, ok := flakyIssuesMap[getIdentityForTest(testFullName, rd.Config.Repo)]; ok && rd.Config.PostIssue {
+			if flakyIssues, ok := flakyIssuesMap[getIdentityForTest(testFullName, rd.Config.Repo)]; ok && !rd.Config.SkipGithubIssue {
 				for _, fi := range flakyIssues {
 					message += fmt.Sprintf("\t%s", fi.issue.GetHTMLURL())
 				}

--- a/tools/flaky-test-reporter/slack_notification.go
+++ b/tools/flaky-test-reporter/slack_notification.go
@@ -177,6 +177,9 @@ func sendSlackNotifications(repoDataAll []*RepoData, c *SlackClient, ghi *Github
 					allErrs = append(allErrs, err)
 					log.Printf("failed sending notification to Slack channel '%s': '%v'", channel.name, err)
 				}
+				if dryrun {
+					log.Printf("[dry run] Slack message not sent. See it below:\n%s\n\n", message)
+				}
 				ch <- true
 				wg.Done()
 			}(&wg)


### PR DESCRIPTION
Better support new job format introduced in #809 when logging.
Print messages that would be sent to Slack when running with -dry-run=true.

/lint