### PR TITLE
Fix gcr locations for devstats images

### DIFF
--- a/tools/devstats/Kubernetes/batch-job-backfill.yaml
+++ b/tools/devstats/Kubernetes/batch-job-backfill.yaml
@@ -23,7 +23,7 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: devstats-backfill
-        image: gcr.io/knative-tests/devstats:latest
+        image: gcr.io/knative-tests/devstats/devstats:latest
         imagePullPolicy: Always
         workingDir: "/mount/data/src/test-infra/tools/devstats"
         command: ["/bin/bash", "-c"]

--- a/tools/devstats/Kubernetes/cli-home.yaml
+++ b/tools/devstats/Kubernetes/cli-home.yaml
@@ -44,7 +44,7 @@ spec:
     spec:
       containers:
       - name: devstats-image
-        image: gcr.io/knative-tests/devstats:latest
+        image: gcr.io/knative-tests/devstats/devstats:latest
         imagePullPolicy: Always
         command: ["tail", "-f", "/dev/null",]
         envFrom:

--- a/tools/devstats/Kubernetes/cron-updates.yaml
+++ b/tools/devstats/Kubernetes/cron-updates.yaml
@@ -26,7 +26,7 @@ spec:
           restartPolicy: OnFailure
           containers:
           - name: devstats-cron
-            image: gcr.io/knative-tests/devstats:latest
+            image: gcr.io/knative-tests/devstats/devstats:latest
             imagePullPolicy: Always
             workingDir: "/mount/data/src/test-infra/tools/devstats"
             command: ["/bin/sh","-c"]

--- a/tools/devstats/Kubernetes/postgres-service.yaml
+++ b/tools/devstats/Kubernetes/postgres-service.yaml
@@ -57,7 +57,7 @@ spec:
           value: "postgres"
         - name: PGDATA
           value: "/mount/data/postgresql"
-        image: gcr.io/knative-tests/devstats-postgres:latest
+        image: gcr.io/knative-tests/devstats/devstats-postgres:latest
         imagePullPolicy: Always
         command: ["/usr/local/bin/postgre-docker-entrypoint.sh", "postgres",]
         ports:


### PR DESCRIPTION
We're storing the images in GCR under a new devstats folder in the knative-tests repository. This updates devstats containers to point to the correct location.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
