### PR TITLE
use UnmarshalStrict for monitoring config parsing

### DIFF
--- a/tools/monitoring/config.go
+++ b/tools/monitoring/config.go
@@ -118,7 +118,7 @@ func ParseYaml(url string) (*Config, error) {
 
 func newConfig(text []byte) (*Config, error) {
 	file := new(Config)
-	if err := yaml.Unmarshal(text, &file); err != nil {
+	if err := yaml.UnmarshalStrict(text, &file); err != nil {
 		return file, err
 	}
 	return file, nil


### PR DESCRIPTION
UnmarshalStrict returns error when encountering unknown field from yaml.
It's a good way to catch mis-spelt and unsupported field names.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #
