### PR TITLE
Unify alias name for productivity approvers/reviewers in OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,7 +1,7 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- test-infra-approvers
+- productivity-approvers
 
 reviewers:
-- test-infra-reviewers
+- productivity-reviewers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,11 +1,11 @@
 # Aliases for approvers and reviewers in test-infra
 
 aliases:
-  test-infra-approvers:
+  productivity-approvers:
   - adrcunha
   - chaodaiG
   - srinivashegde86
-  test-infra-reviewers:
+  productivity-reviewers:
   - adrcunha
   - chaodaiG
   - coryrc


### PR DESCRIPTION
Part of #579.