### PR TITLE
Add a more flexible flaky reporting threshold for jobs with less tests

### DIFF
--- a/tools/flaky-test-reporter/README.md
+++ b/tools/flaky-test-reporter/README.md
@@ -42,7 +42,7 @@ Efficient deduplication is crucial for the sustainability of this tool, and this
 
 #### Too many flaky tests identified
 
-When there are too many tests found to be flaky, most likely something abnormal is going on, and we don't want to create Github issues for all of them, or list all of them in Slack notifications. There is a threshold defined in [`config.go`](config.go), if the flaky rate went over the threshold there will be only 1 Github issue created, and Slack notification will not list all flaky tests.
+When there are too many tests found to be flaky, most likely something abnormal is going on, and we don't want to create Github issues for all of them, or list all of them in Slack notifications. There are thresholds defined in [`config.go`](config.go), if the flaky rate went over a threshold there will be only 1 Github issue created, and Slack notification will not list all flaky tests.
 
 #### Github issue updates
 

--- a/tools/flaky-test-reporter/config.go
+++ b/tools/flaky-test-reporter/config.go
@@ -27,8 +27,9 @@ const (
 	buildsCount = 10
 	// Minimal number of results to be counted as valid results for each testcase, this is an arbitrary number
 	requiredCount = 8
-	// Don't do anything if found more than 1% tests flaky, this is an arbitrary number
-	threshold = 0.01
+	// Don't do anything if found more than 5 tests flaky, or 1% tests flaky, whichever comes first
+	countThreshold = 5
+	percentThreshold = 0.01
 
 	org = "knative"
 )

--- a/tools/flaky-test-reporter/github_issue.go
+++ b/tools/flaky-test-reporter/github_issue.go
@@ -435,7 +435,8 @@ func (gi *GithubIssue) processGithubIssueForRepo(rd *RepoData, flakyIssuesMap ma
 
 	// If there are too many failures, create a single issue tracking it.
 	if flakyRateAboveThreshold(rd) {
-		log.Printf("flaky rate above '%f', creating a single issue", threshold)
+		flakyRate := getFlakyRate(rd)
+		log.Printf("flaky rate above threshold, creating a single issue")
 		identity := getBulkIssueIdentity(rd, flakyRate)
 		if _, ok := flakyIssuesMap[identity]; ok {
 			log.Printf("issue already exist, skip creating")

--- a/tools/flaky-test-reporter/github_issue.go
+++ b/tools/flaky-test-reporter/github_issue.go
@@ -434,8 +434,7 @@ func (gi *GithubIssue) processGithubIssueForRepo(rd *RepoData, flakyIssuesMap ma
 	}
 
 	// If there are too many failures, create a single issue tracking it.
-	flakyRate := getFlakyRate(rd)
-	if flakyRate > threshold {
+	if flakyRateAboveThreshold(rd) {
 		log.Printf("flaky rate above '%f', creating a single issue", threshold)
 		identity := getBulkIssueIdentity(rd, flakyRate)
 		if _, ok := flakyIssuesMap[identity]; ok {

--- a/tools/flaky-test-reporter/github_issue_test.go
+++ b/tools/flaky-test-reporter/github_issue_test.go
@@ -109,10 +109,12 @@ func TestCreateIssue(t *testing.T) {
 		createissue                          bool
 		wantIssues                           int
 	}{
-		{197, 2, 0, 0, false, 1}, // flaky rate > 1%, create only 1 issue
+		{197, 6, 0, 0, false, 1}, // flaky rate > 1% and > 5 flaky tests, create only 1 issue
+		{197, 2, 0, 0, false, 2}, // flaky rate > 1% and < 5 flaky tests, create issue for each
 		{200, 2, 0, 0, false, 2}, // flaky rate < 1%, create issue for each
 		{197, 2, 0, 0, true, 0},  // flaky rate > 1%, flag is set to not create issue
 		{200, 2, 0, 0, true, 0},  // flaky rate < 1%, flag is set to not create issue
+
 	}
 
 	for _, d := range datas {

--- a/tools/flaky-test-reporter/result.go
+++ b/tools/flaky-test-reporter/result.go
@@ -113,6 +113,19 @@ func getFlakyRate(rd *RepoData) float32 {
 	return float32(len(getFlakyTests(rd))) / float32(totalCount)
 }
 
+func flakyRateAboveThreshold(rd *RepoData) bool {
+	// if the percent determined by the test count threshold is higher than
+	// the percent threshold, use that instead of the percent threshold
+	var threshold float32
+	totalCount := len(rd.TestStats)
+	if 0 == totalCount || float32(countThreshold) / float32(totalCount) < percentThreshold {
+		threshold = percentThreshold
+	} else {
+		threshold = float32(countThreshold) / float32(totalCount)
+	}
+	return getFlakyRate(rd) > threshold
+}
+
 // createArtifactForRepo marshals RepoData into json format and stores it in a json file,
 // under local artifacts directory
 func createArtifactForRepo(rd *RepoData) error {

--- a/tools/flaky-test-reporter/result.go
+++ b/tools/flaky-test-reporter/result.go
@@ -116,12 +116,13 @@ func getFlakyRate(rd *RepoData) float32 {
 func flakyRateAboveThreshold(rd *RepoData) bool {
 	// if the percent determined by the test count threshold is higher than
 	// the percent threshold, use that instead of the percent threshold
-	var threshold float32
 	totalCount := len(rd.TestStats)
-	if 0 == totalCount || float32(countThreshold) / float32(totalCount) < percentThreshold {
+	if totalCount == 0 {
+		return true
+	}
+	threshold := float32(countThreshold) / float32(totalCount)
+	if percentThreshold > threshold {
 		threshold = percentThreshold
-	} else {
-		threshold = float32(countThreshold) / float32(totalCount)
 	}
 	return getFlakyRate(rd) > threshold
 }

--- a/tools/flaky-test-reporter/slack_notification.go
+++ b/tools/flaky-test-reporter/slack_notification.go
@@ -108,7 +108,8 @@ func createSlackMessageForRepo(rd *RepoData, flakyIssuesMap map[string][]*flakyI
 		message += fmt.Sprintf("\n(Job is marked to not create GitHub issues)")
 	}
 	if flakyRateAboveThreshold(rd) { // Don't list each test as this can be huge
-		message += fmt.Sprintf("\n>- skip displaying all tests as flaky rate above '%0.2f%%'", threshold)
+		flakyRate := getFlakyRate(rd)
+		message += fmt.Sprintf("\n>- skip displaying all tests as flaky rate above threshold")
 		if flakyIssues, ok := flakyIssuesMap[getBulkIssueIdentity(rd, flakyRate)]; ok && !rd.Config.SkipGithubIssue {
 			// When flaky rate is above threshold, there is only one issue created,
 			// so there is only one element in flakyIssues

--- a/tools/flaky-test-reporter/slack_notification.go
+++ b/tools/flaky-test-reporter/slack_notification.go
@@ -107,8 +107,7 @@ func createSlackMessageForRepo(rd *RepoData, flakyIssuesMap map[string][]*flakyI
 	if rd.Config.SkipGithubIssue {
 		message += fmt.Sprintf("\n(Job is marked to not create GitHub issues)")
 	}
-	flakyRate := getFlakyRate(rd)
-	if flakyRate > threshold { // Don't list each test as this can be huge
+	if flakyRateAboveThreshold(rd) { // Don't list each test as this can be huge
 		message += fmt.Sprintf("\n>- skip displaying all tests as flaky rate above '%0.2f%%'", threshold)
 		if flakyIssues, ok := flakyIssuesMap[getBulkIssueIdentity(rd, flakyRate)]; ok && !rd.Config.SkipGithubIssue {
 			// When flaky rate is above threshold, there is only one issue created,


### PR DESCRIPTION
Previously, if 1% of tests were found flaky only 1 issue was created and Slack message didn't list the tests which failed. This makes sense for serving-continuous, but most other testing jobs have a much smaller number of tests, triggering this threshold after only one or two tests fail.

Now, the threshold is either 1% or 5 tests failing, whichever comes first.

/lint