### PR TITLE
Also retry test cluster creation during GKE updates

### DIFF
--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -257,11 +257,17 @@ function create_test_cluster_with_retries() {
         kubetest "$@" ${geoflag}; } 2>&1 | tee ${cluster_creation_log}
 
       # Exit if test succeeded
-      [[ "$(get_test_return_code)" == "0" ]] && return
-      # If test failed not because of cluster creation stockout, return
-      [[ -z "$(grep -Eio 'does not have enough resources available to fulfill' ${cluster_creation_log})" ]] && return
+      [[ "$(get_test_return_code)" == "0" ]] && return 0
+      # Retry if cluster creation failed because of:
+      # - stockout (https://github.com/knative/test-infra/issues/592)
+      # - latest GKE not available in this region/zone yet (https://github.com/knative/test-infra/issues/694)
+      [[ -z "$(grep -Fo 'does not have enough resources available to fulfill' ${cluster_creation_log})" \
+          && -z "$(grep -Fo 'ResponseError: code=400, message=No valid versions with the prefix' ${cluster_creation_log})" ]] \
+          && return 1
     done
   done
+  echo "No more region/zones to try, quitting"
+  return 1
 }
 
 # Setup the test cluster for running the tests.


### PR DESCRIPTION
During a GKE update, the particular latest version might not be available yet in the particular region/zone we're trying to create the test cluster. A simple solution is to just try again in a backup region/zone.

Fixes #694.