### PR TITLE
Fixes flaky knative serving install

### DIFF
--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -314,6 +314,7 @@ function setup_test_cluster() {
   set +o pipefail
 
   if (( ! SKIP_KNATIVE_SETUP )) && function_exists knative_setup; then
+    echo "Waiting for Istio installation to complete before starting knative_setup"
     (( ! SKIP_ISTIO_ADDON )) && (wait_until_batch_job_complete istio-system || return 1)
     knative_setup || fail_test "Knative setup failed"
   fi

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -279,7 +279,7 @@ function setup_test_cluster() {
   header "Setting up test cluster"
 
   # Set the actual project the test cluster resides in
-  # It will be a project assigned by Boskos if test is running on Prow, 
+  # It will be a project assigned by Boskos if test is running on Prow,
   # otherwise will be ${GCP_PROJECT} set up by user.
   readonly export E2E_PROJECT_ID="$(gcloud config get-value project)"
 
@@ -314,6 +314,7 @@ function setup_test_cluster() {
   set +o pipefail
 
   if (( ! SKIP_KNATIVE_SETUP )) && function_exists knative_setup; then
+    (( ! SKIP_ISTIO_ADDON )) && (wait_until_batch_job_complete istio-system || return 1)
     knative_setup || fail_test "Knative setup failed"
   fi
   if function_exists test_setup; then

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -314,7 +314,7 @@ function setup_test_cluster() {
   set +o pipefail
 
   if (( ! SKIP_KNATIVE_SETUP )) && function_exists knative_setup; then
-    echo "Waiting for Istio installation to complete before starting knative_setup"
+    # Wait for Istio installation to complete, if necessary, before calling knative_setup.
     (( ! SKIP_ISTIO_ADDON )) && (wait_until_batch_job_complete istio-system || return 1)
     knative_setup || fail_test "Knative setup failed"
   fi

--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -337,7 +337,8 @@ function start_latest_knative_serving() {
   # and when the resources that references those CRDs are created.
   # The current workaround is to re-apply serving.yaml if it fails. Remove the retry logic after the
   # race condition is fixed. (https://github.com/knative/serving/issues/4176)
-  if [[ `kubectl apply -f ${KNATIVE_SERVING_RELEASE}` ]]; then
+  if ! kubectl apply -f ${KNATIVE_SERVING_RELEASE}; then
+    echo "Install failed, waiting 60s and then retrying..."
     sleep 60
     kubectl apply -f ${KNATIVE_SERVING_RELEASE} || return 1
   fi

--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -332,8 +332,37 @@ function start_latest_knative_serving() {
   header "Starting Knative Serving"
   subheader "Installing Knative Serving"
   echo "Installing Serving from ${KNATIVE_SERVING_RELEASE}"
-  kubectl apply -f ${KNATIVE_SERVING_RELEASE} || return 1
+  # Some CRDs defined in serving YAML are also referenced by other components in serving. As it takes
+  # time for CRDs to become effective, there is a race condition between when the CRDs are effective
+  # and when the resources that references those CRDs are created.
+  # The current workaround is to re-apply serving.yaml if it fails. Remove the retry logic after the
+  # race condition is fixed.
+  execute_with_retries 30 3 kubectl apply -f ${KNATIVE_SERVING_RELEASE} || return 1
   wait_until_pods_running knative-serving || return 1
+}
+
+# Retry the command a certain number of times before failing it
+# Parameters: $1 - the time to wait before the next retry
+#             $2 - the max number of retries
+#             $3..$n - function to call and its parameters.
+function execute_with_retries() {
+  local runs=0
+  local wt=${1}
+  local ntries=${2}
+  shift 2
+
+  until ${@}; do
+    retval=$?
+    runs=$(($runs + 1))
+    if [[ ${runs} -lt ${ntries} ]]; then
+      echo "'${@}' exited ${retval}, current run: ${runs}, max retries: ${ntries}, retrying in ${wt} seconds."
+      sleep ${wt}
+    else
+      echo "'${@}' exited ${retval}, current run: ${runs}, max retries: ${ntries}, no more retries left."
+      return ${retval}
+    fi
+  done
+  return 0
 }
 
 # Run a go tool, installing it first if necessary.

--- a/test/unit/library-tests.sh
+++ b/test/unit/library-tests.sh
@@ -68,6 +68,11 @@ test_function ${FAILURE} "" is_protected_project "knative-foobar"
 test_function ${FAILURE} "" is_protected_project "foobar-tests"
 test_function ${FAILURE} "" is_protected_project ""
 
+test_function ${SUCCESS} "" execute_with_retries 3 5 true
+test_function ${FAILURE} "false' exited 1, current run: 1, max retries: 3, retrying in 1 seconds.
+'false' exited 1, current run: 2, max retries: 3, retrying in 1 seconds.
+'false' exited 1, current run: 3, max retries: 3, no more retries left." execute_with_retries 1 3 false
+
 echo ">> Testing report_go_test()"
 
 test_report TestSucceeds "^--- PASS: TestSucceeds"

--- a/test/unit/library-tests.sh
+++ b/test/unit/library-tests.sh
@@ -68,11 +68,6 @@ test_function ${FAILURE} "" is_protected_project "knative-foobar"
 test_function ${FAILURE} "" is_protected_project "foobar-tests"
 test_function ${FAILURE} "" is_protected_project ""
 
-test_function ${SUCCESS} "" execute_with_retries 3 5 true
-test_function ${FAILURE} "false' exited 1, current run: 1, max retries: 3, retrying in 1 seconds.
-'false' exited 1, current run: 2, max retries: 3, retrying in 1 seconds.
-'false' exited 1, current run: 3, max retries: 3, no more retries left." execute_with_retries 1 3 false
-
 echo ">> Testing report_go_test()"
 
 test_report TestSucceeds "^--- PASS: TestSucceeds"


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes flaky knative serving install
* wait on istio components to be installed before installing knative-serving
* retry the knative-serving install if it fails

Part of #829
