### PR TITLE
install knative serving in two steps

### DIFF
--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -331,17 +331,10 @@ function report_go_test() {
 function start_latest_knative_serving() {
   header "Starting Knative Serving"
   subheader "Installing Knative Serving"
-  echo "Installing Serving from ${KNATIVE_SERVING_RELEASE}"
-  # Some CRDs defined in serving YAML are also referenced by other components in serving. As it takes
-  # time for CRDs to become effective, there is a race condition between when the CRDs are effective
-  # and when the resources that references those CRDs are created.
-  # The current workaround is to re-apply serving.yaml if it fails. Remove the retry logic after the
-  # race condition is fixed. (https://github.com/knative/serving/issues/4176)
-  if ! kubectl apply -f ${KNATIVE_SERVING_RELEASE}; then
-    echo "Install failed, waiting 60s and then retrying..."
-    sleep 60
-    kubectl apply -f ${KNATIVE_SERVING_RELEASE} || return 1
-  fi
+  echo "Installing Serving CRDs from ${KNATIVE_SERVING_RELEASE}"
+  kubectl apply --selector knative.dev/crd-install=true -f ${KNATIVE_SERVING_RELEASE}
+  echo "Installing the rest of serving components from ${KNATIVE_SERVING_RELEASE}"
+  kubectl apply -f ${KNATIVE_SERVING_RELEASE}
   wait_until_pods_running knative-serving || return 1
 }
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Part of #https://github.com/knative/test-infra/issues/829

Testing done: 
Ran around e2e-tests on test-infra multiple times. In cases where there's below error when running 
`kubectl apply --selector knative.dev/crd-install=true -f ${KNATIVE_SERVING_RELEASE}`, the second install of all components always succeed. 

```
error: unable to recognize "https://storage.googleapis.com/knative-nightly/serving/latest/serving.yaml": no matches for kind "Image" in version "caching.internal.knative.dev/v1alpha1"
```

No failed e2e-test on test-infra when tested multiple times on personal gcp project with the current change. 