### PR TITLE
Allow standard install of a custom Knative Serving

### DIFF
--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -333,9 +333,9 @@ function start_knative_serving() {
   header "Starting Knative Serving"
   subheader "Installing Knative Serving"
   echo "Installing Serving CRDs from $1"
-  kubectl apply --selector knative.dev/crd-install=true -f $1
+  kubectl apply --selector knative.dev/crd-install=true -f "$1"
   echo "Installing the rest of serving components from $1"
-  kubectl apply -f $1
+  kubectl apply -f "$1"
   wait_until_pods_running knative-serving || return 1
 }
 

--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -327,15 +327,21 @@ function report_go_test() {
   return ${failed}
 }
 
-# Install the latest stable Knative/serving in the current cluster.
-function start_latest_knative_serving() {
+# Install Knative Serving in the current cluster.
+# Parameters: $1 - Knative Serving manifest.
+function start_knative_serving() {
   header "Starting Knative Serving"
   subheader "Installing Knative Serving"
-  echo "Installing Serving CRDs from ${KNATIVE_SERVING_RELEASE}"
-  kubectl apply --selector knative.dev/crd-install=true -f ${KNATIVE_SERVING_RELEASE}
-  echo "Installing the rest of serving components from ${KNATIVE_SERVING_RELEASE}"
-  kubectl apply -f ${KNATIVE_SERVING_RELEASE}
+  echo "Installing Serving CRDs from $1"
+  kubectl apply --selector knative.dev/crd-install=true -f $1
+  echo "Installing the rest of serving components from $1"
+  kubectl apply -f $1
   wait_until_pods_running knative-serving || return 1
+}
+
+# Install the latest stable Knative Serving in the current cluster.
+function start_latest_knative_serving() {
+  start_knative_serving "${KNATIVE_SERVING_RELEASE}"
 }
 
 # Run a go tool, installing it first if necessary.


### PR DESCRIPTION
Delegate the process in `start_latest_knative_serving()` to `start_knative_serving()` to the standard install can be used for custom testing as well.

Part of knative/serving#4202