### PR TITLE
Cluster creation retry catching GKE version not supported error

### DIFF
--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -263,6 +263,7 @@ function create_test_cluster_with_retries() {
       # - latest GKE not available in this region/zone yet (https://github.com/knative/test-infra/issues/694)
       [[ -z "$(grep -Fo 'does not have enough resources available to fulfill' ${cluster_creation_log})" \
           && -z "$(grep -Fo 'ResponseError: code=400, message=No valid versions with the prefix' ${cluster_creation_log})" ]] \
+          && -z "$(grep -Po 'ResponseError: code=400, message=Master version "[0-9a-z\-\.]+" is unsupported' ${cluster_creation_log})" ]] \
           && return 1
     done
   done


### PR DESCRIPTION
There is another error related to latest GKE version: `ERROR: (gcloud.beta.container.clusters.create) ResponseError: code=400, message=Master version "1.13.6-gke.5" is unsupported.`, catch it for retry. 
https://gubernator.knative.dev/build/knative-prow/pr-logs/pull/knative_test-infra/853/pull-knative-test-infra-integration-tests/1135599495438929921/
