### PR TITLE
Adding CloudRunEvents to tide.

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -64,6 +64,7 @@ tide:
     - knative/caching
     - knative/website
     - knative/community
+    - GoogleCloudPlatform/cloud-run-events
     labels:
     - lgtm
     - approved

--- a/ci/prow/templates/prow_config_header.yaml
+++ b/ci/prow/templates/prow_config_header.yaml
@@ -69,6 +69,7 @@ tide:
     - knative/caching
     - knative/website
     - knative/community
+    - GoogleCloudPlatform/cloud-run-events
     labels:
     - lgtm
     - approved


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
CloudRunEvents are for Knative Eventing
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
