### PR TITLE
add knative-metrics-robot to coverage tool & config

### DIFF
--- a/tools/coverage/main.go
+++ b/tools/coverage/main.go
@@ -50,14 +50,14 @@ func main() {
 	coverageProfileName := flag.String("profile-name", defaultCoverageProfileName, "file name for coverage profile")
 	githubTokenPath := flag.String("github-token", "", "path to token to access github repo")
 	covThresholdFlag := flag.Int("cov-threshold-percentage", defaultCovThreshold, "token to access github repo")
-	covbotUserName := flag.String("covbot-username", "covbot", "github user name for coverage robot")
+	postingBotUserName := flag.String("posting-robot", "knative-metrics-robot", "github user name for coverage robot")
 	flag.Parse()
 
 	log.Printf("container flag list: postsubmit-gcs-bucket=%s; postSubmitJobName=%s; "+
 		"artifacts=%s; cov-target=%s; profile-name=%s; github-token=%s; "+
-		"cov-threshold-percentage=%d; covbot-username=%s;",
+		"cov-threshold-percentage=%d; posting-robot=%s;",
 		*gcsBucketName, *postSubmitJobName, *artifactsDir, *coverageTargetDir, *coverageProfileName,
-		*githubTokenPath, *covThresholdFlag, *covbotUserName)
+		*githubTokenPath, *covThresholdFlag, *postingBotUserName)
 
 	log.Println("Getting env values")
 	pr := os.Getenv("PULL_NUMBER")
@@ -88,7 +88,7 @@ func main() {
 				buildStr, err)
 		}
 
-		prData := githubPr.New(*githubTokenPath, repoOwner, repoName, pr, *covbotUserName)
+		prData := githubPr.New(*githubTokenPath, repoOwner, repoName, pr, *postingBotUserName)
 		gcsData := &gcs.PresubmitBuild{GcsBuild: gcs.GcsBuild{
 			StorageClient: gcs.NewStorageClient(prData.Ctx),
 			Bucket:        *gcsBucketName,


### PR DESCRIPTION
The rename from covbot to knative-metrics-robot prevents garbage collection of bot comments.


<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #863 

**Special notes to reviewers**:

**User-visible changes in this PR**:

