### PR TITLE
Fix knative-serving/conformance-tests TestGrid tab

### DIFF
--- a/ci/prow/make_config.go
+++ b/ci/prow/make_config.go
@@ -1171,7 +1171,7 @@ func generateDashboard(repoName string, jobNames []string) {
 			executeDashboardTabTemplate("continuous", testGroupName, testgridTabSortByName, noExtras)
 			// This is a special case for knative/serving, as conformance-tests tab is just a filtered view of the continuous tab.
 			if repoName == "knative-serving" {
-				executeDashboardTabTemplate("conformance-tests", testGroupName, "include-filter-by-regex=test/conformance\\\\.&sort-by-name=", noExtras)
+				executeDashboardTabTemplate("conformance-tests", testGroupName, "include-filter-by-regex=test/conformance/&sort-by-name=", noExtras)
 			}
 		case "dot-release", "auto-release", "performance", "performance-mesh", "latency", "playground":
 			extras := make(map[string]string)

--- a/ci/testgrid/config.yaml
+++ b/ci/testgrid/config.yaml
@@ -225,7 +225,7 @@ dashboards:
     base_options: "sort-by-name="
   - name: conformance-tests
     test_group_name: ci-knative-serving-continuous
-    base_options: "include-filter-by-regex=test/conformance\\.&sort-by-name="
+    base_options: "include-filter-by-regex=test/conformance/&sort-by-name="
   - name: istio-1.0.7-mesh
     test_group_name: ci-knative-serving-istio-1.0.7-mesh
     base_options: "sort-by-name="


### PR DESCRIPTION
The conformance tests package path changed after knative/serving#4145.

Fixes #869.