### PR TITLE
Prow version auto bumper part 3: Update Prow versions and create PullRequest

### DIFF
--- a/shared/ghutil/client.go
+++ b/shared/ghutil/client.go
@@ -53,6 +53,8 @@ type GithubOperations interface {
 	EditComment(org, repo string, commentID int64, commentBody string) error
 	AddLabelsToIssue(org, repo string, issueNumber int, labels []string) error
 	RemoveLabelForIssue(org, repo string, issueNumber int, label string) error
+	GetPullRequest(org, repo string, ID int) (*github.PullRequest, error)
+	EditPullRequest(org, repo string, ID int, title, body string) (*github.PullRequest, error)
 	ListPullRequests(org, repo, head, base string) ([]*github.PullRequest, error)
 	ListCommits(org, repo string, ID int) ([]*github.RepositoryCommit, error)
 	ListFiles(org, repo string, ID int) ([]*github.CommitFile, error)

--- a/shared/ghutil/fakeghutil/fakeghutil.go
+++ b/shared/ghutil/fakeghutil/fakeghutil.go
@@ -242,6 +242,27 @@ func (fgc *FakeGithubClient) ListFiles(org, repo string, ID int) ([]*github.Comm
 	return res, nil
 }
 
+// GetPullRequest gets PullRequest by ID
+func (fgc *FakeGithubClient) GetPullRequest(org, repo string, ID int) (*github.PullRequest, error) {
+	if PRs, ok := fgc.PullRequests[repo]; ok {
+		if PR, ok := PRs[ID]; ok {
+			return PR, nil
+		}
+	}
+	return nil, fmt.Errorf("PR not exist: '%d'", ID)
+}
+
+// EditPullRequest updates PullRequest
+func (fgc *FakeGithubClient) EditPullRequest(org, repo string, ID int, title, body string) (*github.PullRequest, error) {
+	PR, err := fgc.GetPullRequest(org, repo, ID)
+	if nil != err {
+		return nil, err
+	}
+	PR.Title = &title
+	PR.Body = &body
+	return PR, nil
+}
+
 // CreatePullRequest creates PullRequest, passing head user and branch name "user:ref-name", and base branch name like "master"
 func (fgc *FakeGithubClient) CreatePullRequest(org, repo, head, base, title, body string) (*github.PullRequest, error) {
 	PRNumber := fgc.getNextNumber()

--- a/shared/ghutil/pullrequest.go
+++ b/shared/ghutil/pullrequest.go
@@ -117,6 +117,45 @@ func (gc *GithubClient) ListFiles(org, repo string, ID int) ([]*github.CommitFil
 	return res, err
 }
 
+// GetPullRequest gets PullRequest by ID
+func (gc *GithubClient) GetPullRequest(org, repo string, ID int) (*github.PullRequest, error) {
+	var res *github.PullRequest
+	_, err := gc.retry(
+		fmt.Sprintf("Get PullRequest '%d'", ID),
+		maxRetryCount,
+		func() (*github.Response, error) {
+			var resp *github.Response
+			var err error
+			res, resp, err = gc.Client.PullRequests.Get(ctx, org, repo, ID)
+			return resp, err
+		},
+	)
+	return res, err
+}
+
+// EditPullRequest updates PullRequest
+func (gc *GithubClient) EditPullRequest(org, repo string, ID int, title, body string) (*github.PullRequest, error) {
+	PR, err := gc.GetPullRequest(org, repo, ID)
+	if nil != err || nil == PR {
+		return nil, err
+	}
+
+	PR.Title = &title
+	PR.Body = &body
+	var res *github.PullRequest
+	_, err = gc.retry(
+		fmt.Sprintf("Update PullRequest '%d', title: '%s'. body: '%s'", ID, title, body),
+		maxRetryCount,
+		func() (*github.Response, error) {
+			var resp *github.Response
+			var err error
+			res, resp, err = gc.Client.PullRequests.Edit(ctx, org, repo, ID, PR)
+			return resp, err
+		},
+	)
+	return res, err
+}
+
 // CreatePullRequest creates PullRequest, passing head user and branch name "user:ref-name", and base branch name like "master"
 func (gc *GithubClient) CreatePullRequest(org, repo, head, base, title, body string) (*github.PullRequest, error) {
 	b := true

--- a/tools/prow-auto-bumper/config.go
+++ b/tools/prow-auto-bumper/config.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/google/go-github/github"
+	"github.com/knative/test-infra/shared/ghutil"
+)
+
+const (
+	// Git info for k8s Prow auto bumper PRs
+	srcOrg  = "kubernetes"
+	srcRepo = "test-infra"
+	// srcPRHead is the head branch of k8s auto version bump PRs
+	// TODO(chaodaiG): using head branch querying is less ideal than using
+	// label `area/prow/bump`, which is not supported by Github API yet. Move
+	// to filter using this label once it's supported
+	srcPRHead = "autobump"
+	// srcPRBase is the base branch of k8s auto version bump PRs
+	srcPRBase = "master"
+	// srcPRUserID is the user from which PR was created
+	srcPRUserID = "k8s-ci-robot"
+
+	// Git info for target repo that Prow version bump PR targets
+	org  = "knative"
+	repo = "test-infra"
+	// PRHead is branch name where the changes occur
+	PRHead = "autobump"
+	// PRBase is the branch name where PR targets
+	PRBase = "master"
+
+	// Index for regex matching groups
+	imageImagePart = 1 // first group is image part
+	imageTagPart   = 2 // second group is tag part
+	// Max delta away from target date
+	maxDelta = 2 * 24 // 2 days
+	// K8s updates Prow versions everyday, which should be ~24 hours,
+	// if a version is updated within 12 hours, it's considered not safe
+	safeDuration = 12 // 12 hours
+	maxRetry     = 3
+
+	oncallAddress = "https://storage.googleapis.com/knative-infra-oncall/oncall.json"
+)
+
+var (
+	// Whitelist of files to be scanned by this tool
+	fileFilters = []*regexp.Regexp{regexp.MustCompile(`\.yaml$`)}
+	// matching            gcr.io /k8s-(prow|testimage)/(tide|kubekin-e2e|.*)    :vYYYYMMDD-HASH-VARIANT
+	imagePattern     = `\b(gcr\.io/k8s[a-z0-9-]{5,29}/[a-zA-Z0-9][a-zA-Z0-9_.-]+):(v[a-zA-Z0-9_.-]+)\b`
+	imageRegexp      = regexp.MustCompile(imagePattern)
+	imageLinePattern = fmt.Sprintf(`\s+[a-z]+:\s+"?'?%s"?'?`, imagePattern)
+	// matching   "-    image: gcr.io /k8s-(prow|testimage)/(tide|kubekin-e2e|.*)    :vYYYYMMDD-HASH-VARIANT"
+	imageMinusRegexp = regexp.MustCompile(fmt.Sprintf(`\-%s`, imageLinePattern))
+	// matching   "+    image: gcr.io /k8s-(prow|testimage)/(tide|kubekin-e2e|.*)    :vYYYYMMDD-HASH-VARIANT"
+	imagePlusRegexp = regexp.MustCompile(fmt.Sprintf(`\+%s`, imageLinePattern))
+	// Preferred time for candidate PR creation date
+	targetTime = time.Now().Add(-time.Hour * 7 * 24) // 7 days
+)
+
+// GHClientWrapper handles methods for github issues
+type GHClientWrapper struct {
+	ghutil.GithubOperations
+}
+
+type gitInfo struct {
+	org      string
+	repo     string
+	head     string // PR head branch
+	base     string // PR base branch
+	userID   string // Github User ID of PR creator
+	userName string // User display name for Git commit
+	email    string // User email address for Git commit
+}
+
+// HeadRef is in the form of "user:head", i.e. "github_user:branch_foo"
+func (gi *gitInfo) getHeadRef() string {
+	return fmt.Sprintf("%s:%s", gi.userID, gi.head)
+}
+
+// versions holds the version change for an image
+// oldVersion and newVersion are both in the format of "vYYYYMMDD-HASH-VARIANT"
+type versions struct {
+	oldVersion string
+	newVersion string
+	variant    string
+}
+
+// PRVersions contains PR and version changes in it
+type PRVersions struct {
+	images map[string][]versions // map of image name: versions struct
+	// The way k8s updates versions doesn't guarantee the same version tag across all images,
+	// dominantVersions is the version that appears most times
+	dominantVersions *versions
+	PR               *github.PullRequest
+}
+
+// Helper method for adding a newly discovered tag into pv
+func (pv *PRVersions) getIndex(image, tag string) int {
+	if _, ok := pv.images[image]; !ok {
+		pv.images[image] = make([]versions, 0, 0)
+	}
+	_, variant := deconstructTag(tag)
+	iv := -1
+	for i, vs := range pv.images[image] {
+		if vs.variant == variant {
+			iv = i
+			break
+		}
+	}
+	if -1 == iv {
+		pv.images[image] = append(pv.images[image], versions{variant: variant})
+		iv = len(pv.images[image]) - 1
+	}
+	return iv
+}

--- a/tools/prow-auto-bumper/file.go
+++ b/tools/prow-auto-bumper/file.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+func cdToRootDir() error {
+	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	output, err := cmd.Output()
+	if err != nil {
+		return err
+	}
+	d := strings.TrimSpace(string(output))
+	log.Printf("Changing working directory to %s...", d)
+	return os.Chdir(d)
+}
+
+func call(cmd string, args ...string) error {
+	c := exec.Command(cmd, args...)
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	return c.Run()
+}
+
+// update all tags in a byte slice
+func updateAllTags(pv *PRVersions, content []byte, imageFilter *regexp.Regexp) ([]byte, string, []string) {
+	var msg string
+	var errMsgs []string
+	indexes := imageFilter.FindAllSubmatchIndex(content, -1)
+	// Not finding any images is not an error.
+	if indexes == nil {
+		return content, msg, errMsgs
+	}
+
+	var res string
+	lastIndex := 0
+	for _, m := range indexes {
+		res += string(content[lastIndex : m[imageImagePart*2+1]+1])
+		image := string(content[m[imageImagePart*2]:m[imageImagePart*2+1]])
+		tag := string(content[m[imageTagPart*2]:m[imageTagPart*2+1]])
+		lastIndex = m[1]
+
+		iv := pv.getIndex(image, tag)
+		if "" != pv.images[image][iv].newVersion {
+			res += pv.images[image][iv].newVersion
+			msg += fmt.Sprintf("\nImage: %s\nOld Tag: %s\nNew Tag: %s", image, tag, pv.images[image][iv].newVersion)
+		} else {
+			errMsg := fmt.Sprintf("Cannot find version for image: '%s:%s'.\n", image, tag)
+			log.Println(errMsg)
+			errMsgs = append(errMsgs, errMsg)
+			res += tag
+		}
+	}
+	res += string(content[lastIndex:])
+
+	return []byte(res), msg, errMsgs
+}
+
+// updateFile updates a file in place.
+func updateFile(pv *PRVersions, filename string, imageFilter *regexp.Regexp, dryrun bool) ([]string, error) {
+	var errMsgs []string
+	content, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return errMsgs, fmt.Errorf("failed to read %s: %v", filename, err)
+	}
+
+	newContent, msg, errMsgs := updateAllTags(pv, content, imageFilter)
+	if err := run(
+		fmt.Sprintf("Update file '%s':%s", filename, msg),
+		func() error {
+			return ioutil.WriteFile(filename, newContent, 0644)
+		},
+		dryrun); err != nil {
+		return errMsgs, fmt.Errorf("failed to write %s: %v", filename, err)
+	}
+	return errMsgs, nil
+}
+
+func updateAllFiles(pv *PRVersions, fileFilters []*regexp.Regexp, imageFilter *regexp.Regexp,
+	dryrun bool) ([]string, error) {
+	var errMsgs []string
+	if err := cdToRootDir(); err != nil {
+		return errMsgs, fmt.Errorf("failed to change to root dir")
+	}
+
+	err := filepath.Walk(".", func(filename string, info os.FileInfo, err error) error {
+		for _, ff := range fileFilters {
+			if ff.Match([]byte(filename)) {
+				msgs, err := updateFile(pv, filename, imageFilter, dryrun)
+				errMsgs = append(errMsgs, msgs...)
+				if err != nil {
+					return fmt.Errorf("Failed to update path %s '%v'", filename, err)
+				}
+			}
+		}
+		return nil
+	})
+	return errMsgs, err
+}

--- a/tools/prow-auto-bumper/main.go
+++ b/tools/prow-auto-bumper/main.go
@@ -23,9 +23,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
-	"math"
 	"regexp"
-	"strings"
 	"time"
 
 	"github.com/google/go-github/github"
@@ -33,26 +31,43 @@ import (
 )
 
 const (
-	org  = "kubernetes"
-	repo = "test-infra"
-	// PRHead is the head branch of k8s auto version bump PRs
+	// Git info for k8s Prow auto bumper PRs
+	srcOrg  = "kubernetes"
+	srcRepo = "test-infra"
+	// srcPRHead is the head branch of k8s auto version bump PRs
 	// TODO(chaodaiG): using head branch querying is less ideal than using
 	// label `area/prow/bump`, which is not supported by Github API yet. Move
 	// to filter using this label once it's supported
-	PRHead = "k8s-ci-robot:autobump"
-	// PRBase is the base branch of k8s auto version bump PRs
+	srcPRHead = "autobump"
+	// srcPRBase is the base branch of k8s auto version bump PRs
+	srcPRBase = "master"
+	// srcPRUserID is the user from which PR was created
+	srcPRUserID = "k8s-ci-robot"
+
+	// Git info for target repo that Prow version bump PR targets
+	org  = "knative"
+	repo = "test-infra"
+	// PRHead is branch name where the changes occur
+	PRHead = "autobump"
+	// PRBase is the branch name where PR targets
 	PRBase = "master"
+
 	// Index for regex matching groups
-	imageImagePart = 1
-	imageTagPart   = 2
-	// Max difference away from target date
+	imageImagePart = 1 // first group is image part
+	imageTagPart   = 2 // second group is tag part
+	// Max delta away from target date
 	maxDelta = 2 * 24 // 2 days
-	// Safe duration is the smallest amount of hours a version stayed
+	// K8s updates Prow versions everyday, which should be ~24 hours,
+	// if a version is updated within 12 hours, it's considered not safe
 	safeDuration = 12 // 12 hours
 	maxRetry     = 3
+
+	oncallAddress = "https://storage.googleapis.com/knative-infra-oncall/oncall.json"
 )
 
 var (
+	// Whitelist of files to be scanned by this tool
+	fileFilters = []*regexp.Regexp{regexp.MustCompile(`\.yaml$`)}
 	// matching            gcr.io /k8s-(prow|testimage)/(tide|kubekin-e2e|.*)    :vYYYYMMDD-HASH-VARIANT
 	imagePattern     = `\b(gcr\.io/k8s[a-z0-9-]{5,29}/[a-zA-Z0-9][a-zA-Z0-9_.-]+):(v[a-zA-Z0-9_.-]+)\b`
 	imageRegexp      = regexp.MustCompile(imagePattern)
@@ -68,6 +83,21 @@ var (
 // GHClientWrapper handles methods for github issues
 type GHClientWrapper struct {
 	ghutil.GithubOperations
+}
+
+type gitInfo struct {
+	org      string
+	repo     string
+	head     string // PR head branch
+	base     string // PR base branch
+	userID   string // Github User ID of PR creator
+	userName string // User display name for Git commit
+	email    string // User email address for Git commit
+}
+
+// HeadRef is in the form of "user:head", i.e. "github_user:branch_foo"
+func (gi *gitInfo) getHeadRef() string {
+	return fmt.Sprintf("%s:%s", gi.userID, gi.head)
 }
 
 // versions holds the version change for an image
@@ -87,188 +117,55 @@ type PRVersions struct {
 	PR               *github.PullRequest
 }
 
-// Helper method for adding a newly discovered tag into pv
-func (pv *PRVersions) getIndex(image, tag string) int {
-	if _, ok := pv.images[image]; !ok {
-		pv.images[image] = make([]versions, 0, 0)
-	}
-	_, variant := deconstructTag(tag)
-	iv := -1
-	for i, vs := range pv.images[image] {
-		if vs.variant == variant {
-			iv = i
-			break
-		}
-	}
-	if -1 == iv {
-		pv.images[image] = append(pv.images[image], versions{variant: variant})
-		iv = len(pv.images[image]) - 1
-	}
-	return iv
-}
-
-// Tags could be in the form of: v[YYYYMMDD]-[GIT_HASH](-[VARIANT_PART]),
-// separate it to `v[YYYYMMDD]-[GIT_HASH]` and `[VARIANT_PART]`
-func deconstructTag(in string) (string, string) {
-	dateCommit := in
-	var variant string
-	parts := strings.Split(in, "-")
-	if len(parts) > 2 {
-		variant = strings.Join(parts[2:], "-")
-	}
-	if len(parts) > 1 {
-		dateCommit = fmt.Sprintf("%s-%s", parts[0], parts[1])
-	}
-	return dateCommit, variant
-}
-
-// get key with highest value
-func getDominantKey(m map[string]int) string {
-	var res string
-	for key, v := range m {
-		if "" == res || v > m[res] {
-			res = key
-		}
-	}
-	return res
-}
-
-func (pv *PRVersions) getDominantVersions() versions {
-	if nil != pv.dominantVersions {
-		return *pv.dominantVersions
-	}
-
-	cOld := make(map[string]int)
-	cNew := make(map[string]int)
-	for _, vss := range pv.images {
-		for _, vs := range vss {
-			normOldTag, _ := deconstructTag(vs.oldVersion)
-			normNewTag, _ := deconstructTag(vs.newVersion)
-			cOld[normOldTag]++
-			cNew[normNewTag]++
-		}
-	}
-
-	pv.dominantVersions = &versions{
-		oldVersion: getDominantKey(cOld),
-		newVersion: getDominantKey(cNew),
-	}
-
-	return *pv.dominantVersions
-}
-
-// parse changelist, find all version changes, and store them in image name: versions map
-func (pv *PRVersions) parseChangelist(gcw *GHClientWrapper) error {
-	fs, err := gcw.ListFiles(org, repo, *pv.PR.Number)
-	if nil != err {
-		return err
-	}
-	for _, f := range fs {
-		if nil == f.Patch {
-			continue
-		}
-		minuses := imageMinusRegexp.FindAllStringSubmatch(*f.Patch, -1)
-		for _, minus := range minuses {
-			iv := pv.getIndex(minus[imageImagePart], minus[imageTagPart])
-			pv.images[minus[imageImagePart]][iv].oldVersion = minus[imageTagPart]
-		}
-
-		pluses := imagePlusRegexp.FindAllStringSubmatch(*f.Patch, -1)
-		for _, plus := range pluses {
-			iv := pv.getIndex(plus[imageImagePart], plus[imageTagPart])
-			pv.images[plus[imageImagePart]][iv].newVersion = plus[imageTagPart]
-		}
-	}
-
-	return nil
-}
-
-// Query all PRs from "k8s-ci-robot:autobump", find PR roughly 7 days old and was not reverted later.
-// Only return error if it's github related
-func getBestVersion(gcw *GHClientWrapper, org, repo, head, base string) (*PRVersions, error) {
-	visited := make(map[string]PRVersions)
-	var bestPv *PRVersions
-	var overallErr error
-	var bestDelta float64 = maxDelta + 1
-	PRs, err := gcw.ListPullRequests(org, repo, head, base)
-	if nil != err {
-		return bestPv, fmt.Errorf("failed list pull request: '%v'", err)
-	}
-
-	for _, PR := range PRs {
-		if nil == PR.State || string(ghutil.PullRequestCloseState) != *PR.State {
-			continue
-		}
-		delta := targetTime.Sub(*PR.CreatedAt).Hours()
-		if delta > maxDelta {
-			break // Over 9 days old, too old
-		}
-		pv := PRVersions{
-			images: make(map[string][]versions),
-			PR:     PR,
-		}
-		if err := pv.parseChangelist(gcw); nil != err {
-			overallErr = fmt.Errorf("failed listing files from PR '%d': '%v'", *PR.Number, err)
-			break
-		}
-		vs := pv.getDominantVersions()
-		if "" == vs.oldVersion || "" == vs.newVersion {
-			log.Printf("Warning: found PR misses version change '%d'", *PR.Number)
-			continue
-		}
-		visited[vs.oldVersion] = pv
-		// check if too fresh here as need the data in visited
-		if delta < -maxDelta { // In past 5 days, too fresh
-			continue
-		}
-		if updatePR, ok := visited[vs.newVersion]; ok {
-			if updatePR.getDominantVersions().newVersion == vs.oldVersion { // The updatePR is reverting this PR
-				continue
-			}
-			if updatePR.PR.CreatedAt.Before(PR.CreatedAt.Add(time.Hour * safeDuration)) {
-				// The update PR is within 12 hours of current PR, consider unsafe
-				continue
-			}
-		}
-		if nil == bestPv || math.Abs(delta) < math.Abs(bestDelta) {
-			bestDelta = delta
-			bestPv = &pv
-		}
-	}
-	return bestPv, overallErr
-}
-
-func retryGetBestVersion(gcw *GHClientWrapper, org, repo, head, base string) (*PRVersions, error) {
-	var bestPv *PRVersions
-	var overallErr error
-	// retry if there is github related error
-	for retryCount := 0; nil == overallErr && retryCount < maxRetry; retryCount++ {
-		bestPv, overallErr = getBestVersion(gcw, org, repo, head, base)
-		if nil != overallErr {
-			log.Println(overallErr)
-			if maxRetry-1 != retryCount {
-				log.Printf("Retry #%d", retryCount+1)
-			}
-		}
-	}
-	return bestPv, overallErr
-}
-
 func main() {
 	githubAccount := flag.String("github-account", "", "Token file for Github authentication")
+	gitUserID := flag.String("git-userid", "", "The github ID of user for hosting fork, i.e. Github ID of bot")
+	gitUserName := flag.String("git-username", "", "The username to use on the git commit. Requires --git-email")
+	gitEmail := flag.String("git-email", "", "The email to use on the git commit. Requires --git-username")
+	dryrun := flag.Bool("dry-run", false, "dry run switch")
 	flag.Parse()
+
+	if nil != dryrun && true == *dryrun {
+		log.Println("running in [dry run mode]")
+	}
 
 	gc, err := ghutil.NewGithubClient(*githubAccount)
 	if nil != err {
 		log.Fatalf("cannot authenticate to github: %v", err)
 	}
-	gcw := &GHClientWrapper{gc}
 
-	bestVersion, err := retryGetBestVersion(gcw, org, repo, PRHead, PRBase)
-	if nil != err {
-		log.Fatalf("cannot get best version from %s/%s: '%v'", org, repo, err)
+	srcGI := gitInfo{
+		org:    srcOrg,
+		repo:   srcRepo,
+		head:   srcPRHead,
+		base:   srcPRBase,
+		userID: srcPRUserID,
 	}
 
-	log.Println(bestVersion.images)
-	log.Println(bestVersion.dominantVersions)
+	targetGI := gitInfo{
+		org:      org,
+		repo:     repo,
+		head:     PRHead,
+		base:     PRBase,
+		userID:   *gitUserID,
+		userName: *gitUserName,
+		email:    *gitEmail,
+	}
+
+	gcw := &GHClientWrapper{gc}
+	bestVersion, err := retryGetBestVersion(gcw, srcGI)
+	if nil != err {
+		log.Fatalf("cannot get best version from %s/%s: '%v'", srcGI.org, srcGI.repo, err)
+	}
+	log.Printf("Found version to update. Old Version: '%s', New Version: '%s'",
+		bestVersion.dominantVersions.oldVersion, bestVersion.dominantVersions.newVersion)
+
+	errMsgs, err := updateAllFiles(bestVersion, fileFilters, imageRegexp, *dryrun)
+	if nil != err {
+		log.Fatalf("failed updating files: '%v'", err)
+	}
+
+	if err = createOrUpdatePR(gcw, bestVersion, targetGI, errMsgs, *dryrun); nil != err {
+		log.Fatalf("failed creating pullrequest: '%v'", err)
+	}
 }

--- a/tools/prow-auto-bumper/parser.go
+++ b/tools/prow-auto-bumper/parser.go
@@ -1,0 +1,197 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// prow-auto-bumper finds stable Prow components version used by k8s,
+// and creates PRs updating them in knative/test-infra
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"math"
+	"strings"
+	"time"
+
+	"github.com/knative/test-infra/shared/ghutil"
+)
+
+// Helper method for adding a newly discovered tag into pv
+func (pv *PRVersions) getIndex(image, tag string) int {
+	if _, ok := pv.images[image]; !ok {
+		pv.images[image] = make([]versions, 0, 0)
+	}
+	_, variant := deconstructTag(tag)
+	iv := -1
+	for i, vs := range pv.images[image] {
+		if vs.variant == variant {
+			iv = i
+			break
+		}
+	}
+	if -1 == iv {
+		pv.images[image] = append(pv.images[image], versions{variant: variant})
+		iv = len(pv.images[image]) - 1
+	}
+	return iv
+}
+
+// Tags could be in the form of: v[YYYYMMDD]-[GIT_HASH](-[VARIANT_PART]),
+// separate it to `v[YYYYMMDD]-[GIT_HASH]` and `[VARIANT_PART]`
+func deconstructTag(in string) (string, string) {
+	dateCommit := in
+	var variant string
+	parts := strings.Split(in, "-")
+	if len(parts) > 2 {
+		variant = strings.Join(parts[2:], "-")
+	}
+	if len(parts) > 1 {
+		dateCommit = fmt.Sprintf("%s-%s", parts[0], parts[1])
+	}
+	return dateCommit, variant
+}
+
+// get key with highest value
+func getDominantKey(m map[string]int) string {
+	var res string
+	for key, v := range m {
+		if "" == res || v > m[res] {
+			res = key
+		}
+	}
+	return res
+}
+
+func (pv *PRVersions) getDominantVersions() versions {
+	if nil != pv.dominantVersions {
+		return *pv.dominantVersions
+	}
+
+	cOld := make(map[string]int)
+	cNew := make(map[string]int)
+	for _, vss := range pv.images {
+		for _, vs := range vss {
+			normOldTag, _ := deconstructTag(vs.oldVersion)
+			normNewTag, _ := deconstructTag(vs.newVersion)
+			cOld[normOldTag]++
+			cNew[normNewTag]++
+		}
+	}
+
+	pv.dominantVersions = &versions{
+		oldVersion: getDominantKey(cOld),
+		newVersion: getDominantKey(cNew),
+	}
+
+	return *pv.dominantVersions
+}
+
+// parse changelist, find all version changes, and store them in image name: versions map
+func (pv *PRVersions) parseChangelist(gcw *GHClientWrapper, gi gitInfo) error {
+	fs, err := gcw.ListFiles(gi.org, gi.repo, *pv.PR.Number)
+	if nil != err {
+		return err
+	}
+	for _, f := range fs {
+		if nil == f.Patch {
+			continue
+		}
+		minuses := imageMinusRegexp.FindAllStringSubmatch(*f.Patch, -1)
+		for _, minus := range minuses {
+			iv := pv.getIndex(minus[imageImagePart], minus[imageTagPart])
+			pv.images[minus[imageImagePart]][iv].oldVersion = minus[imageTagPart]
+		}
+
+		pluses := imagePlusRegexp.FindAllStringSubmatch(*f.Patch, -1)
+		for _, plus := range pluses {
+			iv := pv.getIndex(plus[imageImagePart], plus[imageTagPart])
+			pv.images[plus[imageImagePart]][iv].newVersion = plus[imageTagPart]
+		}
+	}
+
+	return nil
+}
+
+// Query all PRs from "k8s-ci-robot:autobump", find PR roughly 7 days old and was not reverted later.
+// Only return error if it's github related
+func getBestVersion(gcw *GHClientWrapper, gi gitInfo) (*PRVersions, error) {
+	visited := make(map[string]PRVersions)
+	var bestPv *PRVersions
+	var overallErr error
+	var bestDelta float64 = maxDelta + 1
+	PRs, err := gcw.ListPullRequests(gi.org, gi.repo, gi.getHeadRef(), gi.base)
+	if nil != err {
+		return bestPv, fmt.Errorf("failed list pull request: '%v'", err)
+	}
+
+	for _, PR := range PRs {
+		if nil == PR.State || string(ghutil.PullRequestCloseState) != *PR.State {
+			continue
+		}
+		delta := targetTime.Sub(*PR.CreatedAt).Hours()
+		if delta > maxDelta {
+			break // Over 9 days old, too old
+		}
+		pv := PRVersions{
+			images: make(map[string][]versions),
+			PR:     PR,
+		}
+		if err := pv.parseChangelist(gcw, gi); nil != err {
+			overallErr = fmt.Errorf("failed listing files from PR '%d': '%v'", *PR.Number, err)
+			break
+		}
+		vs := pv.getDominantVersions()
+		if "" == vs.oldVersion || "" == vs.newVersion {
+			log.Printf("Warning: found PR misses version change '%d'", *PR.Number)
+			continue
+		}
+		visited[vs.oldVersion] = pv
+		// check if too fresh here as need the data in visited
+		if delta < -maxDelta { // In past 5 days, too fresh
+			continue
+		}
+		if updatePR, ok := visited[vs.newVersion]; ok {
+			if updatePR.getDominantVersions().newVersion == vs.oldVersion { // The updatePR is reverting this PR
+				continue
+			}
+			if updatePR.PR.CreatedAt.Before(PR.CreatedAt.Add(time.Hour * safeDuration)) {
+				// The update PR is within 12 hours of current PR, consider unsafe
+				continue
+			}
+		}
+		if nil == bestPv || math.Abs(delta) < math.Abs(bestDelta) {
+			bestDelta = delta
+			bestPv = &pv
+		}
+	}
+	return bestPv, overallErr
+}
+
+func retryGetBestVersion(gcw *GHClientWrapper, gi gitInfo) (*PRVersions, error) {
+	var bestPv *PRVersions
+	var overallErr error
+	// retry if there is github related error
+	for retryCount := 0; nil == overallErr && retryCount < maxRetry; retryCount++ {
+		bestPv, overallErr = getBestVersion(gcw, gi)
+		if nil != overallErr {
+			log.Println(overallErr)
+			if maxRetry-1 != retryCount {
+				log.Printf("Retry #%d", retryCount+1)
+			}
+		}
+	}
+	return bestPv, overallErr
+}

--- a/tools/prow-auto-bumper/pullrequest.go
+++ b/tools/prow-auto-bumper/pullrequest.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/google/go-github/github"
+	"github.com/knative/test-infra/shared/ghutil"
+)
+
+func makeCommitSummary(vs versions) string {
+	return fmt.Sprintf("Update prow from %s to %s, and other images as necessary.", vs.oldVersion, vs.newVersion)
+}
+
+func getMatchTitle() string {
+	return "Update prow from"
+}
+
+func generatePRBody(extraMsgs []string) string {
+	var body string
+	if len(extraMsgs) > 0 {
+		body += "Warnings:\n"
+		for _, msg := range extraMsgs {
+			body += fmt.Sprintf("%s\n", msg)
+		}
+		body += "\n"
+	}
+
+	oncaller, err := getOncaller()
+	var assignment string
+	if err == nil {
+		if oncaller != "" {
+			assignment = "/cc @" + oncaller
+		} else {
+			assignment = "Nobody is currently oncall, so falling back to Blunderbuss."
+		}
+	} else {
+		assignment = fmt.Sprintf("An error occurred while finding an assignee: `%s`.\nFalling back to Blunderbuss.", err)
+	}
+
+	return body + assignment
+}
+
+func getOncaller() (string, error) {
+	req, err := http.Get(oncallAddress)
+	if err != nil {
+		return "", err
+	}
+	defer req.Body.Close()
+	if req.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("HTTP error %d (%q) fetching current oncaller", req.StatusCode, req.Status)
+	}
+	oncall := struct {
+		Oncall struct {
+			ToolsInfra string `json:"tools-infra"`
+		} `json:"Oncall"`
+	}{}
+	if err := json.NewDecoder(req.Body).Decode(&oncall); err != nil {
+		return "", err
+	}
+	return oncall.Oncall.ToolsInfra, nil
+}
+
+func makeGitCommit(gi gitInfo, message string, dryrun bool) error {
+	if "" == gi.head {
+		log.Fatal("pushing to empty branch ref is not allowed")
+	}
+	if err := run(
+		"Running 'git add -A'",
+		func() error { return call("git", "add", "-A") },
+		dryrun); err != nil {
+		return fmt.Errorf("failed to git add: %v", err)
+	}
+	commitArgs := []string{"commit", "-m", message}
+	if "" != gi.userName && "" != gi.email {
+		commitArgs = append(commitArgs, "--author", fmt.Sprintf("%s <%s>", gi.userName, gi.email))
+	}
+	if err := run(
+		fmt.Sprintf("Running 'git %s'", strings.Join(commitArgs, " ")),
+		func() error { return call("git", commitArgs...) },
+		dryrun); err != nil {
+		return fmt.Errorf("failed to git commit: %v", err)
+	}
+	pushArgs := []string{"push", "-f", fmt.Sprintf("git@github.com:%s/%s.git", gi.userID, gi.repo),
+		fmt.Sprintf("HEAD:%s", gi.head)}
+	if err := run(
+		fmt.Sprintf("Running 'git %s'", strings.Join(pushArgs, " ")),
+		func() error { return call("git", pushArgs...) },
+		dryrun); err != nil {
+		return fmt.Errorf("failed to git push: %v", err)
+	}
+	return nil
+}
+
+// Get existing open PR not merged yet
+func getExistingPR(gcw *GHClientWrapper, gi gitInfo, matchTitle string) (*github.PullRequest, error) {
+	var res *github.PullRequest
+	PRs, err := gcw.ListPullRequests(gi.org, gi.repo, gi.getHeadRef(), gi.base)
+	if nil == err {
+		for _, PR := range PRs {
+			if string(ghutil.PullRequestOpenState) == *PR.State && strings.Contains(*PR.Title, matchTitle) {
+				res = PR
+				break
+			}
+		}
+	}
+	return res, err
+}
+
+func createOrUpdatePR(gcw *GHClientWrapper, pv *PRVersions, gi gitInfo, extraMsgs []string, dryrun bool) error {
+	title := makeCommitSummary(pv.getDominantVersions())
+	matchTitle := getMatchTitle()
+	body := generatePRBody(extraMsgs)
+	if err := makeGitCommit(gi, title, dryrun); nil != err {
+		return fmt.Errorf("failed git commit: '%v'", err)
+	}
+	existPR, err := getExistingPR(gcw, gi, matchTitle)
+	if nil != err {
+		return fmt.Errorf("failed querying existing pullrequests: '%v'", err)
+	}
+	if nil != existPR {
+		log.Printf("found open PR '%d'", *existPR.Number)
+		return run(
+			fmt.Sprintf("Updating PR '%d', title: '%s', body: '%s'", *existPR.Number, title, body),
+			func() error {
+				if _, err := gcw.EditPullRequest(gi.org, gi.repo, *existPR.Number, title, body); nil != err {
+					return fmt.Errorf("failed updating pullrequest: '%v'", err)
+				}
+				return nil
+			},
+			dryrun)
+	}
+	return run(
+		fmt.Sprintf("Creating PR, title: '%s', body: '%s'", title, body),
+		func() error {
+			if _, err := gcw.CreatePullRequest(gi.org, gi.repo, gi.getHeadRef(), gi.base, title, body); nil != err {
+				return fmt.Errorf("failed creating pullrequest: '%v'", err)
+			}
+			return nil
+		},
+		dryrun)
+}

--- a/tools/prow-auto-bumper/run.go
+++ b/tools/prow-auto-bumper/run.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// run.go controls how to run functions that needs dryrun support
+
+package main
+
+import (
+	"log"
+)
+
+func run(message string, call func() error, dryrun bool) error {
+	if dryrun {
+		log.Printf("[dry run] %s", message)
+		return nil
+	}
+	log.Printf(message)
+	return call()
+}


### PR DESCRIPTION
Part 3 of Prow version auto bumper, updating versions and creating pullrequest, contains:
- Splitting main.go into `main.go` and `parser.go` without logic change
- Add `file.go` for updating Prow versions in local files
- Add `pullrequest.go` for creating/updating pullrequest
- Add missing ghutil functions

Part of: #689 
