### PR TITLE
Set 12 Janitor instances so that Boskos recycles faster

### DIFF
--- a/ci/prow/boskos/config.yaml
+++ b/ci/prow/boskos/config.yaml
@@ -104,7 +104,7 @@ metadata:
     app: boskos-janitor
   namespace: test-pods
 spec:
-  replicas: 6  # 6 distributed janitor instances
+  replicas: 12  # 12 distributed janitor instances
   template:
     metadata:
       labels:


### PR DESCRIPTION
We have 40 Boskos projects, and only 6 Janitor instances for now, which is not enough during peak hours. Increase to 12