### PR TITLE
Add a configurable release number as a parameter to launch Knative serving

### DIFF
--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -339,6 +339,12 @@ function start_knative_serving() {
   wait_until_pods_running knative-serving || return 1
 }
 
+# Install the stable release Knative/serving in the current cluster.
+# Parameters: $1 - Knative Serving version number, e.g. 0.6.0.
+function start_release_knative_serving() {
+  start_knative_serving "https://storage.googleapis.com/knative-releases/serving/previous/v$1/serving.yaml"
+}
+
 # Install the latest stable Knative Serving in the current cluster.
 function start_latest_knative_serving() {
   start_knative_serving "${KNATIVE_SERVING_RELEASE}"


### PR DESCRIPTION

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
With the current script, we are only able to launch a Knative serving with the latest version from the source code. With this parameter added, we are able to launch Knative serving for a specific released version.
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #897 

**Special notes to reviewers**:

**User-visible changes in this PR**:

