### PR TITLE
Delete the job for updating Knative Playground

### DIFF
--- a/ci/gubernator/config.yaml
+++ b/ci/gubernator/config.yaml
@@ -56,7 +56,6 @@ jobs:
   - ci-knative-serving-continuous
   - ci-knative-serving-0.2-continuous
   - ci-knative-serving-nightly-release
-  - ci-knative-serving-playground
   - ci-knative-build-continuous
   - ci-knative-build-nightly-release
   - ci-knative-eventing-continuous

--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -2152,39 +2152,6 @@ periodics:
     - name: release-account
       secret:
         secretName: release-account
-- cron: "1 9 * * 6"
-  name: ci-knative-serving-playground
-  agent: kubernetes
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/knative/serving"
-      - "--root=/go/src"
-      - "--service-account=/etc/test-account/service-account.json"
-      - "--upload=gs://knative-prow/logs"
-      - "--timeout=90" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
-      - "./hack/deploy.sh"
-      - "knative-playground"
-      volumeMounts:
-      - name: test-account
-        mountPath: /etc/test-account
-        readOnly: true
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/test-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-    volumes:
-    - name: test-account
-      secret:
-        secretName: test-account
 - cron: "5 8 * * *"
   name: ci-knative-serving-latency
   agent: kubernetes

--- a/ci/prow/config_knative.yaml
+++ b/ci/prow/config_knative.yaml
@@ -160,13 +160,6 @@ periodics:
       cron: "1 9 * * 2" # Run at 02:01PST every Tuesday (09:01 UTC)
     - auto-release: true
       cron: "3 */2 * * *" # Run every two hours and three minutes
-    - custom-job: playground
-      cron: "1 9 * * 6" # Run at 02:01PST every Saturday (09:01 UTC)
-      command:
-      - "./hack/deploy.sh"
-      args:
-      - "knative-playground"
-      timeout: 90
     - latency: true
       cron: "5 8 * * *" # Run at 01:05PST every day (08:05 UTC)
     - performance: true

--- a/ci/prow/make_config.go
+++ b/ci/prow/make_config.go
@@ -1118,7 +1118,7 @@ func generateTestGroup(projName string, repoName string, jobNames []string) {
 		gcsLogDir := fmt.Sprintf("%s/%s/%s", gcsBucket, logsDir, testGroupName)
 		extras := make(map[string]string)
 		switch jobName {
-		case "continuous", "dot-release", "auto-release", "performance", "performance-mesh", "latency", "playground", "nightly":
+		case "continuous", "dot-release", "auto-release", "performance", "performance-mesh", "latency", "nightly":
 			isDailyBranch := regexp.MustCompile(`-[0-9\.]+-continuous`).FindString(testGroupName) != ""
 			if !isDailyBranch && (jobName == "continuous" || jobName == "auto-release") {
 				// TODO(Fredy-Z): this value should be derived from the cron string
@@ -1128,7 +1128,7 @@ func generateTestGroup(projName string, repoName string, jobNames []string) {
 					extras["num_failures_to_alert"] = "3"
 				}
 			}
-			if jobName == "playground" || jobName == "dot-release" {
+			if jobName == "dot-release" {
 				// TODO(Fredy-Z): this value should be derived from the cron string
 				extras["alert_stale_results_hours"] = "170" // 1 week + 2h
 			}
@@ -1176,7 +1176,7 @@ func generateDashboard(projName string, repoName string, jobNames []string) {
 			if projRepoStr == "knative-serving" {
 				executeDashboardTabTemplate("conformance-tests", testGroupName, "include-filter-by-regex=test/conformance/&sort-by-name=", noExtras)
 			}
-		case "dot-release", "auto-release", "performance", "performance-mesh", "latency", "playground":
+		case "dot-release", "auto-release", "performance", "performance-mesh", "latency":
 			extras := make(map[string]string)
 			baseOptions := testgridTabSortByName
 			if jobName == "performance" || jobName == "performance-mesh" {
@@ -1212,7 +1212,7 @@ func executeDashboardTabTemplate(dashboardTabName string, testGroupName string, 
 // getTestGroupName get the testGroupName from the given repoName and jobName
 func getTestGroupName(repoName string, jobName string) string {
 	switch jobName {
-	case "continuous", "dot-release", "auto-release", "performance", "performance-mesh", "latency", "playground":
+	case "continuous", "dot-release", "auto-release", "performance", "performance-mesh", "latency":
 		return strings.ToLower(fmt.Sprintf("ci-%s-%s", repoName, jobName))
 	case "nightly":
 		return strings.ToLower(fmt.Sprintf("ci-%s-%s-release", repoName, jobName))

--- a/ci/testgrid/config.yaml
+++ b/ci/testgrid/config.yaml
@@ -84,9 +84,6 @@ test_groups:
 - name: ci-knative-serving-auto-release
   gcs_prefix: knative-prow/logs/ci-knative-serving-auto-release
   alert_stale_results_hours: 3
-- name: ci-knative-serving-playground
-  gcs_prefix: knative-prow/logs/ci-knative-serving-playground
-  alert_stale_results_hours: 170
 - name: ci-knative-serving-latency
   gcs_prefix: knative-prow/logs/ci-knative-serving-latency
   short_text_metric: "latency"
@@ -262,9 +259,6 @@ dashboards:
     base_options: "sort-by-name="
   - name: auto-release
     test_group_name: ci-knative-serving-auto-release
-    base_options: "sort-by-name="
-  - name: playground
-    test_group_name: ci-knative-serving-playground
     base_options: "sort-by-name="
   - name: latency
     test_group_name: ci-knative-serving-latency


### PR DESCRIPTION
The Knative Playground and Demo environments are not needed anymore, as CloudRun on GKE is in beta.

Fixes https://github.com/knative/serving/issues/4323