### PR TITLE
Support cluster version as [major].[minor] or [major] in e2e tests

### DIFF
--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -502,6 +502,22 @@ function get_latest_knative_yaml_source() {
   fi
 }
 
+# Returns the latest gke version in [major].[minor].[patch] with provided prefix
+# Parameters: $1 - prefix of gke versions
+#             $2 - gcp zone
+function get_latest_gke_version() {
+  local version_prefix="$1"
+  local re_version_match="${version_prefix/./\\.}"
+  re_version_match="${version_prefix/-/\\-}"
+  local gcp_zone="$2"
+  #local full_gke_version=
+  echo "$(gcloud container get-server-config --zone=${gcp_zone} --format="yaml(validMasterVersions)" \
+      | grep -E "${re_version_match}" \
+      | grep -Eo "[0-9]+\.[0-9]+\.[0-9]+" \
+      | sort \
+      | tail -n 1)"
+}
+
 # Initializations that depend on previous functions.
 # These MUST come last.
 

--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -502,22 +502,6 @@ function get_latest_knative_yaml_source() {
   fi
 }
 
-# Returns the latest gke version in [major].[minor].[patch] with provided prefix
-# Parameters: $1 - prefix of gke versions
-#             $2 - gcp zone
-function get_latest_gke_version() {
-  local version_prefix="$1"
-  local re_version_match="${version_prefix/./\\.}"
-  re_version_match="${version_prefix/-/\\-}"
-  local gcp_zone="$2"
-  #local full_gke_version=
-  echo "$(gcloud container get-server-config --zone=${gcp_zone} --format="yaml(validMasterVersions)" \
-      | grep -E "${re_version_match}" \
-      | grep -Eo "[0-9]+\.[0-9]+\.[0-9]+" \
-      | sort \
-      | tail -n 1)"
-}
-
 # Initializations that depend on previous functions.
 # These MUST come last.
 


### PR DESCRIPTION
Currently e2e test would fail if pass in `cluster_version=1.12` or `cluster_version=v1.12`, as kubetest only accepts version in the format of `v[major].[minor].[patch]`, it's not easy to change this behavior as this version is consumed by both `--extract` and gke cluster creation, and `--extract` doesn't work with `v[major].[minor]` at all. So add logic finding latest gke version with same [major].[minor] version

part of: #871 