### PR TITLE
Rename conformance-tests tab to conformance

### DIFF
--- a/ci/prow/make_config.go
+++ b/ci/prow/make_config.go
@@ -1172,9 +1172,9 @@ func generateDashboard(projName string, repoName string, jobNames []string) {
 		switch jobName {
 		case "continuous":
 			executeDashboardTabTemplate("continuous", testGroupName, testgridTabSortByName, noExtras)
-			// This is a special case for knative/serving, as conformance-tests tab is just a filtered view of the continuous tab.
+			// This is a special case for knative/serving, as conformance tab is just a filtered view of the continuous tab.
 			if projRepoStr == "knative-serving" {
-				executeDashboardTabTemplate("conformance-tests", testGroupName, "include-filter-by-regex=test/conformance/&sort-by-name=", noExtras)
+				executeDashboardTabTemplate("conformance", testGroupName, "include-filter-by-regex=test/conformance/&sort-by-name=", noExtras)
 			}
 		case "dot-release", "auto-release", "performance", "performance-mesh", "latency":
 			extras := make(map[string]string)

--- a/ci/testgrid/config.yaml
+++ b/ci/testgrid/config.yaml
@@ -236,7 +236,7 @@ dashboards:
   - name: continuous
     test_group_name: ci-knative-serving-continuous
     base_options: "sort-by-name="
-  - name: conformance-tests
+  - name: conformance
     test_group_name: ci-knative-serving-continuous
     base_options: "include-filter-by-regex=test/conformance/&sort-by-name="
   - name: istio-1.0.7-mesh


### PR DESCRIPTION
It's simpler.

Fixes #715.