### PR TITLE
update plugins to remove usage of deprecated keys

### DIFF
--- a/ci/prow/plugins.yaml
+++ b/ci/prow/plugins.yaml
@@ -16,8 +16,8 @@ approve:
 - repos:
   - knative
   - GoogleCloudPlatform/cloud-run-events
-  implicit_self_approve: true
-  review_acts_as_approve: true
+  require_self_approval: false
+  ignore_review_state: false
 
 repo_milestone:
   knative:


### PR DESCRIPTION
`implicit_self_approve` and `review_acts_as_approve` are deprecating very soon(https://github.com/kubernetes/test-infra/blob/master/prow/ANNOUNCEMENTS.md), update them like k8s: https://github.com/kubernetes/test-infra/commit/70bc3f056ba19c17ce990df26f4ab57ff0ad70dd