### PR TITLE
e2e test meta data works with non latest version

### DIFF
--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -115,7 +115,9 @@ function save_metadata() {
     geo_key="Zone"
     geo_value="${E2E_CLUSTER_REGION}-${E2E_CLUSTER_ZONE}"
   fi
-  local cluster_version="$(gcloud container clusters list --project=${E2E_PROJECT_ID} --format='value(currentMasterVersion)')"
+  local cluster_version="${E2E_CLUSTER_VERSION}"
+  [[ "${cluster_version}" == "gke-latest" ]] && \
+    cluster_version="$(gcloud container clusters list --project=${E2E_PROJECT_ID} --format='value(currentMasterVersion)')"
   cat << EOF > ${ARTIFACTS}/metadata.json
 {
   "E2E:${geo_key}": "${geo_value}",


### PR DESCRIPTION
Forgot to add in PR #905 . Since cluster versions support non `latest`,  `save_metadata` should also change to correctly reflect the version