### PR TITLE
Prow job generation: allow full-command override for better reading

### DIFF
--- a/ci/prow/config_knative.yaml
+++ b/ci/prow/config_knative.yaml
@@ -125,40 +125,16 @@ periodics:
       cron: "45 8 * * *" # Run at 01:45 PST every day (08:45 UTC)
     - custom-job: istio-1.0.7-mesh
       cron: "7 */2 * * *" # Run every other hour and seven minute
-      command:
-      - "./test/e2e-tests.sh"
-      args:
-      - "--istio-version"
-      - "1.0.7"
-      - "--mesh"
-      timeout: 100
+      full-command: "./test/e2e-tests.sh --istio-version 1.0.7 --mesh"
     - custom-job: istio-1.0.7-no-mesh
       cron: "22 */2 * * *" # Run every other hour and twenty-two minute
-      command:
-      - "./test/e2e-tests.sh"
-      args:
-      - "--istio-version"
-      - "1.0.7"
-      - "--no-mesh"
-      timeout: 100
+      full-command: "./test/e2e-tests.sh --istio-version 1.0.7 --no-mesh"
     - custom-job: istio-1.1.7-mesh
       cron: "37 */2 * * *" # Run every other hour and thirty-seven minute
-      command:
-      - "./test/e2e-tests.sh"
-      args:
-      - "--istio-version"
-      - "1.1.7"
-      - "--mesh"
-      timeout: 100
+      full-command: "./test/e2e-tests.sh --istio-version 1.1.7 --mesh"
     - custom-job: istio-1.1.7-no-mesh
       cron: "52 */2 * * *" # Run every other hour and fifty-two minute
-      command:
-      - "./test/e2e-tests.sh"
-      args:
-      - "--istio-version"
-      - "1.1.7"
-      - "--no-mesh"
-      timeout: 100
+      full-command: "./test/e2e-tests.sh --istio-version 1.1.7 --no-mesh"
     - nightly: true
       cron: "1 8 * * *" # Run at 01:01PST every day (08:01 UTC)
     - dot-release: true

--- a/ci/prow/make_config.go
+++ b/ci/prow/make_config.go
@@ -467,6 +467,10 @@ func parseBasicJobConfigOverrides(data *baseProwJobTemplateData, config yaml.Map
 			(*data).Timeout = getInt(item.Value)
 		case "command":
 			(*data).Command = getString(item.Value)
+		case "full-command":
+			parts := strings.Split(getString(item.Value), " ")
+			(*data).Command = parts[0]
+			(*data).Args = parts[1:]
 		case "needs-dind":
 			if getBool(item.Value) {
 				setupDockerInDockerForJob(data)
@@ -639,6 +643,7 @@ func generatePeriodic(title string, repoName string, periodicConfig yaml.MapSlic
 		case "custom-job":
 			jobType = getString(item.Key)
 			jobNameSuffix = getString(item.Value)
+			data.Base.Timeout = 100
 		case "cron":
 			data.CronString = getString(item.Value)
 		case "release":


### PR DESCRIPTION
Allow full-command override in prow job generation to make some of the configs easier to read.
Default custom-job timeout to 100 minutes since they all use this value anyway