### PR TITLE
Increase timeout for eventing periodic jobs

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -2893,7 +2893,7 @@ periodics:
       - "--root=/go/src"
       - "--service-account=/etc/test-account/service-account.json"
       - "--upload=gs://knative-prow/logs"
-      - "--timeout=50" # Avoid overrun
+      - "--timeout=90" # Avoid overrun
       - "--" # end bootstrap args, scenario args below
       - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./test/presubmit-tests.sh"

--- a/ci/prow/config_knative.yaml
+++ b/ci/prow/config_knative.yaml
@@ -216,6 +216,7 @@ periodics:
   knative/eventing:
     - continuous: true
       cron: "30 * * * *" # Run every hour and 30 minutes
+      timeout: 90
     - branch-ci: true
       release: "0.5"
       cron: "40 8 * * *" # Run at 01:40PST every day (08:40 UTC)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Eventing periodic jobs are getting timeout error, see https://testgrid.knative.dev/eventing#continuous.
Increasing timeout to `90m` to mitigate it.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


