### PR TITLE
Increase boskos janitor count to match number of boskos projects.

### DIFF
--- a/ci/prow/boskos/config.yaml
+++ b/ci/prow/boskos/config.yaml
@@ -104,7 +104,7 @@ metadata:
     app: boskos-janitor
   namespace: test-pods
 spec:
-  replicas: 20  # Number distributed janitor instances
+  replicas: 20  # Number of distributed janitor instances
   template:
     metadata:
       labels:
@@ -117,7 +117,6 @@ spec:
         image: gcr.io/k8s-testimages/janitor:v20190604-0afdebd
         args:
         - --resource-type=gke-project
-        - --pool-size=10
         - --
         - --service_account=/etc/test-account/service-account.json
         - --hours=0

--- a/ci/prow/boskos/config.yaml
+++ b/ci/prow/boskos/config.yaml
@@ -104,7 +104,7 @@ metadata:
     app: boskos-janitor
   namespace: test-pods
 spec:
-  replicas: 12  # 12 distributed janitor instances
+  replicas: 40  # This number distributed janitor instances. Should keep around the same number as number of projects.
   template:
     metadata:
       labels:

--- a/ci/prow/boskos/config.yaml
+++ b/ci/prow/boskos/config.yaml
@@ -104,7 +104,7 @@ metadata:
     app: boskos-janitor
   namespace: test-pods
 spec:
-  replicas: 40  # This number distributed janitor instances. Should keep around the same number as number of projects.
+  replicas: 20  # Number distributed janitor instances
   template:
     metadata:
       labels:


### PR DESCRIPTION
We had stockout. If they happen again, it will have to be a different reason.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
/lint
/assign chaodaiG