### PR TITLE
golang format tools

### DIFF
--- a/ci/prow/make_config.go
+++ b/ci/prow/make_config.go
@@ -34,7 +34,7 @@ import (
 	"text/template"
 	"time"
 
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 const (

--- a/shared/testgrid/testgrid.go
+++ b/shared/testgrid/testgrid.go
@@ -38,11 +38,11 @@ const (
 
 // jobNameTestgridURLMap contains harded coded mapping of job name: Testgrid tab URL relative to base URL
 var jobNameTestgridURLMap = map[string]string{
-	"ci-knative-serving-continuous": "serving#continuous",
-	"ci-knative-serving-istio-1.0.7-mesh": "serving#istio-1.0.7-mesh",
+	"ci-knative-serving-continuous":          "serving#continuous",
+	"ci-knative-serving-istio-1.0.7-mesh":    "serving#istio-1.0.7-mesh",
 	"ci-knative-serving-istio-1.0.7-no-mesh": "serving#istio-1.0.7-no-mesh",
-	"ci-knative-serving-istio-1.1.7-mesh": "serving#istio-1.1.7-mesh",
-	"ci-knative-serving-istio-1.1.7-no-mesh":"serving#istio-1.1.7-no-mesh",
+	"ci-knative-serving-istio-1.1.7-mesh":    "serving#istio-1.1.7-mesh",
+	"ci-knative-serving-istio-1.1.7-no-mesh": "serving#istio-1.1.7-no-mesh",
 }
 
 // GetTestgridTabURL gets Testgrid URL for giving job and filters for Testgrid

--- a/tools/coverage/artifacts/profiling.go
+++ b/tools/coverage/artifacts/profiling.go
@@ -51,7 +51,7 @@ func runProfiling(covTargets []string, localArts *LocalArtifacts) {
 	if errCmdOutput != nil {
 		log.Printf("Error running 'go test -coverprofile ': error='%v'; combined output='%s'\n",
 			errCmdOutput, output)
-	} 
+	}
 
 	log.Printf("coverage profile created @ '%s'", localArts.ProfilePath())
 	covIo.CreateMarker(localArts.Directory(), CovProfileCompletionMarker)

--- a/tools/flaky-test-reporter/config.go
+++ b/tools/flaky-test-reporter/config.go
@@ -28,7 +28,7 @@ const (
 	// Minimal number of results to be counted as valid results for each testcase, this is an arbitrary number
 	requiredCount = 8
 	// Don't do anything if found more than 5 tests flaky, or 1% tests flaky, whichever comes first
-	countThreshold = 5
+	countThreshold   = 5
 	percentThreshold = 0.01
 
 	org = "knative"

--- a/tools/monitoring/config/config.go
+++ b/tools/monitoring/config/config.go
@@ -26,7 +26,7 @@ import (
 	"net/http"
 	"regexp"
 
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 type alertCondition struct {

--- a/tools/prow-auto-bumper/getversion_test.go
+++ b/tools/prow-auto-bumper/getversion_test.go
@@ -32,12 +32,12 @@ import (
 
 func getFakeGitInfo() gitInfo {
 	return gitInfo{
-		org:   "fakeorg",
-		repo:  "fakerepo",
-		userID:  "fakeuserID",
-		head:  "fakehead",
-		base:  "fakebase",
-		email: "fake@email",
+		org:    "fakeorg",
+		repo:   "fakerepo",
+		userID: "fakeuserID",
+		head:   "fakehead",
+		base:   "fakebase",
+		email:  "fake@email",
 	}
 }
 
@@ -64,7 +64,7 @@ func TestGetIndex(t *testing.T) {
 		},
 		{
 			map[string][]versions{
-				"o": []versions{{"", "", ""}},
+				"o": {{"", "", ""}},
 			},
 			"o",
 			"a-b-c",
@@ -72,7 +72,7 @@ func TestGetIndex(t *testing.T) {
 		},
 		{
 			map[string][]versions{
-				"o": []versions{{"", "", "b"}},
+				"o": {{"", "", "b"}},
 			},
 			"o",
 			"a-b-c",
@@ -80,7 +80,7 @@ func TestGetIndex(t *testing.T) {
 		},
 		{
 			map[string][]versions{
-				"o": []versions{{"", "", "c"}},
+				"o": {{"", "", "c"}},
 			},
 			"o",
 			"a-b-c",
@@ -88,7 +88,7 @@ func TestGetIndex(t *testing.T) {
 		},
 		{
 			map[string][]versions{
-				"p": []versions{{"", "", "c"}},
+				"p": {{"", "", "c"}},
 			},
 			"o",
 			"a-b-c",
@@ -156,7 +156,7 @@ func TestGetDominantVersion(t *testing.T) {
 		},
 		{
 			map[string][]versions{
-				"o": []versions{
+				"o": {
 					{"a-b", "h-i", ""},
 				},
 			},
@@ -164,11 +164,11 @@ func TestGetDominantVersion(t *testing.T) {
 		},
 		{
 			map[string][]versions{
-				"o": []versions{
+				"o": {
 					{"a-b", "h-i", ""},
 					{"c-d-x", "j-k-x", "x"},
 				},
-				"p": []versions{
+				"p": {
 					{"a-b-y", "h-i-y", "y"},
 				},
 			},
@@ -201,7 +201,7 @@ func TestParseChangelist(t *testing.T) {
 				"+ image: gcr.io/k8s-foofoo/bar:vh-i",
 			},
 			map[string][]versions{
-				"gcr.io/k8s-foofoo/bar": []versions{
+				"gcr.io/k8s-foofoo/bar": {
 					{"va-b", "vh-i", ""},
 				},
 			},
@@ -214,7 +214,7 @@ func TestParseChangelist(t *testing.T) {
 				"+ image: gcr.io/k8s-foofoo/bar:vh-i-x",
 			},
 			map[string][]versions{
-				"gcr.io/k8s-foofoo/bar": []versions{
+				"gcr.io/k8s-foofoo/bar": {
 					{"va-b", "vh-i", ""},
 					{"va-b-x", "vh-i-x", "x"},
 				},
@@ -228,7 +228,7 @@ func TestParseChangelist(t *testing.T) {
 				+ image: gcr.io/k8s-foofoo/bar:vh-i-x`,
 			},
 			map[string][]versions{
-				"gcr.io/k8s-foofoo/bar": []versions{
+				"gcr.io/k8s-foofoo/bar": {
 					{"va-b", "vh-i", ""},
 					{"va-b-x", "vh-i-x", "x"},
 				},
@@ -242,10 +242,10 @@ func TestParseChangelist(t *testing.T) {
 				"+ image: gcr.io/k8s-barbar/baz:vj-k",
 			},
 			map[string][]versions{
-				"gcr.io/k8s-foofoo/bar": []versions{
+				"gcr.io/k8s-foofoo/bar": {
 					{"va-b", "vh-i", ""},
 				},
-				"gcr.io/k8s-barbar/baz": []versions{
+				"gcr.io/k8s-barbar/baz": {
 					{"vc-d", "vj-k", ""},
 				},
 			},

--- a/tools/webhook-apicoverage/coveragecalculator/ignorefields.go
+++ b/tools/webhook-apicoverage/coveragecalculator/ignorefields.go
@@ -21,7 +21,7 @@ import (
 	"io/ioutil"
 	"strings"
 
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 // IgnoredFields encapsulates fields to be ignored in a package for API coverage calculation.


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
/assign @mattmoor
