### PR TITLE
moved prowapi structs to a separate package

### DIFF
--- a/tools/monitoring/main.go
+++ b/tools/monitoring/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/knative/test-infra/shared/mysql"
 	"github.com/knative/test-infra/tools/monitoring/config"
 	"github.com/knative/test-infra/tools/monitoring/mail"
+	"github.com/knative/test-infra/tools/monitoring/prowapi"
 	"github.com/knative/test-infra/tools/monitoring/subscriber"
 )
 
@@ -144,7 +145,7 @@ func testSubscriber(w http.ResponseWriter, r *http.Request) {
 	log.Println("Start listening to messages")
 
 	go func() {
-		err := client.ReceiveMessageAckAll(context.Background(), func(rmsg *subscriber.ReportMessage) {
+		err := client.ReceiveMessageAckAll(context.Background(), func(rmsg *prowapi.ReportMessage) {
 			log.Printf("Report Message: %+v\n", rmsg)
 		})
 		if err != nil {

--- a/tools/monitoring/prowapi/types.go
+++ b/tools/monitoring/prowapi/types.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// TODO(yt3liu): Remove this file after using definition in "k8s.io/test-infra" directly
+// https://github.com/knative/test-infra/issues/912
+
+package prowapi
+
+// ProwJobType specifies how the job is triggered.
+type ProwJobType string
+
+// Various job types.
+const (
+	// PresubmitJob means it runs on unmerged PRs.
+	PresubmitJob ProwJobType = "presubmit"
+	// PostsubmitJob means it runs on each new commit.
+	PostsubmitJob ProwJobType = "postsubmit"
+	// Periodic job means it runs on a time-basis, unrelated to git changes.
+	PeriodicJob ProwJobType = "periodic"
+	// BatchJob tests multiple unmerged PRs at the same time.
+	BatchJob ProwJobType = "batch"
+)
+
+// ProwJobState specifies whether the job is running
+type ProwJobState string
+
+// Various job states.
+const (
+	// TriggeredState means the job has been created but not yet scheduled.
+	TriggeredState ProwJobState = "triggered"
+	// PendingState means the job is scheduled but not yet running.
+	PendingState ProwJobState = "pending"
+	// SuccessState means the job completed without error (exit 0)
+	SuccessState ProwJobState = "success"
+	// FailureState means the job completed with errors (exit non-zero)
+	FailureState ProwJobState = "failure"
+	// AbortedState means prow killed the job early (new commit pushed, perhaps).
+	AbortedState ProwJobState = "aborted"
+	// ErrorState means the job could not schedule (bad config, perhaps).
+	ErrorState ProwJobState = "error"
+)
+
+// Refs describes how the repo was constructed.
+type Refs struct {
+	// Org is something like kubernetes or k8s.io
+	Org string `json:"org"`
+	// Repo is something like test-infra
+	Repo string `json:"repo"`
+	// RepoLink links to the source for Repo.
+	RepoLink string `json:"repo_link,omitempty"`
+
+	BaseRef string `json:"base_ref,omitempty"`
+	BaseSHA string `json:"base_sha,omitempty"`
+	// BaseLink is a link to the commit identified by BaseSHA.
+	BaseLink string `json:"base_link,omitempty"`
+
+	Pulls []Pull `json:"pulls,omitempty"`
+
+	// PathAlias is the location under <root-dir>/src
+	// where this repository is cloned. If this is not
+	// set, <root-dir>/src/github.com/org/repo will be
+	// used as the default.
+	PathAlias string `json:"path_alias,omitempty"`
+	// CloneURI is the URI that is used to clone the
+	// repository. If unset, will default to
+	// `https://github.com/org/repo.git`.
+	CloneURI string `json:"clone_uri,omitempty"`
+	// SkipSubmodules determines if submodules should be
+	// cloned when the job is run. Defaults to true.
+	SkipSubmodules bool `json:"skip_submodules,omitempty"`
+	// CloneDepth is the depth of the clone that will be used.
+	// A depth of zero will do a full clone.
+	CloneDepth int `json:"clone_depth,omitempty"`
+}
+
+// Pull describes a pull request at a particular point in time.
+type Pull struct {
+	Number int    `json:"number"`
+	Author string `json:"author"`
+	SHA    string `json:"sha"`
+	Title  string `json:"title,omitempty"`
+
+	// Ref is git ref can be checked out for a change
+	// for example,
+	// github: pull/123/head
+	// gerrit: refs/changes/00/123/1
+	Ref string `json:"ref,omitempty"`
+	// Link links to the pull request itself.
+	Link string `json:"link,omitempty"`
+	// CommitLink links to the commit identified by the SHA.
+	CommitLink string `json:"commit_link,omitempty"`
+	// AuthorLink links to the author of the pull request.
+	AuthorLink string `json:"author_link,omitempty"`
+}
+
+// ReportMessage is a message structure used to pass a prowjob status to Pub/Sub topic.s
+type ReportMessage struct {
+	Project string       `json:"project"`
+	Topic   string       `json:"topic"`
+	RunID   string       `json:"runid"`
+	Status  ProwJobState `json:"status"`
+	URL     string       `json:"url"`
+	GCSPath string       `json:"gcs_path"`
+	Refs    []Refs       `json:"refs,omitempty"`
+	JobType ProwJobType  `json:"job_type"`
+	JobName string       `json:"job_name"`
+}

--- a/tools/monitoring/subscriber/subscriber.go
+++ b/tools/monitoring/subscriber/subscriber.go
@@ -22,79 +22,8 @@ import (
 	"log"
 
 	"cloud.google.com/go/pubsub"
+	"github.com/knative/test-infra/tools/monitoring/prowapi"
 )
-
-// Refs describes how the repo was constructed.
-// TODO(yt3liu): Use the ReportMessage structure in "k8s.io/test-infra/prow/pubsub/reporter"
-// https://github.com/knative/test-infra/issues/912
-type Refs struct {
-	// Org is something like kubernetes or k8s.io
-	Org string `json:"org"`
-	// Repo is something like test-infra
-	Repo string `json:"repo"`
-	// RepoLink links to the source for Repo.
-	RepoLink string `json:"repo_link,omitempty"`
-
-	BaseRef string `json:"base_ref,omitempty"`
-	BaseSHA string `json:"base_sha,omitempty"`
-	// BaseLink is a link to the commit identified by BaseSHA.
-	BaseLink string `json:"base_link,omitempty"`
-
-	Pulls []Pull `json:"pulls,omitempty"`
-
-	// PathAlias is the location under <root-dir>/src
-	// where this repository is cloned. If this is not
-	// set, <root-dir>/src/github.com/org/repo will be
-	// used as the default.
-	PathAlias string `json:"path_alias,omitempty"`
-	// CloneURI is the URI that is used to clone the
-	// repository. If unset, will default to
-	// `https://github.com/org/repo.git`.
-	CloneURI string `json:"clone_uri,omitempty"`
-	// SkipSubmodules determines if submodules should be
-	// cloned when the job is run. Defaults to true.
-	SkipSubmodules bool `json:"skip_submodules,omitempty"`
-	// CloneDepth is the depth of the clone that will be used.
-	// A depth of zero will do a full clone.
-	CloneDepth int `json:"clone_depth,omitempty"`
-}
-
-// Pull describes a pull request at a particular point in time.
-// TODO(yt3liu): Use the ReportMessage structure in "k8s.io/test-infra/prow/pubsub/reporter"
-// https://github.com/knative/test-infra/issues/912
-type Pull struct {
-	Number int    `json:"number"`
-	Author string `json:"author"`
-	SHA    string `json:"sha"`
-	Title  string `json:"title,omitempty"`
-
-	// Ref is git ref can be checked out for a change
-	// for example,
-	// github: pull/123/head
-	// gerrit: refs/changes/00/123/1
-	Ref string `json:"ref,omitempty"`
-	// Link links to the pull request itself.
-	Link string `json:"link,omitempty"`
-	// CommitLink links to the commit identified by the SHA.
-	CommitLink string `json:"commit_link,omitempty"`
-	// AuthorLink links to the author of the pull request.
-	AuthorLink string `json:"author_link,omitempty"`
-}
-
-// ReportMessage is a message structure used to pass a prowjob status to Pub/Sub topic.
-// TODO(yt3liu): Use the ReportMessage structure in "k8s.io/test-infra/prow/pubsub/reporter"
-// https://github.com/knative/test-infra/issues/912
-type ReportMessage struct {
-	Project string `json:"project"`
-	Topic   string `json:"topic"`
-	RunID   string `json:"runid"`
-	Status  string `json:"status"`
-	URL     string `json:"url"`
-	GCSPath string `json:"gcs_path"`
-	Refs    []Refs `json:"refs,omitempty"`
-	JobType string `json:"job_type"`
-	JobName string `json:"job_name"`
-}
 
 // Client is a wrapper on the subscriber Operation
 type Client struct {
@@ -119,7 +48,7 @@ func NewSubscriberClient(ctx context.Context, projectID string, subName string) 
 
 // ReceiveMessageAckAll acknowledges all incoming pusub messages and convert the pubsub message to ReportMessage.
 // It executes `f` only if the pubsub message can be converted to ReportMessage. Otherwise, ignore the message.
-func (c *Client) ReceiveMessageAckAll(ctx context.Context, f func(*ReportMessage)) error {
+func (c *Client) ReceiveMessageAckAll(ctx context.Context, f func(*prowapi.ReportMessage)) error {
 	return c.Receive(ctx, func(ctx context.Context, msg *pubsub.Message) {
 		if rmsg, err := c.toReportMessage(msg); err != nil {
 			log.Printf("Cannot convert pubsub message (%v) to Report message %v", msg, err)
@@ -130,8 +59,8 @@ func (c *Client) ReceiveMessageAckAll(ctx context.Context, f func(*ReportMessage
 	})
 }
 
-func (c *Client) toReportMessage(msg *pubsub.Message) (*ReportMessage, error) {
-	rmsg := &ReportMessage{}
+func (c *Client) toReportMessage(msg *pubsub.Message) (*prowapi.ReportMessage, error) {
+	rmsg := &prowapi.ReportMessage{}
 	if err := json.Unmarshal(msg.Data, rmsg); err != nil {
 		return nil, err
 	}

--- a/tools/monitoring/subscriber/subscriber_test.go
+++ b/tools/monitoring/subscriber/subscriber_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"cloud.google.com/go/pubsub"
+	"github.com/knative/test-infra/tools/monitoring/prowapi"
 )
 
 type contextKey int
@@ -52,11 +53,11 @@ func (fs *fakeSubscriber) String() string {
 }
 
 func TestSubscriberClient_ReceiveMessageAckAll(t *testing.T) {
-	receivedMsgs := make([]*ReportMessage, 3)
+	receivedMsgs := make([]*prowapi.ReportMessage, 3)
 
 	type arguments struct {
 		ctx context.Context
-		f   func(*ReportMessage)
+		f   func(*prowapi.ReportMessage)
 	}
 	tests := []struct {
 		name string
@@ -67,7 +68,7 @@ func TestSubscriberClient_ReceiveMessageAckAll(t *testing.T) {
 			name: "Message Received",
 			args: arguments{
 				ctx: context.Background(),
-				f: func(message *ReportMessage) {
+				f: func(message *prowapi.ReportMessage) {
 					receivedMsgs[0] = message
 				},
 			},
@@ -77,7 +78,7 @@ func TestSubscriberClient_ReceiveMessageAckAll(t *testing.T) {
 			name: "ReceiveError",
 			args: arguments{
 				ctx: context.WithValue(context.Background(), keyError, errors.New("code = NotFound desc = Resource not found")),
-				f: func(message *ReportMessage) {
+				f: func(message *prowapi.ReportMessage) {
 					receivedMsgs[0] = message
 				},
 			},
@@ -98,20 +99,20 @@ func TestToReportMessage(t *testing.T) {
 	tests := []struct {
 		name string
 		arg  *pubsub.Message
-		want *ReportMessage
+		want *prowapi.ReportMessage
 	}{
 		{
 			name: "Valid report",
 			arg: &pubsub.Message{
 				Data: []byte(`{"project":"knative-tests","topic":"knative-monitoring","runid":"post-knative-serving-go-coverage-dev","status":"triggered","url":"","gcs_path":"gs://","refs":[{"org":"knative","repo":"serving","base_ref":"master","base_sha":"ce96dd74b1c85f024d63ce0991d4bf61aced582a","clone_uri":"https://github.com/knative/serving.git"}],"job_type":"postsubmit","job_name":"post-knative-serving-go-coverage-dev"}`)},
-			want: &ReportMessage{
+			want: &prowapi.ReportMessage{
 				Project: "knative-tests",
 				Topic:   "knative-monitoring",
 				RunID:   "post-knative-serving-go-coverage-dev",
 				Status:  "triggered",
 				URL:     "",
 				GCSPath: "gs://",
-				Refs: []Refs{
+				Refs: []prowapi.Refs{
 					{
 						Org:      "knative",
 						Repo:     "serving",


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:

Move all the prowapi to a separate package so the structs/constants can be reused in other packages. 

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #

**Special notes to reviewers**:

**User-visible changes in this PR**:

