### PR TITLE
Generate cron strings deterministically

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -1867,7 +1867,7 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "0 8 * * *"
+- cron: "6 8 * * *"
   name: ci-knative-serving-0.4-continuous
   agent: kubernetes
   spec:
@@ -1911,7 +1911,7 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "11 8 * * *"
+- cron: "17 8 * * *"
   name: ci-knative-serving-0.5-continuous
   agent: kubernetes
   spec:
@@ -1955,7 +1955,7 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "20 8 * * *"
+- cron: "28 8 * * *"
   name: ci-knative-serving-0.6-continuous
   agent: kubernetes
   spec:
@@ -1999,7 +1999,7 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "12 */2 * * *"
+- cron: "10 */2 * * *"
   name: ci-knative-serving-istio-1.0.7-mesh
   agent: kubernetes
   spec:
@@ -2034,7 +2034,7 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "30 */2 * * *"
+- cron: "31 */2 * * *"
   name: ci-knative-serving-istio-1.0.7-no-mesh
   agent: kubernetes
   spec:
@@ -2069,7 +2069,7 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "21 */2 * * *"
+- cron: "20 */2 * * *"
   name: ci-knative-serving-istio-1.1.7-mesh
   agent: kubernetes
   spec:
@@ -2104,7 +2104,7 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "40 */2 * * *"
+- cron: "42 */2 * * *"
   name: ci-knative-serving-istio-1.1.7-no-mesh
   agent: kubernetes
   spec:
@@ -2139,7 +2139,7 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "50 9 * * *"
+- cron: "56 9 * * *"
   name: ci-knative-serving-nightly-release
   agent: kubernetes
   spec:
@@ -2173,7 +2173,7 @@ periodics:
     - name: nightly-account
       secret:
         secretName: nightly-account
-- cron: "31 9 * * 2"
+- cron: "37 9 * * 2"
   name: ci-knative-serving-dot-release
   agent: kubernetes
   spec:
@@ -2215,7 +2215,7 @@ periodics:
     - name: release-account
       secret:
         secretName: release-account
-- cron: "32 */2 * * *"
+- cron: "34 */2 * * *"
   name: ci-knative-serving-auto-release
   agent: kubernetes
   spec:
@@ -2257,7 +2257,7 @@ periodics:
     - name: release-account
       secret:
         secretName: release-account
-- cron: "33 8 * * *"
+- cron: "38 8 * * *"
   name: ci-knative-serving-latency
   agent: kubernetes
   decorate: true
@@ -2289,7 +2289,7 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "51 8 * * *"
+- cron: "58 8 * * *"
   name: ci-knative-serving-performance
   agent: kubernetes
   spec:
@@ -2331,7 +2331,7 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "52 10 * * *"
+- cron: "50 10 * * *"
   name: ci-knative-serving-performance-mesh
   agent: kubernetes
   spec:
@@ -2464,7 +2464,7 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "35 8 * * *"
+- cron: "30 8 * * *"
   name: ci-knative-build-0.5-continuous
   agent: kubernetes
   spec:
@@ -2552,7 +2552,7 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "14 9 * * *"
+- cron: "10 9 * * *"
   name: ci-knative-build-nightly-release
   agent: kubernetes
   spec:
@@ -2594,7 +2594,7 @@ periodics:
     - name: nightly-account
       secret:
         secretName: nightly-account
-- cron: "53 9 * * 2"
+- cron: "50 9 * * 2"
   name: ci-knative-build-dot-release
   agent: kubernetes
   spec:
@@ -2636,7 +2636,7 @@ periodics:
     - name: release-account
       secret:
         secretName: release-account
-- cron: "54 */2 * * *"
+- cron: "58 */2 * * *"
   name: ci-knative-build-auto-release
   agent: kubernetes
   spec:
@@ -2686,7 +2686,7 @@ periodics:
     - name: release-account
       secret:
         secretName: release-account
-- cron: "55 8 * * *"
+- cron: "51 8 * * *"
   name: ci-knative-build-latency
   agent: kubernetes
   decorate: true
@@ -2740,7 +2740,7 @@ periodics:
       args:
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=80"
-- cron: "1 * * * *"
+- cron: "5 * * * *"
   name: ci-knative-client-continuous
   agent: kubernetes
   spec:
@@ -2774,7 +2774,7 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "42 9 * * *"
+- cron: "40 9 * * *"
   name: ci-knative-client-nightly-release
   agent: kubernetes
   spec:
@@ -2808,7 +2808,7 @@ periodics:
     - name: nightly-account
       secret:
         secretName: nightly-account
-- cron: "22 9 * * 2"
+- cron: "21 9 * * 2"
   name: ci-knative-client-dot-release
   agent: kubernetes
   spec:
@@ -2850,7 +2850,7 @@ periodics:
     - name: release-account
       secret:
         secretName: release-account
-- cron: "23 */2 * * *"
+- cron: "29 */2 * * *"
   name: ci-knative-client-auto-release
   agent: kubernetes
   spec:
@@ -2914,7 +2914,7 @@ periodics:
       args:
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
-- cron: "24 * * * *"
+- cron: "20 * * * *"
   name: ci-knative-docs-continuous
   agent: kubernetes
   spec:
@@ -2978,7 +2978,7 @@ periodics:
       args:
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
-- cron: "36 */2 * * *"
+- cron: "30 */2 * * *"
   name: ci-knative-eventing-continuous
   agent: kubernetes
   spec:
@@ -3012,7 +3012,7 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "37 8 * * *"
+- cron: "36 8 * * *"
   name: ci-knative-eventing-0.5-continuous
   agent: kubernetes
   spec:
@@ -3056,7 +3056,7 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "43 8 * * *"
+- cron: "47 8 * * *"
   name: ci-knative-eventing-0.6-continuous
   agent: kubernetes
   spec:
@@ -3176,7 +3176,7 @@ periodics:
     - name: release-account
       secret:
         secretName: release-account
-- cron: "57 */2 * * *"
+- cron: "53 */2 * * *"
   name: ci-knative-eventing-auto-release
   agent: kubernetes
   spec:
@@ -3240,7 +3240,7 @@ periodics:
       args:
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
-- cron: "38 * * * *"
+- cron: "35 * * * *"
   name: ci-knative-eventing-contrib-continuous
   agent: kubernetes
   spec:
@@ -3274,7 +3274,7 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "39 8 * * *"
+- cron: "31 8 * * *"
   name: ci-knative-eventing-contrib-0.5-continuous
   agent: kubernetes
   spec:
@@ -3318,7 +3318,7 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "44 8 * * *"
+- cron: "42 8 * * *"
   name: ci-knative-eventing-contrib-0.6-continuous
   agent: kubernetes
   spec:
@@ -3362,7 +3362,7 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "16 9 * * *"
+- cron: "10 9 * * *"
   name: ci-knative-eventing-contrib-nightly-release
   agent: kubernetes
   spec:
@@ -3396,7 +3396,7 @@ periodics:
     - name: nightly-account
       secret:
         secretName: nightly-account
-- cron: "58 9 * * 2"
+- cron: "51 9 * * 2"
   name: ci-knative-eventing-contrib-dot-release
   agent: kubernetes
   spec:
@@ -3502,7 +3502,7 @@ periodics:
       args:
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
-- cron: "30 * * * *"
+- cron: "31 * * * *"
   name: ci-knative-build-templates-continuous
   agent: kubernetes
   spec:
@@ -3592,7 +3592,7 @@ periodics:
       args:
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
-- cron: "2 * * * *"
+- cron: "6 * * * *"
   name: ci-knative-caching-continuous
   agent: kubernetes
   spec:
@@ -3682,7 +3682,7 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "4 * * * *"
+- cron: "1 * * * *"
   name: ci-knative-sample-controller-continuous
   agent: kubernetes
   spec:
@@ -3716,7 +3716,7 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "18 * * * *"
+- cron: "13 * * * *"
   name: ci-googlecloudplatform-cloud-run-events-continuous
   agent: kubernetes
   spec:
@@ -3750,7 +3750,7 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "50 9 * * *"
+- cron: "59 9 * * *"
   name: ci-googlecloudplatform-cloud-run-events-nightly-release
   agent: kubernetes
   spec:
@@ -3784,7 +3784,7 @@ periodics:
     - name: nightly-account
       secret:
         secretName: nightly-account
-- cron: "31 9 * * 2"
+- cron: "30 9 * * 2"
   name: ci-googlecloudplatform-cloud-run-events-dot-release
   agent: kubernetes
   spec:
@@ -3826,7 +3826,7 @@ periodics:
     - name: release-account
       secret:
         secretName: release-account
-- cron: "32 */2 * * *"
+- cron: "37 */2 * * *"
   name: ci-googlecloudplatform-cloud-run-events-auto-release
   agent: kubernetes
   spec:


### PR DESCRIPTION
Currently, cron string generation is partially based on the ranking of jobs in `config_knative.yaml`, so if there is a job added somewhere other than the bottom, the rankings of jobs under insertion point will be changed, which results in non-deterministic cron string. Change this behavior to computing cron string only based on it's ascii value to avoid this problem.