### PR TITLE
[coverage] fix testgrid redness on passed tests

### DIFF
--- a/tools/coverage/testgrid/testsuiteXmlWriter.go
+++ b/tools/coverage/testgrid/testsuiteXmlWriter.go
@@ -29,11 +29,15 @@ import (
 
 // NewTestCase constructs the TestCase struct
 func NewTestCase(targetName, coverage string, failure bool) junit.TestCase {
-	f := strconv.FormatBool(failure)
+	var f *string
+	if failure {
+		*f = strconv.FormatBool(failure)
+	}
+
 	tc := junit.TestCase{
 		ClassName: "go_coverage",
 		Name:      targetName,
-		Failure:   &f,
+		Failure:   f,
 	}
 	tc.AddProperty("coverage", coverage)
 

--- a/tools/coverage/testgrid/testsuiteXmlWriter.go
+++ b/tools/coverage/testgrid/testsuiteXmlWriter.go
@@ -29,16 +29,16 @@ import (
 
 // NewTestCase constructs the TestCase struct
 func NewTestCase(targetName, coverage string, failure bool) junit.TestCase {
-	var f *string
-	if failure {
-		*f = strconv.FormatBool(failure)
-	}
-
 	tc := junit.TestCase{
 		ClassName: "go_coverage",
 		Name:      targetName,
-		Failure:   f,
 	}
+
+	if failure {
+		f := strconv.FormatBool(failure)
+		tc.Failure = &f
+	}
+
 	tc.AddProperty("coverage", coverage)
 
 	return tc

--- a/tools/coverage/testgrid/testsuiteXmlWriter.go
+++ b/tools/coverage/testgrid/testsuiteXmlWriter.go
@@ -34,6 +34,8 @@ func NewTestCase(targetName, coverage string, failure bool) junit.TestCase {
 		Name:      targetName,
 	}
 
+	// we want to add <failure> tag to only failed tests. Testgrid treats both
+	// "<failure> true </failure>" and "<failure> false </failure>" as failure
 	if failure {
 		f := strconv.FormatBool(failure)
 		tc.Failure = &f


### PR DESCRIPTION
For more details see discussion on https://github.com/knative/test-infra/issues/919

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #919

**Special notes to reviewers**:

**User-visible changes in this PR**:
testgrid redness on passed tests turns to green
