### PR TITLE
Unit test against testgrid package inconsistent with testgrid config …

### DIFF
--- a/shared/common/common.go
+++ b/shared/common/common.go
@@ -19,6 +19,8 @@ package common
 import (
 	"fmt"
 	"os"
+	"os/exec"
+	"strings"
 )
 
 const allUsersFullPermission = 0777
@@ -38,4 +40,23 @@ func CreateDirWithFileMode(dirPath string, perm os.FileMode) error {
 		}
 	}
 	return nil
+}
+
+// GetRootDir gets directory of git root
+func GetRootDir() (string, error) {
+	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+// CDToRootDir change directory to git root dir
+func CDToRootDir() error {
+	d, err := GetRootDir()
+	if nil != err {
+		return err
+	}
+	return os.Chdir(d)
 }

--- a/shared/testgrid/testgrid_test.go
+++ b/shared/testgrid/testgrid_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package testgrid_test
+package testgrid
 
 import (
 	"io/ioutil"
@@ -24,7 +24,6 @@ import (
 
 	"github.com/knative/test-infra/shared/junit"
 	"github.com/knative/test-infra/shared/prow"
-	"github.com/knative/test-infra/shared/testgrid"
 )
 
 const (
@@ -57,8 +56,23 @@ func TestXMLOutput(t *testing.T) {
 `
 
 	// Create a test file
-	if err := testgrid.CreateXMLOutput(tc, name); err != nil {
+	if err := CreateXMLOutput(tc, name); err != nil {
 		t.Fatalf("Error when creating xml output file: %v", err)
 	}
 	checkFileText(resultFile, want, t)
+}
+
+func TestConfigPath(t *testing.T) {
+	if _, err := NewConfig(); nil != err {
+		t.Fatalf("Testing default config file, want: no err, got: %v", err)
+	}
+}
+
+func TestTabName(t *testing.T) {
+	ac, _ := NewConfig()
+	for tgName, URL := range jobNameTestgridURLMap {
+		if got, _ := ac.GetTabRelURL(tgName); got != URL {
+			t.Fatalf("Testing testgroup/tab mapping for '%s', want: '%s', got: '%s'", tgName, URL, got)
+		}
+	}
 }

--- a/shared/testgrid/yaml.go
+++ b/shared/testgrid/yaml.go
@@ -27,8 +27,8 @@ import (
 
 const configPath = "ci/testgrid/config.yaml"
 
-// AllConfig is entire testgrid config
-type AllConfig struct {
+// Config is entire testgrid config
+type Config struct {
 	Dashboards []Dashboard `yaml:"dashboards"`
 }
 
@@ -45,7 +45,7 @@ type Tab struct {
 }
 
 // NewConfig loads from default config
-func NewConfig() (*AllConfig, error) {
+func NewConfig() (*Config, error) {
 	root, err := common.GetRootDir()
 	if nil != err {
 		return nil, err
@@ -54,18 +54,21 @@ func NewConfig() (*AllConfig, error) {
 }
 
 // NewConfigFromFile loads config from file
-func NewConfigFromFile(fp string) (*AllConfig, error) {
-	ac := &AllConfig{}
+func NewConfigFromFile(fp string) (*Config, error) {
+	ac := &Config{}
 	contents, err := ioutil.ReadFile(fp)
 	if nil == err {
 		err = yaml.Unmarshal(contents, ac)
+	}
+	if nil != err {
+		return nil, err
 	}
 	return ac, err
 }
 
 // GetTabRelURL finds URL relative to testgrid home URL from testgroup name
 // (generally this is prow job name)
-func (ac *AllConfig) GetTabRelURL(tgName string) (string, error) {
+func (ac *Config) GetTabRelURL(tgName string) (string, error) {
 	for _, dashboard := range ac.Dashboards {
 		for _, tab := range dashboard.Tabs {
 			if tab.TestGroupName == tgName {

--- a/shared/testgrid/yaml.go
+++ b/shared/testgrid/yaml.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testgrid
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path"
+
+	"github.com/knative/test-infra/shared/common"
+	"gopkg.in/yaml.v2"
+)
+
+const configPath = "ci/testgrid/config.yaml"
+
+// AllConfig is entire testgrid config
+type AllConfig struct {
+	Dashboards []Dashboard `yaml:"dashboards"`
+}
+
+// Dashboard is single dashboard on testgrid
+type Dashboard struct {
+	Name string `yaml:"name"`
+	Tabs []Tab  `yaml:"dashboard_tab"`
+}
+
+// Tab is a single tab on testgrid
+type Tab struct {
+	Name          string `yaml:"name"`
+	TestGroupName string `yaml:"test_group_name"`
+}
+
+// NewConfig loads from default config
+func NewConfig() (*AllConfig, error) {
+	root, err := common.GetRootDir()
+	if nil != err {
+		return nil, err
+	}
+	return NewConfigFromFile(path.Join(root, configPath))
+}
+
+// NewConfigFromFile loads config from file
+func NewConfigFromFile(fp string) (*AllConfig, error) {
+	ac := &AllConfig{}
+	contents, err := ioutil.ReadFile(fp)
+	if nil == err {
+		err = yaml.Unmarshal(contents, ac)
+	}
+	return ac, err
+}
+
+// GetTabRelURL finds URL relative to testgrid home URL from testgroup name
+// (generally this is prow job name)
+func (ac *AllConfig) GetTabRelURL(tgName string) (string, error) {
+	for _, dashboard := range ac.Dashboards {
+		for _, tab := range dashboard.Tabs {
+			if tab.TestGroupName == tgName {
+				return fmt.Sprintf("%s#%s", dashboard.Name, tab.Name), nil
+			}
+		}
+	}
+	return "", fmt.Errorf("testgroup name '%s' not exist", tgName)
+}

--- a/tools/prow-auto-bumper/file.go
+++ b/tools/prow-auto-bumper/file.go
@@ -23,22 +23,11 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
-	"strings"
-)
 
-func cdToRootDir() error {
-	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
-	output, err := cmd.Output()
-	if err != nil {
-		return err
-	}
-	d := strings.TrimSpace(string(output))
-	log.Printf("Changing working directory to %s...", d)
-	return os.Chdir(d)
-}
+	"github.com/knative/test-infra/shared/common"
+)
 
 // Update all tags in a byte slice
 func (pv *PRVersions) updateAllTags(content []byte, imageFilter *regexp.Regexp) ([]byte, string, []string) {
@@ -103,7 +92,7 @@ func (pv *PRVersions) updateFile(filename string, imageFilter *regexp.Regexp, dr
 func (pv *PRVersions) updateAllFiles(fileFilters []*regexp.Regexp, imageFilter *regexp.Regexp,
 	dryrun bool) ([]string, error) {
 	var errMsgs []string
-	if err := cdToRootDir(); err != nil {
+	if err := common.CDToRootDir(); err != nil {
 		return errMsgs, fmt.Errorf("failed to change to root dir")
 	}
 


### PR DESCRIPTION
Inside `share/testgrid` package, there are hardcoded testgroup name with testgrid tab URL, this can be broken by updating of either side but not both sides. Add unit test to guard against this

Fix: #926 