### PR TITLE
Prow auto bumper: add missing Makefile

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -3978,7 +3978,7 @@ periodics:
       args:
       - "--github-account=/etc/prow-auto-bumper-github-token/token"
       - "--git-userid=knative-prow-updater-robot"
-      - "--git-username=Knative Prow Updater Robot"
+      - "--git-username='Knative Prow Updater Robot'"
       - "--git-email=knative-prow-updater-robot@google.com"
       volumeMounts:
       - name: test-account

--- a/ci/prow/make_config.go
+++ b/ci/prow/make_config.go
@@ -802,7 +802,7 @@ func generateVersionBumpertoolPeriodicJob() {
 	data.Base.Args = []string{
 		"--github-account=/etc/prow-auto-bumper-github-token/token",
 		"--git-userid=knative-prow-updater-robot",
-		"--git-username=Knative Prow Updater Robot",
+		"--git-username='Knative Prow Updater Robot'",
 		"--git-email=knative-prow-updater-robot@google.com"}
 	addExtraEnvVarsToJob(&data.Base)
 	configureServiceAccountForJob(&data.Base)

--- a/tools/prow-auto-bumper/Makefile
+++ b/tools/prow-auto-bumper/Makefile
@@ -1,0 +1,16 @@
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+all:
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build .


### PR DESCRIPTION
Add missing Makefile for pushing image with Prow auto bumper, also fixing cmd arguments