### PR TITLE
Add continuous flow for test-infra

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -3716,6 +3716,40 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
+- cron: "42 * * * *"
+  name: ci-knative-test-infra-continuous
+  agent: kubernetes
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      args:
+      - "--scenario=kubernetes_execute_bazel"
+      - "--clean"
+      - "--job=$(JOB_NAME)"
+      - "--repo=github.com/knative/test-infra"
+      - "--root=/go/src"
+      - "--service-account=/etc/test-account/service-account.json"
+      - "--upload=gs://knative-prow/logs"
+      - "--timeout=50" # Avoid overrun
+      - "--" # end bootstrap args, scenario args below
+      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
+      - "./test/presubmit-tests.sh"
+      - "--all-tests"
+      - "--emit-metrics"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
 - cron: "13 * * * *"
   name: ci-googlecloudplatform-cloud-run-events-continuous
   agent: kubernetes

--- a/ci/prow/config_knative.yaml
+++ b/ci/prow/config_knative.yaml
@@ -195,6 +195,9 @@ periodics:
 
   knative/sample-controller:
     - continuous: true
+  
+  knative/test-infra:
+    - continuous: true
 
   GoogleCloudPlatform/cloud-run-events:
     - continuous: true

--- a/ci/testgrid/config.yaml
+++ b/ci/testgrid/config.yaml
@@ -200,6 +200,10 @@ test_groups:
   gcs_prefix: knative-prow/logs/ci-knative-sample-controller-continuous
   alert_stale_results_hours: 3
   num_failures_to_alert: 3
+- name: ci-knative-test-infra-continuous
+  gcs_prefix: knative-prow/logs/ci-knative-test-infra-continuous
+  alert_stale_results_hours: 3
+  num_failures_to_alert: 3
 - name: ci-knative-serving-0.4-continuous
   gcs_prefix: knative-prow/logs/ci-knative-serving-0.4-continuous
 - name: ci-knative-serving-0.5-continuous
@@ -388,6 +392,11 @@ dashboards:
   - name: continuous
     test_group_name: ci-knative-sample-controller-continuous
     base_options: "sort-by-name="
+- name: test-infra
+  dashboard_tab:
+  - name: continuous
+    test_group_name: ci-knative-test-infra-continuous
+    base_options: "sort-by-name="
 - name: cloud-run-events
   dashboard_tab:
   - name: continuous
@@ -452,6 +461,7 @@ dashboard_groups:
   - "caching"
   - "observability"
   - "sample-controller"
+  - "test-infra"
 - name: GoogleCloudPlatform
   dashboard_names:
   - "cloud-run-events"


### PR DESCRIPTION
Now that we have reasonable amount of tests in test-infra([example](https://gubernator.knative.dev/build/knative-prow/pr-logs/pull/knative_test-infra/961/pull-knative-test-infra-unit-tests/1141072812962746369/)), I think it makes sense for us to have continuous flow to ensure project health. This can also notifies us if something is broken in master, i.e.: https://gubernator.knative.dev/build/knative-prow/pr-logs/pull/knative_test-infra/955/pull-knative-test-infra-unit-tests/1141083384932470785/