### PR TITLE
mock check_links_in_markdown so unit test doesn't really run markdown…

### DIFF
--- a/test/unit/presubmit-tests.sh
+++ b/test/unit/presubmit-tests.sh
@@ -38,6 +38,10 @@ function init_test_env() {
   function mdl() {
     return 0
   }
+
+  function check_links_in_markdown() {
+    return 0
+  }
 }
 
 # Helper functions.


### PR DESCRIPTION
This [unit test](https://github.com/knative/test-infra/blob/cc50f2d588d33a9ffa0a495b8e447ceb070c3e6f/test/unit/presubmit-tests.sh#L261) is supposed to mock testing markdown tests, but it's actually checking links. Mock it so it doesn't happen here