### PR TITLE
Boskos resources update - Increased by 10 GCP project

### DIFF
--- a/ci/prow/boskos/permissions.sh
+++ b/ci/prow/boskos/permissions.sh
@@ -31,17 +31,17 @@ readonly APIS=(
 
 # Add an owner to the PROJECT
 for owner in ${OWNERS[@]}; do
-  gcloud projects add-iam-policy-binding ${PROJECT} --member group:${owner} --role roles/OWNER
+  gcloud projects add-iam-policy-binding ${PROJECT} --member group:${owner} --role roles/owner
 done
 
 # Add all GROUPS as editors
 for group in ${GROUPS[@]}; do
-  gcloud projects add-iam-policy-binding ${PROJECT} --member group:${group} --role roles/EDITOR
+  gcloud projects add-iam-policy-binding ${PROJECT} --member group:${group} --role roles/editor
 done
 
 # Add all service accounts as editors
 for sa in ${SAS[@]}; do
-  gcloud projects add-iam-policy-binding ${PROJECT} --member serviceAccount:${sa} --role roles/EDITOR
+  gcloud projects add-iam-policy-binding ${PROJECT} --member serviceAccount:${sa} --role roles/editor
 done
 
 # Enable APIS

--- a/ci/prow/boskos/resources.yaml
+++ b/ci/prow/boskos/resources.yaml
@@ -54,5 +54,15 @@ resources:
   - knative-boskos-38
   - knative-boskos-39
   - knative-boskos-40
+  - knative-boskos-41
+  - knative-boskos-42
+  - knative-boskos-43
+  - knative-boskos-44
+  - knative-boskos-45
+  - knative-boskos-46
+  - knative-boskos-47
+  - knative-boskos-48
+  - knative-boskos-49
+  - knative-boskos-50
   state: dirty
   type: gke-project


### PR DESCRIPTION
We are observing resource congestion because Janitor is taking more time than the rate at which tests are invoked. This change increases the GCP project pool by adding 10 more projects
