### PR TITLE
Reverting kubekins-e2e image

### DIFF
--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/k8s-testimages/kubekins-e2e:v20190613-295f98c-master
+FROM gcr.io/k8s-testimages/kubekins-e2e:v20190103-edc7696cc-master
 LABEL maintainer "Adriano Cunha <adrcunha@google.com>"
 
 # Install extras on top of base image


### PR DESCRIPTION
This CL is reverting the change made here: https://github.com/knative/test-infra/commit/9320a359edc4e18c1332e133395bc16230a1f6c3

Kubectl 1.14 is not needed at the moment. So reverting the change as we have seen couple of issues with the updated base image.

