### PR TITLE
add more concise JSON report to flaky-test-reporter

### DIFF
--- a/tools/flaky-test-reporter/json-report.go
+++ b/tools/flaky-test-reporter/json-report.go
@@ -26,11 +26,11 @@ import (
 	"github.com/knative/test-infra/shared/prow"
 )
 
-type JsonReport struct {
+type JSONReport struct {
 	Flaky []string `json:"flaky"`
 }
 
-func (jr *JsonReport) writeToArtifactsDir(repo string, dryrun bool) error {
+func (jr *JSONReport) writeToArtifactsDir(repo string, dryrun bool) error {
 	artifactsDir := prow.GetLocalArtifactsDir()
 	// no need to create the directory, it is guaranteed to exist since artifacts were generated earlier
 	outFilePath := path.Join(artifactsDir, repo, "all-flaky-tests.json")
@@ -65,9 +65,9 @@ func getFlakyTestSet(repo string, repoDataAll []*RepoData) []string {
 	return flakyTests
 }
 
-func writeFlakyTestsToJson(repoDataAll []*RepoData, dryrun bool) error {
-	for repo, _ := range jobConfigs {
-		output := JsonReport{Flaky: getFlakyTestSet(repo, repoDataAll)}
+func writeFlakyTestsToJSON(repoDataAll []*RepoData, dryrun bool) error {
+	for repo := range jobConfigs {
+		output := JSONReport{Flaky: getFlakyTestSet(repo, repoDataAll)}
 		err := output.writeToArtifactsDir(repo, dryrun)
 		if err != nil {
 			return err

--- a/tools/flaky-test-reporter/json-report.go
+++ b/tools/flaky-test-reporter/json-report.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"path"
+
+	"github.com/knative/test-infra/shared/prow"
+)
+
+type JsonReport struct {
+	Flaky []string `json:"flaky"`
+}
+
+func (jr *JsonReport) writeToArtifactsDir(repo string, dryrun bool) error {
+	artifactsDir := prow.GetLocalArtifactsDir()
+	// no need to create the directory, it is guaranteed to exist since artifacts were generated earlier
+	outFilePath := path.Join(artifactsDir, repo, "all-flaky-tests.json")
+	contents, err := json.Marshal(jr)
+	if nil != err {
+		return err
+	}
+	return run(
+		fmt.Sprintf("Create JSON report for repo '%s'", repo),
+		func() error {
+			return ioutil.WriteFile(outFilePath, contents, 0644)
+		},
+		dryrun,
+	)
+}
+
+// we want all flaky tests across all jobs for a given repo. There can be duplicate flaky tests
+// if multiple jobs use the same test cases. We remove duplicates by using a map as a "set".
+func getFlakyTestSet(repo string, repoDataAll []*RepoData) []string {
+	testSet := make(map[string]bool)
+	for _, rd := range repoDataAll {
+		if rd.Config.Repo == repo {
+			for _, test := range getFlakyTests(rd) {
+				testSet[test] = true
+			}
+		}
+	}
+	var flakyTests []string
+	for test := range testSet {
+		flakyTests = append(flakyTests, test)
+	}
+	return flakyTests
+}
+
+func writeFlakyTestsToJson(repoDataAll []*RepoData, dryrun bool) error {
+	for repo, _ := range jobConfigs {
+		output := JsonReport{Flaky: getFlakyTestSet(repo, repoDataAll)}
+		err := output.writeToArtifactsDir(repo, dryrun)
+		if err != nil {
+			return err
+		}
+		if dryrun {
+			log.Printf("[dry run] JSON report not written to disk.\n")
+		}
+	}
+	return nil
+}

--- a/tools/flaky-test-reporter/main.go
+++ b/tools/flaky-test-reporter/main.go
@@ -77,13 +77,17 @@ func main() {
 	// happens, it should fail the job after Slack notification
 	githubErr := ghi.processGithubIssues(repoDataAll, *dryrun)
 	slackErr := sendSlackNotifications(repoDataAll, slackClient, ghi, *dryrun)
+	jsonErr := writeFlakyTestsToJson(repoDataAll, *dryrun)
 	if nil != githubErr {
 		log.Printf("Github step failures:\n%v", githubErr)
 	}
 	if nil != slackErr {
 		log.Printf("Slack step failures:\n%v", slackErr)
 	}
-	if nil != githubErr || nil != slackErr { // Fail this job if there is any error
+	if nil != jsonErr {
+		log.Printf("JSON step failures:\n%v", jsonErr)
+	}
+	if nil != githubErr || nil != slackErr || nil != jsonErr { // Fail this job if there is any error
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
This is the first main step in the implementation of the flaky test re-trier. The re-trier needed a more concise logs of the currently flaky tests than what build artifacts can provide. 

This will generate a file named `all-flaky-tests.json` in the local artifacts directory, containing the set of all currently flaky tests for that repository.

/lint
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #

**Special notes to reviewers**:

**User-visible changes in this PR**:

