### PR TITLE
fixing continuous error

### DIFF
--- a/test/e2e/flag.go
+++ b/test/e2e/flag.go
@@ -1,0 +1,38 @@
+// +build e2e
+
+/*
+Copyright 2019 The Knative Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"flag"
+)
+
+// Flags holds the command line flags or defaults for settings in the user's environment.
+// See EnvironmentFlags for a list of supported fields.
+var Flags = initializeFlags()
+
+// EnvironmentFlags define the flags that are needed to run the e2e tests.
+type EnvironmentFlags struct {
+	EmitMetrics bool // Emit metrics
+}
+
+func initializeFlags() *EnvironmentFlags {
+	var f EnvironmentFlags
+
+	flag.BoolVar(&f.EmitMetrics, "emitmetrics", false,
+		"Set this flag to true if you would like tests to emit metrics, e.g. latency of resources being realized in the system.")
+
+	return &f
+}


### PR DESCRIPTION
test-infra continuous flow was enabled and failed due to flag `--emitmetrics` not defined. This PR fixes this error

example: https://gubernator.knative.dev/build/knative-prow/logs/ci-knative-test-infra-continuous/1141748184683384833/