### PR TITLE
deprecating bootstrap, use podutil

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -89,20 +89,15 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-knative-serving-build-tests"
     trigger: "(?m)^/test (all|pull-knative-serving-build-tests),?(\\s+|$)"
+    decorate: true
+    clone_uri: "https://github.com/knative/serving.git"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
+        command:
+        - runner.sh
         args:
-        - "--scenario=kubernetes_execute_bazel"
-        - "--clean"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--service-account=/etc/test-account/service-account.json"
-        - "--upload=gs://knative-prow/pr-logs"
-        - "--" # end bootstrap args, scenario args below
-        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--build-tests"
         volumeMounts:
@@ -124,20 +119,15 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-knative-serving-unit-tests"
     trigger: "(?m)^/test (all|pull-knative-serving-unit-tests),?(\\s+|$)"
+    decorate: true
+    clone_uri: "https://github.com/knative/serving.git"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
+        command:
+        - runner.sh
         args:
-        - "--scenario=kubernetes_execute_bazel"
-        - "--clean"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--service-account=/etc/test-account/service-account.json"
-        - "--upload=gs://knative-prow/pr-logs"
-        - "--" # end bootstrap args, scenario args below
-        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--unit-tests"
         volumeMounts:
@@ -159,20 +149,15 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-knative-serving-integration-tests"
     trigger: "(?m)^/test (all|pull-knative-serving-integration-tests),?(\\s+|$)"
+    decorate: true
+    clone_uri: "https://github.com/knative/serving.git"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
+        command:
+        - runner.sh
         args:
-        - "--scenario=kubernetes_execute_bazel"
-        - "--clean"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--service-account=/etc/test-account/service-account.json"
-        - "--upload=gs://knative-prow/pr-logs"
-        - "--" # end bootstrap args, scenario args below
-        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--run-test"
         - "./test/e2e-tests.sh"
@@ -195,20 +180,15 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-knative-serving-upgrade-tests"
     trigger: "(?m)^/test (all|pull-knative-serving-upgrade-tests),?(\\s+|$)"
+    decorate: true
+    clone_uri: "https://github.com/knative/serving.git"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
+        command:
+        - runner.sh
         args:
-        - "--scenario=kubernetes_execute_bazel"
-        - "--clean"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--service-account=/etc/test-account/service-account.json"
-        - "--upload=gs://knative-prow/pr-logs"
-        - "--" # end bootstrap args, scenario args below
-        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--run-test"
         - "./test/e2e-upgrade-tests.sh"
@@ -231,6 +211,8 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-knative-serving-smoke-tests"
     trigger: "(?m)^/test (all|pull-knative-serving-smoke-tests),?(\\s+|$)"
+    decorate: true
+    clone_uri: "https://github.com/knative/serving.git"
     skip_branches:
     - "release-0.4"
     - "release-0.5"
@@ -239,16 +221,9 @@ presubmits:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
+        command:
+        - runner.sh
         args:
-        - "--scenario=kubernetes_execute_bazel"
-        - "--clean"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--service-account=/etc/test-account/service-account.json"
-        - "--upload=gs://knative-prow/pr-logs"
-        - "--" # end bootstrap args, scenario args below
-        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--run-test"
         - "./test/e2e-smoke-tests.sh"
@@ -327,20 +302,15 @@ presubmits:
     always_run: false
     rerun_command: "/test pull-knative-serving-perf-tests"
     trigger: "(?m)^/test (all|pull-knative-serving-perf-tests),?(\\s+|$)"
+    decorate: true
+    clone_uri: "https://github.com/knative/serving.git"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
+        command:
+        - runner.sh
         args:
-        - "--scenario=kubernetes_execute_bazel"
-        - "--clean"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--service-account=/etc/test-account/service-account.json"
-        - "--upload=gs://knative-prow/pr-logs"
-        - "--" # end bootstrap args, scenario args below
-        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/performance-tests.sh"
         volumeMounts:
         - name: test-account
@@ -362,20 +332,15 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-knative-build-build-tests"
     trigger: "(?m)^/test (all|pull-knative-build-build-tests),?(\\s+|$)"
+    decorate: true
+    clone_uri: "https://github.com/knative/build.git"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
+        command:
+        - runner.sh
         args:
-        - "--scenario=kubernetes_execute_bazel"
-        - "--clean"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--service-account=/etc/test-account/service-account.json"
-        - "--upload=gs://knative-prow/pr-logs"
-        - "--" # end bootstrap args, scenario args below
-        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--build-tests"
         volumeMounts:
@@ -397,20 +362,15 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-knative-build-unit-tests"
     trigger: "(?m)^/test (all|pull-knative-build-unit-tests),?(\\s+|$)"
+    decorate: true
+    clone_uri: "https://github.com/knative/build.git"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
+        command:
+        - runner.sh
         args:
-        - "--scenario=kubernetes_execute_bazel"
-        - "--clean"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--service-account=/etc/test-account/service-account.json"
-        - "--upload=gs://knative-prow/pr-logs"
-        - "--" # end bootstrap args, scenario args below
-        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--unit-tests"
         volumeMounts:
@@ -432,20 +392,15 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-knative-build-integration-tests"
     trigger: "(?m)^/test (all|pull-knative-build-integration-tests),?(\\s+|$)"
+    decorate: true
+    clone_uri: "https://github.com/knative/build.git"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
+        command:
+        - runner.sh
         args:
-        - "--scenario=kubernetes_execute_bazel"
-        - "--clean"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--service-account=/etc/test-account/service-account.json"
-        - "--upload=gs://knative-prow/pr-logs"
-        - "--" # end bootstrap args, scenario args below
-        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--integration-tests"
         securityContext:
@@ -504,20 +459,15 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-knative-client-build-tests"
     trigger: "(?m)^/test (all|pull-knative-client-build-tests),?(\\s+|$)"
+    decorate: true
+    clone_uri: "https://github.com/knative/client.git"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
+        command:
+        - runner.sh
         args:
-        - "--scenario=kubernetes_execute_bazel"
-        - "--clean"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--service-account=/etc/test-account/service-account.json"
-        - "--upload=gs://knative-prow/pr-logs"
-        - "--" # end bootstrap args, scenario args below
-        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--build-tests"
         volumeMounts:
@@ -539,20 +489,15 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-knative-client-unit-tests"
     trigger: "(?m)^/test (all|pull-knative-client-unit-tests),?(\\s+|$)"
+    decorate: true
+    clone_uri: "https://github.com/knative/client.git"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
+        command:
+        - runner.sh
         args:
-        - "--scenario=kubernetes_execute_bazel"
-        - "--clean"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--service-account=/etc/test-account/service-account.json"
-        - "--upload=gs://knative-prow/pr-logs"
-        - "--" # end bootstrap args, scenario args below
-        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--unit-tests"
         volumeMounts:
@@ -574,20 +519,15 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-knative-client-integration-tests"
     trigger: "(?m)^/test (all|pull-knative-client-integration-tests),?(\\s+|$)"
+    decorate: true
+    clone_uri: "https://github.com/knative/client.git"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
+        command:
+        - runner.sh
         args:
-        - "--scenario=kubernetes_execute_bazel"
-        - "--clean"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--service-account=/etc/test-account/service-account.json"
-        - "--upload=gs://knative-prow/pr-logs"
-        - "--" # end bootstrap args, scenario args below
-        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--integration-tests"
         volumeMounts:
@@ -638,20 +578,15 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-knative-eventing-build-tests"
     trigger: "(?m)^/test (all|pull-knative-eventing-build-tests),?(\\s+|$)"
+    decorate: true
+    clone_uri: "https://github.com/knative/eventing.git"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
+        command:
+        - runner.sh
         args:
-        - "--scenario=kubernetes_execute_bazel"
-        - "--clean"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--service-account=/etc/test-account/service-account.json"
-        - "--upload=gs://knative-prow/pr-logs"
-        - "--" # end bootstrap args, scenario args below
-        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--build-tests"
         volumeMounts:
@@ -673,20 +608,15 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-knative-eventing-unit-tests"
     trigger: "(?m)^/test (all|pull-knative-eventing-unit-tests),?(\\s+|$)"
+    decorate: true
+    clone_uri: "https://github.com/knative/eventing.git"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
+        command:
+        - runner.sh
         args:
-        - "--scenario=kubernetes_execute_bazel"
-        - "--clean"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--service-account=/etc/test-account/service-account.json"
-        - "--upload=gs://knative-prow/pr-logs"
-        - "--" # end bootstrap args, scenario args below
-        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--unit-tests"
         volumeMounts:
@@ -708,20 +638,15 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-knative-eventing-integration-tests"
     trigger: "(?m)^/test (all|pull-knative-eventing-integration-tests),?(\\s+|$)"
+    decorate: true
+    clone_uri: "https://github.com/knative/eventing.git"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
+        command:
+        - runner.sh
         args:
-        - "--scenario=kubernetes_execute_bazel"
-        - "--clean"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--service-account=/etc/test-account/service-account.json"
-        - "--upload=gs://knative-prow/pr-logs"
-        - "--" # end bootstrap args, scenario args below
-        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--integration-tests"
         volumeMounts:
@@ -772,20 +697,15 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-knative-eventing-contrib-build-tests"
     trigger: "(?m)^/test (all|pull-knative-eventing-contrib-build-tests),?(\\s+|$)"
+    decorate: true
+    clone_uri: "https://github.com/knative/eventing-contrib.git"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
+        command:
+        - runner.sh
         args:
-        - "--scenario=kubernetes_execute_bazel"
-        - "--clean"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--service-account=/etc/test-account/service-account.json"
-        - "--upload=gs://knative-prow/pr-logs"
-        - "--" # end bootstrap args, scenario args below
-        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--build-tests"
         volumeMounts:
@@ -807,20 +727,15 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-knative-eventing-contrib-unit-tests"
     trigger: "(?m)^/test (all|pull-knative-eventing-contrib-unit-tests),?(\\s+|$)"
+    decorate: true
+    clone_uri: "https://github.com/knative/eventing-contrib.git"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
+        command:
+        - runner.sh
         args:
-        - "--scenario=kubernetes_execute_bazel"
-        - "--clean"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--service-account=/etc/test-account/service-account.json"
-        - "--upload=gs://knative-prow/pr-logs"
-        - "--" # end bootstrap args, scenario args below
-        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--unit-tests"
         volumeMounts:
@@ -842,20 +757,15 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-knative-eventing-contrib-integration-tests"
     trigger: "(?m)^/test (all|pull-knative-eventing-contrib-integration-tests),?(\\s+|$)"
+    decorate: true
+    clone_uri: "https://github.com/knative/eventing-contrib.git"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
+        command:
+        - runner.sh
         args:
-        - "--scenario=kubernetes_execute_bazel"
-        - "--clean"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--service-account=/etc/test-account/service-account.json"
-        - "--upload=gs://knative-prow/pr-logs"
-        - "--" # end bootstrap args, scenario args below
-        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--integration-tests"
         volumeMounts:
@@ -906,20 +816,15 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-knative-docs-build-tests"
     trigger: "(?m)^/test (all|pull-knative-docs-build-tests),?(\\s+|$)"
+    decorate: true
+    clone_uri: "https://github.com/knative/docs.git"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
+        command:
+        - runner.sh
         args:
-        - "--scenario=kubernetes_execute_bazel"
-        - "--clean"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--service-account=/etc/test-account/service-account.json"
-        - "--upload=gs://knative-prow/pr-logs"
-        - "--" # end bootstrap args, scenario args below
-        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--build-tests"
         volumeMounts:
@@ -941,20 +846,15 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-knative-docs-unit-tests"
     trigger: "(?m)^/test (all|pull-knative-docs-unit-tests),?(\\s+|$)"
+    decorate: true
+    clone_uri: "https://github.com/knative/docs.git"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
+        command:
+        - runner.sh
         args:
-        - "--scenario=kubernetes_execute_bazel"
-        - "--clean"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--service-account=/etc/test-account/service-account.json"
-        - "--upload=gs://knative-prow/pr-logs"
-        - "--" # end bootstrap args, scenario args below
-        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--unit-tests"
         volumeMounts:
@@ -976,20 +876,15 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-knative-docs-integration-tests"
     trigger: "(?m)^/test (all|pull-knative-docs-integration-tests),?(\\s+|$)"
+    decorate: true
+    clone_uri: "https://github.com/knative/docs.git"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
+        command:
+        - runner.sh
         args:
-        - "--scenario=kubernetes_execute_bazel"
-        - "--clean"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--service-account=/etc/test-account/service-account.json"
-        - "--upload=gs://knative-prow/pr-logs"
-        - "--" # end bootstrap args, scenario args below
-        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--integration-tests"
         securityContext:
@@ -1048,20 +943,15 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-knative-build-templates-build-tests"
     trigger: "(?m)^/test (all|pull-knative-build-templates-build-tests),?(\\s+|$)"
+    decorate: true
+    clone_uri: "https://github.com/knative/build-templates.git"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
+        command:
+        - runner.sh
         args:
-        - "--scenario=kubernetes_execute_bazel"
-        - "--clean"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--service-account=/etc/test-account/service-account.json"
-        - "--upload=gs://knative-prow/pr-logs"
-        - "--" # end bootstrap args, scenario args below
-        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--build-tests"
         volumeMounts:
@@ -1083,20 +973,15 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-knative-build-templates-unit-tests"
     trigger: "(?m)^/test (all|pull-knative-build-templates-unit-tests),?(\\s+|$)"
+    decorate: true
+    clone_uri: "https://github.com/knative/build-templates.git"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
+        command:
+        - runner.sh
         args:
-        - "--scenario=kubernetes_execute_bazel"
-        - "--clean"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--service-account=/etc/test-account/service-account.json"
-        - "--upload=gs://knative-prow/pr-logs"
-        - "--" # end bootstrap args, scenario args below
-        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--unit-tests"
         volumeMounts:
@@ -1118,20 +1003,15 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-knative-build-templates-integration-tests"
     trigger: "(?m)^/test (all|pull-knative-build-templates-integration-tests),?(\\s+|$)"
+    decorate: true
+    clone_uri: "https://github.com/knative/build-templates.git"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
+        command:
+        - runner.sh
         args:
-        - "--scenario=kubernetes_execute_bazel"
-        - "--clean"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--service-account=/etc/test-account/service-account.json"
-        - "--upload=gs://knative-prow/pr-logs"
-        - "--" # end bootstrap args, scenario args below
-        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--integration-tests"
         volumeMounts:
@@ -1154,20 +1034,15 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-knative-pkg-build-tests"
     trigger: "(?m)^/test (all|pull-knative-pkg-build-tests),?(\\s+|$)"
+    decorate: true
+    clone_uri: "https://github.com/knative/pkg.git"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
+        command:
+        - runner.sh
         args:
-        - "--scenario=kubernetes_execute_bazel"
-        - "--clean"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--service-account=/etc/test-account/service-account.json"
-        - "--upload=gs://knative-prow/pr-logs"
-        - "--" # end bootstrap args, scenario args below
-        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--build-tests"
         volumeMounts:
@@ -1189,20 +1064,15 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-knative-pkg-unit-tests"
     trigger: "(?m)^/test (all|pull-knative-pkg-unit-tests),?(\\s+|$)"
+    decorate: true
+    clone_uri: "https://github.com/knative/pkg.git"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
+        command:
+        - runner.sh
         args:
-        - "--scenario=kubernetes_execute_bazel"
-        - "--clean"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--service-account=/etc/test-account/service-account.json"
-        - "--upload=gs://knative-prow/pr-logs"
-        - "--" # end bootstrap args, scenario args below
-        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--unit-tests"
         volumeMounts:
@@ -1224,20 +1094,15 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-knative-pkg-integration-tests"
     trigger: "(?m)^/test (all|pull-knative-pkg-integration-tests),?(\\s+|$)"
+    decorate: true
+    clone_uri: "https://github.com/knative/pkg.git"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
+        command:
+        - runner.sh
         args:
-        - "--scenario=kubernetes_execute_bazel"
-        - "--clean"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--service-account=/etc/test-account/service-account.json"
-        - "--upload=gs://knative-prow/pr-logs"
-        - "--" # end bootstrap args, scenario args below
-        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--integration-tests"
         volumeMounts:
@@ -1288,20 +1153,15 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-knative-test-infra-build-tests"
     trigger: "(?m)^/test (all|pull-knative-test-infra-build-tests),?(\\s+|$)"
+    decorate: true
+    clone_uri: "https://github.com/knative/test-infra.git"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
+        command:
+        - runner.sh
         args:
-        - "--scenario=kubernetes_execute_bazel"
-        - "--clean"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--service-account=/etc/test-account/service-account.json"
-        - "--upload=gs://knative-prow/pr-logs"
-        - "--" # end bootstrap args, scenario args below
-        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--build-tests"
         volumeMounts:
@@ -1323,20 +1183,15 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-knative-test-infra-unit-tests"
     trigger: "(?m)^/test (all|pull-knative-test-infra-unit-tests),?(\\s+|$)"
+    decorate: true
+    clone_uri: "https://github.com/knative/test-infra.git"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
+        command:
+        - runner.sh
         args:
-        - "--scenario=kubernetes_execute_bazel"
-        - "--clean"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--service-account=/etc/test-account/service-account.json"
-        - "--upload=gs://knative-prow/pr-logs"
-        - "--" # end bootstrap args, scenario args below
-        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--unit-tests"
         volumeMounts:
@@ -1358,20 +1213,15 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-knative-test-infra-integration-tests"
     trigger: "(?m)^/test (all|pull-knative-test-infra-integration-tests),?(\\s+|$)"
+    decorate: true
+    clone_uri: "https://github.com/knative/test-infra.git"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
+        command:
+        - runner.sh
         args:
-        - "--scenario=kubernetes_execute_bazel"
-        - "--clean"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--service-account=/etc/test-account/service-account.json"
-        - "--upload=gs://knative-prow/pr-logs"
-        - "--" # end bootstrap args, scenario args below
-        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--integration-tests"
         volumeMounts:
@@ -1394,20 +1244,15 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-knative-caching-build-tests"
     trigger: "(?m)^/test (all|pull-knative-caching-build-tests),?(\\s+|$)"
+    decorate: true
+    clone_uri: "https://github.com/knative/caching.git"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
+        command:
+        - runner.sh
         args:
-        - "--scenario=kubernetes_execute_bazel"
-        - "--clean"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--service-account=/etc/test-account/service-account.json"
-        - "--upload=gs://knative-prow/pr-logs"
-        - "--" # end bootstrap args, scenario args below
-        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--build-tests"
         volumeMounts:
@@ -1429,20 +1274,15 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-knative-caching-unit-tests"
     trigger: "(?m)^/test (all|pull-knative-caching-unit-tests),?(\\s+|$)"
+    decorate: true
+    clone_uri: "https://github.com/knative/caching.git"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
+        command:
+        - runner.sh
         args:
-        - "--scenario=kubernetes_execute_bazel"
-        - "--clean"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--service-account=/etc/test-account/service-account.json"
-        - "--upload=gs://knative-prow/pr-logs"
-        - "--" # end bootstrap args, scenario args below
-        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--unit-tests"
         volumeMounts:
@@ -1464,20 +1304,15 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-knative-caching-integration-tests"
     trigger: "(?m)^/test (all|pull-knative-caching-integration-tests),?(\\s+|$)"
+    decorate: true
+    clone_uri: "https://github.com/knative/caching.git"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
+        command:
+        - runner.sh
         args:
-        - "--scenario=kubernetes_execute_bazel"
-        - "--clean"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--service-account=/etc/test-account/service-account.json"
-        - "--upload=gs://knative-prow/pr-logs"
-        - "--" # end bootstrap args, scenario args below
-        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--integration-tests"
         volumeMounts:
@@ -1528,20 +1363,15 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-knative-observability-build-tests"
     trigger: "(?m)^/test (all|pull-knative-observability-build-tests),?(\\s+|$)"
+    decorate: true
+    clone_uri: "https://github.com/knative/observability.git"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
+        command:
+        - runner.sh
         args:
-        - "--scenario=kubernetes_execute_bazel"
-        - "--clean"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--service-account=/etc/test-account/service-account.json"
-        - "--upload=gs://knative-prow/pr-logs"
-        - "--" # end bootstrap args, scenario args below
-        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--build-tests"
         volumeMounts:
@@ -1563,20 +1393,15 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-knative-observability-unit-tests"
     trigger: "(?m)^/test (all|pull-knative-observability-unit-tests),?(\\s+|$)"
+    decorate: true
+    clone_uri: "https://github.com/knative/observability.git"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
+        command:
+        - runner.sh
         args:
-        - "--scenario=kubernetes_execute_bazel"
-        - "--clean"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--service-account=/etc/test-account/service-account.json"
-        - "--upload=gs://knative-prow/pr-logs"
-        - "--" # end bootstrap args, scenario args below
-        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--unit-tests"
         volumeMounts:
@@ -1598,20 +1423,15 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-knative-observability-integration-tests"
     trigger: "(?m)^/test (all|pull-knative-observability-integration-tests),?(\\s+|$)"
+    decorate: true
+    clone_uri: "https://github.com/knative/observability.git"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
+        command:
+        - runner.sh
         args:
-        - "--scenario=kubernetes_execute_bazel"
-        - "--clean"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--service-account=/etc/test-account/service-account.json"
-        - "--upload=gs://knative-prow/pr-logs"
-        - "--" # end bootstrap args, scenario args below
-        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--integration-tests"
         volumeMounts:
@@ -1634,20 +1454,15 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-knative-sample-controller-build-tests"
     trigger: "(?m)^/test (all|pull-knative-sample-controller-build-tests),?(\\s+|$)"
+    decorate: true
+    clone_uri: "https://github.com/knative/sample-controller.git"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
+        command:
+        - runner.sh
         args:
-        - "--scenario=kubernetes_execute_bazel"
-        - "--clean"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--service-account=/etc/test-account/service-account.json"
-        - "--upload=gs://knative-prow/pr-logs"
-        - "--" # end bootstrap args, scenario args below
-        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--build-tests"
         volumeMounts:
@@ -1669,20 +1484,15 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-knative-sample-controller-unit-tests"
     trigger: "(?m)^/test (all|pull-knative-sample-controller-unit-tests),?(\\s+|$)"
+    decorate: true
+    clone_uri: "https://github.com/knative/sample-controller.git"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
+        command:
+        - runner.sh
         args:
-        - "--scenario=kubernetes_execute_bazel"
-        - "--clean"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--service-account=/etc/test-account/service-account.json"
-        - "--upload=gs://knative-prow/pr-logs"
-        - "--" # end bootstrap args, scenario args below
-        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--unit-tests"
         volumeMounts:
@@ -1705,20 +1515,15 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-googlecloudplatform-cloud-run-events-build-tests"
     trigger: "(?m)^/test (all|pull-googlecloudplatform-cloud-run-events-build-tests),?(\\s+|$)"
+    decorate: true
+    clone_uri: "https://github.com/GoogleCloudPlatform/cloud-run-events.git"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
+        command:
+        - runner.sh
         args:
-        - "--scenario=kubernetes_execute_bazel"
-        - "--clean"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--service-account=/etc/test-account/service-account.json"
-        - "--upload=gs://knative-prow/pr-logs"
-        - "--" # end bootstrap args, scenario args below
-        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--build-tests"
         volumeMounts:
@@ -1740,20 +1545,15 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-googlecloudplatform-cloud-run-events-unit-tests"
     trigger: "(?m)^/test (all|pull-googlecloudplatform-cloud-run-events-unit-tests),?(\\s+|$)"
+    decorate: true
+    clone_uri: "https://github.com/GoogleCloudPlatform/cloud-run-events.git"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
+        command:
+        - runner.sh
         args:
-        - "--scenario=kubernetes_execute_bazel"
-        - "--clean"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--service-account=/etc/test-account/service-account.json"
-        - "--upload=gs://knative-prow/pr-logs"
-        - "--" # end bootstrap args, scenario args below
-        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--unit-tests"
         volumeMounts:
@@ -1775,20 +1575,15 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-googlecloudplatform-cloud-run-events-integration-tests"
     trigger: "(?m)^/test (all|pull-googlecloudplatform-cloud-run-events-integration-tests),?(\\s+|$)"
+    decorate: true
+    clone_uri: "https://github.com/GoogleCloudPlatform/cloud-run-events.git"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
+        command:
+        - runner.sh
         args:
-        - "--scenario=kubernetes_execute_bazel"
-        - "--clean"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--service-account=/etc/test-account/service-account.json"
-        - "--upload=gs://knative-prow/pr-logs"
-        - "--" # end bootstrap args, scenario args below
-        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--integration-tests"
         volumeMounts:
@@ -1836,21 +1631,19 @@ periodics:
 - cron: "10 */2 * * *"
   name: ci-knative-serving-continuous
   agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: master
+    clone_uri: "https://github.com/knative/serving.git"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
+      command:
+      - runner.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/knative/serving"
-      - "--root=/go/src"
-      - "--service-account=/etc/test-account/service-account.json"
-      - "--upload=gs://knative-prow/logs"
-      - "--timeout=100" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./test/presubmit-tests.sh"
       - "--all-tests"
       - "--emit-metrics"
@@ -1870,21 +1663,19 @@ periodics:
 - cron: "6 8 * * *"
   name: ci-knative-serving-0.4-continuous
   agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: master
+    clone_uri: "https://github.com/knative/serving.git"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
+      command:
+      - runner.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/knative/serving=release-0.4"
-      - "--root=/go/src"
-      - "--service-account=/etc/test-account/service-account.json"
-      - "--upload=gs://knative-prow/logs"
-      - "--timeout=180" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./hack/release.sh"
       - "--nopublish"
       - "--notag-release"
@@ -1914,21 +1705,19 @@ periodics:
 - cron: "17 8 * * *"
   name: ci-knative-serving-0.5-continuous
   agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: master
+    clone_uri: "https://github.com/knative/serving.git"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
+      command:
+      - runner.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/knative/serving=release-0.5"
-      - "--root=/go/src"
-      - "--service-account=/etc/test-account/service-account.json"
-      - "--upload=gs://knative-prow/logs"
-      - "--timeout=180" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./hack/release.sh"
       - "--nopublish"
       - "--notag-release"
@@ -1958,21 +1747,19 @@ periodics:
 - cron: "28 8 * * *"
   name: ci-knative-serving-0.6-continuous
   agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: master
+    clone_uri: "https://github.com/knative/serving.git"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
+      command:
+      - runner.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/knative/serving=release-0.6"
-      - "--root=/go/src"
-      - "--service-account=/etc/test-account/service-account.json"
-      - "--upload=gs://knative-prow/logs"
-      - "--timeout=180" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./hack/release.sh"
       - "--nopublish"
       - "--notag-release"
@@ -2002,21 +1789,19 @@ periodics:
 - cron: "10 */2 * * *"
   name: ci-knative-serving-istio-1.0.7-mesh
   agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: master
+    clone_uri: "https://github.com/knative/serving.git"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
+      command:
+      - runner.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/knative/serving"
-      - "--root=/go/src"
-      - "--service-account=/etc/test-account/service-account.json"
-      - "--upload=gs://knative-prow/logs"
-      - "--timeout=100" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./test/e2e-tests.sh"
       - "--istio-version"
       - "1.0.7"
@@ -2037,21 +1822,19 @@ periodics:
 - cron: "31 */2 * * *"
   name: ci-knative-serving-istio-1.0.7-no-mesh
   agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: master
+    clone_uri: "https://github.com/knative/serving.git"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
+      command:
+      - runner.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/knative/serving"
-      - "--root=/go/src"
-      - "--service-account=/etc/test-account/service-account.json"
-      - "--upload=gs://knative-prow/logs"
-      - "--timeout=100" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./test/e2e-tests.sh"
       - "--istio-version"
       - "1.0.7"
@@ -2072,21 +1855,19 @@ periodics:
 - cron: "20 */2 * * *"
   name: ci-knative-serving-istio-1.1.7-mesh
   agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: master
+    clone_uri: "https://github.com/knative/serving.git"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
+      command:
+      - runner.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/knative/serving"
-      - "--root=/go/src"
-      - "--service-account=/etc/test-account/service-account.json"
-      - "--upload=gs://knative-prow/logs"
-      - "--timeout=100" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./test/e2e-tests.sh"
       - "--istio-version"
       - "1.1.7"
@@ -2107,21 +1888,19 @@ periodics:
 - cron: "42 */2 * * *"
   name: ci-knative-serving-istio-1.1.7-no-mesh
   agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: master
+    clone_uri: "https://github.com/knative/serving.git"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
+      command:
+      - runner.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/knative/serving"
-      - "--root=/go/src"
-      - "--service-account=/etc/test-account/service-account.json"
-      - "--upload=gs://knative-prow/logs"
-      - "--timeout=100" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./test/e2e-tests.sh"
       - "--istio-version"
       - "1.1.7"
@@ -2142,21 +1921,19 @@ periodics:
 - cron: "19 */2 * * *"
   name: ci-knative-serving-k8s-1.12-istio-1.1
   agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: master
+    clone_uri: "https://github.com/knative/serving.git"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
+      command:
+      - runner.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/knative/serving"
-      - "--root=/go/src"
-      - "--service-account=/etc/test-account/service-account.json"
-      - "--upload=gs://knative-prow/logs"
-      - "--timeout=100" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./test/e2e-tests.sh"
       - "--cluster-version"
       - '1.12'
@@ -2178,21 +1955,19 @@ periodics:
 - cron: "8 */2 * * *"
   name: ci-knative-serving-k8s-1.12-istio-1.0
   agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: master
+    clone_uri: "https://github.com/knative/serving.git"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
+      command:
+      - runner.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/knative/serving"
-      - "--root=/go/src"
-      - "--service-account=/etc/test-account/service-account.json"
-      - "--upload=gs://knative-prow/logs"
-      - "--timeout=100" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./test/e2e-tests.sh"
       - "--cluster-version"
       - '1.12'
@@ -2214,21 +1989,19 @@ periodics:
 - cron: "8 */2 * * *"
   name: ci-knative-serving-k8s-1.11-istio-1.1
   agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: master
+    clone_uri: "https://github.com/knative/serving.git"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
+      command:
+      - runner.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/knative/serving"
-      - "--root=/go/src"
-      - "--service-account=/etc/test-account/service-account.json"
-      - "--upload=gs://knative-prow/logs"
-      - "--timeout=100" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./test/e2e-tests.sh"
       - "--cluster-version"
       - '1.11'
@@ -2250,21 +2023,19 @@ periodics:
 - cron: "57 */2 * * *"
   name: ci-knative-serving-k8s-1.11-istio-1.0
   agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: master
+    clone_uri: "https://github.com/knative/serving.git"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
+      command:
+      - runner.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/knative/serving"
-      - "--root=/go/src"
-      - "--service-account=/etc/test-account/service-account.json"
-      - "--upload=gs://knative-prow/logs"
-      - "--timeout=100" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./test/e2e-tests.sh"
       - "--cluster-version"
       - '1.11'
@@ -2286,21 +2057,19 @@ periodics:
 - cron: "56 9 * * *"
   name: ci-knative-serving-nightly-release
   agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: master
+    clone_uri: "https://github.com/knative/serving.git"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
+      command:
+      - runner.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/knative/serving"
-      - "--root=/go/src"
-      - "--service-account=/etc/nightly-account/service-account.json"
-      - "--upload=gs://knative-prow/logs"
-      - "--timeout=90" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./hack/release.sh"
       - "--publish"
       - "--tag-release"
@@ -2320,21 +2089,19 @@ periodics:
 - cron: "37 9 * * 2"
   name: ci-knative-serving-dot-release
   agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: master
+    clone_uri: "https://github.com/knative/serving.git"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
+      command:
+      - runner.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/knative/serving"
-      - "--root=/go/src"
-      - "--service-account=/etc/release-account/service-account.json"
-      - "--upload=gs://knative-prow/logs"
-      - "--timeout=90" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./hack/release.sh"
       - "--dot-release"
       - "--release-gcs knative-releases/serving"
@@ -2362,21 +2129,19 @@ periodics:
 - cron: "34 */2 * * *"
   name: ci-knative-serving-auto-release
   agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: master
+    clone_uri: "https://github.com/knative/serving.git"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
+      command:
+      - runner.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/knative/serving"
-      - "--root=/go/src"
-      - "--service-account=/etc/release-account/service-account.json"
-      - "--upload=gs://knative-prow/logs"
-      - "--timeout=90" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./hack/release.sh"
       - "--auto-release"
       - "--release-gcs knative-releases/serving"
@@ -2436,21 +2201,19 @@ periodics:
 - cron: "58 8 * * *"
   name: ci-knative-serving-performance
   agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: master
+    clone_uri: "https://github.com/knative/serving.git"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
+      command:
+      - runner.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/knative/serving"
-      - "--root=/go/src"
-      - "--service-account=/etc/test-account/service-account.json"
-      - "--upload=gs://knative-prow/logs"
-      - "--timeout=120" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./test/performance-tests.sh"
       volumeMounts:
       - name: monitoring-db-credentials
@@ -2478,21 +2241,19 @@ periodics:
 - cron: "50 10 * * *"
   name: ci-knative-serving-performance-mesh
   agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: master
+    clone_uri: "https://github.com/knative/serving.git"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
+      command:
+      - runner.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/knative/serving"
-      - "--root=/go/src"
-      - "--service-account=/etc/test-account/service-account.json"
-      - "--upload=gs://knative-prow/logs"
-      - "--timeout=120" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./test/performance-tests.sh"
       - "--mesh"
       volumeMounts:
@@ -2521,21 +2282,19 @@ periodics:
 - cron: "13 9 * * *"
   name: ci-knative-serving-webhook-apicoverage
   agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: master
+    clone_uri: "https://github.com/knative/serving.git"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
+      command:
+      - runner.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/knative/serving"
-      - "--root=/go/src"
-      - "--service-account=/etc/test-account/service-account.json"
-      - "--upload=gs://knative-prow/logs"
-      - "--timeout=50" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./test/apicoverage.sh"
       volumeMounts:
       - name: test-account
@@ -2577,21 +2336,19 @@ periodics:
 - cron: "34 * * * *"
   name: ci-knative-build-continuous
   agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: build
+    base_ref: master
+    clone_uri: "https://github.com/knative/build.git"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
+      command:
+      - runner.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/knative/build"
-      - "--root=/go/src"
-      - "--service-account=/etc/test-account/service-account.json"
-      - "--upload=gs://knative-prow/logs"
-      - "--timeout=50" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./test/presubmit-tests.sh"
       - "--all-tests"
       - "--emit-metrics"
@@ -2611,21 +2368,19 @@ periodics:
 - cron: "30 8 * * *"
   name: ci-knative-build-0.5-continuous
   agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: build
+    base_ref: master
+    clone_uri: "https://github.com/knative/build.git"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
+      command:
+      - runner.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/knative/build=release-0.5"
-      - "--root=/go/src"
-      - "--service-account=/etc/test-account/service-account.json"
-      - "--upload=gs://knative-prow/logs"
-      - "--timeout=180" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./hack/release.sh"
       - "--nopublish"
       - "--notag-release"
@@ -2655,21 +2410,19 @@ periodics:
 - cron: "41 8 * * *"
   name: ci-knative-build-0.6-continuous
   agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: build
+    base_ref: master
+    clone_uri: "https://github.com/knative/build.git"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
+      command:
+      - runner.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/knative/build=release-0.6"
-      - "--root=/go/src"
-      - "--service-account=/etc/test-account/service-account.json"
-      - "--upload=gs://knative-prow/logs"
-      - "--timeout=180" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./hack/release.sh"
       - "--nopublish"
       - "--notag-release"
@@ -2699,21 +2452,19 @@ periodics:
 - cron: "10 9 * * *"
   name: ci-knative-build-nightly-release
   agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: build
+    base_ref: master
+    clone_uri: "https://github.com/knative/build.git"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
+      command:
+      - runner.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/knative/build"
-      - "--root=/go/src"
-      - "--service-account=/etc/nightly-account/service-account.json"
-      - "--upload=gs://knative-prow/logs"
-      - "--timeout=90" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./hack/release.sh"
       - "--publish"
       - "--tag-release"
@@ -2741,21 +2492,19 @@ periodics:
 - cron: "50 9 * * 2"
   name: ci-knative-build-dot-release
   agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: build
+    base_ref: master
+    clone_uri: "https://github.com/knative/build.git"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
+      command:
+      - runner.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/knative/build"
-      - "--root=/go/src"
-      - "--service-account=/etc/release-account/service-account.json"
-      - "--upload=gs://knative-prow/logs"
-      - "--timeout=90" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./hack/release.sh"
       - "--dot-release"
       - "--release-gcs knative-releases/build"
@@ -2783,21 +2532,19 @@ periodics:
 - cron: "58 */2 * * *"
   name: ci-knative-build-auto-release
   agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: build
+    base_ref: master
+    clone_uri: "https://github.com/knative/build.git"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
+      command:
+      - runner.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/knative/build"
-      - "--root=/go/src"
-      - "--service-account=/etc/release-account/service-account.json"
-      - "--upload=gs://knative-prow/logs"
-      - "--timeout=90" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./hack/release.sh"
       - "--auto-release"
       - "--release-gcs knative-releases/build"
@@ -2887,21 +2634,19 @@ periodics:
 - cron: "5 * * * *"
   name: ci-knative-client-continuous
   agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: client
+    base_ref: master
+    clone_uri: "https://github.com/knative/client.git"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
+      command:
+      - runner.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/knative/client"
-      - "--root=/go/src"
-      - "--service-account=/etc/test-account/service-account.json"
-      - "--upload=gs://knative-prow/logs"
-      - "--timeout=50" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./test/presubmit-tests.sh"
       - "--all-tests"
       - "--emit-metrics"
@@ -2921,21 +2666,19 @@ periodics:
 - cron: "40 9 * * *"
   name: ci-knative-client-nightly-release
   agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: client
+    base_ref: master
+    clone_uri: "https://github.com/knative/client.git"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
+      command:
+      - runner.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/knative/client"
-      - "--root=/go/src"
-      - "--service-account=/etc/nightly-account/service-account.json"
-      - "--upload=gs://knative-prow/logs"
-      - "--timeout=90" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./hack/release.sh"
       - "--publish"
       - "--tag-release"
@@ -2955,21 +2698,19 @@ periodics:
 - cron: "21 9 * * 2"
   name: ci-knative-client-dot-release
   agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: client
+    base_ref: master
+    clone_uri: "https://github.com/knative/client.git"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
+      command:
+      - runner.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/knative/client"
-      - "--root=/go/src"
-      - "--service-account=/etc/release-account/service-account.json"
-      - "--upload=gs://knative-prow/logs"
-      - "--timeout=90" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./hack/release.sh"
       - "--dot-release"
       - "--release-gcs knative-releases/client"
@@ -2997,21 +2738,19 @@ periodics:
 - cron: "29 */2 * * *"
   name: ci-knative-client-auto-release
   agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: client
+    base_ref: master
+    clone_uri: "https://github.com/knative/client.git"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
+      command:
+      - runner.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/knative/client"
-      - "--root=/go/src"
-      - "--service-account=/etc/release-account/service-account.json"
-      - "--upload=gs://knative-prow/logs"
-      - "--timeout=90" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./hack/release.sh"
       - "--auto-release"
       - "--release-gcs knative-releases/client"
@@ -3061,21 +2800,19 @@ periodics:
 - cron: "20 * * * *"
   name: ci-knative-docs-continuous
   agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: docs
+    base_ref: master
+    clone_uri: "https://github.com/knative/docs.git"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
+      command:
+      - runner.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/knative/docs"
-      - "--root=/go/src"
-      - "--service-account=/etc/test-account/service-account.json"
-      - "--upload=gs://knative-prow/logs"
-      - "--timeout=50" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./test/presubmit-tests.sh"
       - "--all-tests"
       - "--emit-metrics"
@@ -3125,21 +2862,19 @@ periodics:
 - cron: "30 */2 * * *"
   name: ci-knative-eventing-continuous
   agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: eventing
+    base_ref: master
+    clone_uri: "https://github.com/knative/eventing.git"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
+      command:
+      - runner.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/knative/eventing"
-      - "--root=/go/src"
-      - "--service-account=/etc/test-account/service-account.json"
-      - "--upload=gs://knative-prow/logs"
-      - "--timeout=90" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./test/presubmit-tests.sh"
       - "--all-tests"
       - "--emit-metrics"
@@ -3159,21 +2894,19 @@ periodics:
 - cron: "36 8 * * *"
   name: ci-knative-eventing-0.5-continuous
   agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: eventing
+    base_ref: master
+    clone_uri: "https://github.com/knative/eventing.git"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
+      command:
+      - runner.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/knative/eventing=release-0.5"
-      - "--root=/go/src"
-      - "--service-account=/etc/test-account/service-account.json"
-      - "--upload=gs://knative-prow/logs"
-      - "--timeout=180" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./hack/release.sh"
       - "--nopublish"
       - "--notag-release"
@@ -3203,21 +2936,19 @@ periodics:
 - cron: "47 8 * * *"
   name: ci-knative-eventing-0.6-continuous
   agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: eventing
+    base_ref: master
+    clone_uri: "https://github.com/knative/eventing.git"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
+      command:
+      - runner.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/knative/eventing=release-0.6"
-      - "--root=/go/src"
-      - "--service-account=/etc/test-account/service-account.json"
-      - "--upload=gs://knative-prow/logs"
-      - "--timeout=180" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./hack/release.sh"
       - "--nopublish"
       - "--notag-release"
@@ -3247,21 +2978,19 @@ periodics:
 - cron: "15 9 * * *"
   name: ci-knative-eventing-nightly-release
   agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: eventing
+    base_ref: master
+    clone_uri: "https://github.com/knative/eventing.git"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
+      command:
+      - runner.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/knative/eventing"
-      - "--root=/go/src"
-      - "--service-account=/etc/nightly-account/service-account.json"
-      - "--upload=gs://knative-prow/logs"
-      - "--timeout=90" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./hack/release.sh"
       - "--publish"
       - "--tag-release"
@@ -3281,21 +3010,19 @@ periodics:
 - cron: "56 9 * * 2"
   name: ci-knative-eventing-dot-release
   agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: eventing
+    base_ref: master
+    clone_uri: "https://github.com/knative/eventing.git"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
+      command:
+      - runner.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/knative/eventing"
-      - "--root=/go/src"
-      - "--service-account=/etc/release-account/service-account.json"
-      - "--upload=gs://knative-prow/logs"
-      - "--timeout=90" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./hack/release.sh"
       - "--dot-release"
       - "--release-gcs knative-releases/eventing"
@@ -3323,21 +3050,19 @@ periodics:
 - cron: "53 */2 * * *"
   name: ci-knative-eventing-auto-release
   agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: eventing
+    base_ref: master
+    clone_uri: "https://github.com/knative/eventing.git"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
+      command:
+      - runner.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/knative/eventing"
-      - "--root=/go/src"
-      - "--service-account=/etc/release-account/service-account.json"
-      - "--upload=gs://knative-prow/logs"
-      - "--timeout=90" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./hack/release.sh"
       - "--auto-release"
       - "--release-gcs knative-releases/eventing"
@@ -3387,21 +3112,19 @@ periodics:
 - cron: "35 * * * *"
   name: ci-knative-eventing-contrib-continuous
   agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: eventing-contrib
+    base_ref: master
+    clone_uri: "https://github.com/knative/eventing-contrib.git"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
+      command:
+      - runner.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/knative/eventing-contrib"
-      - "--root=/go/src"
-      - "--service-account=/etc/test-account/service-account.json"
-      - "--upload=gs://knative-prow/logs"
-      - "--timeout=50" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./test/presubmit-tests.sh"
       - "--all-tests"
       - "--emit-metrics"
@@ -3421,21 +3144,19 @@ periodics:
 - cron: "31 8 * * *"
   name: ci-knative-eventing-contrib-0.5-continuous
   agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: eventing-contrib
+    base_ref: master
+    clone_uri: "https://github.com/knative/eventing-contrib.git"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
+      command:
+      - runner.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/knative/eventing-contrib=release-0.5"
-      - "--root=/go/src"
-      - "--service-account=/etc/test-account/service-account.json"
-      - "--upload=gs://knative-prow/logs"
-      - "--timeout=180" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./hack/release.sh"
       - "--nopublish"
       - "--notag-release"
@@ -3465,21 +3186,19 @@ periodics:
 - cron: "42 8 * * *"
   name: ci-knative-eventing-contrib-0.6-continuous
   agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: eventing-contrib
+    base_ref: master
+    clone_uri: "https://github.com/knative/eventing-contrib.git"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
+      command:
+      - runner.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/knative/eventing-contrib=release-0.6"
-      - "--root=/go/src"
-      - "--service-account=/etc/test-account/service-account.json"
-      - "--upload=gs://knative-prow/logs"
-      - "--timeout=180" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./hack/release.sh"
       - "--nopublish"
       - "--notag-release"
@@ -3509,21 +3228,19 @@ periodics:
 - cron: "10 9 * * *"
   name: ci-knative-eventing-contrib-nightly-release
   agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: eventing-contrib
+    base_ref: master
+    clone_uri: "https://github.com/knative/eventing-contrib.git"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
+      command:
+      - runner.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/knative/eventing-contrib"
-      - "--root=/go/src"
-      - "--service-account=/etc/nightly-account/service-account.json"
-      - "--upload=gs://knative-prow/logs"
-      - "--timeout=90" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./hack/release.sh"
       - "--publish"
       - "--tag-release"
@@ -3543,21 +3260,19 @@ periodics:
 - cron: "51 9 * * 2"
   name: ci-knative-eventing-contrib-dot-release
   agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: eventing-contrib
+    base_ref: master
+    clone_uri: "https://github.com/knative/eventing-contrib.git"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
+      command:
+      - runner.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/knative/eventing-contrib"
-      - "--root=/go/src"
-      - "--service-account=/etc/release-account/service-account.json"
-      - "--upload=gs://knative-prow/logs"
-      - "--timeout=90" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./hack/release.sh"
       - "--dot-release"
       - "--release-gcs knative-releases/eventing-contrib"
@@ -3585,21 +3300,19 @@ periodics:
 - cron: "59 */2 * * *"
   name: ci-knative-eventing-contrib-auto-release
   agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: eventing-contrib
+    base_ref: master
+    clone_uri: "https://github.com/knative/eventing-contrib.git"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
+      command:
+      - runner.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/knative/eventing-contrib"
-      - "--root=/go/src"
-      - "--service-account=/etc/release-account/service-account.json"
-      - "--upload=gs://knative-prow/logs"
-      - "--timeout=90" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./hack/release.sh"
       - "--auto-release"
       - "--release-gcs knative-releases/eventing-contrib"
@@ -3649,21 +3362,19 @@ periodics:
 - cron: "31 * * * *"
   name: ci-knative-build-templates-continuous
   agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: build-templates
+    base_ref: master
+    clone_uri: "https://github.com/knative/build-templates.git"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
+      command:
+      - runner.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/knative/build-templates"
-      - "--root=/go/src"
-      - "--service-account=/etc/test-account/service-account.json"
-      - "--upload=gs://knative-prow/logs"
-      - "--timeout=50" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./test/presubmit-tests.sh"
       - "--all-tests"
       - "--emit-metrics"
@@ -3683,21 +3394,19 @@ periodics:
 - cron: "17 * * * *"
   name: ci-knative-pkg-continuous
   agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: pkg
+    base_ref: master
+    clone_uri: "https://github.com/knative/pkg.git"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
+      command:
+      - runner.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/knative/pkg"
-      - "--root=/go/src"
-      - "--service-account=/etc/test-account/service-account.json"
-      - "--upload=gs://knative-prow/logs"
-      - "--timeout=50" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./test/presubmit-tests.sh"
       - "--all-tests"
       - "--emit-metrics"
@@ -3739,21 +3448,19 @@ periodics:
 - cron: "6 * * * *"
   name: ci-knative-caching-continuous
   agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: caching
+    base_ref: master
+    clone_uri: "https://github.com/knative/caching.git"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
+      command:
+      - runner.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/knative/caching"
-      - "--root=/go/src"
-      - "--service-account=/etc/test-account/service-account.json"
-      - "--upload=gs://knative-prow/logs"
-      - "--timeout=50" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./test/presubmit-tests.sh"
       - "--all-tests"
       - "--emit-metrics"
@@ -3795,21 +3502,19 @@ periodics:
 - cron: "3 * * * *"
   name: ci-knative-observability-continuous
   agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: observability
+    base_ref: master
+    clone_uri: "https://github.com/knative/observability.git"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
+      command:
+      - runner.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/knative/observability"
-      - "--root=/go/src"
-      - "--service-account=/etc/test-account/service-account.json"
-      - "--upload=gs://knative-prow/logs"
-      - "--timeout=50" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./test/presubmit-tests.sh"
       - "--all-tests"
       - "--emit-metrics"
@@ -3829,21 +3534,19 @@ periodics:
 - cron: "1 * * * *"
   name: ci-knative-sample-controller-continuous
   agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: sample-controller
+    base_ref: master
+    clone_uri: "https://github.com/knative/sample-controller.git"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
+      command:
+      - runner.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/knative/sample-controller"
-      - "--root=/go/src"
-      - "--service-account=/etc/test-account/service-account.json"
-      - "--upload=gs://knative-prow/logs"
-      - "--timeout=50" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./test/presubmit-tests.sh"
       - "--all-tests"
       - "--emit-metrics"
@@ -3863,21 +3566,19 @@ periodics:
 - cron: "42 * * * *"
   name: ci-knative-test-infra-continuous
   agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: test-infra
+    base_ref: master
+    clone_uri: "https://github.com/knative/test-infra.git"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
+      command:
+      - runner.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/knative/test-infra"
-      - "--root=/go/src"
-      - "--service-account=/etc/test-account/service-account.json"
-      - "--upload=gs://knative-prow/logs"
-      - "--timeout=50" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./test/presubmit-tests.sh"
       - "--all-tests"
       - "--emit-metrics"
@@ -3897,21 +3598,19 @@ periodics:
 - cron: "13 * * * *"
   name: ci-googlecloudplatform-cloud-run-events-continuous
   agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: GoogleCloudPlatform
+    repo: cloud-run-events
+    base_ref: master
+    clone_uri: "https://github.com/GoogleCloudPlatform/cloud-run-events.git"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
+      command:
+      - runner.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/GoogleCloudPlatform/cloud-run-events"
-      - "--root=/go/src"
-      - "--service-account=/etc/test-account/service-account.json"
-      - "--upload=gs://knative-prow/logs"
-      - "--timeout=50" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./test/presubmit-tests.sh"
       - "--all-tests"
       - "--emit-metrics"
@@ -3931,21 +3630,19 @@ periodics:
 - cron: "59 9 * * *"
   name: ci-googlecloudplatform-cloud-run-events-nightly-release
   agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: GoogleCloudPlatform
+    repo: cloud-run-events
+    base_ref: master
+    clone_uri: "https://github.com/GoogleCloudPlatform/cloud-run-events.git"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
+      command:
+      - runner.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/GoogleCloudPlatform/cloud-run-events"
-      - "--root=/go/src"
-      - "--service-account=/etc/nightly-account/service-account.json"
-      - "--upload=gs://knative-prow/logs"
-      - "--timeout=90" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./hack/release.sh"
       - "--publish"
       - "--tag-release"
@@ -3965,21 +3662,19 @@ periodics:
 - cron: "30 9 * * 2"
   name: ci-googlecloudplatform-cloud-run-events-dot-release
   agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: GoogleCloudPlatform
+    repo: cloud-run-events
+    base_ref: master
+    clone_uri: "https://github.com/GoogleCloudPlatform/cloud-run-events.git"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
+      command:
+      - runner.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/GoogleCloudPlatform/cloud-run-events"
-      - "--root=/go/src"
-      - "--service-account=/etc/release-account/service-account.json"
-      - "--upload=gs://knative-prow/logs"
-      - "--timeout=90" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./hack/release.sh"
       - "--dot-release"
       - "--release-gcs knative-releases/cloud-run-events"
@@ -4007,21 +3702,19 @@ periodics:
 - cron: "37 */2 * * *"
   name: ci-googlecloudplatform-cloud-run-events-auto-release
   agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: GoogleCloudPlatform
+    repo: cloud-run-events
+    base_ref: master
+    clone_uri: "https://github.com/GoogleCloudPlatform/cloud-run-events.git"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
+      command:
+      - runner.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/GoogleCloudPlatform/cloud-run-events"
-      - "--root=/go/src"
-      - "--service-account=/etc/release-account/service-account.json"
-      - "--upload=gs://knative-prow/logs"
-      - "--timeout=90" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./hack/release.sh"
       - "--auto-release"
       - "--release-gcs knative-releases/cloud-run-events"

--- a/ci/prow/templates/prow_periodic_test_job.yaml
+++ b/ci/prow/templates/prow_periodic_test_job.yaml
@@ -2,21 +2,15 @@
   name: [[.PeriodicJobName]]
   agent: kubernetes
   [[indent_section 4 "labels" .Base.Labels]]
+  decorate: true
+  [[indent_section 2 "extra_refs" .Base.ExtraRefs]]
   spec:
     containers:
     - image: [[.Base.Image]]
       imagePullPolicy: Always
+      command:
+      - runner.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=[[repo .Base]]"
-      - "--root=/go/src"
-      - "--service-account=[[.Base.ServiceAccount]]"
-      - "--upload=[[.Base.GcsLogDir]]"
-      - "--timeout=[[.Base.Timeout]]" # Avoid overrun
-      - "--" # end bootstrap args, scenario args below
-      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       [[indent_array 6 .PeriodicCommand]]
       [[indent_section 8 "securityContext" .Base.SecurityContext]]
       [[indent_section 6 "volumeMounts" .Base.VolumeMounts]]

--- a/ci/prow/templates/prow_presubmit_job.yaml
+++ b/ci/prow/templates/prow_presubmit_job.yaml
@@ -5,21 +5,16 @@
     always_run: [[.Base.AlwaysRun]]
     rerun_command: "/test [[.PresubmitPullJobName]]"
     trigger: "(?m)^/test (all|[[.PresubmitPullJobName]]),?(\\s+|$)"
+    decorate: true
+    clone_uri: [[.Base.CloneURI]]
     [[indent_array_section 4 "skip_branches" .Base.SkipBranches]]
     spec:
       containers:
       - image: [[.Base.Image]]
         imagePullPolicy: Always
+        command:
+        - runner.sh
         args:
-        - "--scenario=kubernetes_execute_bazel"
-        - "--clean"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--service-account=[[.Base.ServiceAccount]]"
-        - "--upload=[[.Base.GcsPresubmitLogDir]]"
-        - "--" # end bootstrap args, scenario args below
-        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         [[indent_array 8 .PresubmitCommand]]
         [[indent_section 10 "securityContext" .Base.SecurityContext]]
         [[indent_section 8 "volumeMounts" .Base.VolumeMounts]]


### PR DESCRIPTION
For migrating sample-controller to knative.dev/sample-controller in this PR https://github.com/knative/sample-controller/pull/24 and more along the line, we still need to move forward with podutil.

This change has been manually tested and worked as expected on test-infra jobs:
https://gubernator.knative.dev/build/knative-prow/logs/ci-knative-test-infra-continuous/1141777769940652032/
https://gubernator.knative.dev/build/knative-prow/pr-logs/pull/knative_test-infra/977/pull-knative-test-infra-unit-tests/1141763036952924160/
https://gubernator.knative.dev/build/knative-prow/pr-logs/pull/knative_test-infra/977/pull-knative-test-infra-build-tests/1141752593760915456/

Note: with this change we are losing timestamp like `I0620 18:24:19.414]`. I brought this issue out of k8s issues pile here: https://github.com/kubernetes/test-infra/issues/10100

Fixes #265.