### PR TITLE
Prow Config: Default region update for E2E tests 

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -113,7 +113,9 @@ presubmits:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
-          value: us-central1
+          value: us-west1
+        - name: E2E_CLUSTER_BACKUP_REGIONS
+          value: 'us-east1 us-central1'
       volumes:
       - name: test-account
         secret:
@@ -148,7 +150,9 @@ presubmits:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
-          value: us-central1
+          value: us-west1
+        - name: E2E_CLUSTER_BACKUP_REGIONS
+          value: 'us-east1 us-central1'
       volumes:
       - name: test-account
         secret:
@@ -184,7 +188,9 @@ presubmits:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
-          value: us-central1
+          value: us-west1
+        - name: E2E_CLUSTER_BACKUP_REGIONS
+          value: 'us-east1 us-central1'
       volumes:
       - name: test-account
         secret:
@@ -220,7 +226,9 @@ presubmits:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
-          value: us-central1
+          value: us-west1
+        - name: E2E_CLUSTER_BACKUP_REGIONS
+          value: 'us-east1 us-central1'
       volumes:
       - name: test-account
         secret:
@@ -260,7 +268,9 @@ presubmits:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
-          value: us-central1
+          value: us-west1
+        - name: E2E_CLUSTER_BACKUP_REGIONS
+          value: 'us-east1 us-central1'
       volumes:
       - name: test-account
         secret:
@@ -350,7 +360,9 @@ presubmits:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
-          value: us-central1
+          value: us-west1
+        - name: E2E_CLUSTER_BACKUP_REGIONS
+          value: 'us-east1 us-central1'
       volumes:
       - name: test-account
         secret:
@@ -386,7 +398,9 @@ presubmits:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
-          value: us-central1
+          value: us-west1
+        - name: E2E_CLUSTER_BACKUP_REGIONS
+          value: 'us-east1 us-central1'
       volumes:
       - name: test-account
         secret:
@@ -421,7 +435,9 @@ presubmits:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
-          value: us-central1
+          value: us-west1
+        - name: E2E_CLUSTER_BACKUP_REGIONS
+          value: 'us-east1 us-central1'
       volumes:
       - name: test-account
         secret:
@@ -462,7 +478,9 @@ presubmits:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
-          value: us-central1
+          value: us-west1
+        - name: E2E_CLUSTER_BACKUP_REGIONS
+          value: 'us-east1 us-central1'
       volumes:
       - name: docker-graph
         emptyDir: {}
@@ -528,7 +546,9 @@ presubmits:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
-          value: us-central1
+          value: us-west1
+        - name: E2E_CLUSTER_BACKUP_REGIONS
+          value: 'us-east1 us-central1'
       volumes:
       - name: test-account
         secret:
@@ -563,7 +583,9 @@ presubmits:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
-          value: us-central1
+          value: us-west1
+        - name: E2E_CLUSTER_BACKUP_REGIONS
+          value: 'us-east1 us-central1'
       volumes:
       - name: test-account
         secret:
@@ -598,7 +620,9 @@ presubmits:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
-          value: us-central1
+          value: us-west1
+        - name: E2E_CLUSTER_BACKUP_REGIONS
+          value: 'us-east1 us-central1'
       volumes:
       - name: test-account
         secret:
@@ -662,7 +686,9 @@ presubmits:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
-          value: us-central1
+          value: us-west1
+        - name: E2E_CLUSTER_BACKUP_REGIONS
+          value: 'us-east1 us-central1'
       volumes:
       - name: test-account
         secret:
@@ -697,7 +723,9 @@ presubmits:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
-          value: us-central1
+          value: us-west1
+        - name: E2E_CLUSTER_BACKUP_REGIONS
+          value: 'us-east1 us-central1'
       volumes:
       - name: test-account
         secret:
@@ -732,7 +760,9 @@ presubmits:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
-          value: us-central1
+          value: us-west1
+        - name: E2E_CLUSTER_BACKUP_REGIONS
+          value: 'us-east1 us-central1'
       volumes:
       - name: test-account
         secret:
@@ -796,7 +826,9 @@ presubmits:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
-          value: us-central1
+          value: us-west1
+        - name: E2E_CLUSTER_BACKUP_REGIONS
+          value: 'us-east1 us-central1'
       volumes:
       - name: test-account
         secret:
@@ -831,7 +863,9 @@ presubmits:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
-          value: us-central1
+          value: us-west1
+        - name: E2E_CLUSTER_BACKUP_REGIONS
+          value: 'us-east1 us-central1'
       volumes:
       - name: test-account
         secret:
@@ -866,7 +900,9 @@ presubmits:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
-          value: us-central1
+          value: us-west1
+        - name: E2E_CLUSTER_BACKUP_REGIONS
+          value: 'us-east1 us-central1'
       volumes:
       - name: test-account
         secret:
@@ -930,7 +966,9 @@ presubmits:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
-          value: us-central1
+          value: us-west1
+        - name: E2E_CLUSTER_BACKUP_REGIONS
+          value: 'us-east1 us-central1'
       volumes:
       - name: test-account
         secret:
@@ -965,7 +1003,9 @@ presubmits:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
-          value: us-central1
+          value: us-west1
+        - name: E2E_CLUSTER_BACKUP_REGIONS
+          value: 'us-east1 us-central1'
       volumes:
       - name: test-account
         secret:
@@ -1006,7 +1046,9 @@ presubmits:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
-          value: us-central1
+          value: us-west1
+        - name: E2E_CLUSTER_BACKUP_REGIONS
+          value: 'us-east1 us-central1'
       volumes:
       - name: docker-graph
         emptyDir: {}
@@ -1072,7 +1114,9 @@ presubmits:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
-          value: us-central1
+          value: us-west1
+        - name: E2E_CLUSTER_BACKUP_REGIONS
+          value: 'us-east1 us-central1'
       volumes:
       - name: test-account
         secret:
@@ -1107,7 +1151,9 @@ presubmits:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
-          value: us-central1
+          value: us-west1
+        - name: E2E_CLUSTER_BACKUP_REGIONS
+          value: 'us-east1 us-central1'
       volumes:
       - name: test-account
         secret:
@@ -1142,7 +1188,9 @@ presubmits:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
-          value: us-central1
+          value: us-west1
+        - name: E2E_CLUSTER_BACKUP_REGIONS
+          value: 'us-east1 us-central1'
       volumes:
       - name: test-account
         secret:
@@ -1178,7 +1226,9 @@ presubmits:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
-          value: us-central1
+          value: us-west1
+        - name: E2E_CLUSTER_BACKUP_REGIONS
+          value: 'us-east1 us-central1'
       volumes:
       - name: test-account
         secret:
@@ -1213,7 +1263,9 @@ presubmits:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
-          value: us-central1
+          value: us-west1
+        - name: E2E_CLUSTER_BACKUP_REGIONS
+          value: 'us-east1 us-central1'
       volumes:
       - name: test-account
         secret:
@@ -1248,7 +1300,9 @@ presubmits:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
-          value: us-central1
+          value: us-west1
+        - name: E2E_CLUSTER_BACKUP_REGIONS
+          value: 'us-east1 us-central1'
       volumes:
       - name: test-account
         secret:
@@ -1312,7 +1366,9 @@ presubmits:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
-          value: us-central1
+          value: us-west1
+        - name: E2E_CLUSTER_BACKUP_REGIONS
+          value: 'us-east1 us-central1'
       volumes:
       - name: test-account
         secret:
@@ -1347,7 +1403,9 @@ presubmits:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
-          value: us-central1
+          value: us-west1
+        - name: E2E_CLUSTER_BACKUP_REGIONS
+          value: 'us-east1 us-central1'
       volumes:
       - name: test-account
         secret:
@@ -1382,7 +1440,9 @@ presubmits:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
-          value: us-central1
+          value: us-west1
+        - name: E2E_CLUSTER_BACKUP_REGIONS
+          value: 'us-east1 us-central1'
       volumes:
       - name: test-account
         secret:
@@ -1418,7 +1478,9 @@ presubmits:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
-          value: us-central1
+          value: us-west1
+        - name: E2E_CLUSTER_BACKUP_REGIONS
+          value: 'us-east1 us-central1'
       volumes:
       - name: test-account
         secret:
@@ -1453,7 +1515,9 @@ presubmits:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
-          value: us-central1
+          value: us-west1
+        - name: E2E_CLUSTER_BACKUP_REGIONS
+          value: 'us-east1 us-central1'
       volumes:
       - name: test-account
         secret:
@@ -1488,7 +1552,9 @@ presubmits:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
-          value: us-central1
+          value: us-west1
+        - name: E2E_CLUSTER_BACKUP_REGIONS
+          value: 'us-east1 us-central1'
       volumes:
       - name: test-account
         secret:
@@ -1552,7 +1618,9 @@ presubmits:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
-          value: us-central1
+          value: us-west1
+        - name: E2E_CLUSTER_BACKUP_REGIONS
+          value: 'us-east1 us-central1'
       volumes:
       - name: test-account
         secret:
@@ -1587,7 +1655,9 @@ presubmits:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
-          value: us-central1
+          value: us-west1
+        - name: E2E_CLUSTER_BACKUP_REGIONS
+          value: 'us-east1 us-central1'
       volumes:
       - name: test-account
         secret:
@@ -1622,7 +1692,9 @@ presubmits:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
-          value: us-central1
+          value: us-west1
+        - name: E2E_CLUSTER_BACKUP_REGIONS
+          value: 'us-east1 us-central1'
       volumes:
       - name: test-account
         secret:
@@ -1658,7 +1730,9 @@ presubmits:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
-          value: us-central1
+          value: us-west1
+        - name: E2E_CLUSTER_BACKUP_REGIONS
+          value: 'us-east1 us-central1'
       volumes:
       - name: test-account
         secret:
@@ -1693,7 +1767,9 @@ presubmits:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
-          value: us-central1
+          value: us-west1
+        - name: E2E_CLUSTER_BACKUP_REGIONS
+          value: 'us-east1 us-central1'
       volumes:
       - name: test-account
         secret:
@@ -1729,7 +1805,9 @@ presubmits:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
-          value: us-central1
+          value: us-west1
+        - name: E2E_CLUSTER_BACKUP_REGIONS
+          value: 'us-east1 us-central1'
       volumes:
       - name: test-account
         secret:
@@ -1764,7 +1842,9 @@ presubmits:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
-          value: us-central1
+          value: us-west1
+        - name: E2E_CLUSTER_BACKUP_REGIONS
+          value: 'us-east1 us-central1'
       volumes:
       - name: test-account
         secret:
@@ -1799,7 +1879,9 @@ presubmits:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
-          value: us-central1
+          value: us-west1
+        - name: E2E_CLUSTER_BACKUP_REGIONS
+          value: 'us-east1 us-central1'
       volumes:
       - name: test-account
         secret:

--- a/ci/prow/make_config.go
+++ b/ci/prow/make_config.go
@@ -594,7 +594,8 @@ func generatePresubmit(title string, repoName string, presubmitConfig yaml.MapSl
 	data.PresubmitPostJobName = "post-" + data.PresubmitJobName
 	if data.Base.ServiceAccount != "" {
 		addEnvToJob(&data.Base, "GOOGLE_APPLICATION_CREDENTIALS", data.Base.ServiceAccount)
-		addEnvToJob(&data.Base, "E2E_CLUSTER_REGION", "us-central1")
+		addEnvToJob(&data.Base, "E2E_CLUSTER_REGION", "us-west1")
+		addEnvToJob(&data.Base, "E2E_CLUSTER_BACKUP_REGIONS", "'us-east1 us-central1'")
 	}
 	addExtraEnvVarsToJob(&data.Base)
 	configureServiceAccountForJob(&data.Base)

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -44,7 +44,7 @@ export E2E_CLUSTER_REGION=${E2E_CLUSTER_REGION:-us-central1}
 export E2E_CLUSTER_ZONE=${E2E_CLUSTER_ZONE:-}
 
 # Default backup regions in case of stockouts; by default we don't fall back to a different zone in the same region
-readonly E2E_CLUSTER_BACKUP_REGIONS=${E2E_CLUSTER_BACKUP_REGIONS:-us-west1 us-east1}
+readonly E2E_CLUSTER_BACKUP_REGIONS=${E2E_CLUSTER_BACKUP_REGIONS:-us-east1 us-central1}
 readonly E2E_CLUSTER_BACKUP_ZONES=${E2E_CLUSTER_BACKUP_ZONES:-}
 
 readonly E2E_CLUSTER_MACHINE=${E2E_CLUSTER_MACHINE:-n1-standard-4}


### PR DESCRIPTION
We are observing latency issues and stockout issue with us-central1. This change moves some of the PR tests to use us-west1 region.



