### PR TITLE
Enable Spyglass on Prow

### DIFF
--- a/ci/prow/cluster.yaml
+++ b/ci/prow/cluster.yaml
@@ -219,6 +219,7 @@ spec:
         args:
         - --hook-url=http://hook:8888/plugin-help
         - --tide-url=http://tide/
+        - --spyglass
         ports:
           - name: http
             containerPort: 8080

--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -34,6 +34,21 @@ plank:
       bucket: "knative-prow"
       path_strategy: "explicit"
     gcs_credentials_secret: "test-account"
+deck:
+  spyglass:
+    size_limit: 500000000 # 500MB
+    gcs_browser_prefix: https://console.cloud.google.com/storage/browser/
+    testgrid_config: gs://knative-testgrid/config
+    testgrid_root: https://testgrid.knative.dev/
+    viewers:
+      "started.json|finished.json":
+      - "metadata"
+      "build-log.txt":
+      - "buildlog"
+      "artifacts/junit.*\\.xml":
+      - "junit"
+    announcement: "The old job viewer, Gubernator, has been deprecated in favour of this page, Spyglass.{{if .ArtifactPath}} For now, the old page is <a href='https://gubernator.knative.dev/build/{{.ArtifactPath}}'>still available</a>.{{end}} Please send feedback to Knative productivity."
+  tide_update_period: 1s
 prowjob_namespace: default
 pod_namespace: test-pods
 log_level: debug

--- a/ci/prow/templates/prow_config_header.yaml
+++ b/ci/prow/templates/prow_config_header.yaml
@@ -37,6 +37,22 @@ plank:
       path_strategy: "explicit"
     gcs_credentials_secret: "test-account"
 
+deck:
+  spyglass:
+    size_limit: 500000000 # 500MB
+    gcs_browser_prefix: https://console.cloud.google.com/storage/browser/
+    testgrid_config: gs://knative-testgrid/config
+    testgrid_root: https://testgrid.knative.dev/
+    viewers:
+      "started.json|finished.json":
+      - "metadata"
+      "build-log.txt":
+      - "buildlog"
+      "artifacts/junit.*\\.xml":
+      - "junit"
+    announcement: "The old job viewer, Gubernator, has been deprecated in favour of this page, Spyglass.{{if .ArtifactPath}} For now, the old page is <a href='https://gubernator.knative.dev/build/{{.ArtifactPath}}'>still available</a>.{{end}} Please send feedback to Knative productivity."
+  tide_update_period: 1s
+
 prowjob_namespace: default
 pod_namespace: test-pods
 log_level: debug

--- a/ci/prow/templates/testgrid_config_header.yaml
+++ b/ci/prow/templates/testgrid_config_header.yaml
@@ -36,7 +36,7 @@ default_test_group:
 
 default_dashboard_tab:
   open_test_template:            # The URL template to visit after clicking on a cell
-    url: https://gubernator.knative.dev/build/<gcs_prefix>/<changelist>
+    url: https://prow.knative.dev/view/gcs/<gcs_prefix>/<changelist>
   file_bug_template:             # The URL template to visit when filing a bug
     url: https://github.com/knative/serving/issues/new
     options:
@@ -48,9 +48,9 @@ default_dashboard_tab:
     url:                         # Empty
     options:                     # Empty
   # Text to show in the about menu as a link to another view of the results
-  results_text: See these results in Gubernator
+  results_text: See these results on Prow
   results_url_template:          # The URL template to visit after clicking
-    url: https://gubernator.knative.dev/builds/<gcs_prefix>
+    url: https://prow.knative.dev/job-history/<gcs_prefix>
   # URL for regression search links.
   code_search_path: github.com/knative/serving/search
   num_columns_recent: 10

--- a/ci/testgrid/config.yaml
+++ b/ci/testgrid/config.yaml
@@ -33,7 +33,7 @@ default_test_group:
   num_passes_to_disable_alert: 1 # Consider a failing test passing if it has 1 or more consecutive passes
 default_dashboard_tab:
   open_test_template:            # The URL template to visit after clicking on a cell
-    url: https://gubernator.knative.dev/build/<gcs_prefix>/<changelist>
+    url: https://prow.knative.dev/view/gcs/<gcs_prefix>/<changelist>
   file_bug_template:             # The URL template to visit when filing a bug
     url: https://github.com/knative/serving/issues/new
     options:
@@ -45,9 +45,9 @@ default_dashboard_tab:
     url:                         # Empty
     options:                     # Empty
   # Text to show in the about menu as a link to another view of the results
-  results_text: See these results in Gubernator
+  results_text: See these results on Prow
   results_url_template:          # The URL template to visit after clicking
-    url: https://gubernator.knative.dev/builds/<gcs_prefix>
+    url: https://prow.knative.dev/job-history/<gcs_prefix>
   # URL for regression search links.
   code_search_path: github.com/knative/serving/search
   num_columns_recent: 10


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Enable Spyglass on Prow by following documents below:
https://github.com/kubernetes/test-infra/tree/master/prow/spyglass
https://github.com/kubernetes/test-infra/blob/82770741f93b4fbf727fc70f81aebe8a0da35ff3/prow/config.yaml#L27
https://github.com/kubernetes/test-infra/blob/c9d7409d4a1ecad5476b02ca21fe71d5eda3a335/testgrid/config.yaml#L28
https://github.com/kubernetes/test-infra/blob/e9e544733854d54403aa1dfd84ca009fd9b942f0/prow/cluster/deck_deployment.yaml#L37

Things to do after this PR goes in:
1. Run `make -C ci/prow update-cluster`
2. Run `make -C ci/prow update-config`
3. Check if Spyglass works by visiting a URL like https://prow.knative.dev/view/gcs/knative-prow/logs/ci-knative-serving-continuous/1141315079623413760
4. If step3 passes, run `make -C ci/testgrid update-config`

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #710 

/cc @dushyanthsc 
/cc @adrcunha 

