### PR TITLE
add shared JSON report library and client in flaky-test-reporter

### DIFF
--- a/shared/jsonreport/jsonreport.go
+++ b/shared/jsonreport/jsonreport.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jsonreport
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"path"
+
+	"github.com/knative/test-infra/shared/common"
+	"github.com/knative/test-infra/shared/prow"
+)
+
+const (
+	filename = "flaky-tests.json"
+)
+
+type Report struct {
+	Repo  string   `json:"-"`
+	Flaky []string `json:"flaky"`
+}
+
+func (r *Report) WriteToArtifactsDir() error {
+	artifactsDir := prow.GetLocalArtifactsDir()
+	err := common.CreateDir(path.Join(artifactsDir, r.Repo))
+	if nil != err {
+		return err
+	}
+	outFilePath := path.Join(artifactsDir, r.Repo, filename)
+	contents, err := json.Marshal(r)
+	if nil != err {
+		return err
+	}
+	return ioutil.WriteFile(outFilePath, contents, 0644)
+}
+
+func GetReportForRepo(repo string) (*Report, error) {
+	var report Report
+	artifactsDir := prow.GetLocalArtifactsDir()
+	content, err := ioutil.ReadFile(path.Join(artifactsDir, repo, filename))
+	if err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal(content, &report)
+	if err != nil {
+		return nil, err
+	}
+	return &report, nil
+}
+
+func NewReport(repo string, flaky []string) *Report {
+	return &Report{
+		Repo:  repo,
+		Flaky: flaky,
+	}
+}

--- a/shared/jsonreport/jsonreport.go
+++ b/shared/jsonreport/jsonreport.go
@@ -49,7 +49,9 @@ func (r *Report) WriteToArtifactsDir() error {
 }
 
 func GetReportForRepo(repo string) (*Report, error) {
-	var report Report
+	report := &Report{
+    Repo: repo,
+  }
 	artifactsDir := prow.GetLocalArtifactsDir()
 	content, err := ioutil.ReadFile(path.Join(artifactsDir, repo, filename))
 	if err != nil {
@@ -59,7 +61,7 @@ func GetReportForRepo(repo string) (*Report, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &report, nil
+	return report, nil
 }
 
 func NewReport(repo string, flaky []string) *Report {

--- a/tools/flaky-test-reporter/json_reporter.go
+++ b/tools/flaky-test-reporter/json_reporter.go
@@ -21,7 +21,7 @@ import (
 	"log"
 	"sync"
 
-	"github.com/TrevorFarrelly/test-infra/shared/jsonreport"
+	"github.com/knative/test-infra/shared/jsonreport"
 )
 
 func getFlakyTestSet(repoDataAll []*RepoData) map[string]map[string]bool {

--- a/tools/flaky-test-reporter/json_reporter.go
+++ b/tools/flaky-test-reporter/json_reporter.go
@@ -24,8 +24,11 @@ import (
 	"github.com/knative/test-infra/tools/flaky-test-reporter/jsonreport"
 )
 
+// when reporting on all flaky tests in a repo, we want to eliminate the "job" layer, compressing all flaky
+// tests in that repo into a single list. There can be duplicate tests across jobs, though, so we store tests
+// in a nested map first to eliminate those duplicates.
 func getFlakyTestSet(repoDataAll []*RepoData) map[string]map[string]bool {
-	// use a map for each repo as a "set", to eliminate duplicates
+	// this map represents "repo: test: exists"
 	flakyTestSet := map[string]map[string]bool{}
 	for _, rd := range repoDataAll {
 		if flakyTestSet[rd.Config.Repo] == nil {

--- a/tools/flaky-test-reporter/json_reporter.go
+++ b/tools/flaky-test-reporter/json_reporter.go
@@ -61,7 +61,7 @@ func writeFlakyTestsToJSON(repoDataAll []*RepoData, dryrun bool) error {
 				},
 				dryrun); nil != err {
 				allErrs = append(allErrs, err)
-				log.Printf("failed writing JSON report for repo '%s': '%v'", err)
+				log.Printf("failed writing JSON report for repo '%s': '%v'", repo, err)
 			}
 			if dryrun {
 				log.Printf("[dry run] JSON report not written to bucket\n")

--- a/tools/flaky-test-reporter/json_reporter.go
+++ b/tools/flaky-test-reporter/json_reporter.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"sync"
+
+	"github.com/TrevorFarrelly/test-infra/shared/jsonreport"
+)
+
+func getFlakyTestSet(repoDataAll []*RepoData) map[string]map[string]bool {
+	// use a map for each repo as a "set", to eliminate duplicates
+	flakyTestSets := map[string]map[string]bool{}
+	for _, rd := range repoDataAll {
+		if flakyTestSet[rd.Config.Repo] == nil {
+			flakyTestSet[rd.Config.Repo] = map[string]bool{}
+		}
+		for _, test := range getFlakyTests(rd) {
+			flakyTestSet[rd.Config.Repo][test] = true
+		}
+	}
+	return flakyTestSet
+}
+
+func writeFlakyTestsToJSON(repoDataAll []*RepoData, dryrun bool) error {
+	var allErrs []error
+	flakyTestSets := getFlakyTestSet(repoDataAll)
+	ch := make(chan bool, len(flakyTestSets))
+	wg := sync.WaitGroup{}
+	for repo, tests := range flakyTestSets {
+		wg.Add(1)
+		go func(wg *sync.WaitGroup) {
+			report := jsonreport.NewReport(repo, nil)
+			for test := range tests {
+				report.Flaky = append(report.Flaky, test)
+			}
+			if err := run(
+				fmt.Sprintf("writing JSON report for repo '%s'", repo),
+				func() error {
+					return report.WriteToArtifactsDir()
+				},
+				dryrun); nil != err {
+				allErrs = append(allErrs, err)
+				log.Printf("failed writing JSON report for repo '%s': '%v'", err)
+			}
+			if dryrun {
+				log.Printf("[dry run] JSON report not written. See it below:\n%s\n\n", report)
+			}
+			ch <- true
+			wg.Done()
+		}(&wg)
+	}
+	wg.Wait()
+	close(ch)
+	return combineErrors(allErrs)
+}

--- a/tools/flaky-test-reporter/jsonreport/jsonreport.go
+++ b/tools/flaky-test-reporter/jsonreport/jsonreport.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	filename = "flaky-tests.json"
-  jobName = "ci-knative-flakes-reporter" // flaky-test-reporter's Prow job name
+	jobName  = "ci-knative-flakes-reporter" // flaky-test-reporter's Prow job name
 )
 
 type Report struct {
@@ -50,27 +50,27 @@ func (r *Report) writeToArtifactsDir() error {
 }
 
 func getBuildForID(buildID int) (*prow.Build, error) {
-  job := prow.NewJob(jobName, prow.PeriodicJob, "", 0)
-  if buildID == 0 {
-      latest, err := job.GetLatestBuildNumber()
-      if err != nil {
-        return nil, err
-      }
-      return job.NewBuild(latest), nil
-  } else {
-    return job.NewBuild(buildID), nil
-  }
+	job := prow.NewJob(jobName, prow.PeriodicJob, "", 0)
+	if buildID == 0 {
+		latest, err := job.GetLatestBuildNumber()
+		if err != nil {
+			return nil, err
+		}
+		return job.NewBuild(latest), nil
+	} else {
+		return job.NewBuild(buildID), nil
+	}
 }
 
 func GetReportForRepo(repo string, buildID int) (*Report, error) {
 	report := &Report{
-    Repo: repo,
-  }
-  build, err := getBuildForID(buildID)
-  if err != nil {
-    return nil, err
-  }
-  content, err := build.ReadFile(path.Join(repo, filename))
+		Repo: repo,
+	}
+	build, err := getBuildForID(buildID)
+	if err != nil {
+		return nil, err
+	}
+	content, err := build.ReadFile(path.Join(repo, filename))
 	if err != nil {
 		return nil, err
 	}
@@ -81,14 +81,14 @@ func GetReportForRepo(repo string, buildID int) (*Report, error) {
 }
 
 func CreateReportForRepo(repo string, flaky []string, writeFile bool) (*Report, error) {
-  report := &Report{
-    Repo: repo,
-    Flaky: flaky,
-  }
-  if writeFile {
-    if err := report.writeToArtifactsDir(); err != nil {
-      return report, err
-    }
-  }
-  return report, nil
+	report := &Report{
+		Repo:  repo,
+		Flaky: flaky,
+	}
+	if writeFile {
+		if err := report.writeToArtifactsDir(); err != nil {
+			return report, err
+		}
+	}
+	return report, nil
 }

--- a/tools/flaky-test-reporter/jsonreport/jsonreport.go
+++ b/tools/flaky-test-reporter/jsonreport/jsonreport.go
@@ -34,7 +34,7 @@ type Report struct {
 	Flaky []string `json:"flaky"`
 }
 
-func (r *Report) WriteToArtifactsDir() error {
+func (r *Report) writeToArtifactsDir() error {
 	artifactsDir := prow.GetLocalArtifactsDir()
 	err := common.CreateDir(path.Join(artifactsDir, r.Repo))
 	if nil != err {
@@ -48,7 +48,7 @@ func (r *Report) WriteToArtifactsDir() error {
 	return ioutil.WriteFile(outFilePath, contents, 0644)
 }
 
-func GetReportForRepo(repo string) (*Report, error) {
+func GetReportForRepo(repo string, buildID int) (*Report, error) {
 	report := &Report{
     Repo: repo,
   }
@@ -64,9 +64,15 @@ func GetReportForRepo(repo string) (*Report, error) {
 	return report, nil
 }
 
-func NewReport(repo string, flaky []string) *Report {
-	return &Report{
-		Repo:  repo,
-		Flaky: flaky,
-	}
+func CreateReportForRepo(repo string, flaky []string, writeFile bool) (*Report, error) {
+  report := &Report{
+    Repo: repo,
+    Flaky: flaky,
+  }
+  if writeFile {
+    if err := report.writeToArtifactsDir(); err != nil {
+      return report, err
+    }
+  }
+  return report, nil
 }

--- a/tools/flaky-test-reporter/jsonreport/jsonreport.go
+++ b/tools/flaky-test-reporter/jsonreport/jsonreport.go
@@ -64,14 +64,14 @@ func getJSONForBuild(repo string, buildID int) ([]byte, error) {
 }
 
 // inexpensively sort and find the most recent JSON file. Assumes build IDs are in sequential order.
-func getLatestValidJSON(job *prow.Job, path string) ([]byte, error) {
+func getLatestValidJSON(job *prow.Job, relPath string) ([]byte, error) {
 	maxElapsedTime, _ := time.ParseDuration(fmt.Sprintf("%dh", maxAge*24))
 	buildIDs := job.GetBuildIDs()
 	sort.Sort(sort.Reverse(sort.IntSlice(buildIDs)))
 	for _, buildID := range buildIDs {
 		build := job.NewBuild(buildID)
 		// check for JSON
-		if contents, err := build.ReadFile(path); err != nil {
+		if contents, err := build.ReadFile(relPath); err != nil {
 			continue
 		} else {
 			// JSON exists, check timestamp

--- a/tools/flaky-test-reporter/jsonreport/jsonreport.go
+++ b/tools/flaky-test-reporter/jsonreport/jsonreport.go
@@ -18,7 +18,7 @@ package jsonreport
 
 import (
 	"encoding/json"
-  "fmt"
+	"fmt"
 	"io/ioutil"
 	"path"
 
@@ -27,9 +27,9 @@ import (
 )
 
 const (
-	filename = "flaky-tests.json"
-	jobName  = "ci-knative-flakes-reporter" // flaky-test-reporter's Prow job name
-  buildCount = 3
+	filename   = "flaky-tests.json"
+	jobName    = "ci-knative-flakes-reporter" // flaky-test-reporter's Prow job name
+	buildCount = 3
 )
 
 // Report contains concise information about current flaky tests
@@ -53,17 +53,17 @@ func (r *Report) writeToArtifactsDir() error {
 }
 
 func getJSONForBuild(repo string, buildID int) ([]byte, error) {
-  relPath := path.Join(prow.ArtifactsDir, repo, filename)
-  job := prow.NewJob(jobName, prow.PeriodicJob, "", 0)
-  if buildID != -1 { // if buildID is specified, use it regardless of if it exists
-    return job.NewBuild(buildID).ReadFile(relPath)
-  }
-  for build := range job.GetLatestBuilds(buildCount) { // otherwise find most recent build with a report
-    if contents, err := build.ReadFile(relPath); err == nil {
-      return contents, err
-    }
-  }
-  return nil, fmt.Errorf("no JSON file found in %d most recent builds", buildCount)
+	relPath := path.Join(prow.ArtifactsDir, repo, filename)
+	job := prow.NewJob(jobName, prow.PeriodicJob, "", 0)
+	if buildID != -1 { // if buildID is specified, use it regardless of if it exists
+		return job.NewBuild(buildID).ReadFile(relPath)
+	}
+	for build := range job.GetLatestBuilds(buildCount) { // otherwise find most recent build with a report
+		if contents, err := build.ReadFile(relPath); err == nil {
+			return contents, err
+		}
+	}
+	return nil, fmt.Errorf("no JSON file found in %d most recent builds", buildCount)
 }
 
 // GetReportForRepo gets a Report struct from a specific build for a given repo
@@ -89,7 +89,7 @@ func CreateReportForRepo(repo string, flaky []string, writeFile bool) (*Report, 
 		Flaky: flaky,
 	}
 	if writeFile {
-	   return report, report.writeToArtifactsDir()
+		return report, report.writeToArtifactsDir()
 	}
 	return report, nil
 }

--- a/tools/flaky-test-reporter/jsonreport/jsonreport.go
+++ b/tools/flaky-test-reporter/jsonreport/jsonreport.go
@@ -42,8 +42,7 @@ type Report struct {
 
 func (r *Report) writeToArtifactsDir() error {
 	artifactsDir := prow.GetLocalArtifactsDir()
-	err := common.CreateDir(path.Join(artifactsDir, r.Repo))
-	if nil != err {
+	if err := common.CreateDir(path.Join(artifactsDir, r.Repo)); nil != err {
 		return err
 	}
 	outFilePath := path.Join(artifactsDir, r.Repo, filename)

--- a/tools/flaky-test-reporter/jsonreport/jsonreport.go
+++ b/tools/flaky-test-reporter/jsonreport/jsonreport.go
@@ -18,6 +18,7 @@ package jsonreport
 
 import (
 	"encoding/json"
+  "fmt"
 	"io/ioutil"
 	"path"
 
@@ -28,8 +29,10 @@ import (
 const (
 	filename = "flaky-tests.json"
 	jobName  = "ci-knative-flakes-reporter" // flaky-test-reporter's Prow job name
+  buildCount = 3
 )
 
+// Report contains concise information about current flaky tests
 type Report struct {
 	Repo  string   `json:"-"`
 	Flaky []string `json:"flaky"`
@@ -49,46 +52,44 @@ func (r *Report) writeToArtifactsDir() error {
 	return ioutil.WriteFile(outFilePath, contents, 0644)
 }
 
-func getBuildForID(buildID int) (*prow.Build, error) {
-	job := prow.NewJob(jobName, prow.PeriodicJob, "", 0)
-	if buildID == 0 {
-		latest, err := job.GetLatestBuildNumber()
-		if err != nil {
-			return nil, err
-		}
-		return job.NewBuild(latest), nil
-	} else {
-		return job.NewBuild(buildID), nil
-	}
+func getJSONForBuild(repo string, buildID int) ([]byte, error) {
+  relPath := path.Join(prow.ArtifactsDir, repo, filename)
+  job := prow.NewJob(jobName, prow.PeriodicJob, "", 0)
+  if buildID != -1 { // if buildID is specified, use it regardless of if it exists
+    return job.NewBuild(buildID).ReadFile(relPath)
+  }
+  for build := range job.GetLatestBuilds(buildCount) { // otherwise find most recent build with a report
+    if contents, err := build.ReadFile(relPath); err == nil {
+      return contents, err
+    }
+  }
+  return nil, fmt.Errorf("no JSON file found in %d most recent builds", buildCount)
 }
 
+// GetReportForRepo gets a Report struct from a specific build for a given repo
+// use buildID = -1 for most recent successful report
 func GetReportForRepo(repo string, buildID int) (*Report, error) {
 	report := &Report{
 		Repo: repo,
 	}
-	build, err := getBuildForID(buildID)
+	contents, err := getJSONForBuild(repo, buildID)
 	if err != nil {
 		return nil, err
 	}
-	content, err := build.ReadFile(path.Join(repo, filename))
-	if err != nil {
-		return nil, err
-	}
-	if err = json.Unmarshal(content, &report); err != nil {
+	if err = json.Unmarshal(contents, &report); err != nil {
 		return nil, err
 	}
 	return report, nil
 }
 
+// CreateReportForRepo generates a Report struct and optionally writes it to disk
 func CreateReportForRepo(repo string, flaky []string, writeFile bool) (*Report, error) {
 	report := &Report{
 		Repo:  repo,
 		Flaky: flaky,
 	}
 	if writeFile {
-		if err := report.writeToArtifactsDir(); err != nil {
-			return report, err
-		}
+	   return report, report.writeToArtifactsDir()
 	}
 	return report, nil
 }

--- a/tools/flaky-test-reporter/main.go
+++ b/tools/flaky-test-reporter/main.go
@@ -77,13 +77,17 @@ func main() {
 	// happens, it should fail the job after Slack notification
 	githubErr := ghi.processGithubIssues(repoDataAll, *dryrun)
 	slackErr := sendSlackNotifications(repoDataAll, slackClient, ghi, *dryrun)
+	jsonErr := writeFlakyTestsToJSON(repoDataAll, *dryrun)
 	if nil != githubErr {
 		log.Printf("Github step failures:\n%v", githubErr)
 	}
 	if nil != slackErr {
 		log.Printf("Slack step failures:\n%v", slackErr)
 	}
-	if nil != githubErr || nil != slackErr { // Fail this job if there is any error
+	if nil != jsonErr {
+		log.Printf("JSON step failures:\n%v", jsonErr)
+	}
+	if nil != githubErr || nil != slackErr || nil != jsonErr { // Fail this job if there is any error
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Step 1 for implementation of the flaky test re-trier. Adds a shared `jsonreport` library for reading and writing flaky data to the artifacts directory, and implements a flaky-test-reporter client using this library.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #984 

**Special notes to reviewers**:
I have not written unit tests for the library because I am not sure the right way to test a tool which reads/writes files to local directories.

**User-visible changes in this PR**:

