### PR TITLE
Fix GKE version parsing

### DIFF
--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -146,7 +146,7 @@ function resolve_k8s_version() {
       --format='value(validMasterVersions)' \
       --zone=$2)"
   [[ -z "${versions}" ]] && return 1
-  local gke_versions=($(echo -n "${versions//;/ /}"))
+  local gke_versions=($(echo -n "${versions//;/ }"))
   echo "Available GKE versions in $2 are [${versions//;/, }]"
   if [[ "${target_version}" == "gke-latest" ]]; then
     # Get first (latest) version, excluding the "-gke.#" suffix


### PR DESCRIPTION
This extra `/` prepends slash for every version, makes regex matching fail. like: https://gubernator.knative.dev/build/knative-prow/logs/ci-knative-serving-k8s-1.12-istio-1.1/1141833117372256256/

/cc @adrcunha 