### PR TITLE
Cache bazel version in prow-images

### DIFF
--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -37,6 +37,10 @@ RUN rm -rf /usr/local/go && \
     tar xzf "${GO_TARBALL}" -C /usr/local && \
     rm "${GO_TARBALL}"
 
+# Extract bazel version
+RUN bazel version > /bazel_version
+RUN bazel shutdown
+
 # Extra tools through go get
 RUN go get -u github.com/google/ko/cmd/ko
 RUN go get -u github.com/golang/dep/cmd/dep

--- a/scripts/presubmit-tests.sh
+++ b/scripts/presubmit-tests.sh
@@ -299,7 +299,7 @@ function main() {
     echo ">> git version"
     git version
     echo ">> bazel version"
-    bazel version 2> /dev/null
+    [[ -f /bazel_version ]] && cat /bazel_version || echo "unknown"
     if [[ "${DOCKER_IN_DOCKER_ENABLED}" == "true" ]]; then
       echo ">> docker version"
       docker version


### PR DESCRIPTION
Show it instead of running bazel. This should reduce the memory pressure on Prow nodes by not starting bazel server for just showing its version.