### PR TITLE
Adding resource limits to test-pods namespace

### DIFF
--- a/ci/prow/config_start.yaml
+++ b/ci/prow/config_start.yaml
@@ -372,3 +372,29 @@ subjects:
 - kind: ServiceAccount
   name: "crier"
   namespace: default
+---
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: mem-limit-range
+  namespace: test-pods
+spec:
+  limits:
+    - default:
+        memory: 4Gi
+      defaultRequest:
+        memory: 2Gi
+      type: Container
+---
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: cpu-limit-range
+  namespace: test-pods
+spec:
+  limits:
+    - default:
+        cpu: 4000m
+      defaultRequest:
+        cpu: 2000m
+      type: Container


### PR DESCRIPTION
This change adds default resource limits to test-pods namespace in prow.

