### PR TITLE
fix(dep-collector): Rebuild dep-collector unconditionally

### DIFF
--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -376,16 +376,25 @@ function update_licenses() {
   cd ${REPO_ROOT_DIR} || return 1
   local dst=$1
   shift
-  run_go_tool ./vendor/github.com/knative/test-infra/tools/dep-collector dep-collector $@ > ./${dst}
+  run_dep_collector $@ > ./${dst}
 }
 
 # Run dep-collector to check for forbidden liceses.
 # Parameters: $1...$n - directories and files to inspect.
 function check_licenses() {
-  # Fetch the google/licenseclassifier for its license db
-  go get -u github.com/google/licenseclassifier
   # Check that we don't have any forbidden licenses in our images.
-  run_go_tool ./vendor/github.com/knative/test-infra/tools/dep-collector dep-collector -check $@
+  run_dep_collector -check $@
+}
+
+function run_dep_collector() {
+  # Prefer a vendored dep-collector over picking it up over the air, but
+  # unconditionally rebuild it
+  if [ -d ./vendor/github.com/knative/test-infra/tools/dep-collector ]; then
+    go install ./vendor/github.com/knative/test-infra/tools/dep-collector
+    dep-collector $@
+  else
+    go run github.com/knative/test-infra/tools/dep-collector $@
+  fi
 }
 
 # Run the given linter on the given files, checking it exists first.


### PR DESCRIPTION
Don't reuse an existing dep-collector in /go/bin as this might be broken
and might be created by a different job which requires a different
version.
Instead rebuild dep-collector for each run afresh, either by
picking it up from a vendored dependency,
or, if toosl/dep-collector is not vendored in the project under test,
then install the latest version directly over the air.

The `go get` for licenseclassifier has been removed as this will be
performed implicitely by the build of dep-collector anyway.

I would recommend to switch over for other go tools, too, to *not*
pick up existing binaries especially when there are different versions
used in different projects (which is why there is support for installing
from the vendor dir, right ?). So `run_go_tool` looks broken to me anyway.
