### PR TITLE
Each container in test-pods request 1 CPU

### DIFF
--- a/ci/prow/config_start.yaml
+++ b/ci/prow/config_start.yaml
@@ -396,5 +396,5 @@ spec:
     - default:
         cpu: 4000m
       defaultRequest:
-        cpu: 2000m
+        cpu: 1000m
       type: Container

--- a/ci/prow/config_start.yaml
+++ b/ci/prow/config_start.yaml
@@ -381,7 +381,7 @@ metadata:
 spec:
   limits:
     - default:
-        memory: 4Gi
+        memory: 8Gi
       defaultRequest:
         memory: 2Gi
       type: Container


### PR DESCRIPTION
There are 2 containers running inside a test pod, so 2CPU per container means each test pod requests 4CPU. As 1 node has 16 CPU, it can only schedule 3 test pods at a time. Lower it to 1CPU so each node can schedule 7 test pods
Also increase memory limit from 4G to 8G, as it looks like it's killing build test in serving

/cc @mattmoor 
/cc @adrcunha 
/cc @dushyanthsc 