### PR TITLE
Fixes for Prow configs

### DIFF
--- a/ci/prow/Makefile
+++ b/ci/prow/Makefile
@@ -19,27 +19,36 @@ JOB_NAMESPACE ?= test-pods
 
 PROW_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 TESTGRID_DIR := $(PROW_DIR)/../testgrid
+UNSET_CONTEXT := kubectl config unset current-context
 
 get-cluster-credentials:
 	gcloud container clusters get-credentials "$(CLUSTER)" --project="$(PROJECT)" --zone="$(ZONE)"
+
+unset-cluster-credentials:
+	$(UNSET_CONTEXT)
 
 config:
 	go run make_config.go --prow-config-output="$(PROW_DIR)/config.yaml" --testgrid-config-output="$(TESTGRID_DIR)/config.yaml" config_knative.yaml
 
 update-config: get-cluster-credentials
 	kubectl create configmap config --from-file=config.yaml=config.yaml --dry-run -o yaml | kubectl replace configmap config -f -
+	$(UNSET_CONTEXT)
 
 update-plugins: get-cluster-credentials
 	kubectl create configmap plugins --from-file=plugins.yaml=plugins.yaml --dry-run -o yaml | kubectl replace configmap plugins -f -
+	$(UNSET_CONTEXT)
 
 update-boskos: get-cluster-credentials
 	kubectl apply -f boskos/config.yaml
+	$(UNSET_CONTEXT)
 
 update-boskos-config: get-cluster-credentials
 	kubectl create configmap resources --from-file=config=boskos/resources.yaml --dry-run -o yaml | kubectl --namespace="$(JOB_NAMESPACE)" replace configmap resources -f -
+	$(UNSET_CONTEXT)
 
 update-cluster: get-cluster-credentials
 	kubectl apply -f cluster.yaml
+	$(UNSET_CONTEXT)
 
 test:
 	@echo "*** Checking config generator for prow and testgrid"

--- a/ci/prow/cluster.yaml
+++ b/ci/prow/cluster.yaml
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This file contains Kubernetes YAML files for the most important prow components.
+# Definitions for the most important Prow components.
+
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -386,4 +387,29 @@ spec:
       - name: oauth
         secret:
           secretName: oauth-token
-
+---
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: mem-limit-range
+  namespace: test-pods
+spec:
+  limits:
+    - default:
+        memory: 8Gi
+      defaultRequest:
+        memory: 2Gi
+      type: Container
+---
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: cpu-limit-range
+  namespace: test-pods
+spec:
+  limits:
+    - default:
+        cpu: 4000m
+      defaultRequest:
+        cpu: 1000m
+      type: Container

--- a/ci/prow/config_start.yaml
+++ b/ci/prow/config_start.yaml
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Initial configuration of prow cluster
+# Initial configuration of prow cluster.
+# Intended to be used when (re)creating the cluster.
 
 # Configs
 
@@ -372,29 +373,3 @@ subjects:
 - kind: ServiceAccount
   name: "crier"
   namespace: default
----
-apiVersion: v1
-kind: LimitRange
-metadata:
-  name: mem-limit-range
-  namespace: test-pods
-spec:
-  limits:
-    - default:
-        memory: 8Gi
-      defaultRequest:
-        memory: 2Gi
-      type: Container
----
-apiVersion: v1
-kind: LimitRange
-metadata:
-  name: cpu-limit-range
-  namespace: test-pods
-spec:
-  limits:
-    - default:
-        cpu: 4000m
-      defaultRequest:
-        cpu: 1000m
-      type: Container


### PR DESCRIPTION
* unset kubectl context after updating Prow cluster to avoid further interactions with the cluster by mistake
* move LimitRange to cluster.yaml