### PR TITLE
Display ko version on presubmit

### DIFF
--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -37,16 +37,19 @@ RUN rm -rf /usr/local/go && \
     tar xzf "${GO_TARBALL}" -C /usr/local && \
     rm "${GO_TARBALL}"
 
-# Extract bazel version
-RUN bazel version > /bazel_version
-RUN bazel shutdown
-
 # Extra tools through go get
 RUN go get -u github.com/google/ko/cmd/ko
 RUN go get -u github.com/golang/dep/cmd/dep
 RUN go get -u github.com/google/licenseclassifier
 RUN go get -u github.com/jstemmer/go-junit-report
 RUN go get -u github.com/raviqqe/liche
+
+# Extract bazel version
+RUN bazel version > /bazel_version
+RUN bazel shutdown
+
+# Extract ko version
+git ls-remote https://github.com/google/ko HEAD | cut -f1 > /ko_version
 
 # Extra tools through gem
 RUN gem install mixlib-config -v 2.2.4  # required because ruby is 2.1

--- a/scripts/presubmit-tests.sh
+++ b/scripts/presubmit-tests.sh
@@ -298,6 +298,8 @@ function main() {
     go version
     echo ">> git version"
     git version
+    echo ">> ko built from commit"
+    [[ -f /ko_version ]] && cat /ko_version || echo "unknown"
     echo ">> bazel version"
     [[ -f /bazel_version ]] && cat /bazel_version || echo "unknown"
     if [[ "${DOCKER_IN_DOCKER_ENABLED}" == "true" ]]; then


### PR DESCRIPTION
ko version is the commit hash it was built from.

This is based on ko's own version command:

https://github.com/google/ko/blob/master/pkg/commands/version.go#L44