### PR TITLE
golang format tools

### DIFF
--- a/shared/testgrid/yaml.go
+++ b/shared/testgrid/yaml.go
@@ -22,7 +22,7 @@ import (
 	"path"
 
 	"github.com/knative/test-infra/shared/common"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 const configPath = "ci/testgrid/config.yaml"


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
/assign @adrcunha
