### PR TITLE
Request same memory for limit and request

### DIFF
--- a/ci/prow/cluster.yaml
+++ b/ci/prow/cluster.yaml
@@ -398,7 +398,7 @@ spec:
     - default:
         memory: 8Gi
       defaultRequest:
-        memory: 2Gi
+        memory: 8Gi
       type: Container
 ---
 apiVersion: v1


### PR DESCRIPTION
serving build test sometimes fail due to OOM: https://prow.knative.dev/view/gcs/knative-prow/logs/ci-knative-serving-continuous/1143159507447189505
As Matt suggested, up the request memory to be same as limit

/cc @mattmoor 
/cc @adrcunha 