### PR TITLE
Default memory request 4G each container

### DIFF
--- a/ci/prow/cluster.yaml
+++ b/ci/prow/cluster.yaml
@@ -398,7 +398,7 @@ spec:
     - default:
         memory: 8Gi
       defaultRequest:
-        memory: 8Gi
+        memory: 4Gi
       type: Container
 ---
 apiVersion: v1


### PR DESCRIPTION
My bad, forgot there are 2 containers for each pod, so 8G per container means 16G per test pod, which made each node schedule max 3 pods instead of 7