### PR TITLE
Readd default maintainer for the milestone plugin

### DIFF
--- a/ci/prow/plugins.yaml
+++ b/ci/prow/plugins.yaml
@@ -20,7 +20,8 @@ approve:
   ignore_review_state: false
 
 repo_milestone:
-  knative:
+  # Default maintainer
+  '':
     # You can curl the following endpoint in order to determine the github ID of
     # your team responsible for maintaining the milestones:
     # curl -H "Authorization: token <token>" https://api.github.com/orgs/<org-name>/teams


### PR DESCRIPTION
Without the default maintainer, the plugin won't work.

If GoogleCloudPlatform/cloud-run-events has a different set of maintainers, override the settings for this repo like in https://github.com/kubernetes/test-infra/blob/0b17ca83fa6e142fc8d6e953a70e850d84f93f96/prow/plugins.yaml#L228

Fixes #1029 