### PR TITLE
Add Ingress object for stats site.

### DIFF
--- a/devstats/Kubernetes/grafana-service.yaml
+++ b/devstats/Kubernetes/grafana-service.yaml
@@ -19,11 +19,11 @@ metadata:
   namespace: default
 spec:
   ports:
-  - protocol: "TCP"
-    port: 3000
+  - port: 80
+    targetPort: 3000
   selector:
     app: grafana
-  type: LoadBalancer
+  type: NodePort
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -74,3 +74,24 @@ spec:
       - name: "nfs"
         persistentVolumeClaim:
           claimName: "devstats-claim"
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: stats-ing
+  annotations:
+    kubernetes.io/ingress.class: "gce"
+    kubernetes.io/ingress.global-static-ip-name: stats-ingress
+spec:
+  tls:
+  - secretName: tls-secret
+    hosts:
+    - stats.knative.dev
+  rules:
+  - host: stats.knative.dev
+    http:
+      paths:
+      - path: /*
+        backend:
+          serviceName: grafana-service
+          servicePort: 80


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**: We realized that using a LoadBalancer service for the stats.knative.dev site meant that we couldn't apply a TLS configuration for the site, so we needed to make a change to introduce an Ingress object [for this functionality](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#ingresstls-v1beta1-extensions). The tls-secret secret was generated separately. This site is now [consistent with how prow](https://github.com/knative/test-infra/blob/b4351229870f3e452c4d888470a01485a4e83cd2/ci/prow/cluster.yaml#L276) uses services/Ingress. 

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #754 

**Special notes to reviewers**: This change has already been applied to the cluster. This is simply for adding the proper configuration to the repository. 
**User-visible changes in this PR**: stats.knative.dev URL is working now

