### PR TITLE
Run perf jobs every 3 hours instead of once a day

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -2264,7 +2264,7 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "58 8 * * *"
+- cron: "0 */3 * * *"
   name: ci-knative-serving-performance
   agent: kubernetes
   decorate: true
@@ -2281,9 +2281,6 @@ periodics:
       args:
       - "./test/performance-tests.sh"
       volumeMounts:
-      - name: monitoring-db-credentials
-        mountPath: /secrets/cloudsql/monitoringdb
-        readOnly: true
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -2297,13 +2294,10 @@ periodics:
       - name: E2E_CLUSTER_REGION
         value: us-central1
     volumes:
-    - name: monitoring-db-credentials
-      secret:
-        secretName: monitoring-db-credentials
     - name: test-account
       secret:
         secretName: test-account
-- cron: "50 10 * * *"
+- cron: "0 */3 * * *"
   name: ci-knative-serving-performance-mesh
   agent: kubernetes
   decorate: true
@@ -2321,9 +2315,6 @@ periodics:
       - "./test/performance-tests.sh"
       - "--mesh"
       volumeMounts:
-      - name: monitoring-db-credentials
-        mountPath: /secrets/cloudsql/monitoringdb
-        readOnly: true
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -2337,9 +2328,6 @@ periodics:
       - name: E2E_CLUSTER_REGION
         value: us-central1
     volumes:
-    - name: monitoring-db-credentials
-      secret:
-        secretName: monitoring-db-credentials
     - name: test-account
       secret:
         secretName: test-account
@@ -3128,7 +3116,7 @@ periodics:
     - name: release-account
       secret:
         secretName: release-account
-- cron: "17 8 * * *"
+- cron: "0 */3 * * *"
   name: ci-knative-eventing-performance
   agent: kubernetes
   decorate: true
@@ -3145,9 +3133,6 @@ periodics:
       args:
       - "./test/performance-tests.sh"
       volumeMounts:
-      - name: monitoring-db-credentials
-        mountPath: /secrets/cloudsql/monitoringdb
-        readOnly: true
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -3161,9 +3146,6 @@ periodics:
       - name: E2E_CLUSTER_REGION
         value: us-central1
     volumes:
-    - name: monitoring-db-credentials
-      secret:
-        secretName: monitoring-db-credentials
     - name: test-account
       secret:
         secretName: test-account

--- a/ci/prow/periodic_config.go
+++ b/ci/prow/periodic_config.go
@@ -33,12 +33,16 @@ const (
 	periodicCustomJob = "prow_periodic_custom_job.yaml"
 
 	// Cron strings for key jobs
-	goCoveragePeriodicJobCron        = "0 1 * * *"  // Run at 01:00 every day
-	cleanupPeriodicJobCron           = "0 19 * * 1" // Run at 11:00PST/12:00PST every Monday (19:00 UTC)
-	flakesReporterPeriodicJobCron    = "0 12 * * *" // Run at 4:00PST/5:00PST every day (12:00 UTC)
-	prowversionbumperPeriodicJobCron = "0 20 * * 1" // Run at 12:00PST/13:00PST every Monday (20:00 UTC)
-	backupPeriodicJobCron            = "15 9 * * *" // Run at 02:15PST every day (09:15 UTC)
+	goCoveragePeriodicJobCron        = "0 1 * * *"   // Run at 01:00 every day
+	cleanupPeriodicJobCron           = "0 19 * * 1"  // Run at 11:00PST/12:00PST every Monday (19:00 UTC)
+	flakesReporterPeriodicJobCron    = "0 12 * * *"  // Run at 4:00PST/5:00PST every day (12:00 UTC)
+	prowversionbumperPeriodicJobCron = "0 20 * * 1"  // Run at 12:00PST/13:00PST every Monday (20:00 UTC)
+	backupPeriodicJobCron            = "15 9 * * *"  // Run at 02:15PST every day (09:15 UTC)
+	perfPeriodicJobCron              = "0 */3 * * *" // Run every 3 hours
 
+	// Perf job constants
+	perfTimeout = 120  // Job timeout in minutes
+	perfNodes   = "16" // Number of nodes needed to run perf tests. Needs to be string
 )
 
 // periodicJobTemplateData contains data about a periodic Prow job.
@@ -115,11 +119,11 @@ func generatePeriodic(title string, repoName string, periodicConfig yaml.MapSlic
 			jobType = getString(item.Key)
 			jobNameSuffix = getString(item.Key)
 			data.Base.Command = performanceScript
+			data.CronString = perfPeriodicJobCron
 			// We need a larger cluster of at least 16 nodes for perf tests
-			addEnvToJob(&data.Base, "E2E_MIN_CLUSTER_NODES", "16")
-			addEnvToJob(&data.Base, "E2E_MAX_CLUSTER_NODES", "16")
-			addVolumeToJob(&data.Base, "/secrets/cloudsql/monitoringdb", "monitoring-db-credentials", true)
-			data.Base.Timeout = 120
+			addEnvToJob(&data.Base, "E2E_MIN_CLUSTER_NODES", perfNodes)
+			addEnvToJob(&data.Base, "E2E_MAX_CLUSTER_NODES", perfNodes)
+			data.Base.Timeout = perfTimeout
 		case "latency":
 			if !getBool(item.Value) {
 				return


### PR DESCRIPTION
Part of #1041 

The perf jobs take ~2 hours to run. Running them multiple times a day provides us with more metrics to account for the variance in dealing with the cluster used to run the tests

Also, remove the sql secret as we dont want to store the metrics there anymore.