### PR TITLE
Prow jobs for pkg repo uses knative.dev alias

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -1020,6 +1020,7 @@ presubmits:
     rerun_command: "/test pull-knative-pkg-build-tests"
     trigger: "(?m)^/test (all|pull-knative-pkg-build-tests),?(\\s+|$)"
     decorate: true
+    path_alias: knative.dev/pkg
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1049,6 +1050,7 @@ presubmits:
     rerun_command: "/test pull-knative-pkg-unit-tests"
     trigger: "(?m)^/test (all|pull-knative-pkg-unit-tests),?(\\s+|$)"
     decorate: true
+    path_alias: knative.dev/pkg
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1078,6 +1080,7 @@ presubmits:
     rerun_command: "/test pull-knative-pkg-integration-tests"
     trigger: "(?m)^/test (all|pull-knative-pkg-integration-tests),?(\\s+|$)"
     decorate: true
+    path_alias: knative.dev/pkg
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1108,6 +1111,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-pkg-go-coverage),?(\\s+|$)"
     optional: true
     decorate: true
+    path_alias: knative.dev/pkg
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/coverage:latest
@@ -3493,6 +3497,7 @@ periodics:
   - org: knative
     repo: pkg
     base_ref: master
+    path_alias: knative.dev/pkg
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -3628,7 +3633,7 @@ periodics:
   - org: knative
     repo: sample-controller
     base_ref: master
-  path_alias: knative.dev/sample-controller
+    path_alias: knative.dev/sample-controller
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable

--- a/ci/prow/config_knative.yaml
+++ b/ci/prow/config_knative.yaml
@@ -79,9 +79,13 @@ presubmits:
 
   knative/pkg:
     - build-tests: true
+      dot-dev: true
     - unit-tests: true
+      dot-dev: true
     - integration-tests: true
+      dot-dev: true
     - go-coverage: true
+      dot-dev: true
 
   knative/test-infra:
     - build-tests: true
@@ -206,6 +210,7 @@ periodics:
 
   knative/pkg:
     - continuous: true
+      dot-dev: true
 
   knative/caching:
     - continuous: true

--- a/ci/prow/make_config.go
+++ b/ci/prow/make_config.go
@@ -427,7 +427,7 @@ func parseBasicJobConfigOverrides(data *baseProwJobTemplateData, config yaml.Map
 			(*data).AlwaysRun = getBool(item.Value)
 		case "dot-dev":
 			(*data).PathAlias = "path_alias: knative.dev/" + (*data).RepoName
-			(*data).ExtraRefs = append((*data).ExtraRefs, (*data).PathAlias)
+			(*data).ExtraRefs = append((*data).ExtraRefs, "  "+(*data).PathAlias)
 		case nil: // already processed
 			continue
 		default:


### PR DESCRIPTION
By the way fixes continuous job for sample-controller repo

/cc @mattmoor 