### PR TITLE
Unset cluster credential after manual job tests

### DIFF
--- a/ci/prow/run_job.sh
+++ b/ci/prow/run_job.sh
@@ -34,3 +34,5 @@ CONFIG_YAML=${REPO_ROOT_DIR}/ci/prow/config.yaml
 ${run_mkpj} --job=$1 --config-path=${CONFIG_YAML} > ${JOB_YAML}
 echo "Job YAML file saved to ${JOB_YAML}"
 kubectl apply -f ${JOB_YAML}
+
+make -C ./ci/prow unset-cluster-credentials


### PR DESCRIPTION
To avoid unawared kubectl context switched to prow