### PR TITLE
Don't fail Flaky test report if failed collecting results for a singl…

### DIFF
--- a/tools/flaky-test-reporter/main.go
+++ b/tools/flaky-test-reporter/main.go
@@ -22,6 +22,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 	"os"
 
@@ -69,7 +70,13 @@ func main() {
 		log.Printf("collecting results for job '%s' in repo '%s'\n", jc.Name, jc.Repo)
 		rd, err := collectTestResultsForRepo(jc)
 		if nil != err {
-			log.Fatalf("Error collecting results for job '%s' in repo '%s': %v", jc.Name, jc.Repo, err)
+			err = fmt.Errorf("WARNING: error collecting results for job '%s' in repo '%s': %v", jc.Name, jc.Repo, err)
+			log.Printf("%v", err)
+			jobErrs = append(jobErrs, err)
+		}
+		if nil == rd.LastBuildStartTime {
+			log.Printf("WARNING: no build found, skipping '%s' in repo '%s'", jc.Name, jc.Repo)
+			continue
 		}
 		if err = createArtifactForRepo(rd); nil != err {
 			log.Fatalf("Error creating artifacts for job '%s' in repo '%s': %v", jc.Name, jc.Repo, err)


### PR DESCRIPTION
When we add a new repo/job to be analyzed by Flaky test reporter, it might happen that there is no valid runs in that repo/job, which currently fails the entire run. Print a warning and let it continue instead, then report job status as failure at the end