### PR TITLE
WIP: add flaky-test-retryer code skeleton

### DIFF
--- a/tools/flaky-test-retryer/handler.go
+++ b/tools/flaky-test-retryer/handler.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// flaky-test-retryer detects failed integration jobs on new pull requests,
+// determines if they failed due to flaky tests, posts comments describing the
+// issue, and retries them until they succeed.
+
+package main
+
+import (
+	"log"
+
+	"github.com/knative/test-infra/tools/flaky-test-reporter/jsonreport"
+	// TODO: remove this import once "k8s.io/test-infra" import problems are fixed
+	// https://github.com/test-infra/test-infra/issues/912
+	"github.com/knative/test-infra/tools/monitoring/prowapi"
+)
+
+// TODO(TrevorFarrelly): supported repos depend on flaky-test-reporter's
+// configuration. Unify the reporter and retryer configs somehow?
+var repos = []string{"serving"}
+
+func validStatus(msg *prowapi.ReportMessage) bool {
+	return msg.Status == prowapi.FailureState
+}
+
+func validType(msg *prowapi.ReportMessage) bool {
+	return msg.JobType == prowapi.PresubmitJob
+}
+
+func validRepo(msg *prowapi.ReportMessage) bool {
+	if len(msg.Refs) > 0 {
+		for _, repo := range repos {
+			if msg.Refs[0].Repo == repo {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// spawn a goroutine for each valid message received
+func handleDriver(msg *prowapi.ReportMessage) {
+	if validStatus(msg) && validType(msg) && validRepo(msg) {
+		go handleMessage(msg)
+	}
+}
+
+func handleMessage(msg *prowapi.ReportMessage) {
+	log.Printf("Message fit all criteria - Starting analysis\n")
+	// verify job failed due to tests, not build issues. Get current flaky tests,
+	// cross-reference failed tests with flaky tests, retest if the failed tests are flaky.
+}

--- a/tools/flaky-test-retryer/main.go
+++ b/tools/flaky-test-retryer/main.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// flaky-test-retryer detects failed integration jobs on new pull requests,
+// determines if they failed due to flaky tests, posts comments describing the
+// issue, and retries them until they succeed.
+
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+
+	"github.com/knative/test-infra/shared/ghutil"
+	"github.com/knative/test-infra/tools/monitoring/subscriber"
+)
+
+const (
+	projectName = "knative-tests"
+	pubsubTopic = "test-infra-monitoring-sub"
+)
+
+func main() {
+	githubAccount := flag.String("github-account", "", "Token file for Github authentication")
+	flag.Parse()
+
+	ctx := context.Background()
+
+	// will be used later
+	_, err := ghutil.NewGithubClient(*githubAccount)
+	if nil != err {
+		log.Fatalf("Cannot setup GitHub client: '%v'", err)
+	}
+	pubsubClient, err := subscriber.NewSubscriberClient(ctx, projectName, pubsubTopic)
+	if nil != err {
+		log.Fatalf("Coud not create Pub/Sub client: '%v'", err)
+	}
+
+	for {
+		pubsubClient.ReceiveMessageAckAll(ctx, handleDriver)
+	}
+}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
First step in implementation of the flaky-test-retryer. Can accept Pub/Sub messages from the same topic in use by tools/monitoring/. JSON parsing, GitHub integration, etc will come in later PRs.
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Part of #985, #986, #987

**Special notes to reviewers**:
Affected by #912, will need updating once that issue is fixed.

**User-visible changes in this PR**:

