### PR TITLE
Fix update-full target

### DIFF
--- a/ci/prow/Makefile
+++ b/ci/prow/Makefile
@@ -19,10 +19,11 @@ JOB_NAMESPACE ?= test-pods
 
 PROW_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 TESTGRID_DIR := $(PROW_DIR)/../testgrid
+SET_CONTEXT := gcloud container clusters get-credentials "$(CLUSTER)" --project="$(PROJECT)" --zone="$(ZONE)"
 UNSET_CONTEXT := kubectl config unset current-context
 
 get-cluster-credentials:
-	gcloud container clusters get-credentials "$(CLUSTER)" --project="$(PROJECT)" --zone="$(ZONE)"
+	$(SET_CONTEXT)
 
 unset-cluster-credentials:
 	$(UNSET_CONTEXT)
@@ -30,27 +31,32 @@ unset-cluster-credentials:
 config:
 	go run *_config.go --prow-config-output="$(PROW_DIR)/config.yaml" --testgrid-config-output="$(TESTGRID_DIR)/config.yaml" config_knative.yaml
 
-update-config: get-cluster-credentials
+update-config:
+	$(SET_CONTEXT)
 	kubectl create configmap config --from-file=config.yaml=config.yaml --dry-run -o yaml | kubectl replace configmap config -f -
 	$(UNSET_CONTEXT)
 
-update-plugins: get-cluster-credentials
+update-plugins:
+	$(SET_CONTEXT)
 	kubectl create configmap plugins --from-file=plugins.yaml=plugins.yaml --dry-run -o yaml | kubectl replace configmap plugins -f -
 	$(UNSET_CONTEXT)
 
-update-boskos: get-cluster-credentials
+update-boskos:
+	$(SET_CONTEXT)
 	kubectl apply -f boskos/config.yaml
 	$(UNSET_CONTEXT)
 
-update-boskos-config: get-cluster-credentials
+update-boskos-config:
+	$(SET_CONTEXT)
 	kubectl create configmap resources --from-file=config=boskos/resources.yaml --dry-run -o yaml | kubectl --namespace="$(JOB_NAMESPACE)" replace configmap resources -f -
 	$(UNSET_CONTEXT)
 
-update-cluster: get-cluster-credentials
+update-cluster:
+	$(SET_CONTEXT)
 	kubectl apply -f cluster.yaml
 	$(UNSET_CONTEXT)
 
-update-full: get-cluster-credentials update-cluster update-config update-boskos
+update-full: update-cluster update-config update-boskos
 
 test:
 	@echo "*** Checking config generator for prow and testgrid"


### PR DESCRIPTION
Transitive dependencies in Makefile are not executed, so update-full got context unset after the first target, and failed on second. Use direct invocation instead