### PR TITLE
golang format tools

### DIFF
--- a/shared/testgrid/testgrid.go
+++ b/shared/testgrid/testgrid.go
@@ -38,7 +38,7 @@ const (
 
 // jobNameTestgridURLMap contains harded coded mapping of job name: Testgrid tab URL relative to base URL
 var jobNameTestgridURLMap = map[string]string{
-	"ci-knative-serving-continuous":          "serving#continuous",
+	"ci-knative-serving-continuous":        "serving#continuous",
 	"ci-knative-serving-istio-1.0-mesh":    "serving#istio-1.0-mesh",
 	"ci-knative-serving-istio-1.0-no-mesh": "serving#istio-1.0-no-mesh",
 	"ci-knative-serving-istio-1.1-mesh":    "serving#istio-1.1-mesh",


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
/assign @adrcunha
