### PR TITLE
Boskos project creation scripts.

### DIFF
--- a/ci/prow/boskos/create_projects
+++ b/ci/prow/boskos/create_projects
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+readonly FIRST=${1:?"First argument is the first number of the new projects."}
+readonly LAST=${2:?"Second argument is the last number of the new projects."}
+readonly BILLING_ACCOUNT=${3:?"Third argument must be the billing account."}
+readonly OUTPUT_FILE=${4:?"Fourth argument should be a file name all project names will be appended to in a resources.yaml format."}
+
+cd "${BASH_SOURCE%/*}/"
+
+i=$FIRST
+while [ $i -le $LAST ]; do
+  PROJECT=knative-boskos-$i
+  ./project_create ${PROJECT} ${BILLING_ACCOUNT} && ./permissions.sh ${PROJECT} && echo "  - ${PROJECT}" >> ${OUTPUT_FILE}
+  i=$(($i+1))
+done

--- a/ci/prow/boskos/permissions.sh
+++ b/ci/prow/boskos/permissions.sh
@@ -16,7 +16,7 @@
 
 set -e
 
-readonly PROJECT=${1:?"First argument must be the new boskos project name."}
+readonly PROJECT=${1:?"First argument must be the boskos project name."}
 readonly PROJECT_OWNERS=("prime-engprod-sea@google.com")
 readonly PROJECT_GROUPS=("knative-productivity-admins@googlegroups.com")
 readonly PROJECT_SAS=(
@@ -31,20 +31,24 @@ readonly PROJECT_APIS=(
 
 # Add an owner to the PROJECT
 for owner in ${PROJECT_OWNERS[@]}; do
+  echo "NOTE: Adding owner ${owner}"
   gcloud projects add-iam-policy-binding ${PROJECT} --member group:${owner} --role roles/owner
 done
 
 # Add all GROUPS as editors
 for group in ${PROJECT_GROUPS[@]}; do
+  echo "NOTE: Adding group ${group}"
   gcloud projects add-iam-policy-binding ${PROJECT} --member group:${group} --role roles/editor
 done
 
 # Add all service accounts as editors
 for sa in ${PROJECT_SAS[@]}; do
+  echo "NOTE: Adding service account ${sa}"
   gcloud projects add-iam-policy-binding ${PROJECT} --member serviceAccount:${sa} --role roles/editor
 done
 
 # Enable APIS
 for api in ${PROJECT_APIS[@]}; do
+  echo "NOTE: Enabling API ${api}"
   gcloud services enable ${api} --project=${PROJECT}
 done

--- a/ci/prow/boskos/project_create
+++ b/ci/prow/boskos/project_create
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+readonly PROJECT=${1:?"First argument must be the new boskos project name."}
+readonly BILLING_ACCOUNT=${2:?"Second argument must be the billing account."}
+
+# This Folder ID is google.com/google-default
+gcloud projects create ${PROJECT} --folder=396521612403
+
+gcloud beta billing projects link ${PROJECT} --billing-account=${BILLING_ACCOUNT}

--- a/ci/prow_setup.md
+++ b/ci/prow_setup.md
@@ -23,14 +23,24 @@
 
 ## Expanding Boskos pool
 
-1. Create a new GCP project and add it to
-   [resources.yaml](./prow/boskos/resources.yaml). Please follow the current
-   naming scheme.
+1. All projects and permissions can be created by running `./ci/prow/boskos/create_projects`.
+   For example, to create 10 projects named knative-boskos-51,
+   knative-boskos-52, ... knative-boskos-60, run:
+   `./ci/prow/boskos/create_projects 51 60 0X0X0X-0X0X0X-0X0X0X /tmp/successful.out`.
+   You will need to substitute the actual billing ID for the third argument.
 
-1. Run `./ci/prow/boskos/permissions.sh <project_name>` to setup the IAM
-   permissions and APIs needed.
+1. Edit [resources.yaml](./prow/boskos/resources.yaml) with the new projects.
+   Conveniently ready for cut-and-paste from the output file in the previous
+   step.
+
+1. Get the commit reviewed.
 
 1. Run `make update-boskos-config` to update the Boskos config.
+
+In the event the create_projects fails, it is a script you should easily be
+follow along with in the GUI or run on the CLI. The gcloud billing command is
+still in alpha/beta, so it's probably the section most likely to give you
+trouble.
 
 ## Setting up Prow for a new organization
 


### PR DESCRIPTION
One script to iterate over multiple projects.
Another script to create the project and assign billing ID.
Update the documentation.
Add logging to permission-setting script.

/lint
/assign @chaodaiG 
fix: #1074 