### PR TITLE
add Initialize() func to jsonreport

### DIFF
--- a/tools/flaky-test-reporter/jsonreport/jsonreport.go
+++ b/tools/flaky-test-reporter/jsonreport/jsonreport.go
@@ -40,6 +40,7 @@ type Report struct {
 	Flaky []string `json:"flaky"`
 }
 
+// Initialize wraps prow's init, which must be called before any other prow functions are used.
 func Initialize(credentials string) error {
 	return prow.Initialize(credentials)
 }

--- a/tools/flaky-test-reporter/jsonreport/jsonreport.go
+++ b/tools/flaky-test-reporter/jsonreport/jsonreport.go
@@ -40,6 +40,10 @@ type Report struct {
 	Flaky []string `json:"flaky"`
 }
 
+func Initialize(credentials string) error {
+	return prow.Initialize(credentials)
+}
+
 func (r *Report) writeToArtifactsDir() error {
 	artifactsDir := prow.GetLocalArtifactsDir()
 	if err := common.CreateDir(path.Join(artifactsDir, r.Repo)); nil != err {
@@ -99,7 +103,7 @@ func GetReportForRepo(repo string, buildID int) (*Report, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err = json.Unmarshal(contents, &report); err != nil {
+	if err = json.Unmarshal(contents, report); err != nil {
 		return nil, err
 	}
 	return report, nil

--- a/tools/flaky-test-reporter/jsonreport/jsonreport.go
+++ b/tools/flaky-test-reporter/jsonreport/jsonreport.go
@@ -41,8 +41,8 @@ type Report struct {
 }
 
 // Initialize wraps prow's init, which must be called before any other prow functions are used.
-func Initialize(credentials string) error {
-	return prow.Initialize(credentials)
+func Initialize(serviceAccount string) error {
+	return prow.Initialize(serviceAccount)
 }
 
 func (r *Report) writeToArtifactsDir() error {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Allows us to initialize Prow from the jsonreport library, bypassing a panic that occurs when `golang.org/x/net/trace.init()` is called from multiple contexts. Necessary for further development of the flaky-test-retryer.
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #

**Special notes to reviewers**:

**User-visible changes in this PR**:

