### PR TITLE
Add flaky-test-retryer skeleton

### DIFF
--- a/tools/flaky-test-retryer/github_commenter.go
+++ b/tools/flaky-test-retryer/github_commenter.go
@@ -33,6 +33,6 @@ type GithubClient struct {
 
 func NewGithubClient(githubAccount string) (*GithubClient, error) {
 	ghc, err := ghutil.NewGithubClient(githubAccount)
-	log.Printf("temporary - otherwise compiler will yell about ghc being an unused var: %s\n", ghc)
+	log.Printf("temporary - otherwise compiler will yell about ghc being an unused var: %v\n", ghc)
 	return &GithubClient{ghc}, err
 }

--- a/tools/flaky-test-retryer/github_commenter.go
+++ b/tools/flaky-test-retryer/github_commenter.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// github_commenter.go finds the relevant pull requests for the failed jobs that
+// triggered the retryer and posts comments to it, either retrying the test or
+// telling the contributors why we cannot retry.
+
+package main
+
+import (
+	"log"
+
+	"github.com/knative/test-infra/shared/ghutil"
+)
+
+// GithubClient wraps the ghutil Github client
+type GithubClient struct {
+	*ghutil.GithubClient
+}
+
+func NewGithubClient(githubAccount string) (*GithubClient, error) {
+	ghc, err := ghutil.NewGithubClient(githubAccount)
+	log.Printf("temporary - otherwise compiler will yell about ghc being an unused var: %s\n", ghc)
+	return &GithubClient{ghc}, err
+}

--- a/tools/flaky-test-retryer/handler.go
+++ b/tools/flaky-test-retryer/handler.go
@@ -67,6 +67,7 @@ func expectedMsg(msg *prowapi.ReportMessage) bool {
 		for _, repo := range repos {
 			if msg.Refs[0].Repo == repo {
 				expRepo = true
+				break
 			}
 		}
 	}

--- a/tools/flaky-test-retryer/handler.go
+++ b/tools/flaky-test-retryer/handler.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// handler.go contains most of the main logic for the flaky-test-retryer. Listen for
+// incoming Pubsub messages, verify that the message we received is one we want to
+// process, compare flaky and failed tests, and trigger retests if necessary.
+
+package main
+
+import (
+	"context"
+	"log"
+
+	"github.com/knative/test-infra/tools/monitoring/subscriber"
+	// TODO: remove this import once "k8s.io/test-infra" import problems are fixed
+	// https://github.com/test-infra/test-infra/issues/912
+	"github.com/knative/test-infra/tools/monitoring/prowapi"
+)
+
+// HandlerClient wraps the other clients we need when processing failed jobs.
+type HandlerClient struct {
+	context.Context
+	*subscriber.Client
+	*GithubClient
+}
+
+// JobData contains the relevant fields from a failed ReportMessage struct
+type JobData struct {
+	Name string
+	Type string
+	Repo string
+	Pull int
+}
+
+func NewHandlerClient(githubClient *GithubClient) (*HandlerClient, error) {
+	ctx := context.Background()
+	pubsubClient, err := subscriber.NewSubscriberClient(ctx, projectName, pubsubTopic)
+	return &HandlerClient{
+		ctx,
+		pubsubClient,
+		githubClient,
+	}, err
+}
+
+// expectedMsg checks that the message we received is one we want to process.
+func expectedMsg(msg *prowapi.ReportMessage) bool {
+	expStatus := msg.Status == prowapi.FailureState
+	expType := msg.JobType == prowapi.PresubmitJob
+
+	repos, err := getReportRepos()
+	if err != nil {
+		log.Printf("Failed getting reporter's repos: %v")
+		return false
+	}
+	expRepo := false
+	if len(msg.Refs) > 0 {
+		for _, repo := range repos {
+			if msg.Refs[0].Repo == repo {
+				expRepo = true
+			}
+		}
+	}
+
+	return expStatus && expType && expRepo
+}
+
+// Listen scans for incoming Pubsub messages, spawning a new goroutine for each
+// one that fits our criteria.
+func (hc *HandlerClient) Listen() {
+	log.Printf("Listening for failed jobs...\n")
+	for {
+		hc.ReceiveMessageAckAll(hc, func(msg *prowapi.ReportMessage) {
+			if expectedMsg(msg) {
+				go hc.HandleMessage(&JobData{
+					Name: msg.JobName,
+					Type: string(msg.JobType),
+					Repo: msg.Refs[0].Repo,
+					Pull: msg.Refs[0].Pulls[0].Number,
+				})
+			} else {
+				log.Println("Job did not fit criteria - skipping")
+			}
+		})
+	}
+}
+
+// HandleMessage gets the job's failed tests and the current flaky tests,
+// compares them, and triggers a retest if all the failed tests are flaky.
+func (hc *HandlerClient) HandleMessage(job *JobData) {
+	log.Println("Job fit all criteria - Starting analysis")
+	// TODO: ensure job failed due to tests, get job's failed tests, get current
+	//       flaky tests, cross-reference failed tests and flaky tests, retry tests
+	//       if all failed tests are flaky.
+}

--- a/tools/flaky-test-retryer/handler.go
+++ b/tools/flaky-test-retryer/handler.go
@@ -51,7 +51,7 @@ func NewHandlerClient(githubClient *GithubClient) (*HandlerClient, error) {
 func expectedMsg(msg *prowapi.ReportMessage) bool {
 	repos, err := getReportRepos()
 	if err != nil {
-		log.Printf("Failed getting reporter's repos: %v")
+		log.Printf("Failed getting reporter's repos: %v", err)
 		return false
 	}
 	expRepo := false

--- a/tools/flaky-test-retryer/handler.go
+++ b/tools/flaky-test-retryer/handler.go
@@ -57,9 +57,6 @@ func NewHandlerClient(githubClient *GithubClient) (*HandlerClient, error) {
 
 // expectedMsg checks that the message we received is one we want to process.
 func expectedMsg(msg *prowapi.ReportMessage) bool {
-	expStatus := msg.Status == prowapi.FailureState
-	expType := msg.JobType == prowapi.PresubmitJob
-
 	repos, err := getReportRepos()
 	if err != nil {
 		log.Printf("Failed getting reporter's repos: %v")
@@ -74,7 +71,7 @@ func expectedMsg(msg *prowapi.ReportMessage) bool {
 		}
 	}
 
-	return expStatus && expType && expRepo
+	return expRepo && msg.Status == prowapi.FailureState && msg.JobType == prowapi.PresubmitJob
 }
 
 // Listen scans for incoming Pubsub messages, spawning a new goroutine for each

--- a/tools/flaky-test-retryer/handler.go
+++ b/tools/flaky-test-retryer/handler.go
@@ -37,8 +37,12 @@ type HandlerClient struct {
 	github *GithubClient
 }
 
-func NewHandlerClient(githubClient *GithubClient) (*HandlerClient, error) {
+func NewHandlerClient(githubAccount string) (*HandlerClient, error) {
 	ctx := context.Background()
+	githubClient, err := NewGithubClient(githubAccount)
+	if err != nil {
+		return nil, err
+	}
 	pubsubClient, err := subscriber.NewSubscriberClient(ctx, projectName, pubsubTopic)
 	return &HandlerClient{
 		ctx,

--- a/tools/flaky-test-retryer/log_parser.go
+++ b/tools/flaky-test-retryer/log_parser.go
@@ -32,13 +32,11 @@ func InitLogParser(serviceAccount string) error {
 // TODO: combine this with the function for getting flaky tests, as they will be
 //       almost exactly the same thing.
 func getReportRepos() ([]string, error) {
-	reports, err := jsonreport.GetFlakyTestReport("", -1)
-	if err != nil {
-		return nil, err
-	}
 	var repos []string
-	for _, r := range reports {
-		repos = append(repos, r.Repo)
+	if reports, err := jsonreport.GetFlakyTestReport("", -1); err == nil && len(reports) > 0 {
+		for _, r := range reports {
+			repos = append(repos, r.Repo)
+		}
 	}
-	return repos, nil
+	return repos, err
 }

--- a/tools/flaky-test-retryer/log_parser.go
+++ b/tools/flaky-test-retryer/log_parser.go
@@ -33,8 +33,8 @@ func InitLogParser(serviceAccount string) error {
 //       almost exactly the same thing.
 func getReportRepos() ([]string, error) {
 	var repos []string
-	var err error
-	if reports, err := jsonreport.GetFlakyTestReport("", -1); err == nil && len(reports) > 0 {
+	reports, err := jsonreport.GetFlakyTestReport("", -1)
+	if err == nil && len(reports) > 0 {
 		for _, r := range reports {
 			repos = append(repos, r.Repo)
 		}

--- a/tools/flaky-test-retryer/log_parser.go
+++ b/tools/flaky-test-retryer/log_parser.go
@@ -33,6 +33,7 @@ func InitLogParser(serviceAccount string) error {
 //       almost exactly the same thing.
 func getReportRepos() ([]string, error) {
 	var repos []string
+	var err error
 	if reports, err := jsonreport.GetFlakyTestReport("", -1); err == nil && len(reports) > 0 {
 		for _, r := range reports {
 			repos = append(repos, r.Repo)

--- a/tools/flaky-test-retryer/log_parser.go
+++ b/tools/flaky-test-retryer/log_parser.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// log_parser.go collects failed tests from jobs that triggered the retryer and
+// finds flaky tests that are relevant to that failed job.
+
+package main
+
+import (
+	"github.com/knative/test-infra/tools/flaky-test-reporter/jsonreport"
+)
+
+// InitLogParser configures jsonreport's dependencies
+func InitLogParser(serviceAccount string) error {
+	return jsonreport.Initialize(serviceAccount)
+}
+
+// getReportRepos gets all of the repositories where we are reporting flaky tests
+// TODO: combine this with the function for getting flaky tests, as they will be
+//       almost exactly the same thing.
+func getReportRepos() ([]string, error) {
+	reports, err := jsonreport.GetFlakyTestReport("", -1)
+	if err != nil {
+		return nil, err
+	}
+	var repos []string
+	for _, r := range reports {
+		repos = append(repos, r.Repo)
+	}
+	return repos, nil
+}

--- a/tools/flaky-test-retryer/main.go
+++ b/tools/flaky-test-retryer/main.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// flaky-test-retryer detects failed integration jobs on new pull requests,
+// determines if they failed due to flaky tests, posts comments describing the
+// issue, and retries them until they succeed.
+
+package main
+
+import (
+	"flag"
+	"log"
+	"os"
+)
+
+const (
+	projectName = "knative"
+	pubsubTopic = "test-infra-monitoring-sub"
+)
+
+func main() {
+	serviceAccount := flag.String("service-account", os.Getenv("GOOGLE_APPLICATION_CREDENTIALS"), "JSON key file for GCS service account")
+	githubAccount := flag.String("github-account", "", "Token file for Github authentication")
+	flag.Parse()
+
+	if err := InitLogParser(*serviceAccount); nil != err {
+		log.Fatalf("Failed authenticating GCS: '%v'", err)
+	}
+
+	githubClient, err := NewGithubClient(*githubAccount)
+	if nil != err {
+		log.Fatalf("Cannot setup GitHub client: '%v'", err)
+	}
+
+	handler, err := NewHandlerClient(githubClient)
+	if err != nil {
+		log.Fatalf("Coud not create Pub/Sub client: '%v'", err)
+	}
+
+	handler.Listen()
+}

--- a/tools/flaky-test-retryer/main.go
+++ b/tools/flaky-test-retryer/main.go
@@ -40,12 +40,7 @@ func main() {
 		log.Fatalf("Failed authenticating GCS: '%v'", err)
 	}
 
-	githubClient, err := NewGithubClient(*githubAccount)
-	if nil != err {
-		log.Fatalf("Cannot setup GitHub client: '%v'", err)
-	}
-
-	handler, err := NewHandlerClient(githubClient)
+	handler, err := NewHandlerClient(*githubAccount)
 	if err != nil {
 		log.Fatalf("Coud not create Pub/Sub client: '%v'", err)
 	}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Adds the basic outline of the flaky-test-retryer, including pubsub integration. 

* `main.go` configures everything and listens for pubsub messages.
* `handler.go` handles incoming pubsub messages and will hold the main logic of the program.
* `log_parser.go` will fetch both flaky test reports and the failed tests from the job that triggered the message.
* `github_commenter.go` will handle all integration with the github API.

/lint
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #986 

**Special notes to reviewers**:

**User-visible changes in this PR**:

