### PR TITLE
refactor jsonreport to better support multi-repo searching

### DIFF
--- a/tools/flaky-test-reporter/jsonreport/jsonreport.go
+++ b/tools/flaky-test-reporter/jsonreport/jsonreport.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"path"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/knative/test-infra/shared/common"
@@ -108,6 +109,23 @@ func GetReportForRepo(repo string, buildID int) (*Report, error) {
 		return nil, err
 	}
 	return report, nil
+}
+
+//GetReposWithReports gets all the repositories that are currently being reported on
+func GetReposWithReports() ([]string, error) {
+	job := prow.NewJob(jobName, prow.PeriodicJob, "", 0)
+	buildNum, err := job.GetLatestBuildNumber()
+	if err != nil {
+		return nil, err
+	}
+	build := job.NewBuild(buildNum)
+	artifactPaths := build.GetArtifacts()
+	var repos []string
+	for _, path := range artifactPaths {
+		splitPath := strings.Split(path, "/")
+		repos = append(repos, splitPath[len(splitPath)-1])
+	}
+	return repos, nil
 }
 
 // CreateReportForRepo generates a Report struct and optionally writes it to disk

--- a/tools/flaky-test-reporter/jsonreport/jsonreport.go
+++ b/tools/flaky-test-reporter/jsonreport/jsonreport.go
@@ -69,12 +69,12 @@ func (r *RepoReport) writeToArtifactsDir() error {
 // most recent report
 func (r *Report) GetFlakyTestReport(repo string, buildID int) error {
 	job := prow.NewJob(jobName, prow.PeriodicJob, "", 0)
+	var err error
 	if buildID == -1 {
-		latestBuild, err := getLatestValidBuild(job, repo)
+		buildID, err = getLatestValidBuild(job, repo)
 		if err != nil {
 			return err
 		}
-		return r.GetFlakyTestReport(repo, latestBuild)
 	}
 	build := job.NewBuild(buildID)
 	for _, filepath := range getReportPaths(build, repo) {

--- a/tools/flaky-test-reporter/jsonreport/jsonreport.go
+++ b/tools/flaky-test-reporter/jsonreport/jsonreport.go
@@ -37,7 +37,11 @@ const (
 
 // Report contains concise information about current flaky tests
 type Report struct {
-	Repo  string   `json:"-"`
+	AllReports []RepoReport
+}
+
+type RepoReport struct {
+	Repo  string   `json:"repo"`
 	Flaky []string `json:"flaky"`
 }
 
@@ -46,7 +50,8 @@ func Initialize(serviceAccount string) error {
 	return prow.Initialize(serviceAccount)
 }
 
-func (r *Report) writeToArtifactsDir() error {
+// writeToArtifactsDir writes the flaky test data for this repo to disk.
+func (r *RepoReport) writeToArtifactsDir() error {
 	artifactsDir := prow.GetLocalArtifactsDir()
 	if err := common.CreateDir(path.Join(artifactsDir, r.Repo)); nil != err {
 		return err
@@ -59,78 +64,86 @@ func (r *Report) writeToArtifactsDir() error {
 	return ioutil.WriteFile(outFilePath, contents, 0644)
 }
 
-func getJSONForBuild(repo string, buildID int) ([]byte, error) {
-	relPath := path.Join(prow.ArtifactsDir, repo, filename)
+// GetFlakyTestReport collects flaky test reports from the given buildID and repo.
+//Use repo = "" to get reports from all repositories, and buildID = -1 to get the
+// most recent report
+func (r *Report) GetFlakyTestReport(repo string, buildID int) error {
 	job := prow.NewJob(jobName, prow.PeriodicJob, "", 0)
-	if buildID != -1 {
-		return job.NewBuild(buildID).ReadFile(relPath)
+	if buildID == -1 {
+		latestBuild, err := getLatestValidBuild(job, repo)
+		if err != nil {
+			return err
+		}
+		return r.GetFlakyTestReport(repo, latestBuild)
 	}
-	return getLatestValidJSON(job, relPath)
+	build := job.NewBuild(buildID)
+	for _, filepath := range getReportPaths(build, repo) {
+		report, err := readJSONReport(build, filepath)
+		if err != nil {
+			return err
+		}
+		r.AllReports = append(r.AllReports, *report)
+	}
+	return nil
 }
 
-// inexpensively sort and find the most recent JSON file. Assumes build IDs are in sequential order.
-func getLatestValidJSON(job *prow.Job, relPath string) ([]byte, error) {
+// getLatestValidBuild inexpensively sorts and finds the most recent JSON report.
+// Assumes build IDs are in sequential order.
+func getLatestValidBuild(job *prow.Job, repo string) (int, error) {
 	maxElapsedTime, _ := time.ParseDuration(fmt.Sprintf("%dh", maxAge*24))
 	buildIDs := job.GetBuildIDs()
 	sort.Sort(sort.Reverse(sort.IntSlice(buildIDs)))
 	for _, buildID := range buildIDs {
 		build := job.NewBuild(buildID)
-		// check for JSON
-		if contents, err := build.ReadFile(relPath); err != nil {
+		// check if reports exist for this build
+		if reports := getReportPaths(build, repo); len(reports) == 0 {
 			continue
+		}
+		// check if this report is too old
+		startTimeInt, err := build.GetStartTime()
+		if err != nil {
+			continue
+		}
+		startTime := time.Unix(startTimeInt, 0)
+		if time.Since(startTime) < maxElapsedTime {
+			return buildID, nil
 		} else {
-			// JSON exists, check timestamp
-			startTimeInt, err := build.GetStartTime()
-			if err != nil {
-				continue
-			}
-			startTime := time.Unix(startTimeInt, 0)
-			if time.Since(startTime) < maxElapsedTime {
-				return contents, nil
-			} else {
-				return nil, fmt.Errorf("latest JSON log is outdated: %.2f days old", time.Since(startTime).Hours()/24)
-			}
+			return 0, fmt.Errorf("latest JSON log is outdated: %.2f days old", time.Since(startTime).Hours()/24)
 		}
 	}
-	return nil, fmt.Errorf("no JSON logs found in recent builds")
+	return 0, fmt.Errorf("no JSON logs found in recent builds")
 }
 
-// GetReportForRepo gets a Report struct from a specific build for a given repo
-// use buildID = -1 for most recent successful report
-func GetReportForRepo(repo string, buildID int) (*Report, error) {
-	report := &Report{
-		Repo: repo,
+// getReportPaths searches build artifacts for reports from the given repo, returning
+// the path to any matching files. Use repo = "" to get all reports from all repos.
+func getReportPaths(build *prow.Build, repo string) []string {
+	var matches []string
+	suffix := path.Join(repo, filename)
+	for _, artifact := range build.GetArtifacts() {
+		if strings.HasSuffix(artifact, suffix) {
+			matches = append(matches, artifact)
+		}
 	}
-	contents, err := getJSONForBuild(repo, buildID)
+	return matches
+}
+
+// readJSONReport builds a repo-specific report object from a given json file path.
+func readJSONReport(build *prow.Build, filename string) (*RepoReport, error) {
+	report := &RepoReport{}
+	contents, err := build.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}
-	if err = json.Unmarshal(contents, report); err != nil {
+	if err := json.Unmarshal(contents, report); err != nil {
 		return nil, err
 	}
 	return report, nil
 }
 
-//GetReposWithReports gets all the repositories that are currently being reported on
-func GetReposWithReports() ([]string, error) {
-	job := prow.NewJob(jobName, prow.PeriodicJob, "", 0)
-	buildNum, err := job.GetLatestBuildNumber()
-	if err != nil {
-		return nil, err
-	}
-	build := job.NewBuild(buildNum)
-	artifactPaths := build.GetArtifacts()
-	var repos []string
-	for _, path := range artifactPaths {
-		splitPath := strings.Split(path, "/")
-		repos = append(repos, splitPath[len(splitPath)-1])
-	}
-	return repos, nil
-}
-
-// CreateReportForRepo generates a Report struct and optionally writes it to disk
-func CreateReportForRepo(repo string, flaky []string, writeFile bool) (*Report, error) {
-	report := &Report{
+// CreateReportForRepo generates a flaky report for a given repository, and optionally
+// writes it to disk.
+func CreateReportForRepo(repo string, flaky []string, writeFile bool) (*RepoReport, error) {
+	report := &RepoReport{
 		Repo:  repo,
 		Flaky: flaky,
 	}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
With this refactoring, we can get JSON reports via build ID and/or repository, meaning we now support getting all reports from all repos at once

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #

**Special notes to reviewers**:
Depends on #1110, /hold until that is merged
**User-visible changes in this PR**:

