### PR TITLE
Make restore working Prow config easier

### DIFF
--- a/ci/prow/Makefile
+++ b/ci/prow/Makefile
@@ -33,8 +33,16 @@ config:
 
 update-config:
 	$(SET_CONTEXT)
-	kubectl create configmap config --from-file=config.yaml=config.yaml --dry-run -o yaml | kubectl replace configmap config -f -
+	$(eval OLD_YAML_CONFIG := $(shell mktemp))
+	$(eval NEW_YAML_CONFIG := $(shell mktemp))
+	$(eval GCS_DEST := gs://knative-prow/configs/config-$(shell date '+%Y_%m_%d_%H:%M:%S').yaml)
+	@kubectl get configmap config -o jsonpath="{.data}" 2>/dev/null > "${OLD_YAML_CONFIG}"
+	@gsutil cp "${OLD_YAML_CONFIG}" "${GCS_DEST}" > /dev/null
+	@sed -e "s/((COMMIT_HASH_TOKEN))/$(shell git rev-parse HEAD)/" "config.yaml" > "${NEW_YAML_CONFIG}"
+	kubectl create configmap config --from-file=config.yaml=${NEW_YAML_CONFIG} --dry-run -o yaml | kubectl replace configmap config -f -
 	$(UNSET_CONTEXT)
+	@echo "Inspect uploaded config file at: ${NEW_YAML_CONFIG}"
+	@echo "Old config file saved at: ${GCS_DEST}"
 
 update-plugins:
 	$(SET_CONTEXT)

--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -17,6 +17,7 @@
 # ####     USE "make config" TO REGENERATE THIS FILE.     ####
 # ####                                                    ####
 # ############################################################
+# FROM COMMIT: ((COMMIT_HASH_TOKEN))
 plank:
   job_url_template: 'https://prow.knative.dev/view/gcs/knative-prow/{{if or (eq .Spec.Type "presubmit") (eq .Spec.Type "batch")}}pr-logs/pull{{with .Spec.Refs}}/{{.Org}}_{{.Repo}}{{end}}{{else}}logs{{end}}{{if eq .Spec.Type "presubmit"}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}{{else if eq .Spec.Type "batch"}}/batch{{end}}/{{.Spec.Job}}/{{.Status.BuildID}}/'
   report_template: '[Full PR test history](https://gubernator.knative.dev/pr/{{.Spec.Refs.Org}}_{{.Spec.Refs.Repo}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}). [Your PR dashboard](https://gubernator.knative.dev/pr/{{with index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}).'

--- a/ci/prow/templates/prow_config_header.yaml
+++ b/ci/prow/templates/prow_config_header.yaml
@@ -18,6 +18,7 @@
 # ####     USE "make config" TO REGENERATE THIS FILE.     ####
 # ####                                                    ####
 # ############################################################
+# FROM COMMIT: ((COMMIT_HASH_TOKEN))
 
 plank:
   job_url_template: 'https://prow.knative.dev/view/gcs/[[.GcsBucket]]/{{if or (eq .Spec.Type "presubmit") (eq .Spec.Type "batch")}}[[.PresubmitLogsDir]]/pull{{with .Spec.Refs}}/{{.Org}}_{{.Repo}}{{end}}{{else}}[[.LogsDir]]{{end}}{{if eq .Spec.Type "presubmit"}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}{{else if eq .Spec.Type "batch"}}/batch{{end}}/{{.Spec.Job}}/{{.Status.BuildID}}/'


### PR DESCRIPTION
Currently we don't have a good way of restoring to previous working Prow config, this PR provides a way of tracking previous working config, as well as commit hash, which should make restoring easier

Fix: https://github.com/knative/test-infra/issues/1108

/cc @adrcunha 
/cc @Fredy-Z 
