### PR TITLE
GetArtifacts should return all files instead of only direct children …

### DIFF
--- a/shared/prow/prow.go
+++ b/shared/prow/prow.go
@@ -280,7 +280,7 @@ func (b *Build) GetFinishTime() (int64, error) {
 
 // GetArtifacts gets gcs path for all artifacts of current build
 func (b *Build) GetArtifacts() []string {
-	return gcs.ListDirectChildren(ctx, BucketName, b.GetArtifactsDir())
+	return gcs.ListChildrenFiles(ctx, BucketName, b.GetArtifactsDir())
 }
 
 // GetArtifactsDir gets gcs path for artifacts of current build


### PR DESCRIPTION
/cc @srinivashegde86 
FYI @TrevorFarrelly 