### PR TITLE
Fixing coverage job path_alias to let them pass

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -3623,6 +3623,7 @@ periodics:
   - org: knative
     repo: pkg
     base_ref: master
+    path_alias: knative.dev/pkg
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/coverage:latest
@@ -3676,6 +3677,7 @@ periodics:
   - org: knative
     repo: caching
     base_ref: master
+    path_alias: knative.dev/caching
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/coverage:latest
@@ -4340,6 +4342,7 @@ postsubmits:
     - master
     agent: kubernetes
     decorate: true
+    path_alias: knative.dev/pkg
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/coverage:latest
@@ -4355,6 +4358,7 @@ postsubmits:
     - master
     agent: kubernetes
     decorate: true
+    path_alias: knative.dev/caching
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/coverage:latest

--- a/ci/prow/periodic_config.go
+++ b/ci/prow/periodic_config.go
@@ -21,6 +21,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"path"
 
 	yaml "gopkg.in/yaml.v2"
 )
@@ -291,6 +292,9 @@ func generateGoCoveragePeriodic(title string, repoName string, _ yaml.MapSlice) 
 			fmt.Sprintf("--cov-threshold-percentage=%d", data.Base.GoCoverageThreshold)}
 		data.Base.ServiceAccount = ""
 		data.Base.ExtraRefs = append(data.Base.ExtraRefs, "  base_ref: "+data.Base.RepoBranch)
+		if repositories[i].DotDev {
+			data.Base.ExtraRefs = append(data.Base.ExtraRefs, "  path_alias: knative.dev/"+path.Base(repoName))
+		}
 		addExtraEnvVarsToJob(&data.Base)
 		addLabelToJob(&data.Base, "prow.k8s.io/pubsub.project", "knative-tests")
 		addLabelToJob(&data.Base, "prow.k8s.io/pubsub.topic", "knative-monitoring")


### PR DESCRIPTION
**What this PR does, why we need it**:
Coverage jobs in pkg and caching are failing due to prow jobs for postsubmit and ci are not up-to-date with `knative.dev` import path. Fixing jobs here

/cc @adrcunha 