### PR TITLE
Also make testgrid URL one-line

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,8 @@
+<style>
+/* Increase content width from 640px to 800px for systems with larger font to avoid line break. */
+.inner {max-width: 800px;}
+</style>
+
 # Prow: <https://prow.knative.dev>
 
 # TestGrid: <https://testgrid.knative.dev>


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
A very small improvement for https://knative.github.io/test-infra/:
On Mac chrome, the URL of testgrid is shown two lines because it uses a different font. Set `max-width` to `700px` to avoid line break, see https://fredy-z.github.io/test-infra/

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @adrcunha 
/cc @chaodaiG 
