### PR TITLE
Add new method to parse default monitoring config

### DIFF
--- a/tools/monitoring/alert/alert.go
+++ b/tools/monitoring/alert/alert.go
@@ -30,8 +30,6 @@ import (
 	"github.com/knative/test-infra/tools/monitoring/subscriber"
 )
 
-const YamlURL = "https://raw.githubusercontent.com/knative/test-infra/master/tools/monitoring/config/config.yaml"
-
 // Client holds all the resources required to run alerting
 type Client struct {
 	*subscriber.Client
@@ -62,7 +60,7 @@ func (c *Client) RunAlerting() {
 
 func (c *Client) handleReportMessage(rmsg *prowapi.ReportMessage) {
 	if rmsg.Status == prowapi.SuccessState || rmsg.Status == prowapi.FailureState || rmsg.Status == prowapi.AbortedState {
-		config, err := config.ParseYaml(YamlURL)
+		config, err := config.ParseDefaultConfig()
 		if err != nil {
 			log.Printf("Failed to config yaml (%v): %v\n", config, err)
 			return

--- a/tools/monitoring/clearalerts/main.go
+++ b/tools/monitoring/clearalerts/main.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/knative/test-infra/shared/mysql"
-	"github.com/knative/test-infra/tools/monitoring/alert"
 	"github.com/knative/test-infra/tools/monitoring/config"
 	msql "github.com/knative/test-infra/tools/monitoring/mysql"
 )
@@ -45,7 +44,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	c, err := config.ParseYaml(alert.YamlURL)
+	c, err := config.ParseDefaultConfig()
 	if err != nil {
 		log.Fatalf("Failed to parse the config yaml: %v", err)
 	}

--- a/tools/monitoring/log_parser/log_parser.go
+++ b/tools/monitoring/log_parser/log_parser.go
@@ -20,9 +20,8 @@ import (
 	"log"
 	"regexp"
 
-	"github.com/knative/test-infra/tools/monitoring/mysql"
-
 	"github.com/knative/test-infra/tools/monitoring/config"
+	"github.com/knative/test-infra/tools/monitoring/mysql"
 )
 
 // collectMatches collects error messages that matches the patterns from text.


### PR DESCRIPTION
This prevents us from exposing the yam lurl outside the config pkg. 

Also, renamed a few vars to use short names