### PR TITLE
serving works with vanity URL knative.dev

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -2087,6 +2087,7 @@ periodics:
   - org: knative
     repo: serving
     base_ref: master
+    path_alias: knative.dev/serving
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -2294,6 +2295,7 @@ periodics:
   - org: knative
     repo: serving
     base_ref: master
+    path_alias: knative.dev/serving
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -2326,6 +2328,7 @@ periodics:
   - org: knative
     repo: serving
     base_ref: master
+    path_alias: knative.dev/serving
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -2362,6 +2365,7 @@ periodics:
   - org: knative
     repo: serving
     base_ref: master
+    path_alias: knative.dev/serving
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -2394,6 +2398,7 @@ periodics:
   - org: knative
     repo: serving
     base_ref: master
+    path_alias: knative.dev/serving
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -2426,6 +2431,7 @@ periodics:
   - org: knative
     repo: serving
     base_ref: master
+    path_alias: knative.dev/serving
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -2458,6 +2464,7 @@ periodics:
   - org: knative
     repo: serving
     base_ref: master
+    path_alias: knative.dev/serving
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -2490,6 +2497,7 @@ periodics:
   - org: knative
     repo: serving
     base_ref: master
+    path_alias: knative.dev/serving
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -2521,6 +2529,7 @@ periodics:
   - org: knative
     repo: serving
     base_ref: master
+    path_alias: knative.dev/serving
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -2564,6 +2573,7 @@ periodics:
   - org: knative
     repo: serving
     base_ref: master
+    path_alias: knative.dev/serving
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -2607,6 +2617,7 @@ periodics:
   - org: knative
     repo: serving
     base_ref: master
+    path_alias: knative.dev/serving
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/metrics:latest
@@ -2642,6 +2653,7 @@ periodics:
   - org: knative
     repo: serving
     base_ref: master
+    path_alias: knative.dev/serving
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -2679,6 +2691,7 @@ periodics:
   - org: knative
     repo: serving
     base_ref: master
+    path_alias: knative.dev/serving
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -2713,6 +2726,7 @@ periodics:
   - org: knative
     repo: serving
     base_ref: master
+    path_alias: knative.dev/serving
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -2748,6 +2762,7 @@ periodics:
   - org: knative
     repo: serving
     base_ref: master
+    path_alias: knative.dev/serving
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/coverage:latest

--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -281,6 +281,10 @@ presubmits:
           secretName: test-account
   - name: pull-knative-serving-integration-tests
     agent: kubernetes
+    labels:
+      prow.k8s.io/pubsub.project: knative-tests
+      prow.k8s.io/pubsub.topic: knative-monitoring
+      prow.k8s.io/pubsub.runID: pull-knative-serving-integration-tests
     context: pull-knative-serving-integration-tests
     always_run: true
     rerun_command: "/test pull-knative-serving-integration-tests"
@@ -2114,6 +2118,10 @@ periodics:
 - cron: "6 8 * * *"
   name: ci-knative-serving-0.4-continuous
   agent: kubernetes
+  labels:
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-knative-serving-0.4-continuous
   decorate: true
   extra_refs:
   - org: knative
@@ -2158,7 +2166,7 @@ periodics:
   labels:
     prow.k8s.io/pubsub.project: knative-tests
     prow.k8s.io/pubsub.topic: knative-monitoring
-    prow.k8s.io/pubsub.runID: ci-knative-serving-0.4-continuous
+    prow.k8s.io/pubsub.runID: ci-knative-serving-0.5-continuous
   decorate: true
   extra_refs:
   - org: knative
@@ -2203,7 +2211,7 @@ periodics:
   labels:
     prow.k8s.io/pubsub.project: knative-tests
     prow.k8s.io/pubsub.topic: knative-monitoring
-    prow.k8s.io/pubsub.runID: ci-knative-serving-0.5-continuous
+    prow.k8s.io/pubsub.runID: ci-knative-serving-0.6-continuous
   decorate: true
   extra_refs:
   - org: knative
@@ -2245,6 +2253,10 @@ periodics:
 - cron: "39 8 * * *"
   name: ci-knative-serving-0.7-continuous
   agent: kubernetes
+  labels:
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-knative-serving-0.7-continuous
   decorate: true
   extra_refs:
   - org: knative
@@ -2286,10 +2298,6 @@ periodics:
 - cron: "28 */2 * * *"
   name: ci-knative-serving-istio-1.0-mesh
   agent: kubernetes
-  labels:
-    prow.k8s.io/pubsub.project: knative-tests
-    prow.k8s.io/pubsub.topic: knative-monitoring
-    prow.k8s.io/pubsub.runID: ci-knative-serving-0.6-continuous
   decorate: true
   extra_refs:
   - org: knative
@@ -2356,10 +2364,6 @@ periodics:
 - cron: "39 */2 * * *"
   name: ci-knative-serving-istio-1.1-mesh
   agent: kubernetes
-  labels:
-    prow.k8s.io/pubsub.project: knative-tests
-    prow.k8s.io/pubsub.topic: knative-monitoring
-    prow.k8s.io/pubsub.runID: ci-knative-serving-0.7-continuous
   decorate: true
   extra_refs:
   - org: knative
@@ -2492,6 +2496,10 @@ periodics:
 - cron: "56 9 * * *"
   name: ci-knative-serving-nightly-release
   agent: kubernetes
+  labels:
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-knative-serving-nightly-release
   decorate: true
   extra_refs:
   - org: knative
@@ -2524,6 +2532,10 @@ periodics:
 - cron: "37 9 * * 2"
   name: ci-knative-serving-dot-release
   agent: kubernetes
+  labels:
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-knative-serving-dot-release
   decorate: true
   extra_refs:
   - org: knative
@@ -2567,7 +2579,7 @@ periodics:
   labels:
     prow.k8s.io/pubsub.project: knative-tests
     prow.k8s.io/pubsub.topic: knative-monitoring
-    prow.k8s.io/pubsub.runID: ci-knative-serving-dot-release
+    prow.k8s.io/pubsub.runID: ci-knative-serving-auto-release
   decorate: true
   extra_refs:
   - org: knative

--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -532,6 +532,11 @@ presubmits:
     optional: true
     decorate: true
     path_alias: knative.dev/serving
+    skip_branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/coverage-dev:latest-dev
@@ -4857,6 +4862,11 @@ postsubmits:
     agent: kubernetes
     decorate: true
     path_alias: knative.dev/serving
+    skip_branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/coverage-dev:latest-dev

--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -2087,48 +2087,6 @@ periodics:
   - org: knative
     repo: serving
     base_ref: master
-  branches:
-    - "release-0.4"
-    - "release-0.5"
-    - "release-0.6"
-    - "release-0.7"
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./test/presubmit-tests.sh"
-      - "--all-tests"
-      - "--emit-metrics"
-      volumeMounts:
-      - name: test-account
-        mountPath: /etc/test-account
-        readOnly: true
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/test-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-    volumes:
-    - name: test-account
-      secret:
-        secretName: test-account
-- cron: "10 */2 * * *"
-  name: ci-knative-serving-continuous
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: knative
-    repo: serving
-    base_ref: master
-    path_alias: knative.dev/serving
-  skip_branches:
-    - "release-0.4"
-    - "release-0.5"
-    - "release-0.6"
-    - "release-0.7"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -2160,11 +2118,6 @@ periodics:
   - org: knative
     repo: serving
     base_ref: release-0.4
-  branches:
-    - "release-0.4"
-    - "release-0.5"
-    - "release-0.6"
-    - "release-0.7"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -2198,8 +2151,8 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "6 8 * * *"
-  name: ci-knative-serving-0.4-continuous
+- cron: "17 8 * * *"
+  name: ci-knative-serving-0.5-continuous
   agent: kubernetes
   labels:
     prow.k8s.io/pubsub.project: knative-tests
@@ -2209,13 +2162,7 @@ periodics:
   extra_refs:
   - org: knative
     repo: serving
-    base_ref: release-0.4
-    path_alias: knative.dev/serving
-  skip_branches:
-    - "release-0.4"
-    - "release-0.5"
-    - "release-0.6"
-    - "release-0.7"
+    base_ref: release-0.5
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -2242,15 +2189,15 @@ periodics:
       - name: E2E_CLUSTER_REGION
         value: us-central1
       - name: PULL_BASE_REF
-        value: release-0.4
+        value: release-0.5
     volumes:
     - name: docker-graph
       emptyDir: {}
     - name: test-account
       secret:
         secretName: test-account
-- cron: "17 8 * * *"
-  name: ci-knative-serving-0.5-continuous
+- cron: "28 8 * * *"
+  name: ci-knative-serving-0.6-continuous
   agent: kubernetes
   labels:
     prow.k8s.io/pubsub.project: knative-tests
@@ -2260,12 +2207,7 @@ periodics:
   extra_refs:
   - org: knative
     repo: serving
-    base_ref: release-0.5
-  branches:
-    - "release-0.4"
-    - "release-0.5"
-    - "release-0.6"
-    - "release-0.7"
+    base_ref: release-0.6
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -2292,27 +2234,21 @@ periodics:
       - name: E2E_CLUSTER_REGION
         value: us-central1
       - name: PULL_BASE_REF
-        value: release-0.5
+        value: release-0.6
     volumes:
     - name: docker-graph
       emptyDir: {}
     - name: test-account
       secret:
         secretName: test-account
-- cron: "17 8 * * *"
-  name: ci-knative-serving-0.5-continuous
+- cron: "39 8 * * *"
+  name: ci-knative-serving-0.7-continuous
   agent: kubernetes
   decorate: true
   extra_refs:
   - org: knative
     repo: serving
-    base_ref: release-0.5
-    path_alias: knative.dev/serving
-  skip_branches:
-    - "release-0.4"
-    - "release-0.5"
-    - "release-0.6"
-    - "release-0.7"
+    base_ref: release-0.7
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -2339,15 +2275,15 @@ periodics:
       - name: E2E_CLUSTER_REGION
         value: us-central1
       - name: PULL_BASE_REF
-        value: release-0.5
+        value: release-0.7
     volumes:
     - name: docker-graph
       emptyDir: {}
     - name: test-account
       secret:
         secretName: test-account
-- cron: "28 8 * * *"
-  name: ci-knative-serving-0.6-continuous
+- cron: "28 */2 * * *"
+  name: ci-knative-serving-istio-1.0-mesh
   agent: kubernetes
   labels:
     prow.k8s.io/pubsub.project: knative-tests
@@ -2357,12 +2293,7 @@ periodics:
   extra_refs:
   - org: knative
     repo: serving
-    base_ref: release-0.6
-  branches:
-    - "release-0.4"
-    - "release-0.5"
-    - "release-0.6"
-    - "release-0.7"
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -2370,46 +2301,31 @@ periodics:
       command:
       - runner.sh
       args:
-      - "./hack/release.sh"
-      - "--nopublish"
-      - "--notag-release"
-      securityContext:
-        privileged: true
+      - "./test/e2e-tests.sh"
+      - "--istio-version"
+      - "1.0-latest"
+      - "--mesh"
       volumeMounts:
-      - name: docker-graph
-        mountPath: /docker-graph
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
       env:
-      - name: DOCKER_IN_DOCKER_ENABLED
-        value: "true"
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: release-0.6
     volumes:
-    - name: docker-graph
-      emptyDir: {}
     - name: test-account
       secret:
         secretName: test-account
-- cron: "28 8 * * *"
-  name: ci-knative-serving-0.6-continuous
+- cron: "40 */2 * * *"
+  name: ci-knative-serving-istio-1.0-no-mesh
   agent: kubernetes
   decorate: true
   extra_refs:
   - org: knative
     repo: serving
-    base_ref: release-0.6
-    path_alias: knative.dev/serving
-  skip_branches:
-    - "release-0.4"
-    - "release-0.5"
-    - "release-0.6"
-    - "release-0.7"
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -2417,34 +2333,25 @@ periodics:
       command:
       - runner.sh
       args:
-      - "./hack/release.sh"
-      - "--nopublish"
-      - "--notag-release"
-      securityContext:
-        privileged: true
+      - "./test/e2e-tests.sh"
+      - "--istio-version"
+      - "1.0-latest"
+      - "--no-mesh"
       volumeMounts:
-      - name: docker-graph
-        mountPath: /docker-graph
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
       env:
-      - name: DOCKER_IN_DOCKER_ENABLED
-        value: "true"
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: release-0.6
     volumes:
-    - name: docker-graph
-      emptyDir: {}
     - name: test-account
       secret:
         secretName: test-account
-- cron: "39 8 * * *"
-  name: ci-knative-serving-0.7-continuous
+- cron: "39 */2 * * *"
+  name: ci-knative-serving-istio-1.1-mesh
   agent: kubernetes
   labels:
     prow.k8s.io/pubsub.project: knative-tests
@@ -2454,293 +2361,7 @@ periodics:
   extra_refs:
   - org: knative
     repo: serving
-    base_ref: release-0.7
-  branches:
-    - "release-0.4"
-    - "release-0.5"
-    - "release-0.6"
-    - "release-0.7"
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./hack/release.sh"
-      - "--nopublish"
-      - "--notag-release"
-      securityContext:
-        privileged: true
-      volumeMounts:
-      - name: docker-graph
-        mountPath: /docker-graph
-      - name: test-account
-        mountPath: /etc/test-account
-        readOnly: true
-      env:
-      - name: DOCKER_IN_DOCKER_ENABLED
-        value: "true"
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/test-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-      - name: PULL_BASE_REF
-        value: release-0.7
-    volumes:
-    - name: docker-graph
-      emptyDir: {}
-    - name: test-account
-      secret:
-        secretName: test-account
-- cron: "39 8 * * *"
-  name: ci-knative-serving-0.7-continuous
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: knative
-    repo: serving
-    base_ref: release-0.7
-    path_alias: knative.dev/serving
-  skip_branches:
-    - "release-0.4"
-    - "release-0.5"
-    - "release-0.6"
-    - "release-0.7"
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./hack/release.sh"
-      - "--nopublish"
-      - "--notag-release"
-      securityContext:
-        privileged: true
-      volumeMounts:
-      - name: docker-graph
-        mountPath: /docker-graph
-      - name: test-account
-        mountPath: /etc/test-account
-        readOnly: true
-      env:
-      - name: DOCKER_IN_DOCKER_ENABLED
-        value: "true"
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/test-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-      - name: PULL_BASE_REF
-        value: release-0.7
-    volumes:
-    - name: docker-graph
-      emptyDir: {}
-    - name: test-account
-      secret:
-        secretName: test-account
-- cron: "28 */2 * * *"
-  name: ci-knative-serving-istio-1.0-mesh
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: knative
-    repo: serving
     base_ref: master
-  branches:
-    - "release-0.4"
-    - "release-0.5"
-    - "release-0.6"
-    - "release-0.7"
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./test/e2e-tests.sh"
-      - "--istio-version"
-      - "1.0-latest"
-      - "--mesh"
-      volumeMounts:
-      - name: test-account
-        mountPath: /etc/test-account
-        readOnly: true
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/test-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-    volumes:
-    - name: test-account
-      secret:
-        secretName: test-account
-- cron: "28 */2 * * *"
-  name: ci-knative-serving-istio-1.0-mesh
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: knative
-    repo: serving
-    base_ref: master
-    path_alias: knative.dev/serving
-  skip_branches:
-    - "release-0.4"
-    - "release-0.5"
-    - "release-0.6"
-    - "release-0.7"
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./test/e2e-tests.sh"
-      - "--istio-version"
-      - "1.0-latest"
-      - "--mesh"
-      volumeMounts:
-      - name: test-account
-        mountPath: /etc/test-account
-        readOnly: true
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/test-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-    volumes:
-    - name: test-account
-      secret:
-        secretName: test-account
-- cron: "40 */2 * * *"
-  name: ci-knative-serving-istio-1.0-no-mesh
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: knative
-    repo: serving
-    base_ref: master
-  branches:
-    - "release-0.4"
-    - "release-0.5"
-    - "release-0.6"
-    - "release-0.7"
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./test/e2e-tests.sh"
-      - "--istio-version"
-      - "1.0-latest"
-      - "--no-mesh"
-      volumeMounts:
-      - name: test-account
-        mountPath: /etc/test-account
-        readOnly: true
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/test-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-    volumes:
-    - name: test-account
-      secret:
-        secretName: test-account
-- cron: "40 */2 * * *"
-  name: ci-knative-serving-istio-1.0-no-mesh
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: knative
-    repo: serving
-    base_ref: master
-    path_alias: knative.dev/serving
-  skip_branches:
-    - "release-0.4"
-    - "release-0.5"
-    - "release-0.6"
-    - "release-0.7"
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./test/e2e-tests.sh"
-      - "--istio-version"
-      - "1.0-latest"
-      - "--no-mesh"
-      volumeMounts:
-      - name: test-account
-        mountPath: /etc/test-account
-        readOnly: true
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/test-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-    volumes:
-    - name: test-account
-      secret:
-        secretName: test-account
-- cron: "39 */2 * * *"
-  name: ci-knative-serving-istio-1.1-mesh
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: knative
-    repo: serving
-    base_ref: master
-  branches:
-    - "release-0.4"
-    - "release-0.5"
-    - "release-0.6"
-    - "release-0.7"
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./test/e2e-tests.sh"
-      - "--istio-version"
-      - "1.1-latest"
-      - "--mesh"
-      volumeMounts:
-      - name: test-account
-        mountPath: /etc/test-account
-        readOnly: true
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/test-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-    volumes:
-    - name: test-account
-      secret:
-        secretName: test-account
-- cron: "39 */2 * * *"
-  name: ci-knative-serving-istio-1.1-mesh
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: knative
-    repo: serving
-    base_ref: master
-    path_alias: knative.dev/serving
-  skip_branches:
-    - "release-0.4"
-    - "release-0.5"
-    - "release-0.6"
-    - "release-0.7"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -2773,49 +2394,6 @@ periodics:
   - org: knative
     repo: serving
     base_ref: master
-  branches:
-    - "release-0.4"
-    - "release-0.5"
-    - "release-0.6"
-    - "release-0.7"
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./test/e2e-tests.sh"
-      - "--istio-version"
-      - "1.1-latest"
-      - "--no-mesh"
-      volumeMounts:
-      - name: test-account
-        mountPath: /etc/test-account
-        readOnly: true
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/test-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-    volumes:
-    - name: test-account
-      secret:
-        secretName: test-account
-- cron: "50 */2 * * *"
-  name: ci-knative-serving-istio-1.1-no-mesh
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: knative
-    repo: serving
-    base_ref: master
-    path_alias: knative.dev/serving
-  skip_branches:
-    - "release-0.4"
-    - "release-0.5"
-    - "release-0.6"
-    - "release-0.7"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -2848,49 +2426,6 @@ periodics:
   - org: knative
     repo: serving
     base_ref: master
-  branches:
-    - "release-0.4"
-    - "release-0.5"
-    - "release-0.6"
-    - "release-0.7"
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./test/e2e-tests.sh"
-      - "--istio-version"
-      - "1.2-latest"
-      - "--mesh"
-      volumeMounts:
-      - name: test-account
-        mountPath: /etc/test-account
-        readOnly: true
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/test-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-    volumes:
-    - name: test-account
-      secret:
-        secretName: test-account
-- cron: "40 */2 * * *"
-  name: ci-knative-serving-istio-1.2-mesh
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: knative
-    repo: serving
-    base_ref: master
-    path_alias: knative.dev/serving
-  skip_branches:
-    - "release-0.4"
-    - "release-0.5"
-    - "release-0.6"
-    - "release-0.7"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -2923,49 +2458,6 @@ periodics:
   - org: knative
     repo: serving
     base_ref: master
-  branches:
-    - "release-0.4"
-    - "release-0.5"
-    - "release-0.6"
-    - "release-0.7"
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./test/e2e-tests.sh"
-      - "--istio-version"
-      - "1.2-latest"
-      - "--no-mesh"
-      volumeMounts:
-      - name: test-account
-        mountPath: /etc/test-account
-        readOnly: true
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/test-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-    volumes:
-    - name: test-account
-      secret:
-        secretName: test-account
-- cron: "1 */2 * * *"
-  name: ci-knative-serving-istio-1.2-no-mesh
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: knative
-    repo: serving
-    base_ref: master
-    path_alias: knative.dev/serving
-  skip_branches:
-    - "release-0.4"
-    - "release-0.5"
-    - "release-0.6"
-    - "release-0.7"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -2998,48 +2490,6 @@ periodics:
   - org: knative
     repo: serving
     base_ref: master
-  branches:
-    - "release-0.4"
-    - "release-0.5"
-    - "release-0.6"
-    - "release-0.7"
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./hack/release.sh"
-      - "--publish"
-      - "--tag-release"
-      volumeMounts:
-      - name: nightly-account
-        mountPath: /etc/nightly-account
-        readOnly: true
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/nightly-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-    volumes:
-    - name: nightly-account
-      secret:
-        secretName: nightly-account
-- cron: "56 9 * * *"
-  name: ci-knative-serving-nightly-release
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: knative
-    repo: serving
-    base_ref: master
-    path_alias: knative.dev/serving
-  skip_branches:
-    - "release-0.4"
-    - "release-0.5"
-    - "release-0.6"
-    - "release-0.7"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -3071,60 +2521,6 @@ periodics:
   - org: knative
     repo: serving
     base_ref: master
-  branches:
-    - "release-0.4"
-    - "release-0.5"
-    - "release-0.6"
-    - "release-0.7"
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./hack/release.sh"
-      - "--dot-release"
-      - "--release-gcs knative-releases/serving"
-      - "--release-gcr gcr.io/knative-releases"
-      - "--github-token /etc/hub-token/token"
-      volumeMounts:
-      - name: hub-token
-        mountPath: /etc/hub-token
-        readOnly: true
-      - name: release-account
-        mountPath: /etc/release-account
-        readOnly: true
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/release-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-    volumes:
-    - name: hub-token
-      secret:
-        secretName: hub-token
-    - name: release-account
-      secret:
-        secretName: release-account
-- cron: "37 9 * * 2"
-  name: ci-knative-serving-dot-release
-  agent: kubernetes
-  labels:
-    prow.k8s.io/pubsub.project: knative-tests
-    prow.k8s.io/pubsub.topic: knative-monitoring
-    prow.k8s.io/pubsub.runID: ci-knative-serving-nightly-release
-  decorate: true
-  extra_refs:
-  - org: knative
-    repo: serving
-    base_ref: master
-    path_alias: knative.dev/serving
-  skip_branches:
-    - "release-0.4"
-    - "release-0.5"
-    - "release-0.6"
-    - "release-0.7"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -3168,60 +2564,6 @@ periodics:
   - org: knative
     repo: serving
     base_ref: master
-  branches:
-    - "release-0.4"
-    - "release-0.5"
-    - "release-0.6"
-    - "release-0.7"
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./hack/release.sh"
-      - "--auto-release"
-      - "--release-gcs knative-releases/serving"
-      - "--release-gcr gcr.io/knative-releases"
-      - "--github-token /etc/hub-token/token"
-      volumeMounts:
-      - name: hub-token
-        mountPath: /etc/hub-token
-        readOnly: true
-      - name: release-account
-        mountPath: /etc/release-account
-        readOnly: true
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/release-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-    volumes:
-    - name: hub-token
-      secret:
-        secretName: hub-token
-    - name: release-account
-      secret:
-        secretName: release-account
-- cron: "34 */2 * * *"
-  name: ci-knative-serving-auto-release
-  agent: kubernetes
-  labels:
-    prow.k8s.io/pubsub.project: knative-tests
-    prow.k8s.io/pubsub.topic: knative-monitoring
-    prow.k8s.io/pubsub.runID: ci-knative-serving-auto-release
-  decorate: true
-  extra_refs:
-  - org: knative
-    repo: serving
-    base_ref: master
-    path_alias: knative.dev/serving
-  skip_branches:
-    - "release-0.4"
-    - "release-0.5"
-    - "release-0.6"
-    - "release-0.7"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -3261,52 +2603,10 @@ periodics:
       prow.k8s.io/pubsub.runID: ci-knative-serving-latency
   agent: kubernetes
   decorate: true
-  branches:
-    - "release-0.4"
-    - "release-0.5"
-    - "release-0.6"
-    - "release-0.7"
   extra_refs:
   - org: knative
     repo: serving
     base_ref: master
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/metrics:latest
-      imagePullPolicy: Always
-      command:
-      - "/metrics"
-      args:
-      - "--source-directory=ci-knative-serving-continuous"
-      - "--artifacts-dir=$(ARTIFACTS)"
-      - "--service-account=/etc/test-account/service-account.json"
-      volumeMounts:
-      - name: test-account
-        mountPath: /etc/test-account
-        readOnly: true
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/test-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-    volumes:
-    - name: test-account
-      secret:
-        secretName: test-account
-- cron: "38 8 * * *"
-  name: ci-knative-serving-latency
-  agent: kubernetes
-  decorate: true
-  skip_branches:
-    - "release-0.4"
-    - "release-0.5"
-    - "release-0.6"
-    - "release-0.7"
-  extra_refs:
-  - org: knative
-    repo: serving
-    base_ref: master
-    path_alias: knative.dev/serving
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/metrics:latest
@@ -3342,11 +2642,6 @@ periodics:
   - org: knative
     repo: serving
     base_ref: master
-  branches:
-    - "release-0.4"
-    - "release-0.5"
-    - "release-0.6"
-    - "release-0.7"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -3355,84 +2650,6 @@ periodics:
       - runner.sh
       args:
       - "./test/performance-tests.sh"
-      volumeMounts:
-      - name: test-account
-        mountPath: /etc/test-account
-        readOnly: true
-      env:
-      - name: E2E_MIN_CLUSTER_NODES
-        value: "16"
-      - name: E2E_MAX_CLUSTER_NODES
-        value: "16"
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/test-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-    volumes:
-    - name: test-account
-      secret:
-        secretName: test-account
-- cron: "0 */3 * * *"
-  name: ci-knative-serving-performance
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: knative
-    repo: serving
-    base_ref: master
-    path_alias: knative.dev/serving
-  skip_branches:
-    - "release-0.4"
-    - "release-0.5"
-    - "release-0.6"
-    - "release-0.7"
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./test/performance-tests.sh"
-      volumeMounts:
-      - name: test-account
-        mountPath: /etc/test-account
-        readOnly: true
-      env:
-      - name: E2E_MIN_CLUSTER_NODES
-        value: "16"
-      - name: E2E_MAX_CLUSTER_NODES
-        value: "16"
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/test-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-    volumes:
-    - name: test-account
-      secret:
-        secretName: test-account
-- cron: "0 */3 * * *"
-  name: ci-knative-serving-performance-mesh
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: knative
-    repo: serving
-    base_ref: master
-  branches:
-    - "release-0.4"
-    - "release-0.5"
-    - "release-0.6"
-    - "release-0.7"
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./test/performance-tests.sh"
-      - "--mesh"
       volumeMounts:
       - name: test-account
         mountPath: /etc/test-account
@@ -3462,12 +2679,6 @@ periodics:
   - org: knative
     repo: serving
     base_ref: master
-    path_alias: knative.dev/serving
-  skip_branches:
-    - "release-0.4"
-    - "release-0.5"
-    - "release-0.6"
-    - "release-0.7"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -3502,48 +2713,6 @@ periodics:
   - org: knative
     repo: serving
     base_ref: master
-  branches:
-    - "release-0.4"
-    - "release-0.5"
-    - "release-0.6"
-    - "release-0.7"
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./test/apicoverage.sh"
-      volumeMounts:
-      - name: test-account
-        mountPath: /etc/test-account
-        readOnly: true
-      env:
-      - name: SYSTEM_NAMESPACE
-        value: knative-serving
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/test-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-    volumes:
-    - name: test-account
-      secret:
-        secretName: test-account
-- cron: "13 9 * * *"
-  name: ci-knative-serving-webhook-apicoverage
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: knative
-    repo: serving
-    base_ref: master
-    path_alias: knative.dev/serving
-  skip_branches:
-    - "release-0.4"
-    - "release-0.5"
-    - "release-0.6"
-    - "release-0.7"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -3575,42 +2744,10 @@ periodics:
       prow.k8s.io/pubsub.runID: ci-knative-serving-go-coverage
   agent: kubernetes
   decorate: true
-  branches:
-    - "release-0.4"
-    - "release-0.5"
-    - "release-0.6"
-    - "release-0.7"
   extra_refs:
   - org: knative
     repo: serving
     base_ref: master
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/coverage:latest
-      imagePullPolicy: Always
-      command:
-      - "/coverage"
-      args:
-      - "--artifacts=$(ARTIFACTS)"
-      - "--cov-threshold-percentage=80"
-- cron: "0 1 * * *"
-  name: ci-knative-serving-go-coverage
-  labels:
-      prow.k8s.io/pubsub.project: knative-tests
-      prow.k8s.io/pubsub.topic: knative-monitoring
-      prow.k8s.io/pubsub.runID: ci-knative-serving-go-coverage
-  agent: kubernetes
-  decorate: true
-  skip_branches:
-    - "release-0.4"
-    - "release-0.5"
-    - "release-0.6"
-    - "release-0.7"
-  extra_refs:
-  - org: knative
-    repo: serving
-    base_ref: master
-    path_alias: knative.dev/serving
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/coverage:latest

--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -109,6 +109,46 @@ presubmits:
     rerun_command: "/test pull-knative-serving-build-tests"
     trigger: "(?m)^/test (all|pull-knative-serving-build-tests),?(\\s+|$)"
     decorate: true
+    branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--build-tests"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-serving-build-tests
+    agent: kubernetes
+    context: pull-knative-serving-build-tests
+    always_run: true
+    rerun_command: "/test pull-knative-serving-build-tests"
+    trigger: "(?m)^/test (all|pull-knative-serving-build-tests),?(\\s+|$)"
+    decorate: true
+    path_alias: knative.dev/serving
+    skip_branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -138,6 +178,46 @@ presubmits:
     rerun_command: "/test pull-knative-serving-unit-tests"
     trigger: "(?m)^/test (all|pull-knative-serving-unit-tests),?(\\s+|$)"
     decorate: true
+    branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--unit-tests"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-serving-unit-tests
+    agent: kubernetes
+    context: pull-knative-serving-unit-tests
+    always_run: true
+    rerun_command: "/test pull-knative-serving-unit-tests"
+    trigger: "(?m)^/test (all|pull-knative-serving-unit-tests),?(\\s+|$)"
+    decorate: true
+    path_alias: knative.dev/serving
+    skip_branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -171,6 +251,47 @@ presubmits:
     rerun_command: "/test pull-knative-serving-integration-tests"
     trigger: "(?m)^/test (all|pull-knative-serving-integration-tests),?(\\s+|$)"
     decorate: true
+    branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-tests.sh"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-serving-integration-tests
+    agent: kubernetes
+    context: pull-knative-serving-integration-tests
+    always_run: true
+    rerun_command: "/test pull-knative-serving-integration-tests"
+    trigger: "(?m)^/test (all|pull-knative-serving-integration-tests),?(\\s+|$)"
+    decorate: true
+    path_alias: knative.dev/serving
+    skip_branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -201,6 +322,47 @@ presubmits:
     rerun_command: "/test pull-knative-serving-upgrade-tests"
     trigger: "(?m)^/test (all|pull-knative-serving-upgrade-tests),?(\\s+|$)"
     decorate: true
+    branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-upgrade-tests.sh"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-serving-upgrade-tests
+    agent: kubernetes
+    context: pull-knative-serving-upgrade-tests
+    always_run: true
+    rerun_command: "/test pull-knative-serving-upgrade-tests"
+    trigger: "(?m)^/test (all|pull-knative-serving-upgrade-tests),?(\\s+|$)"
+    decorate: true
+    path_alias: knative.dev/serving
+    skip_branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -231,10 +393,44 @@ presubmits:
     rerun_command: "/test pull-knative-serving-smoke-tests"
     trigger: "(?m)^/test (all|pull-knative-serving-smoke-tests),?(\\s+|$)"
     decorate: true
+    branches:
+    - "release-0.7"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-smoke-tests.sh"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-serving-smoke-tests
+    agent: kubernetes
+    context: pull-knative-serving-smoke-tests
+    always_run: true
+    rerun_command: "/test pull-knative-serving-smoke-tests"
+    trigger: "(?m)^/test (all|pull-knative-serving-smoke-tests),?(\\s+|$)"
+    decorate: true
+    path_alias: knative.dev/serving
     skip_branches:
     - "release-0.4"
     - "release-0.5"
     - "release-0.6"
+    - "release-0.7"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -266,6 +462,44 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-serving-go-coverage),?(\\s+|$)"
     optional: true
     decorate: true
+    branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/coverage:latest
+        imagePullPolicy: Always
+        command:
+        - "/coverage"
+        args:
+        - "--postsubmit-job-name=post-knative-serving-go-coverage"
+        - "--artifacts=$(ARTIFACTS)"
+        - "--cov-threshold-percentage=80"
+        - "--github-token=/etc/covbot-token/token"
+        volumeMounts:
+        - name: covbot-token
+          mountPath: /etc/covbot-token
+          readOnly: true
+      volumes:
+      - name: covbot-token
+        secret:
+          secretName: covbot-token
+  - name: pull-knative-serving-go-coverage
+    agent: kubernetes
+    context: pull-knative-serving-go-coverage
+    always_run: true
+    rerun_command: "/test pull-knative-serving-go-coverage"
+    trigger: "(?m)^/test (all|pull-knative-serving-go-coverage),?(\\s+|$)"
+    optional: true
+    decorate: true
+    path_alias: knative.dev/serving
+    skip_branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/coverage:latest
@@ -293,6 +527,7 @@ presubmits:
     trigger: "(?m)^/test (pull-knative-serving-go-coverage-dev),?(\\s+|$)"
     optional: true
     decorate: true
+    path_alias: knative.dev/serving
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/coverage-dev:latest-dev
@@ -319,6 +554,45 @@ presubmits:
     rerun_command: "/test pull-knative-serving-perf-tests"
     trigger: "(?m)^/test (all|pull-knative-serving-perf-tests),?(\\s+|$)"
     decorate: true
+    branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/performance-tests.sh"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-serving-perf-tests
+    agent: kubernetes
+    context: pull-knative-serving-perf-tests
+    always_run: false
+    rerun_command: "/test pull-knative-serving-perf-tests"
+    trigger: "(?m)^/test (all|pull-knative-serving-perf-tests),?(\\s+|$)"
+    decorate: true
+    path_alias: knative.dev/serving
+    skip_branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1813,6 +2087,48 @@ periodics:
   - org: knative
     repo: serving
     base_ref: master
+  branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./test/presubmit-tests.sh"
+      - "--all-tests"
+      - "--emit-metrics"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "10 */2 * * *"
+  name: ci-knative-serving-continuous
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: master
+    path_alias: knative.dev/serving
+  skip_branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1839,6 +2155,52 @@ periodics:
 - cron: "6 8 * * *"
   name: ci-knative-serving-0.4-continuous
   agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: release-0.4
+  branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--nopublish"
+      - "--notag-release"
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - name: docker-graph
+        mountPath: /docker-graph
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.4
+    volumes:
+    - name: docker-graph
+      emptyDir: {}
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "6 8 * * *"
+  name: ci-knative-serving-0.4-continuous
+  agent: kubernetes
   labels:
     prow.k8s.io/pubsub.project: knative-tests
     prow.k8s.io/pubsub.topic: knative-monitoring
@@ -1848,6 +2210,12 @@ periodics:
   - org: knative
     repo: serving
     base_ref: release-0.4
+    path_alias: knative.dev/serving
+  skip_branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1893,6 +2261,58 @@ periodics:
   - org: knative
     repo: serving
     base_ref: release-0.5
+  branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--nopublish"
+      - "--notag-release"
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - name: docker-graph
+        mountPath: /docker-graph
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.5
+    volumes:
+    - name: docker-graph
+      emptyDir: {}
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "17 8 * * *"
+  name: ci-knative-serving-0.5-continuous
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: release-0.5
+    path_alias: knative.dev/serving
+  skip_branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1938,6 +2358,58 @@ periodics:
   - org: knative
     repo: serving
     base_ref: release-0.6
+  branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--nopublish"
+      - "--notag-release"
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - name: docker-graph
+        mountPath: /docker-graph
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.6
+    volumes:
+    - name: docker-graph
+      emptyDir: {}
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "28 8 * * *"
+  name: ci-knative-serving-0.6-continuous
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: release-0.6
+    path_alias: knative.dev/serving
+  skip_branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1983,6 +2455,58 @@ periodics:
   - org: knative
     repo: serving
     base_ref: release-0.7
+  branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--nopublish"
+      - "--notag-release"
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - name: docker-graph
+        mountPath: /docker-graph
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.7
+    volumes:
+    - name: docker-graph
+      emptyDir: {}
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "39 8 * * *"
+  name: ci-knative-serving-0.7-continuous
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: release-0.7
+    path_alias: knative.dev/serving
+  skip_branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -2024,6 +2548,49 @@ periodics:
   - org: knative
     repo: serving
     base_ref: master
+  branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./test/e2e-tests.sh"
+      - "--istio-version"
+      - "1.0-latest"
+      - "--mesh"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "28 */2 * * *"
+  name: ci-knative-serving-istio-1.0-mesh
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: master
+    path_alias: knative.dev/serving
+  skip_branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -2056,6 +2623,49 @@ periodics:
   - org: knative
     repo: serving
     base_ref: master
+  branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./test/e2e-tests.sh"
+      - "--istio-version"
+      - "1.0-latest"
+      - "--no-mesh"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "40 */2 * * *"
+  name: ci-knative-serving-istio-1.0-no-mesh
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: master
+    path_alias: knative.dev/serving
+  skip_branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -2088,6 +2698,49 @@ periodics:
   - org: knative
     repo: serving
     base_ref: master
+  branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./test/e2e-tests.sh"
+      - "--istio-version"
+      - "1.1-latest"
+      - "--mesh"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "39 */2 * * *"
+  name: ci-knative-serving-istio-1.1-mesh
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: master
+    path_alias: knative.dev/serving
+  skip_branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -2120,6 +2773,49 @@ periodics:
   - org: knative
     repo: serving
     base_ref: master
+  branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./test/e2e-tests.sh"
+      - "--istio-version"
+      - "1.1-latest"
+      - "--no-mesh"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "50 */2 * * *"
+  name: ci-knative-serving-istio-1.1-no-mesh
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: master
+    path_alias: knative.dev/serving
+  skip_branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -2152,6 +2848,49 @@ periodics:
   - org: knative
     repo: serving
     base_ref: master
+  branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./test/e2e-tests.sh"
+      - "--istio-version"
+      - "1.2-latest"
+      - "--mesh"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "40 */2 * * *"
+  name: ci-knative-serving-istio-1.2-mesh
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: master
+    path_alias: knative.dev/serving
+  skip_branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -2184,6 +2923,49 @@ periodics:
   - org: knative
     repo: serving
     base_ref: master
+  branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./test/e2e-tests.sh"
+      - "--istio-version"
+      - "1.2-latest"
+      - "--no-mesh"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "1 */2 * * *"
+  name: ci-knative-serving-istio-1.2-no-mesh
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: master
+    path_alias: knative.dev/serving
+  skip_branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -2211,15 +2993,53 @@ periodics:
 - cron: "56 9 * * *"
   name: ci-knative-serving-nightly-release
   agent: kubernetes
-  labels:
-    prow.k8s.io/pubsub.project: knative-tests
-    prow.k8s.io/pubsub.topic: knative-monitoring
-    prow.k8s.io/pubsub.runID: ci-knative-serving-nightly-release
   decorate: true
   extra_refs:
   - org: knative
     repo: serving
     base_ref: master
+  branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--publish"
+      - "--tag-release"
+      volumeMounts:
+      - name: nightly-account
+        mountPath: /etc/nightly-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/nightly-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: nightly-account
+      secret:
+        secretName: nightly-account
+- cron: "56 9 * * *"
+  name: ci-knative-serving-nightly-release
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: master
+    path_alias: knative.dev/serving
+  skip_branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -2246,15 +3066,65 @@ periodics:
 - cron: "37 9 * * 2"
   name: ci-knative-serving-dot-release
   agent: kubernetes
-  labels:
-    prow.k8s.io/pubsub.project: knative-tests
-    prow.k8s.io/pubsub.topic: knative-monitoring
-    prow.k8s.io/pubsub.runID: ci-knative-serving-dot-release
   decorate: true
   extra_refs:
   - org: knative
     repo: serving
     base_ref: master
+  branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--dot-release"
+      - "--release-gcs knative-releases/serving"
+      - "--release-gcr gcr.io/knative-releases"
+      - "--github-token /etc/hub-token/token"
+      volumeMounts:
+      - name: hub-token
+        mountPath: /etc/hub-token
+        readOnly: true
+      - name: release-account
+        mountPath: /etc/release-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: hub-token
+      secret:
+        secretName: hub-token
+    - name: release-account
+      secret:
+        secretName: release-account
+- cron: "37 9 * * 2"
+  name: ci-knative-serving-dot-release
+  agent: kubernetes
+  labels:
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-knative-serving-nightly-release
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: master
+    path_alias: knative.dev/serving
+  skip_branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -2292,12 +3162,66 @@ periodics:
   labels:
     prow.k8s.io/pubsub.project: knative-tests
     prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-knative-serving-dot-release
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: master
+  branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--auto-release"
+      - "--release-gcs knative-releases/serving"
+      - "--release-gcr gcr.io/knative-releases"
+      - "--github-token /etc/hub-token/token"
+      volumeMounts:
+      - name: hub-token
+        mountPath: /etc/hub-token
+        readOnly: true
+      - name: release-account
+        mountPath: /etc/release-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: hub-token
+      secret:
+        secretName: hub-token
+    - name: release-account
+      secret:
+        secretName: release-account
+- cron: "34 */2 * * *"
+  name: ci-knative-serving-auto-release
+  agent: kubernetes
+  labels:
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
     prow.k8s.io/pubsub.runID: ci-knative-serving-auto-release
   decorate: true
   extra_refs:
   - org: knative
     repo: serving
     base_ref: master
+    path_alias: knative.dev/serving
+  skip_branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -2337,10 +3261,52 @@ periodics:
       prow.k8s.io/pubsub.runID: ci-knative-serving-latency
   agent: kubernetes
   decorate: true
+  branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
   extra_refs:
   - org: knative
     repo: serving
     base_ref: master
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/metrics:latest
+      imagePullPolicy: Always
+      command:
+      - "/metrics"
+      args:
+      - "--source-directory=ci-knative-serving-continuous"
+      - "--artifacts-dir=$(ARTIFACTS)"
+      - "--service-account=/etc/test-account/service-account.json"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "38 8 * * *"
+  name: ci-knative-serving-latency
+  agent: kubernetes
+  decorate: true
+  skip_branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: master
+    path_alias: knative.dev/serving
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/metrics:latest
@@ -2376,6 +3342,11 @@ periodics:
   - org: knative
     repo: serving
     base_ref: master
+  branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -2384,6 +3355,84 @@ periodics:
       - runner.sh
       args:
       - "./test/performance-tests.sh"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: E2E_MIN_CLUSTER_NODES
+        value: "16"
+      - name: E2E_MAX_CLUSTER_NODES
+        value: "16"
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "0 */3 * * *"
+  name: ci-knative-serving-performance
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: master
+    path_alias: knative.dev/serving
+  skip_branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./test/performance-tests.sh"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: E2E_MIN_CLUSTER_NODES
+        value: "16"
+      - name: E2E_MAX_CLUSTER_NODES
+        value: "16"
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "0 */3 * * *"
+  name: ci-knative-serving-performance-mesh
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: master
+  branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./test/performance-tests.sh"
+      - "--mesh"
       volumeMounts:
       - name: test-account
         mountPath: /etc/test-account
@@ -2413,6 +3462,12 @@ periodics:
   - org: knative
     repo: serving
     base_ref: master
+    path_alias: knative.dev/serving
+  skip_branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -2447,6 +3502,48 @@ periodics:
   - org: knative
     repo: serving
     base_ref: master
+  branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./test/apicoverage.sh"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: SYSTEM_NAMESPACE
+        value: knative-serving
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "13 9 * * *"
+  name: ci-knative-serving-webhook-apicoverage
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: master
+    path_alias: knative.dev/serving
+  skip_branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -2478,10 +3575,42 @@ periodics:
       prow.k8s.io/pubsub.runID: ci-knative-serving-go-coverage
   agent: kubernetes
   decorate: true
+  branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
   extra_refs:
   - org: knative
     repo: serving
     base_ref: master
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/coverage:latest
+      imagePullPolicy: Always
+      command:
+      - "/coverage"
+      args:
+      - "--artifacts=$(ARTIFACTS)"
+      - "--cov-threshold-percentage=80"
+- cron: "0 1 * * *"
+  name: ci-knative-serving-go-coverage
+  labels:
+      prow.k8s.io/pubsub.project: knative-tests
+      prow.k8s.io/pubsub.topic: knative-monitoring
+      prow.k8s.io/pubsub.runID: ci-knative-serving-go-coverage
+  agent: kubernetes
+  decorate: true
+  skip_branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: master
+    path_alias: knative.dev/serving
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/coverage:latest
@@ -4524,6 +5653,31 @@ postsubmits:
     - master
     agent: kubernetes
     decorate: true
+    branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/coverage:latest
+        imagePullPolicy: Always
+        command:
+        - "/coverage"
+        args:
+        - "--artifacts=$(ARTIFACTS)"
+        - "--cov-threshold-percentage=0"
+  - name: post-knative-serving-go-coverage
+    branches:
+    - master
+    agent: kubernetes
+    decorate: true
+    path_alias: knative.dev/serving
+    skip_branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/coverage:latest
@@ -4538,6 +5692,7 @@ postsubmits:
     - master
     agent: kubernetes
     decorate: true
+    path_alias: knative.dev/serving
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/coverage-dev:latest-dev

--- a/ci/prow/config_knative.yaml
+++ b/ci/prow/config_knative.yaml
@@ -139,6 +139,7 @@ periodics:
   knative/serving:
     - continuous: true
       timeout: 100
+      dot-dev: true
     - branch-ci: true
       release: "0.4"
     - branch-ci: true
@@ -149,25 +150,38 @@ periodics:
       release: "0.7"
     - custom-job: istio-1.0-mesh
       full-command: "./test/e2e-tests.sh --istio-version 1.0-latest --mesh"
+      dot-dev: true
     - custom-job: istio-1.0-no-mesh
       full-command: "./test/e2e-tests.sh --istio-version 1.0-latest --no-mesh"
+      dot-dev: true
     - custom-job: istio-1.1-mesh
       full-command: "./test/e2e-tests.sh --istio-version 1.1-latest --mesh"
+      dot-dev: true
     - custom-job: istio-1.1-no-mesh
       full-command: "./test/e2e-tests.sh --istio-version 1.1-latest --no-mesh"
+      dot-dev: true
     - custom-job: istio-1.2-mesh
       full-command: "./test/e2e-tests.sh --istio-version 1.2-latest --mesh"
+      dot-dev: true
     - custom-job: istio-1.2-no-mesh
       full-command: "./test/e2e-tests.sh --istio-version 1.2-latest --no-mesh"
+      dot-dev: true
     - nightly: true
+      dot-dev: true
     - dot-release: true
+      dot-dev: true
     - auto-release: true
+      dot-dev: true
     - latency: true
+      dot-dev: true
     - performance: true
+      dot-dev: true
     - performance-mesh: true
+      dot-dev: true
       args:
       - "--mesh"
     - webhook-apicoverage: true
+      dot-dev: true
 
   knative/build:
     - continuous: true

--- a/ci/prow/config_knative.yaml
+++ b/ci/prow/config_knative.yaml
@@ -14,6 +14,12 @@
 
 presubmits:
   knative/serving:
+    - nil:
+      legacy-branches:
+      - release-0.4
+      - release-0.5
+      - release-0.6
+      - release-0.7
     - build-tests: true
     - unit-tests: true
     - integration-tests: true

--- a/ci/prow/config_knative.yaml
+++ b/ci/prow/config_knative.yaml
@@ -14,7 +14,7 @@
 
 presubmits:
   knative/serving:
-    - nil:
+    - repo-settings:
       legacy-branches:
       - release-0.4
       - release-0.5

--- a/ci/prow/make_config.go
+++ b/ci/prow/make_config.go
@@ -66,6 +66,7 @@ type repositoryData struct {
 	GoCoverageThreshold int
 	Processed           bool
 	DotDev              bool
+	LegacyBranches      []string
 }
 
 // baseProwJobTemplateData contains basic data about a Prow job.
@@ -81,6 +82,7 @@ type baseProwJobTemplateData struct {
 	CloneURI            string
 	SecurityContext     []string
 	SkipBranches        []string
+	Branches            []string
 	DecorationConfig    []string
 	ExtraRefs           []string
 	Command             string
@@ -299,6 +301,51 @@ func getMapSlice(m interface{}) yaml.MapSlice {
 	return nil
 }
 
+func combineSlices(a1 []string, a2 []string) []string {
+	var res []string
+	res = append(res, a1...)
+	for _, e2 := range a2 {
+		add := true
+		for _, e1 := range a1 {
+			if e1 == e2 {
+				add = false
+			}
+		}
+		if add {
+			res = append(res, e2)
+		}
+	}
+	return res
+}
+
+// Consolidate approved and skipped branches with newly added approved/skipped
+func consolidateBranches(approved []string, skipped []string, newApproved []string, newSkipped []string) ([]string, []string) {
+	// Combine skipped, combine approved
+	// If there is any approved, pop the save element exist in skipped, and empty skipped
+	// If there is no approved, just return
+	var combinedApproved []string
+	var combinedSkipped []string
+	combinedApproved = combineSlices(approved, newApproved)
+	combinedSkipped = combineSlices(skipped, newSkipped)
+	if len(combinedApproved) > 0 {
+		var tmp []string
+		for _, elem := range combinedApproved {
+			add := true
+			for _, skip := range combinedSkipped {
+				if elem == skip {
+					add = false
+				}
+			}
+			if add {
+				tmp = append(tmp, elem)
+			}
+		}
+		combinedApproved = tmp
+		combinedSkipped = make([]string, 0)
+	}
+	return combinedApproved, combinedSkipped
+}
+
 // Config generation functions.
 
 // newbaseProwJobTemplateData returns a baseProwJobTemplateData type with its initial, default values.
@@ -424,6 +471,8 @@ func parseBasicJobConfigOverrides(data *baseProwJobTemplateData, config yaml.Map
 		switch item.Key {
 		case "skip_branches":
 			(*data).SkipBranches = getStringArray(item.Value)
+		case "branches":
+			(*data).Branches = getStringArray(item.Value)
 		case "args":
 			(*data).Args = getStringArray(item.Value)
 		case "timeout":
@@ -446,6 +495,12 @@ func parseBasicJobConfigOverrides(data *baseProwJobTemplateData, config yaml.Map
 					repositories[i].DotDev = true
 				}
 			}
+		case "legacy-branches":
+			for i, repo := range repositories {
+				if path.Base(repo.Name) == (*data).RepoName {
+					repositories[i].LegacyBranches = getStringArray(item.Value)
+				}
+			}
 		case nil: // already processed
 			continue
 		default:
@@ -455,6 +510,7 @@ func parseBasicJobConfigOverrides(data *baseProwJobTemplateData, config yaml.Map
 		// Knock-out the item, signalling it was already parsed.
 		config[i] = yaml.MapItem{}
 	}
+	// Add DotDev
 	for _, repo := range repositories {
 		if path.Base(repo.Name) == (*data).RepoName && repo.DotDev {
 			(*data).PathAlias = "path_alias: knative.dev/" + (*data).RepoName
@@ -477,6 +533,7 @@ func generatePresubmit(title string, repoName string, presubmitConfig yaml.MapSl
 	jobTemplate := readTemplate(presubmitJob)
 	repoData := repositoryData{Name: repoName, EnableGoCoverage: false, GoCoverageThreshold: data.Base.GoCoverageThreshold}
 	isMonitoredJob := false
+	generateJob := true
 	for i, item := range presubmitConfig {
 		switch item.Key {
 		case "build-tests", "unit-tests", "integration-tests":
@@ -507,6 +564,8 @@ func generatePresubmit(title string, repoName string, presubmitConfig yaml.MapSl
 		case "go-coverage-threshold":
 			data.Base.GoCoverageThreshold = getInt(item.Value)
 			repoData.GoCoverageThreshold = data.Base.GoCoverageThreshold
+		case "nil":
+			generateJob = false
 		default:
 			continue
 		}
@@ -515,6 +574,9 @@ func generatePresubmit(title string, repoName string, presubmitConfig yaml.MapSl
 	}
 	repositories = append(repositories, repoData)
 	parseBasicJobConfigOverrides(&data.Base, presubmitConfig)
+	if !generateJob {
+		return
+	}
 	data.PresubmitCommand = createCommand(data.Base)
 	data.PresubmitPullJobName = "pull-" + data.PresubmitJobName
 	data.PresubmitPostJobName = "post-" + data.PresubmitJobName
@@ -527,7 +589,27 @@ func generatePresubmit(title string, repoName string, presubmitConfig yaml.MapSl
 	}
 	addExtraEnvVarsToJob(&data.Base)
 	configureServiceAccountForJob(&data.Base)
-	executeJobTemplate("presubmit", jobTemplate, title, repoName, data.PresubmitPullJobName, true, data)
+	for _, repo := range repositories {
+		if path.Base(repo.Name) == data.Base.RepoName && len(repo.LegacyBranches) > 0 {
+			repoData.LegacyBranches = repo.LegacyBranches
+		}
+	}
+	if len(repoData.LegacyBranches) == 0 {
+		executeJobTemplate("presubmit", jobTemplate, title, repoName, data.PresubmitPullJobName, true, data)
+	} else {
+		approvedBranches := data.Base.Branches
+		ignoredBranches := data.Base.SkipBranches
+		data.Base.Branches, data.Base.SkipBranches = consolidateBranches(data.Base.Branches, data.Base.SkipBranches, repoData.LegacyBranches, make([]string, 0))
+		executeJobTemplate("presubmit", jobTemplate, title, repoName, data.PresubmitPullJobName, true, data)
+		data.Base.Branches = approvedBranches
+		data.Base.SkipBranches = ignoredBranches
+		data.Base.Branches, data.Base.SkipBranches = consolidateBranches(data.Base.Branches, data.Base.SkipBranches, make([]string, 0), repoData.LegacyBranches)
+		data.Base.PathAlias = "path_alias: knative.dev/" + data.Base.RepoName
+		data.Base.ExtraRefs = append(data.Base.ExtraRefs, "  "+data.Base.PathAlias)
+		executeJobTemplate("presubmit", jobTemplate, title, repoName, data.PresubmitPullJobName, true, data)
+		data.Base.Branches = approvedBranches
+		data.Base.SkipBranches = ignoredBranches
+	}
 	// TODO(adrcunha): remove once the coverage-dev job isn't necessary anymore.
 	// Generate config for pull-knative-serving-go-coverage-dev right after pull-knative-serving-go-coverage
 	if data.PresubmitPullJobName == "pull-knative-serving-go-coverage" {
@@ -542,17 +624,38 @@ func generatePresubmit(title string, repoName string, presubmitConfig yaml.MapSl
 // generateGoCoveragePostsubmit generates the go coverage postsubmit job config for the given repo.
 func generateGoCoveragePostsubmit(title, repoName string, _ yaml.MapSlice) {
 	var data postsubmitJobTemplateData
+	var legacyBranches []string
 	data.Base = newbaseProwJobTemplateData(repoName)
 	data.Base.Image = coverageDockerImage
 	data.PostsubmitJobName = fmt.Sprintf("post-%s-go-coverage", data.Base.RepoNameForJob)
 	for _, repo := range repositories {
-		if repo.Name == repoName && repo.DotDev {
-			data.Base.PathAlias = "path_alias: knative.dev/" + path.Base(repoName)
+		if repo.Name == repoName {
+			if repo.DotDev {
+				data.Base.PathAlias = "path_alias: knative.dev/" + path.Base(repoName)
+			}
+			if len(repo.LegacyBranches) > 0 {
+				legacyBranches = repo.LegacyBranches
+			}
 		}
 	}
 	addExtraEnvVarsToJob(&data.Base)
 	configureServiceAccountForJob(&data.Base)
-	executeJobTemplate("postsubmit go coverage", readTemplate(goCoveragePostsubmitJob), "postsubmits", repoName, data.PostsubmitJobName, true, data)
+	if len(legacyBranches) == 0 {
+		executeJobTemplate("postsubmit go coverage", readTemplate(goCoveragePostsubmitJob), "postsubmits", repoName, data.PostsubmitJobName, true, data)
+	} else {
+		approvedBranches := data.Base.Branches
+		ignoredBranches := data.Base.SkipBranches
+		data.Base.Branches, data.Base.SkipBranches = consolidateBranches(data.Base.Branches, data.Base.SkipBranches, legacyBranches, make([]string, 0))
+		executeJobTemplate("postsubmit go coverage", readTemplate(goCoveragePostsubmitJob), "postsubmits", repoName, data.PostsubmitJobName, true, data)
+		data.Base.Branches = approvedBranches
+		data.Base.SkipBranches = ignoredBranches
+		data.Base.Branches, data.Base.SkipBranches = consolidateBranches(data.Base.Branches, data.Base.SkipBranches, make([]string, 0), legacyBranches)
+		data.Base.PathAlias = "path_alias: knative.dev/" + data.Base.RepoName
+		data.Base.ExtraRefs = append(data.Base.ExtraRefs, "  "+data.Base.PathAlias)
+		executeJobTemplate("postsubmit go coverage", readTemplate(goCoveragePostsubmitJob), "postsubmits", repoName, data.PostsubmitJobName, true, data)
+		data.Base.Branches = approvedBranches
+		data.Base.SkipBranches = ignoredBranches
+	}
 	// TODO(adrcunha): remove once the coverage-dev job isn't necessary anymore.
 	// Generate config for post-knative-serving-go-coverage-dev right after post-knative-serving-go-coverage
 	if data.PostsubmitJobName == "post-knative-serving-go-coverage" {

--- a/ci/prow/periodic_config.go
+++ b/ci/prow/periodic_config.go
@@ -205,31 +205,7 @@ func generatePeriodic(title string, repoName string, periodicConfig yaml.MapSlic
 	}
 	addExtraEnvVarsToJob(&data.Base)
 	configureServiceAccountForJob(&data.Base)
-
-	var legacyBranches []string
-	for _, repo := range repositories {
-		if repo.Name == repoName {
-			if len(repo.LegacyBranches) > 0 {
-				legacyBranches = repo.LegacyBranches
-			}
-		}
-	}
-	if len(legacyBranches) == 0 {
-		executeJobTemplate("periodic", jobTemplate, title, repoName, data.PeriodicJobName, false, data)
-	} else {
-		approvedBranches := data.Base.Branches
-		ignoredBranches := data.Base.SkipBranches
-		data.Base.Branches, data.Base.SkipBranches = consolidateBranches(data.Base.Branches, data.Base.SkipBranches, legacyBranches, make([]string, 0))
-		executeJobTemplate("periodic", jobTemplate, title, repoName, data.PeriodicJobName, false, data)
-		data.Base.Branches = approvedBranches
-		data.Base.SkipBranches = ignoredBranches
-		data.Base.Branches, data.Base.SkipBranches = consolidateBranches(data.Base.Branches, data.Base.SkipBranches, make([]string, 0), legacyBranches)
-		data.Base.PathAlias = "path_alias: knative.dev/" + data.Base.RepoName
-		data.Base.ExtraRefs = append(data.Base.ExtraRefs, "  "+data.Base.PathAlias)
-		executeJobTemplate("periodic", jobTemplate, title, repoName, data.PeriodicJobName, false, data)
-		data.Base.Branches = approvedBranches
-		data.Base.SkipBranches = ignoredBranches
-	}
+	executeJobTemplate("periodic", jobTemplate, title, repoName, data.PeriodicJobName, false, data)
 }
 
 // generateCleanupPeriodicJob generates the cleanup job config.
@@ -334,31 +310,7 @@ func generateGoCoveragePeriodic(title string, repoName string, _ yaml.MapSlice) 
 		addExtraEnvVarsToJob(&data.Base)
 		addMonitoringPubsubLabelsToJob(&data.Base, data.PeriodicJobName)
 		configureServiceAccountForJob(&data.Base)
-		var legacyBranches []string
-		// Unfortunately this has to be handled twice, as there are multiple elements exist in repositories with same repo name
-		for _, repo := range repositories {
-			if repo.Name == repoName {
-				if len(repo.LegacyBranches) > 0 {
-					legacyBranches = repo.LegacyBranches
-				}
-			}
-		}
-		if len(legacyBranches) == 0 {
-			executeJobTemplate("periodic go coverage", readTemplate(periodicCustomJob), title, repoName, data.PeriodicJobName, false, data)
-		} else {
-			approvedBranches := data.Base.Branches
-			ignoredBranches := data.Base.SkipBranches
-			data.Base.Branches, data.Base.SkipBranches = consolidateBranches(data.Base.Branches, data.Base.SkipBranches, legacyBranches, make([]string, 0))
-			executeJobTemplate("periodic go coverage", readTemplate(periodicCustomJob), title, repoName, data.PeriodicJobName, false, data)
-			data.Base.Branches = approvedBranches
-			data.Base.SkipBranches = ignoredBranches
-			data.Base.Branches, data.Base.SkipBranches = consolidateBranches(data.Base.Branches, data.Base.SkipBranches, make([]string, 0), legacyBranches)
-			data.Base.PathAlias = "path_alias: knative.dev/" + data.Base.RepoName
-			data.Base.ExtraRefs = append(data.Base.ExtraRefs, "  "+data.Base.PathAlias)
-			executeJobTemplate("periodic go coverage", readTemplate(periodicCustomJob), title, repoName, data.PeriodicJobName, false, data)
-			data.Base.Branches = approvedBranches
-			data.Base.SkipBranches = ignoredBranches
-		}
+		executeJobTemplate("periodic go coverage", readTemplate(periodicCustomJob), title, repoName, data.PeriodicJobName, false, data)
 		return
 	}
 }

--- a/ci/prow/periodic_config.go
+++ b/ci/prow/periodic_config.go
@@ -205,7 +205,31 @@ func generatePeriodic(title string, repoName string, periodicConfig yaml.MapSlic
 	}
 	addExtraEnvVarsToJob(&data.Base)
 	configureServiceAccountForJob(&data.Base)
-	executeJobTemplate("periodic", jobTemplate, title, repoName, data.PeriodicJobName, false, data)
+
+	var legacyBranches []string
+	for _, repo := range repositories {
+		if repo.Name == repoName {
+			if len(repo.LegacyBranches) > 0 {
+				legacyBranches = repo.LegacyBranches
+			}
+		}
+	}
+	if len(legacyBranches) == 0 {
+		executeJobTemplate("periodic", jobTemplate, title, repoName, data.PeriodicJobName, false, data)
+	} else {
+		approvedBranches := data.Base.Branches
+		ignoredBranches := data.Base.SkipBranches
+		data.Base.Branches, data.Base.SkipBranches = consolidateBranches(data.Base.Branches, data.Base.SkipBranches, legacyBranches, make([]string, 0))
+		executeJobTemplate("periodic", jobTemplate, title, repoName, data.PeriodicJobName, false, data)
+		data.Base.Branches = approvedBranches
+		data.Base.SkipBranches = ignoredBranches
+		data.Base.Branches, data.Base.SkipBranches = consolidateBranches(data.Base.Branches, data.Base.SkipBranches, make([]string, 0), legacyBranches)
+		data.Base.PathAlias = "path_alias: knative.dev/" + data.Base.RepoName
+		data.Base.ExtraRefs = append(data.Base.ExtraRefs, "  "+data.Base.PathAlias)
+		executeJobTemplate("periodic", jobTemplate, title, repoName, data.PeriodicJobName, false, data)
+		data.Base.Branches = approvedBranches
+		data.Base.SkipBranches = ignoredBranches
+	}
 }
 
 // generateCleanupPeriodicJob generates the cleanup job config.
@@ -310,7 +334,31 @@ func generateGoCoveragePeriodic(title string, repoName string, _ yaml.MapSlice) 
 		addExtraEnvVarsToJob(&data.Base)
 		addMonitoringPubsubLabelsToJob(&data.Base, data.PeriodicJobName)
 		configureServiceAccountForJob(&data.Base)
-		executeJobTemplate("periodic go coverage", readTemplate(periodicCustomJob), title, repoName, data.PeriodicJobName, false, data)
+		var legacyBranches []string
+		// Unfortunately this has to be handled twice, as there are multiple elements exist in repositories with same repo name
+		for _, repo := range repositories {
+			if repo.Name == repoName {
+				if len(repo.LegacyBranches) > 0 {
+					legacyBranches = repo.LegacyBranches
+				}
+			}
+		}
+		if len(legacyBranches) == 0 {
+			executeJobTemplate("periodic go coverage", readTemplate(periodicCustomJob), title, repoName, data.PeriodicJobName, false, data)
+		} else {
+			approvedBranches := data.Base.Branches
+			ignoredBranches := data.Base.SkipBranches
+			data.Base.Branches, data.Base.SkipBranches = consolidateBranches(data.Base.Branches, data.Base.SkipBranches, legacyBranches, make([]string, 0))
+			executeJobTemplate("periodic go coverage", readTemplate(periodicCustomJob), title, repoName, data.PeriodicJobName, false, data)
+			data.Base.Branches = approvedBranches
+			data.Base.SkipBranches = ignoredBranches
+			data.Base.Branches, data.Base.SkipBranches = consolidateBranches(data.Base.Branches, data.Base.SkipBranches, make([]string, 0), legacyBranches)
+			data.Base.PathAlias = "path_alias: knative.dev/" + data.Base.RepoName
+			data.Base.ExtraRefs = append(data.Base.ExtraRefs, "  "+data.Base.PathAlias)
+			executeJobTemplate("periodic go coverage", readTemplate(periodicCustomJob), title, repoName, data.PeriodicJobName, false, data)
+			data.Base.Branches = approvedBranches
+			data.Base.SkipBranches = ignoredBranches
+		}
 		return
 	}
 }

--- a/ci/prow/templates/prow_periodic_custom_job.yaml
+++ b/ci/prow/templates/prow_periodic_custom_job.yaml
@@ -4,6 +4,8 @@
   agent: kubernetes
   decorate: true
   [[indent_section 4 "decoration_config" .Base.DecorationConfig]]
+  [[indent_array_section 4 "branches" .Base.Branches]]
+  [[indent_array_section 4 "skip_branches" .Base.SkipBranches]]
   [[indent_section 2 "extra_refs" .Base.ExtraRefs]]
   spec:
     containers:

--- a/ci/prow/templates/prow_periodic_test_job.yaml
+++ b/ci/prow/templates/prow_periodic_test_job.yaml
@@ -4,6 +4,8 @@
   [[indent_section 4 "labels" .Base.Labels]]
   decorate: true
   [[indent_section 2 "extra_refs" .Base.ExtraRefs]]
+  [[indent_array_section 4 "branches" .Base.Branches]]
+  [[indent_array_section 4 "skip_branches" .Base.SkipBranches]]
   spec:
     containers:
     - image: [[.Base.Image]]

--- a/ci/prow/templates/prow_postsubmit_gocoverage_job.yaml
+++ b/ci/prow/templates/prow_postsubmit_gocoverage_job.yaml
@@ -5,6 +5,8 @@
     [[indent_section 8 "labels" .Base.Labels]]
     decorate: true
     [[.Base.PathAlias]]
+    [[indent_array_section 4 "branches" .Base.Branches]]
+    [[indent_array_section 4 "skip_branches" .Base.SkipBranches]]
     spec:
       containers:
       - image: [[.Base.Image]]

--- a/ci/prow/templates/prow_presubmit_gocoverate_job.yaml
+++ b/ci/prow/templates/prow_presubmit_gocoverate_job.yaml
@@ -8,6 +8,8 @@
     optional: true
     decorate: true
     [[.Base.PathAlias]]
+    [[indent_array_section 4 "branches" .Base.Branches]]
+    [[indent_array_section 4 "skip_branches" .Base.SkipBranches]]
     spec:
       containers:
       - image: [[.Base.Image]]

--- a/ci/prow/templates/prow_presubmit_job.yaml
+++ b/ci/prow/templates/prow_presubmit_job.yaml
@@ -7,6 +7,7 @@
     trigger: "(?m)^/test (all|[[.PresubmitPullJobName]]),?(\\s+|$)"
     decorate: true
     [[.Base.PathAlias]]
+    [[indent_array_section 4 "branches" .Base.Branches]]
     [[indent_array_section 4 "skip_branches" .Base.SkipBranches]]
     spec:
       containers:


### PR DESCRIPTION
knative/serving is going to use vanity URL `knative.dev` as importing path, and this change is not planned to be backfilled into earlier release branches including 0.7. But presubmit and CI jobs are still needed for these old branches. So we will need to support 2 Prow jobs with same name but slightly different definition. For example:
For older branches:
```
branches:
    - "release-0.4"
    - "release-0.5"
    - "release-0.6"
    - "release-0.7"
```
For newer branches:
```
path_alias: knative.dev/serving
    skip_branches:
    - "release-0.4"
    - "release-0.5"
    - "release-0.6"
    - "release-0.7"
```

This PR provides a way of defining such a state, as well as applying this on serving repo.

/hold
Will need to coordinate with https://github.com/knative/serving/pull/4521