### PR TITLE
support adding error rates as metrics in perf tests

### DIFF
--- a/shared/loadgenerator/loadgenerator.go
+++ b/shared/loadgenerator/loadgenerator.go
@@ -200,30 +200,29 @@ func (gr *GeneratorResults) ErrorsPercentage(idx int) float64 {
 		return 0
 	}
 
-	successes, errors := gr.errorSuccessCounts(idx)
-	return float64(errors*100) / float64(errors+successes)
+	errors, total := gr.errorAndTotalCounts(idx)
+	return float64(errors*100) / float64(total)
 }
 
 // ErrorsPercentageOverall returns the error percentage of the result based on response codes.
 // Any non 200 response will be counted as errors.
 func (gr *GeneratorResults) ErrorsPercentageOverall() float64 {
-	var successes, errors int64
+	var errors, total int64
 	for i := 0; i < len(gr.Result); i++ {
-		subSuccesses, subErrors := gr.errorSuccessCounts(i)
-		successes += subSuccesses
+		subErrors, subTotal := gr.errorAndTotalCounts(i)
 		errors += subErrors
+		total += subTotal
 	}
-	return float64(errors*100) / float64(errors+successes)
+	return float64(errors*100) / float64(total)
 }
 
-func (gr *GeneratorResults) errorSuccessCounts(idx int) (int64, int64) {
-	var successes, errors int64
+func (gr *GeneratorResults) errorAndTotalCounts(idx int) (int64, int64) {
+	var errors, total int64
 	for retCode, count := range gr.Result[idx].RetCodes {
-		if retCode == http.StatusOK {
-			successes = successes + count
-		} else {
-			errors = errors + count
+		if retCode != http.StatusOK {
+			errors += count
 		}
+		total += count
 	}
-	return successes, errors
+	return errors, total
 }

--- a/shared/performance/performance.go
+++ b/shared/performance/performance.go
@@ -23,29 +23,16 @@ import (
 )
 
 const (
-	// Latency of the performance test, it's a property name used by testgrid
-	perfLatency = "perf_latency"
-	// Error rate of the performance test
-	perfErrorRate = "perf_error_rate"
+	// Property name of the performance test, it's used by testgrid for visualization
+	perfPropertyName = "perf_latency"
 )
 
-// CreatePerfLatencyTestCase creates a perf latency test case with the provided name and value
-func CreatePerfLatencyTestCase(metricValue float32, metricName, testName string) junit.TestCase {
-	tp := []junit.TestProperty{{Name: perfLatency, Value: fmt.Sprintf("%f", metricValue)}}
+// CreatePerfTestCase creates a perf test case with the provided name and value
+func CreatePerfTestCase(metricValue float32, metricName, testName string) junit.TestCase {
+	tp := []junit.TestProperty{{Name: perfPropertyName, Value: fmt.Sprintf("%f", metricValue)}}
 	tc := junit.TestCase{
 		ClassName:  testName,
 		Name:       fmt.Sprintf("%s/%s", testName, metricName),
-		Properties: junit.TestProperties{Properties: tp}}
-
-	return tc
-}
-
-// CreatePerfErrorRateTestCase creates a perf error rate test case with the provided value
-func CreatePerfErrorRateTestCase(metricValue float32, testName string) junit.TestCase {
-	tp := []junit.TestProperty{{Name: perfErrorRate, Value: fmt.Sprintf("%f", metricValue)}}
-	tc := junit.TestCase{
-		ClassName:  testName,
-		Name:       fmt.Sprintf("%s/error_rate", testName),
 		Properties: junit.TestProperties{Properties: tp}}
 
 	return tc

--- a/shared/performance/performance.go
+++ b/shared/performance/performance.go
@@ -23,16 +23,29 @@ import (
 )
 
 const (
-	// Property name used by testgrid
+	// Latency of the performance test, it's a property name used by testgrid
 	perfLatency = "perf_latency"
+	// Error rate of the performance test
+	perfErrorRate = "perf_error_rate"
 )
 
-// CreatePerfTestCase creates a perf test case with the provided name and value
-func CreatePerfTestCase(metricValue float32, metricName, testName string) junit.TestCase {
+// CreatePerfLatencyTestCase creates a perf latency test case with the provided name and value
+func CreatePerfLatencyTestCase(metricValue float32, metricName, testName string) junit.TestCase {
 	tp := []junit.TestProperty{{Name: perfLatency, Value: fmt.Sprintf("%f", metricValue)}}
 	tc := junit.TestCase{
 		ClassName:  testName,
 		Name:       fmt.Sprintf("%s/%s", testName, metricName),
+		Properties: junit.TestProperties{Properties: tp}}
+
+	return tc
+}
+
+// CreatePerfErrorRateTestCase creates a perf error rate test case with the provided value
+func CreatePerfErrorRateTestCase(metricValue float32, testName string) junit.TestCase {
+	tp := []junit.TestProperty{{Name: perfErrorRate, Value: fmt.Sprintf("%f", metricValue)}}
+	tc := junit.TestCase{
+		ClassName:  testName,
+		Name:       fmt.Sprintf("%s/error_rate", testName),
 		Properties: junit.TestProperties{Properties: tp}}
 
 	return tc


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
1. Add `ErrorsPercentageOverall` to get the overall `ErrorRate` from the performance testing result.
2. Rename the `perfPropertyName` to make it less confusing.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @srinivashegde86 