### PR TITLE
add flaky-test-reporter's config.yaml to its image

### DIFF
--- a/images/flaky-test-reporter/Dockerfile
+++ b/images/flaky-test-reporter/Dockerfile
@@ -25,6 +25,7 @@ ADD . $TEMP_REPO_DIR
 # Build flaky test reporter tool in the container
 RUN make -C $TEMP_REPO_DIR/tools/$TOOL_NAME/
 RUN cp $TEMP_REPO_DIR/tools/$TOOL_NAME/$TOOL_NAME /$TOOL_NAME
+RUN cp $TEMP_REPO_DIR/tools/$TOOL_NAME/config.yaml config.yaml
 
 # Remove test-infra from the container
 RUN rm -fr $TEMP_REPO_DIR


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
add the reporter's new yaml config format to its Dockerfile in the expected default location.

If it makes more sense somewhere else in the image, we will need to add a flag in `ci/prow/periodic_config.go`.
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #

**Special notes to reviewers**:

**User-visible changes in this PR**:

