### PR TITLE
Move boskos to different namespace

### DIFF
--- a/ci/prow/Makefile
+++ b/ci/prow/Makefile
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-CLUSTER       ?= prow
-PROJECT       ?= knative-tests
-ZONE          ?= us-central1-f
-JOB_NAMESPACE ?= test-pods
+CLUSTER          ?= prow
+PROJECT          ?= knative-tests
+ZONE             ?= us-central1-f
+JOB_NAMESPACE    ?= test-pods
+BOSKOS_NAMESPACE ?= boskos-pods
 
 PROW_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 TESTGRID_DIR := $(PROW_DIR)/../testgrid
@@ -57,7 +58,7 @@ update-boskos:
 
 update-boskos-config:
 	$(SET_CONTEXT)
-	kubectl create configmap resources --from-file=config=boskos/resources.yaml --dry-run -o yaml | kubectl --namespace="$(JOB_NAMESPACE)" replace configmap resources -f -
+	kubectl create configmap resources --from-file=config=boskos/resources.yaml --dry-run -o yaml | kubectl --namespace="$(BOSKOS_NAMESPACE)" replace configmap resources -f -
 	$(UNSET_CONTEXT)
 
 update-cluster:

--- a/ci/prow/boskos/config.yaml
+++ b/ci/prow/boskos/config.yaml
@@ -20,11 +20,11 @@ metadata:
   labels:
     app: boskos
   name: boskos-storage
-  namespace: test-pods
+  namespace: boskos-pods
 spec:
   claimRef:
     name: boskos-volume-boskos-0
-    namespace: test-pods
+    namespace: boskos-pods
   capacity:
     storage: 1Gi
   accessModes:
@@ -39,7 +39,7 @@ apiVersion: apps/v1beta1
 kind: StatefulSet
 metadata:
   name: boskos
-  namespace: test-pods
+  namespace: boskos-pods
 spec:
   serviceName: "boskos"
   replicas: 1  # one canonical source of resources
@@ -47,7 +47,7 @@ spec:
     metadata:
       labels:
         app: boskos
-      namespace: test-pods
+      namespace: boskos-pods
     spec:
       serviceAccountName: "boskos"
       terminationGracePeriodSeconds: 30
@@ -57,7 +57,7 @@ spec:
         args:
         - --storage=/store/boskos.json
         - --config=/etc/config/config
-        - --namespace=test-pods
+        - --namespace=boskos-pods
         ports:
           - containerPort: 8080
             protocol: TCP
@@ -85,7 +85,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: boskos
-  namespace: test-pods
+  namespace: boskos-pods
 spec:
   selector:
     app: boskos
@@ -102,7 +102,7 @@ metadata:
   name: boskos-janitor
   labels:
     app: boskos-janitor
-  namespace: test-pods
+  namespace: boskos-pods
 spec:
   replicas: 35  # Number of distributed janitor instances
   template:
@@ -137,7 +137,7 @@ metadata:
   name: boskos-reaper
   labels:
     app: boskos-reaper
-  namespace: test-pods
+  namespace: boskos-pods
 spec:
   replicas: 1  # one canonical source of resources
   template:

--- a/ci/prow/boskos/config_start.yaml
+++ b/ci/prow/boskos/config_start.yaml
@@ -18,6 +18,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: resources
-  namespace: test-pods
+  namespace: boskos-pods
 data:
   resources: ""

--- a/ci/prow/config_start.yaml
+++ b/ci/prow/config_start.yaml
@@ -51,13 +51,13 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: "boskos"
-  namespace: test-pods
+  namespace: boskos-pods
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: "boskos"
-  namespace: test-pods
+  namespace: boskos-pods
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -65,13 +65,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: "boskos"
-  namespace: test-pods
+  namespace: boskos-pods
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: "boskos"
-  namespace: test-pods
+  namespace: boskos-pods
 rules:
   - apiGroups:
       - apiextensions.k8s.io

--- a/ci/prow/config_start.yaml
+++ b/ci/prow/config_start.yaml
@@ -44,6 +44,11 @@ kind: Namespace
 metadata:
   name: test-pods
 ---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: boskos-pods
+---
 
 # Service accounts, roles and bindings
 


### PR DESCRIPTION
Since this change https://github.com/knative/test-infra/blob/a48a69542f32d426f089d8a12b3aa55547176b69/ci/prow/cluster.yaml#L427, there is a default min request of 1 CPU for every pod under `test-pods` namespace, this includes all pods from boskos as well as janitor. There are 35 Janitors right now, which means there are 35 CPUs reserved for Janitors, which is almost half of what is allocated for Prow cluster right now. 
This PR Moves Boskos out of `test-pods` namespace so they don't occupy as much spaces

/cc @adrcunha 
/cc @srinivashegde86 
/cc @krzyzacy