### PR TITLE
flaky-test-retryer: add all log parsing functionality

### DIFF
--- a/tools/flaky-test-reporter/result.go
+++ b/tools/flaky-test-reporter/result.go
@@ -158,6 +158,9 @@ func addSuiteToRepoData(suite *junit.TestSuite, buildID int, rd *RepoData) {
 	}
 }
 
+// TODO: This function has been directly copy-pasted into tools/flaky-test-retryer/log_parser.go
+// Refactor it out into a shared library.
+
 // getCombinedResultsForBuild gets all junit results from a build,
 // and converts each one into a junit TestSuites struct
 func getCombinedResultsForBuild(build *prow.Build) ([]*junit.TestSuites, error) {

--- a/tools/flaky-test-retryer/github_commenter.go
+++ b/tools/flaky-test-retryer/github_commenter.go
@@ -21,8 +21,6 @@ limitations under the License.
 package main
 
 import (
-	"fmt"
-
 	"github.com/knative/test-infra/shared/ghutil"
 )
 
@@ -35,7 +33,7 @@ type GithubClient struct {
 func NewGithubClient(githubAccount string) (*GithubClient, error) {
 	ghc, err := ghutil.NewGithubClient(githubAccount)
 	if err != nil {
-		return nil, fmt.Errorf("Could not create GitHub client: %v", err)
+		return nil, err
 	}
 	return &GithubClient{ghc}, err
 }

--- a/tools/flaky-test-retryer/github_commenter.go
+++ b/tools/flaky-test-retryer/github_commenter.go
@@ -21,7 +21,7 @@ limitations under the License.
 package main
 
 import (
-	"log"
+	"fmt"
 
 	"github.com/knative/test-infra/shared/ghutil"
 )
@@ -33,6 +33,8 @@ type GithubClient struct {
 
 func NewGithubClient(githubAccount string) (*GithubClient, error) {
 	ghc, err := ghutil.NewGithubClient(githubAccount)
-	log.Printf("temporary - otherwise compiler will yell about ghc being an unused var: %v\n", ghc)
+	if err != nil {
+		return nil, fmt.Errorf("Could not create GitHub client: %v", err)
+	}
 	return &GithubClient{ghc}, err
 }

--- a/tools/flaky-test-retryer/github_commenter.go
+++ b/tools/flaky-test-retryer/github_commenter.go
@@ -31,6 +31,7 @@ type GithubClient struct {
 	*ghutil.GithubClient
 }
 
+// NewGithubClient builds us a GitHub client based on the token file passed in
 func NewGithubClient(githubAccount string) (*GithubClient, error) {
 	ghc, err := ghutil.NewGithubClient(githubAccount)
 	if err != nil {

--- a/tools/flaky-test-retryer/main.go
+++ b/tools/flaky-test-retryer/main.go
@@ -27,8 +27,8 @@ import (
 )
 
 const (
-	projectName = "knative"
-	pubsubTopic = "test-infra-monitoring-sub"
+	projectName = "knative-tests"
+	pubsubTopic = "knative-monitoring"
 )
 
 func main() {

--- a/tools/flaky-test-retryer/main.go
+++ b/tools/flaky-test-retryer/main.go
@@ -42,7 +42,7 @@ func main() {
 
 	handler, err := NewHandlerClient(*githubAccount)
 	if err != nil {
-		log.Fatalf("Coud not create Pub/Sub client: '%v'", err)
+		log.Fatalf("Coud not create handler: '%v'", err)
 	}
 
 	handler.Listen()


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Adds all log-parsing necessities to the retryer: reads the flaky test reporter's artifacts to determine supported repositories and the current flaky tests, reads the failed job's artifacts to find the failing tests that triggered this message, and compares the two to determine if we can retry.

These changes make up the main functionality to the retryer. As it stands, running the tool now is essentially running the final version in [dry run] mode. This means we can build a docker image and a basic deployment yaml to test it on a real cluster and see how it handles the real workload.
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #985 

**Special notes to reviewers**:
`GetCombinedResultsForBuild()` in `log_parser.go` is directly copied and pasted from reporter's `result.go`. I will eventually refactor this into a separate library, I held off doing this in case it makes sense to do more than just move a function to a different file.

**User-visible changes in this PR**:

