### PR TITLE
Add optional presubmit jobs for different ingress

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -623,6 +623,444 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
+  - name: pull-knative-serving-istio-1.0-mesh
+    agent: kubernetes
+    context: pull-knative-serving-istio-1.0-mesh
+    always_run: false
+    rerun_command: "/test pull-knative-serving-istio-1.0-mesh"
+    trigger: "(?m)^/test (all|pull-knative-serving-istio-1.0-mesh),?(\\s+|$)"
+    decorate: true
+    branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/e2e-tests.sh"
+        - "--istio-version"
+        - "1.0-latest"
+        - "--mesh"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-serving-istio-1.0-mesh
+    agent: kubernetes
+    context: pull-knative-serving-istio-1.0-mesh
+    always_run: false
+    rerun_command: "/test pull-knative-serving-istio-1.0-mesh"
+    trigger: "(?m)^/test (all|pull-knative-serving-istio-1.0-mesh),?(\\s+|$)"
+    decorate: true
+    path_alias: knative.dev/serving
+    skip_branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/e2e-tests.sh"
+        - "--istio-version"
+        - "1.0-latest"
+        - "--mesh"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-serving-istio-1.0-no-mesh
+    agent: kubernetes
+    context: pull-knative-serving-istio-1.0-no-mesh
+    always_run: false
+    rerun_command: "/test pull-knative-serving-istio-1.0-no-mesh"
+    trigger: "(?m)^/test (all|pull-knative-serving-istio-1.0-no-mesh),?(\\s+|$)"
+    decorate: true
+    branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/e2e-tests.sh"
+        - "--istio-version"
+        - "1.0-latest"
+        - "--no-mesh"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-serving-istio-1.0-no-mesh
+    agent: kubernetes
+    context: pull-knative-serving-istio-1.0-no-mesh
+    always_run: false
+    rerun_command: "/test pull-knative-serving-istio-1.0-no-mesh"
+    trigger: "(?m)^/test (all|pull-knative-serving-istio-1.0-no-mesh),?(\\s+|$)"
+    decorate: true
+    path_alias: knative.dev/serving
+    skip_branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/e2e-tests.sh"
+        - "--istio-version"
+        - "1.0-latest"
+        - "--no-mesh"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-serving-istio-1.1-mesh
+    agent: kubernetes
+    context: pull-knative-serving-istio-1.1-mesh
+    always_run: false
+    rerun_command: "/test pull-knative-serving-istio-1.1-mesh"
+    trigger: "(?m)^/test (all|pull-knative-serving-istio-1.1-mesh),?(\\s+|$)"
+    decorate: true
+    branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/e2e-tests.sh"
+        - "--istio-version"
+        - "1.1-latest"
+        - "--mesh"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-serving-istio-1.1-mesh
+    agent: kubernetes
+    context: pull-knative-serving-istio-1.1-mesh
+    always_run: false
+    rerun_command: "/test pull-knative-serving-istio-1.1-mesh"
+    trigger: "(?m)^/test (all|pull-knative-serving-istio-1.1-mesh),?(\\s+|$)"
+    decorate: true
+    path_alias: knative.dev/serving
+    skip_branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/e2e-tests.sh"
+        - "--istio-version"
+        - "1.1-latest"
+        - "--mesh"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-serving-istio-1.1-no-mesh
+    agent: kubernetes
+    context: pull-knative-serving-istio-1.1-no-mesh
+    always_run: false
+    rerun_command: "/test pull-knative-serving-istio-1.1-no-mesh"
+    trigger: "(?m)^/test (all|pull-knative-serving-istio-1.1-no-mesh),?(\\s+|$)"
+    decorate: true
+    branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/e2e-tests.sh"
+        - "--istio-version"
+        - "1.1-latest"
+        - "--no-mesh"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-serving-istio-1.1-no-mesh
+    agent: kubernetes
+    context: pull-knative-serving-istio-1.1-no-mesh
+    always_run: false
+    rerun_command: "/test pull-knative-serving-istio-1.1-no-mesh"
+    trigger: "(?m)^/test (all|pull-knative-serving-istio-1.1-no-mesh),?(\\s+|$)"
+    decorate: true
+    path_alias: knative.dev/serving
+    skip_branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/e2e-tests.sh"
+        - "--istio-version"
+        - "1.1-latest"
+        - "--no-mesh"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-serving-istio-1.2-mesh
+    agent: kubernetes
+    context: pull-knative-serving-istio-1.2-mesh
+    always_run: false
+    rerun_command: "/test pull-knative-serving-istio-1.2-mesh"
+    trigger: "(?m)^/test (all|pull-knative-serving-istio-1.2-mesh),?(\\s+|$)"
+    decorate: true
+    branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/e2e-tests.sh"
+        - "--istio-version"
+        - "1.2-latest"
+        - "--mesh"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-serving-istio-1.2-mesh
+    agent: kubernetes
+    context: pull-knative-serving-istio-1.2-mesh
+    always_run: false
+    rerun_command: "/test pull-knative-serving-istio-1.2-mesh"
+    trigger: "(?m)^/test (all|pull-knative-serving-istio-1.2-mesh),?(\\s+|$)"
+    decorate: true
+    path_alias: knative.dev/serving
+    skip_branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/e2e-tests.sh"
+        - "--istio-version"
+        - "1.2-latest"
+        - "--mesh"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-serving-istio-1.2-no-mesh
+    agent: kubernetes
+    context: pull-knative-serving-istio-1.2-no-mesh
+    always_run: false
+    rerun_command: "/test pull-knative-serving-istio-1.2-no-mesh"
+    trigger: "(?m)^/test (all|pull-knative-serving-istio-1.2-no-mesh),?(\\s+|$)"
+    decorate: true
+    branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/e2e-tests.sh"
+        - "--istio-version"
+        - "1.2-latest"
+        - "--no-mesh"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-serving-istio-1.2-no-mesh
+    agent: kubernetes
+    context: pull-knative-serving-istio-1.2-no-mesh
+    always_run: false
+    rerun_command: "/test pull-knative-serving-istio-1.2-no-mesh"
+    trigger: "(?m)^/test (all|pull-knative-serving-istio-1.2-no-mesh),?(\\s+|$)"
+    decorate: true
+    path_alias: knative.dev/serving
+    skip_branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/e2e-tests.sh"
+        - "--istio-version"
+        - "1.2-latest"
+        - "--no-mesh"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
   knative/build:
   - name: pull-knative-build-build-tests
     agent: kubernetes

--- a/ci/prow/config_knative.yaml
+++ b/ci/prow/config_knative.yaml
@@ -44,6 +44,24 @@ presubmits:
       always_run: false
       command:
       - "./test/performance-tests.sh"
+    - custom-test: istio-1.0-mesh
+      always_run: false
+      full-command: "./test/e2e-tests.sh --istio-version 1.0-latest --mesh"
+    - custom-test: istio-1.0-no-mesh
+      always_run: false
+      full-command: "./test/e2e-tests.sh --istio-version 1.0-latest --no-mesh"
+    - custom-test: istio-1.1-mesh
+      always_run: false
+      full-command: "./test/e2e-tests.sh --istio-version 1.1-latest --mesh"
+    - custom-test: istio-1.1-no-mesh
+      always_run: false
+      full-command: "./test/e2e-tests.sh --istio-version 1.1-latest --no-mesh"
+    - custom-test: istio-1.2-mesh
+      always_run: false
+      full-command: "./test/e2e-tests.sh --istio-version 1.2-latest --mesh"
+    - custom-test: istio-1.2-no-mesh
+      always_run: false
+      full-command: "./test/e2e-tests.sh --istio-version 1.2-latest --no-mesh"
 
   knative/build:
     - build-tests: true


### PR DESCRIPTION
As requested by #networking WG, it would be nice to have a way of verifying different ingress tests in PR before merging changes related to networking. 
This PR adds optional presubmit jobs for different ingress, which can be triggered manually by devs by commands like `/test pull-knative-serving-istio-1.0-mesh`

/cc @adrcunha 
/cc @srinivashegde86 
fyi @tcnghia 