### PR TITLE
Update monitoring email to knative-productivity-dev

### DIFF
--- a/tools/monitoring/main.go
+++ b/tools/monitoring/main.go
@@ -41,7 +41,7 @@ var (
 	wfClient   *alert.Client
 	db         *msql.DB
 
-	alertEmailRecipients = []string{"knative-productivity-oncall@googlegroups.com"}
+	alertEmailRecipients = []string{"knative-productivity-dev@googlegroups.com"}
 )
 
 const (


### PR DESCRIPTION
We already have an existing team group, which we should instead of creating this new one. Need to expand that group to add the existing members, which will be done separately.