### PR TITLE
Retry publishing to GitHub 3 times in case of error.

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -555,10 +555,17 @@ function publish_to_github() {
   git_push tag ${TAG}
 
   [[ -n "${RELEASE_BRANCH}" ]] && commitish="--commitish=${RELEASE_BRANCH}"
-  hub_tool release create \
-      --prerelease \
-      ${attachments[@]} \
-      --file=${description} \
-      ${commitish} \
-      ${TAG}
+  for i in {2..0}; do
+    hub_tool release create \
+        --prerelease \
+        ${attachments[@]} \
+        --file=${description} \
+        ${commitish} \
+        ${TAG} && return 0
+    if [[ "${i}" -gt 0 ]]; then
+      echo "Error publishing the release, retrying in 15s..."
+      sleep 15
+    fi
+  done
+  abort "Cannot publish release to GitHub"
 }

--- a/test/unit/release-tests.sh
+++ b/test/unit/release-tests.sh
@@ -32,6 +32,20 @@ function mock_publish_to_github() {
   publish_to_github "$@" 2>&1
 }
 
+function mock_publish_to_github_fails() {
+  set -e
+  PUBLISH_TO_GITHUB=1
+  TAG=sometag
+  function git() {
+	echo $@
+  }
+  function hub() {
+	echo $@
+        return 1
+  }
+  publish_to_github "$@" 2>&1
+}
+
 function build_release() {
   return 0
 }
@@ -97,6 +111,7 @@ test_function ${SUCCESS} "" publish_to_github
 test_function 129 "usage: git tag" call_function_pre PUBLISH_TO_GITHUB=1 publish_to_github
 test_function ${FAILURE} "No such file" call_function_pre PUBLISH_TO_GITHUB=1 publish_to_github a.yaml b.yaml
 test_function ${SUCCESS} "release create" mock_publish_to_github $(mktemp) $(mktemp)
+test_function ${FAILURE} "Cannot publish release to GitHub" mock_publish_to_github_fails $(mktemp) $(mktemp)
 
 echo ">> Testing validation tests"
 


### PR DESCRIPTION
This is the simplest way of dealing with weird 502 errors in the hub tool.

Fixes #713.