### PR TITLE
retryer: add log cache

### DIFF
--- a/tools/flaky-test-retryer/handler.go
+++ b/tools/flaky-test-retryer/handler.go
@@ -74,34 +74,34 @@ func (hc *HandlerClient) Listen() {
 // HandleMessage gets the job's failed tests and the current flaky tests,
 // compares them, and triggers a retest if all the failed tests are flaky.
 func (hc *HandlerClient) HandleJob(jd *JobData) {
-	log.Printf("Job %s: fit all criteria - Starting analysis", jd.String())
+	jd.Logf("fit all criteria - Starting analysis\n")
 
 	failedTests, err := jd.getFailedTests()
 	if err != nil {
-		log.Printf("Job %s: could not get failed tests: %v", jd.String(), err)
+		jd.Logf("could not get failed tests: %v", err)
 		return
 	}
 	if len(failedTests) == 0 {
-		log.Printf("Job %s: no failed tests, skipping\n", jd.String())
+		jd.Logf("no failed tests, skipping\n")
 		return
 	}
-	log.Printf("Job %s: got %d failed tests\n", jd.String(), len(failedTests))
+	jd.Logf("got %d failed tests", len(failedTests))
 
 	flakyTests, err := jd.getFlakyTests()
 	if err != nil {
-		log.Printf("Job %s: could not get flaky tests: %v", jd.String(), err)
+		jd.Logf("could not get flaky tests: %v", err)
 		return
 	}
-	log.Printf("Job %s: got %d flaky tests from today's report\n", jd.String(), len(flakyTests))
+	jd.Logf("got %d flaky tests from today's report\n", len(flakyTests))
 
 	if outliers := getNonFlakyTests(failedTests, flakyTests); len(outliers) > 0 {
-		log.Printf("Job %s: %d of %d failed tests are not flaky, cannot retry\n", jd.String(), len(outliers), len(failedTests))
+		jd.Logf("%d of %d failed tests are not flaky, cannot retry\n", len(outliers), len(failedTests))
 		// TODO: Post GitHub comment describing why we cannot retry, listing the
 		// non-flaky failed tests that the developer needs to fix. Logic will be in
 		// github_commenter.go
 		return
 	}
-	log.Printf("Job %s: all failed tests are flaky, triggering retry\n", jd.String())
+	jd.Logf("all failed tests are flaky, triggering retry\n")
 	// TODO: Post GitHub comment stating as such, and trigger the job. Do not post
 	// comment if we are out of retries. Logic will be in github_commenter.go
 }

--- a/tools/flaky-test-retryer/handler.go
+++ b/tools/flaky-test-retryer/handler.go
@@ -57,47 +57,29 @@ func NewHandlerClient(githubAccount string) (*HandlerClient, error) {
 	}, nil
 }
 
-// expectedMsg checks that the message we received is one we want to process.
-func expectedMsg(msg *prowapi.ReportMessage) bool {
-	repos, err := getReportRepos()
-	if err != nil {
-		log.Printf("Failed getting reporter's repos: %v", err)
-		return false
-	}
-	expRepo := false
-	if len(msg.Refs) > 0 {
-		for _, repo := range repos {
-			if msg.Refs[0].Repo == repo {
-				expRepo = true
-				break
-			}
-		}
-	}
-	return expRepo && msg.Status == prowapi.FailureState && msg.JobType == prowapi.PresubmitJob
-}
-
 // Listen scans for incoming Pubsub messages, spawning a new goroutine for each
 // one that fits our criteria.
 func (hc *HandlerClient) Listen() {
 	log.Printf("Listening for failed jobs...\n")
 	for {
 		hc.pubsub.ReceiveMessageAckAll(hc, func(msg *prowapi.ReportMessage) {
-			if expectedMsg(msg) {
-				go hc.HandleMessage(msg)
-			} else {
-				log.Println("Job did not fit criteria - skipping")
+			data := NewJobData(msg)
+			if err := data.IsSupported(); err != nil {
+				log.Printf("Job did not fit criteria: %v", err)
+				return
 			}
+			go hc.HandleMessage(data)
 		})
 	}
 }
 
 // HandleMessage gets the job's failed tests and the current flaky tests,
 // compares them, and triggers a retest if all the failed tests are flaky.
-func (hc *HandlerClient) HandleMessage(msg *prowapi.ReportMessage) {
-	prefix := fmt.Sprintf("%s/pull/%d-%s", msg.Refs[0].Repo, msg.Refs[0].Pulls[0].Number, msg.JobName)
+func (hc *HandlerClient) HandleMessage(jd *JobData) {
+	prefix := jd.String()
 	log.Printf("Job %s: fit all criteria - Starting analysis", prefix)
 
-	failedTests, err := getFailedTests(msg.JobName, string(msg.JobType), msg.Refs[0].Repo, msg.Refs[0].Pulls[0].Number)
+	failedTests, err := jd.getFailedTests()
 	if err != nil {
 		log.Printf("Job %s: could not get failed tests: %v", prefix, err)
 		return
@@ -108,7 +90,7 @@ func (hc *HandlerClient) HandleMessage(msg *prowapi.ReportMessage) {
 	}
 	log.Printf("Job %s: got %d failed tests\n", prefix, len(failedTests))
 
-	flakyTests, err := getFlakyTests(msg.Refs[0].Repo)
+	flakyTests, err := jd.getFlakyTests()
 	if err != nil {
 		log.Printf("Job %s: could not get flaky tests: %v", prefix, err)
 		return
@@ -116,10 +98,10 @@ func (hc *HandlerClient) HandleMessage(msg *prowapi.ReportMessage) {
 	log.Printf("Job %s: got %d flaky tests from today's report\n", prefix, len(flakyTests))
 
 	if outliers := getNonFlakyTests(failedTests, flakyTests); len(outliers) > 0 {
-		log.Printf("Job %s: found %d non-flaky tests, cannot retry\n", prefix, len(outliers))
+		log.Printf("Job %s: %d of %d failed tests are not flaky, cannot retry\n", prefix, len(outliers), len(failedTests))
 		// TODO: Post GitHub comment describing why we cannot retry, listing the
-		// possible non-flaky failed tests that the developer needs to fix. Logic
-		// will be in github_commenter.go
+		// non-flaky failed tests that the developer needs to fix. Logic will be in
+		// github_commenter.go
 		return
 	}
 	log.Printf("Job %s: all failed tests are flaky, triggering retry\n", prefix)

--- a/tools/flaky-test-retryer/handler.go
+++ b/tools/flaky-test-retryer/handler.go
@@ -64,11 +64,9 @@ func (hc *HandlerClient) Listen() {
 	for {
 		hc.pubsub.ReceiveMessageAckAll(hc, func(msg *prowapi.ReportMessage) {
 			data := NewJobData(msg)
-			if supported, err := data.IsSupported(); !supported {
-				log.Printf("Job did not fit criteria: %v", err)
-				return
+			if data.IsSupported() {
+				go hc.HandleJob(data)
 			}
-			go hc.HandleJob(data)
 		})
 	}
 }

--- a/tools/flaky-test-retryer/handler.go
+++ b/tools/flaky-test-retryer/handler.go
@@ -109,6 +109,6 @@ func (hc *HandlerClient) HandleJob(jd *JobData) {
 // logWithPrefix wraps a call to log.Printf, prefixing the arguments with details
 // about the job passed in.
 func logWithPrefix(jd *JobData, format string, a ...interface{}) {
-	input := append([]interface{}{jd.Repo, jd.Pull, jd.Name}, a...)
+	input := append([]interface{}{jd.Refs[0].Repo, jd.Refs[0].Pulls[0].Number, jd.JobName}, a...)
 	log.Printf("%s/pull/%d: %s: "+format, input...)
 }

--- a/tools/flaky-test-retryer/log_parser.go
+++ b/tools/flaky-test-retryer/log_parser.go
@@ -111,8 +111,10 @@ func (jd *JobData) IsSupported() bool {
 	return true
 }
 
-func (jd *JobData) String() string {
-	return fmt.Sprintf("%s/pull/%d: %s", jd.Repo, jd.Pull, jd.Name)
+// Logf prefixes a call to log.Printf with information about the job it is being called on
+func (jd *JobData) Logf(format string, a ...interface{}) {
+	input := append([]interface{}{jd.Repo, jd.Pull, jd.Name}, a...)
+	log.Printf("%s/pull/%d: %s: "+format, input...)
 }
 
 // getFailedTests gets all the tests that failed in the given job.

--- a/tools/flaky-test-retryer/log_parser.go
+++ b/tools/flaky-test-retryer/log_parser.go
@@ -27,6 +27,9 @@ import (
 	"github.com/knative/test-infra/shared/junit"
 	"github.com/knative/test-infra/shared/prow"
 	"github.com/knative/test-infra/tools/flaky-test-reporter/jsonreport"
+	// TODO: remove this import once "k8s.io/test-infra" import problems are fixed
+	// https://github.com/test-infra/test-infra/issues/912
+	"github.com/knative/test-infra/tools/monitoring/prowapi"
 )
 
 // InitLogParser configures jsonreport's dependencies.
@@ -34,9 +37,66 @@ func InitLogParser(serviceAccount string) error {
 	return jsonreport.Initialize(serviceAccount)
 }
 
+// JobData contains stripped-down information about a failed job, and local caches
+// of its failed tests and the flaky report it is referencing.
+type JobData struct {
+	message      *prowapi.ReportMessage
+	failedTests  []string
+	flakyReports []jsonreport.Report
+}
+
+// NewJobData creates a JobData object for the given message, and returns an error
+// if it does not fit the criteria we have set for it.
+func NewJobData(msg *prowapi.ReportMessage) *JobData {
+	return &JobData{message: msg}
+}
+
+// IsSupported checks to make sure the message can be processed with the current flaky
+// test information
+func (jd *JobData) IsSupported() error {
+	if jd.message.Status != prowapi.FailureState {
+		return fmt.Errorf("Was not a failure: %v\n", jd.message.Status)
+	}
+	// check type
+	if jd.message.JobType != prowapi.PresubmitJob {
+		return fmt.Errorf("Was not presubmit: %v\n", jd.message.JobType)
+	}
+	// check repo
+	if len(jd.message.Refs) == 0 {
+		return fmt.Errorf("No ref in message.\n")
+	}
+	repos, err := jd.getReportRepos()
+	if err != nil {
+		return err
+	}
+	expRepo := false
+	for _, repo := range repos {
+		if jd.message.Refs[0].Repo == repo {
+			expRepo = true
+			break
+		}
+	}
+	if !expRepo {
+		return fmt.Errorf("Repo unsupported: %v\n", jd.message.Refs[0].Repo)
+	}
+	// make sure pull ID exists
+	if len(jd.message.Refs[0].Pulls) == 0 {
+		return fmt.Errorf("No pull ID in message\n")
+	}
+	return nil
+}
+
+func (jd *JobData) String() string {
+	return fmt.Sprintf("%s/pull/%d: %s", jd.message.Refs[0].Repo, jd.message.Refs[0].Pulls[0].Number, jd.message.JobName)
+}
+
 // getFailedTests gets all the tests that failed in the given job.
-func getFailedTests(jobName, jobType, repo string, pull int) ([]string, error) {
-	job := prow.NewJob(jobName, jobType, repo, pull)
+func (jd *JobData) getFailedTests() ([]string, error) {
+	// use cache if it is populated
+	if jd.failedTests != nil {
+		return jd.failedTests, nil
+	}
+	job := prow.NewJob(jd.message.JobName, string(jd.message.JobType), jd.message.Refs[0].Repo, jd.message.Refs[0].Pulls[0].Number)
 	buildID, err := job.GetLatestBuildNumber()
 	if err != nil {
 		return nil, err
@@ -56,6 +116,7 @@ func getFailedTests(jobName, jobType, repo string, pull int) ([]string, error) {
 			}
 		}
 	}
+	jd.failedTests = tests
 	return tests, nil
 }
 
@@ -85,29 +146,33 @@ func GetCombinedResultsForBuild(build *prow.Build) ([]*junit.TestSuites, error) 
 	return allSuites, nil
 }
 
-// getFlakyTests gets the latest flaky tests for the given repository.
-func getFlakyTests(repo string) ([]string, error) {
-	return parseFlakyLog(func(report jsonreport.Report, result *[]string) {
-		if report.Repo == repo {
+// getFlakyTests gets the latest flaky tests that could affect this job
+func (jd *JobData) getFlakyTests() ([]string, error) {
+	return jd.parseFlakyLog(func(report jsonreport.Report, result *[]string) {
+		if report.Repo == jd.message.Refs[0].Repo {
 			*result = report.Flaky
 		}
 	})
 }
 
 // getReportRepos gets all of the repositories where we collect flaky tests.
-func getReportRepos() ([]string, error) {
-	return parseFlakyLog(func(report jsonreport.Report, result *[]string) {
+func (jd *JobData) getReportRepos() ([]string, error) {
+	return jd.parseFlakyLog(func(report jsonreport.Report, result *[]string) {
 		*result = append(*result, report.Repo)
 	})
 }
 
 // parseFlakyLog reads the latest flaky test report and returns filtered results based
 // on the function the caller passes in.
-func parseFlakyLog(f func(report jsonreport.Report, result *[]string)) ([]string, error) {
+func (jd *JobData) parseFlakyLog(f func(report jsonreport.Report, result *[]string)) ([]string, error) {
 	var results []string
-	reports, err := jsonreport.GetFlakyTestReport("", -1)
-	if err == nil && len(reports) > 0 {
-		for _, r := range reports {
+	var err error
+	// populate cache if it is empty
+	if jd.flakyReports == nil {
+		jd.flakyReports, err = jsonreport.GetFlakyTestReport("", -1)
+	}
+	if err == nil && len(jd.flakyReports) > 0 {
+		for _, r := range jd.flakyReports {
 			f(r, &results)
 		}
 	}

--- a/tools/flaky-test-retryer/log_parser.go
+++ b/tools/flaky-test-retryer/log_parser.go
@@ -55,15 +55,15 @@ func NewJobData(msg *prowapi.ReportMessage) *JobData {
 // test information
 func (jd *JobData) IsSupported() error {
 	if jd.message.Status != prowapi.FailureState {
-		return fmt.Errorf("Was not a failure: %v\n", jd.message.Status)
+		return fmt.Errorf("was not a failure: %v", jd.message.Status)
 	}
 	// check type
 	if jd.message.JobType != prowapi.PresubmitJob {
-		return fmt.Errorf("Was not presubmit: %v\n", jd.message.JobType)
+		return fmt.Errorf("was not presubmit: %v", jd.message.JobType)
 	}
 	// check repo
 	if len(jd.message.Refs) == 0 {
-		return fmt.Errorf("No ref in message.\n")
+		return fmt.Errorf("no ref in message")
 	}
 	repos, err := jd.getReportRepos()
 	if err != nil {
@@ -77,11 +77,11 @@ func (jd *JobData) IsSupported() error {
 		}
 	}
 	if !expRepo {
-		return fmt.Errorf("Repo unsupported: %v\n", jd.message.Refs[0].Repo)
+		return fmt.Errorf("repo unsupported: %v", jd.message.Refs[0].Repo)
 	}
 	// make sure pull ID exists
 	if len(jd.message.Refs[0].Pulls) == 0 {
-		return fmt.Errorf("No pull ID in message\n")
+		return fmt.Errorf("no pull ID in message")
 	}
 	return nil
 }

--- a/tools/flaky-test-retryer/log_parser.go
+++ b/tools/flaky-test-retryer/log_parser.go
@@ -59,6 +59,8 @@ func NewJobData(msg *prowapi.ReportMessage) *JobData {
 		Status: msg.Status,
 	}
 	// add repo data if it exists
+	// msg.Refs' first element is always the repo that that triggered this job, later elements
+	// are other dependencies the job needed that were not already in the main repository.
 	if len(msg.Refs) > 0 {
 		jd.Org = msg.Refs[0].Org
 		jd.Repo = msg.Refs[0].Repo


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
flaky and failed test results are queried multiple times each time a job is processed. If a job happens to be processing when a new report comes in, the reports used across the run are mismatched. This PR associates caches on a per-message basis which are referenced in place of API calls if they are populated.

In addition to mitigating the risk of mismatched reports, the cache also minimizes GCS API calls and speeds up execution slightly.
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #1134

**Special notes to reviewers**:

**User-visible changes in this PR**:

