### PR TITLE
disable the clear-alerts prow job

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -5392,28 +5392,6 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "0,30 * * * *"
-  name: ci-knative-test-infra-monitoring-clear-alerts
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: knative
-    repo: test-infra
-    base_ref: master
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/monitoring/clear-alerts:latest
-      imagePullPolicy: Always
-      command:
-      - "/clearalerts"
-      volumeMounts:
-      - name: monitoring-db-credentials
-        mountPath: /secrets/cloudsql/monitoringdb
-        readOnly: true
-    volumes:
-    - name: monitoring-db-credentials
-      secret:
-        secretName: monitoring-db-credentials
 - cron: "0 12 * * *"
   name: ci-knative-flakes-reporter
   agent: kubernetes

--- a/ci/prow/make_config.go
+++ b/ci/prow/make_config.go
@@ -144,7 +144,6 @@ var (
 	prowversionbumperDockerImage string
 	githubCommenterDockerImage   string
 	coverageDockerImage          string
-	clearalertsDockerImage       string
 	prowTestsDockerImage         string
 	presubmitScript              string
 	releaseScript                string
@@ -1042,7 +1041,6 @@ func main() {
 	flag.StringVar(&flakesreporterDockerImage, "flaky-test-reporter-docker", "gcr.io/knative-tests/test-infra/flaky-test-reporter:latest", "Docker image for flaky test reporting tool")
 	flag.StringVar(&prowversionbumperDockerImage, "prow-auto-bumper", "gcr.io/knative-tests/test-infra/prow-auto-bumper:latest", "Docker image for Prow version bumping tool")
 	flag.StringVar(&coverageDockerImage, "coverage-docker", "gcr.io/knative-tests/test-infra/coverage:latest", "Docker image for coverage tool")
-	flag.StringVar(&clearalertsDockerImage, "clear-alerts", "gcr.io/knative-tests/test-infra/monitoring/clear-alerts:latest", "Docker image for clearing alerts in test-infra monitoring")
 	flag.StringVar(&prowTestsDockerImage, "prow-tests-docker", "gcr.io/knative-tests/test-infra/prow-tests:stable", "prow-tests docker image")
 	flag.StringVar(&githubCommenterDockerImage, "github-commenter-docker", "gcr.io/k8s-prow/commenter:v20190731-e3f7b9853", "github commenter docker image")
 	flag.StringVar(&presubmitScript, "presubmit-script", "./test/presubmit-tests.sh", "Executable for running presubmit tests")

--- a/ci/prow/make_config.go
+++ b/ci/prow/make_config.go
@@ -1089,7 +1089,6 @@ func main() {
 			return !repo.Processed && repo.EnableGoCoverage
 		}, generateGoCoveragePeriodic)
 		generateCleanupPeriodicJob()
-		generateClearAlertsPeriodicJob()
 		generateFlakytoolPeriodicJob()
 		generateVersionBumpertoolPeriodicJob()
 		generateBackupPeriodicJob()

--- a/ci/prow/periodic_config.go
+++ b/ci/prow/periodic_config.go
@@ -41,7 +41,6 @@ const (
 	issueTrackerPeriodicJobCron      = "0 */12 * * *" // Run every 12 hours
 	backupPeriodicJobCron            = "15 9 * * *"   // Run at 02:15PST every day (09:15 UTC)
 	perfPeriodicJobCron              = "0 */3 * * *"  // Run every 3 hours
-	clearAlertsPeriodicJobCron       = "0,30 * * * *" // Run every 30 minutes
 
 	// Perf job constants
 	perfTimeout = 120 // Job timeout in minutes
@@ -314,19 +313,6 @@ func generateGoCoveragePeriodic(title string, repoName string, _ yaml.MapSlice) 
 		executeJobTemplate("periodic go coverage", readTemplate(periodicCustomJob), title, repoName, data.PeriodicJobName, false, data)
 		return
 	}
-}
-
-// generateClearAlertsPeriodicJob generates the monitoring clear alerts job config.
-func generateClearAlertsPeriodicJob() {
-	var data periodicJobTemplateData
-	data.Base = newbaseProwJobTemplateData("knative/test-infra")
-	data.Base.Image = clearalertsDockerImage
-	data.PeriodicJobName = "ci-knative-test-infra-monitoring-clear-alerts"
-	data.CronString = clearAlertsPeriodicJobCron
-	data.Base.Command = "/clearalerts"
-	data.Base.ExtraRefs = append(data.Base.ExtraRefs, "  base_ref: "+data.Base.RepoBranch)
-	addVolumeToJob(&data.Base, "/secrets/cloudsql/monitoringdb", "monitoring-db-credentials", true, "")
-	executeJobTemplate("periodic clearalert", readTemplate(periodicCustomJob), "presubmits", "", data.PeriodicJobName, false, data)
 }
 
 func generateIssueTrackerPeriodicJobs() {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:

Disabling the clear-alerts prow job. 

Reason: 
The prow cluster does not have ip-alias enabled. So it cannot connect to the cloud sql instance through private ip. Currently, there's no safe, easy way to convert an existing cluster to be a vpc-native cluster. 

The current clear-alerts job checks the same config as the alerting workflow. So clear-alerts workflow deletes the Alert from the database only when alerting workflow consider those alerts as expired. So even with the prow job enabled, the clear-alerts job does not clear the alert faster. This job will be more useful if when the configs are separated for those two workflows. 

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #

**Special notes to reviewers**:

**User-visible changes in this PR**:

/cc @srinivashegde86 
/cc @steuhs 

