### PR TITLE
add prow job for running Knative-Serving e2e against Gloo

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -2729,7 +2729,7 @@ periodics:
       secret:
         secretName: test-account
 - cron: "28 */2 * * *"
-  name: ci-knative-serving-gloo-0.17.0
+  name: ci-knative-serving-gloo-0.17.1
   agent: kubernetes
   decorate: true
   extra_refs:
@@ -2745,7 +2745,7 @@ periodics:
       args:
       - "./test/e2e-tests.sh"
       - "--gloo-version"
-      - "0.17.0"
+      - "0.17.1"
       volumeMounts:
       - name: test-account
         mountPath: /etc/test-account

--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -2728,6 +2728,37 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
+- cron: "28 */2 * * *"
+  name: ci-knative-serving-gloo-0.17.0
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: master
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./test/e2e-tests.sh"
+      - "--gloo-version"
+      - "0.17.0"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
 - cron: "56 9 * * *"
   name: ci-knative-serving-nightly-release
   agent: kubernetes

--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -2728,7 +2728,7 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "28 */2 * * *"
+- cron: "35 */2 * * *"
   name: ci-knative-serving-gloo-0.17.1
   agent: kubernetes
   decorate: true
@@ -2736,6 +2736,7 @@ periodics:
   - org: knative
     repo: serving
     base_ref: master
+    path_alias: knative.dev/serving
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable

--- a/ci/prow/config_knative.yaml
+++ b/ci/prow/config_knative.yaml
@@ -176,6 +176,9 @@ periodics:
     - custom-job: istio-1.2-no-mesh
       full-command: "./test/e2e-tests.sh --istio-version 1.2-latest --no-mesh"
       dot-dev: true
+    - custom-job: gloo-0.17.1
+      full-command: "./test/e2e-tests.sh --gloo-version 0.17.1"
+      dot-dev: true
     - nightly: true
       dot-dev: true
     - dot-release: true

--- a/ci/prow/testgrid_config.go
+++ b/ci/prow/testgrid_config.go
@@ -152,7 +152,7 @@ func generateTestGroup(projName string, repoName string, jobNames []string) {
 			extras["short_text_metric"] = "coverage"
 			// Do not alert on coverage failures (i.e., coverage below threshold)
 			extras["num_failures_to_alert"] = "9999"
-		case "istio-1.1-mesh", "istio-1.1-no-mesh", "istio-1.2-mesh", "istio-1.2-no-mesh":
+		case "istio-1.1-mesh", "istio-1.1-no-mesh", "istio-1.2-mesh", "istio-1.2-no-mesh", "gloo-0.17.1":
 			extras["alert_stale_results_hours"] = "3"
 			extras["num_failures_to_alert"] = "3"
 		default:
@@ -200,7 +200,7 @@ func generateDashboard(projName string, repoName string, jobNames []string) {
 			executeDashboardTabTemplate("nightly", testGroupName, testgridTabSortByName, noExtras)
 		case "test-coverage":
 			executeDashboardTabTemplate("coverage", testGroupName, testgridTabGroupByDir, noExtras)
-		case "istio-1.1-mesh", "istio-1.1-no-mesh", "istio-1.2-mesh", "istio-1.2-no-mesh":
+		case "istio-1.1-mesh", "istio-1.1-no-mesh", "istio-1.2-mesh", "istio-1.2-no-mesh", "gloo-0.17.1":
 			executeDashboardTabTemplate(jobName, testGroupName, testgridTabSortByName, noExtras)
 		default:
 			log.Fatalf("Unknown job name %q", jobName)
@@ -227,7 +227,7 @@ func getTestGroupName(repoName string, jobName string) string {
 		return strings.ToLower(fmt.Sprintf("ci-%s-%s-release", repoName, jobName))
 	case "test-coverage":
 		return strings.ToLower(fmt.Sprintf("pull-%s-%s", repoName, jobName))
-	case "istio-1.1-mesh", "istio-1.1-no-mesh", "istio-1.2-mesh", "istio-1.2-no-mesh":
+	case "istio-1.1-mesh", "istio-1.1-no-mesh", "istio-1.2-mesh", "istio-1.2-no-mesh", "gloo-0.17.1":
 		return strings.ToLower(fmt.Sprintf("ci-%s-%s", repoName, jobName))
 	}
 	log.Fatalf("Unknown jobName for getTestGroupName: %s", jobName)

--- a/ci/testgrid/config.yaml
+++ b/ci/testgrid/config.yaml
@@ -76,6 +76,10 @@ test_groups:
   gcs_prefix: knative-prow/logs/ci-knative-serving-istio-1.2-no-mesh
   alert_stale_results_hours: 3
   num_failures_to_alert: 3
+- name: ci-knative-serving-gloo-0.17.1
+  gcs_prefix: knative-prow/logs/ci-knative-serving-gloo-0.17.1
+  alert_stale_results_hours: 3
+  num_failures_to_alert: 3
 - name: ci-knative-serving-nightly-release
   gcs_prefix: knative-prow/logs/ci-knative-serving-nightly-release
 - name: ci-knative-serving-dot-release
@@ -285,6 +289,9 @@ dashboards:
     base_options: "sort-by-name="
   - name: istio-1.2-no-mesh
     test_group_name: ci-knative-serving-istio-1.2-no-mesh
+    base_options: "sort-by-name="
+  - name: gloo-0.17.1
+    test_group_name: ci-knative-serving-gloo-0.17.1
     base_options: "sort-by-name="
   - name: nightly
     test_group_name: ci-knative-serving-nightly-release

--- a/shared/testgrid/testgrid.go
+++ b/shared/testgrid/testgrid.go
@@ -43,6 +43,7 @@ var jobNameTestgridURLMap = map[string]string{
 	"ci-knative-serving-istio-1.1-no-mesh": "serving#istio-1.1-no-mesh",
 	"ci-knative-serving-istio-1.2-mesh":    "serving#istio-1.2-mesh",
 	"ci-knative-serving-istio-1.2-no-mesh": "serving#istio-1.2-no-mesh",
+	"ci-knative-serving-gloo-0.17.1":       "serving#gloo-0.17.1",
 }
 
 // GetTestgridTabURL gets Testgrid URL for giving job and filters for Testgrid


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:

 https://github.com/knative/serving/pull/4704 introduced the ability to run the Serving e2e test suite using Gloo as the clusteringress rather than Istio. 

The changes in this PR add a Prow job to enable running that flavor of the tests in CI.

