### PR TITLE
flaky-test-retryer: add github integration

### DIFF
--- a/shared/ghutil/client.go
+++ b/shared/ghutil/client.go
@@ -51,6 +51,7 @@ type GithubOperations interface {
 	GetComment(org, repo string, commentID int64) (*github.IssueComment, error)
 	CreateComment(org, repo string, issueNumber int, commentBody string) (*github.IssueComment, error)
 	EditComment(org, repo string, commentID int64, commentBody string) error
+	DeleteComment(org, repo string, commentID int64) error
 	AddLabelsToIssue(org, repo string, issueNumber int, labels []string) error
 	RemoveLabelForIssue(org, repo string, issueNumber int, label string) error
 	GetPullRequest(org, repo string, ID int) (*github.PullRequest, error)

--- a/shared/ghutil/fakeghutil/fakeghutil.go
+++ b/shared/ghutil/fakeghutil/fakeghutil.go
@@ -160,6 +160,17 @@ func (fgc *FakeGithubClient) EditComment(org, repo string, commentID int64, comm
 	return nil
 }
 
+// DeleteComment deletes comment from issue
+func (gc *GithubClient) DeleteComment(org, repo string, commentID int64) error {
+	for _, comments := range fgc.Comments {
+		if comment, ok := comments[commentID]; ok {
+			delete(comments, commentID)
+			return nil
+		}
+	}
+	return fmt.Errorf("cannot find comment")
+}
+
 // AddLabelsToIssue adds label on issue
 func (fgc *FakeGithubClient) AddLabelsToIssue(org, repo string, issueNumber int, labels []string) error {
 	targetIssue := fgc.Issues[repo][issueNumber]

--- a/shared/ghutil/fakeghutil/fakeghutil.go
+++ b/shared/ghutil/fakeghutil/fakeghutil.go
@@ -163,7 +163,7 @@ func (fgc *FakeGithubClient) EditComment(org, repo string, commentID int64, comm
 // DeleteComment deletes comment from issue
 func (fgc *FakeGithubClient) DeleteComment(org, repo string, commentID int64) error {
 	for _, comments := range fgc.Comments {
-		if comment, ok := comments[commentID]; ok {
+		if _, ok := comments[commentID]; ok {
 			delete(comments, commentID)
 			return nil
 		}

--- a/shared/ghutil/fakeghutil/fakeghutil.go
+++ b/shared/ghutil/fakeghutil/fakeghutil.go
@@ -161,7 +161,7 @@ func (fgc *FakeGithubClient) EditComment(org, repo string, commentID int64, comm
 }
 
 // DeleteComment deletes comment from issue
-func (gc *GithubClient) DeleteComment(org, repo string, commentID int64) error {
+func (fgc *FakeGithubClient) DeleteComment(org, repo string, commentID int64) error {
 	for _, comments := range fgc.Comments {
 		if comment, ok := comments[commentID]; ok {
 			delete(comments, commentID)

--- a/shared/ghutil/issue.go
+++ b/shared/ghutil/issue.go
@@ -199,6 +199,19 @@ func (gc *GithubClient) EditComment(org, repo string, commentID int64, commentBo
 	return err
 }
 
+// DeleteComment deletes comment from issue
+func (gc *GithubClient) DeleteComment(org, repo string, commentID int64) error {
+	_, err := gc.retry(
+		fmt.Sprintf("deleting comment '%s %s %d'", org, repo, commentID),
+		maxRetryCount,
+		func() (*github.Response, error) {
+			resp, err := gc.Client.Issues.DeleteComment(ctx, org, repo, commentID)
+			return resp, err
+		},
+	)
+	return err
+}
+
 // AddLabelsToIssue adds label on issue
 func (gc *GithubClient) AddLabelsToIssue(org, repo string, issueNumber int, labels []string) error {
 	_, err := gc.retry(

--- a/tools/flaky-test-retryer/github_commenter.go
+++ b/tools/flaky-test-retryer/github_commenter.go
@@ -21,7 +21,23 @@ limitations under the License.
 package main
 
 import (
+	"fmt"
+	"log"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/google/go-github/github"
 	"github.com/knative/test-infra/shared/ghutil"
+)
+
+const (
+	maxRetries = 3
+)
+
+var (
+	commentTemplate = "The following tests failed due to flakiness:\n\n" +
+		"Test name | Retries\n--- | ---\n%s\n\n%s"
 )
 
 // GithubClient wraps the ghutil Github client
@@ -36,4 +52,108 @@ func NewGithubClient(githubAccount string) (*GithubClient, error) {
 		return nil, err
 	}
 	return &GithubClient{ghc}, err
+}
+
+// PostComment posts a new comment on the PR specified in JobData, retrying the job that triggered it.
+// The comment body is dynamically built based on previous retry comments on this PR, and any old
+// comments are removed before the new one is posted.
+func (gc *GithubClient) PostComment(jd *JobData, outliers []string, dryrun bool) error {
+	oldComment, err := gc.getOldComment(jd.Refs[0].Org, jd.Refs[0].Repo, jd.Refs[0].Pulls[0].Number)
+	if err != nil {
+		return err
+	}
+	oldEntries, err := parseEntries(oldComment)
+	if err != nil {
+		return err
+	}
+	if _, ok := oldEntries[jd.JobName]; !ok {
+		oldEntries[jd.JobName] = 0
+	}
+	newComment, canRetry := buildNewComment(jd, oldEntries, outliers)
+	if !canRetry {
+		return fmt.Errorf("expended all %d retries", maxRetries)
+	}
+	if dryrun {
+		log.Printf("[dry run] Comment not updated. See it here:\n%s\n", newComment)
+		return nil
+	}
+	if oldComment != nil {
+		if err := gc.DeleteComment(jd.Refs[0].Org, jd.Refs[0].Repo, oldComment.GetID()); err != nil {
+			return err
+		}
+	}
+	_, err = gc.CreateComment(jd.Refs[0].Org, jd.Refs[0].Repo, jd.Refs[0].Pulls[0].Number, newComment)
+	return err
+}
+
+// getOldComment queries the GitHub PR specified and gets the comment made by us. If no comment
+// is found, we do not error, since we will be creating a new one anyways.
+func (gc *GithubClient) getOldComment(org, repo string, pull int) (*github.IssueComment, error) {
+	comments, err := gc.ListComments(org, repo, pull)
+	if err != nil {
+		return nil, err
+	}
+	user, err := gc.GetGithubUser()
+	if err != nil {
+		return nil, err
+	}
+	for _, comment := range comments {
+		if *comment.GetUser().Login == *user.Login {
+			return comment, nil
+		}
+	}
+	return nil, nil
+}
+
+// parseEntries collects retry information from the given comment, so we can reuse it in
+// a new comment.
+func parseEntries(comment *github.IssueComment) (map[string]int, error) {
+	entries := map[string]int{}
+	if comment == nil {
+		return entries, nil
+	}
+	re := regexp.MustCompile(`.* \| \d`)
+	entryStrings := re.FindAll([]byte(comment.GetBody()), -1)
+	for _, e := range entryStrings {
+		fields := strings.Split(string(e), " | ")
+		retry, err := strconv.Atoi(strings.TrimSuffix(fields[1], "/3"))
+		if err != nil {
+			return nil, err
+		}
+		entries[strings.Trim(fields[0], "`")] = retry
+	}
+	return entries, nil
+}
+
+// buildNewComment takes the old entry data, the job we are processing, and any outlying
+// non-flaky tests, building a comment body based on these parameters.
+func buildNewComment(jd *JobData, entries map[string]int, outliers []string) (string, bool) {
+	var cmd string
+	var entryString []string
+	if len(outliers) > 0 {
+		cmd = buildNoRetryString(jd.JobName, outliers)
+	} else {
+		cmd = buildRetryString(jd.JobName, entries)
+	}
+	for test, retry := range entries {
+		entryString = append(entryString, fmt.Sprintf("`%s` | %d/%d", test, retry, maxRetries))
+	}
+	return fmt.Sprintf(commentTemplate, strings.Join(entryString, "\n"), cmd), entries[jd.JobName] <= maxRetries
+}
+
+// buildRetryString increments the retry counter and generates a /test string if we have
+// more retries available.
+func buildRetryString(job string, entries map[string]int) string {
+	entries[job]++
+	if entries[job] <= maxRetries {
+		return fmt.Sprintf("Automatically retrying...\n/test %s", job)
+	}
+	return ""
+}
+
+// buildNoRetryString formats the tests that prevent us from retrying into a drop-down
+// menu underneath the table of retries.
+func buildNoRetryString(job string, outliers []string) string {
+	dropdownFmt := "<details>\n<summary>Non-flaky tests preventing automatic retry of %s</summary>\n<br>\n<code>%s</code>\n</details>"
+	return fmt.Sprintf(dropdownFmt, job, strings.Join(outliers, "</code>\n<code>"))
 }

--- a/tools/flaky-test-retryer/github_commenter.go
+++ b/tools/flaky-test-retryer/github_commenter.go
@@ -136,7 +136,7 @@ func buildNewComment(jd *JobData, entries map[string]int, outliers []string) (st
 		cmd = buildRetryString(jd.JobName, entries)
 	}
 	for test, retry := range entries {
-		entryString = append(entryString, fmt.Sprintf("`%s` | %d/%d", test, retry, maxRetries))
+		entryString = append(entryString, fmt.Sprintf("%s | %d/%d", test, retry, maxRetries))
 	}
 	return fmt.Sprintf(commentTemplate, strings.Join(entryString, "\n"), cmd), entries[jd.JobName] <= maxRetries
 }
@@ -154,6 +154,6 @@ func buildRetryString(job string, entries map[string]int) string {
 // buildNoRetryString formats the tests that prevent us from retrying into a drop-down
 // menu underneath the table of retries.
 func buildNoRetryString(job string, outliers []string) string {
-	dropdownFmt := "<details>\n<summary>Non-flaky tests preventing automatic retry of %s</summary>\n<br>\n<code>%s</code>\n</details>"
-	return fmt.Sprintf(dropdownFmt, job, strings.Join(outliers, "</code>\n<code>"))
+	dropdownFmt := "<details>\n<summary>Non-flaky failing tests preventing automatic retry of %s:</summary>\n<br>\n<code>%s</code>\n</details>"
+	return fmt.Sprintf(dropdownFmt, job, strings.Join(outliers, "\n"))
 }

--- a/tools/flaky-test-retryer/github_commenter.go
+++ b/tools/flaky-test-retryer/github_commenter.go
@@ -45,7 +45,7 @@ var (
 // GithubClient wraps the ghutil Github client
 type GithubClient struct {
 	*ghutil.GithubClient
-	Login string
+	Login  string
 	Dryrun bool
 }
 

--- a/tools/flaky-test-retryer/github_commenter_test.go
+++ b/tools/flaky-test-retryer/github_commenter_test.go
@@ -17,17 +17,17 @@ limitations under the License.
 package main
 
 import (
-  "fmt"
-  "reflect"
+	"fmt"
+	"reflect"
 	"testing"
 
-	"github.com/google/go-github/github"
 	"github.com/TrevorFarrelly/test-infra/shared/ghutil/fakeghutil"
-  "github.com/knative/test-infra/tools/monitoring/prowapi"
+	"github.com/google/go-github/github"
+	"github.com/knative/test-infra/tools/monitoring/prowapi"
 )
 
 var (
-  fakeCommentBody = `<!--AUTOMATED-FLAKY-RETRYER-->
+	fakeCommentBody = `<!--AUTOMATED-FLAKY-RETRYER-->
   The following tests are currently flaky. Running them again to verify...
 
   Test name | Retries
@@ -36,96 +36,93 @@ var (
   fakejob2 | 1/3
 
   /test fakejob2`
-  fakeOrg = "fakeorg"
-  fakeRepo = "fakerepo"
-  fakePullNumber = 127
-  fakeUserID = int64(99)
-  fakeUserLogin = "fakelogin"
-  fakeUser = &github.User{
-    ID: &fakeUserID,
-    Login: &fakeUserLogin,
-  }
-  fakeJob = JobData{
-   &prowapi.ReportMessage{
-     JobName: "test-job-2",
-     Refs: []prowapi.Refs{{
-       Org: fakeOrg,
-       Repo: fakeRepo,
-       Pulls: []prowapi.Pull{{
-         Number: fakePullNumber,
-       },},
-     },},
-   },
-   nil,
-   nil,
-  }
-  fakeOldComment = &github.IssueComment{
-    Body: &fakeCommentBody,
-    User: fakeUser,
-  }
+	fakeOrg        = "fakeorg"
+	fakeRepo       = "fakerepo"
+	fakePullNumber = 127
+	fakeUserID     = int64(99)
+	fakeUserLogin  = "fakelogin"
+	fakeUser       = &github.User{
+		ID:    &fakeUserID,
+		Login: &fakeUserLogin,
+	}
+	fakeJob = JobData{
+		&prowapi.ReportMessage{
+			JobName: "test-job-2",
+			Refs: []prowapi.Refs{{
+				Org:  fakeOrg,
+				Repo: fakeRepo,
+				Pulls: []prowapi.Pull{{
+					Number: fakePullNumber,
+				}},
+			}},
+		},
+		nil,
+		nil,
+	}
+	fakeOldComment = &github.IssueComment{
+		Body: &fakeCommentBody,
+		User: fakeUser,
+	}
 )
 
-
 func getFakeGithubClient() *GithubClient {
-  gc := fakeghutil.NewFakeGithubClient()
-  gc.Repos = []string{fakeRepo}
+	gc := fakeghutil.NewFakeGithubClient()
+	gc.Repos = []string{fakeRepo}
 	gc.User = fakeUser
-  return &GithubClient{
-    gc,
-    *gc.User.Login,
-    false,
-  }
+	return &GithubClient{
+		gc,
+		*gc.User.Login,
+		false,
+	}
 }
 
 func TestGetOldComment(t *testing.T) {
-  gc := getFakeGithubClient()
-  cases := []struct{
-    client *GithubClient
-    org, repo string
-    pull int
-    wantComment *github.IssueComment
-    wantErr error
-  }{
-    {gc, fakeOrg, fakeRepo, fakePullNumber, nil, nil},
-    {gc, fakeOrg, fakeRepo, fakePullNumber, fakeOldComment, nil},
-    {gc, fakeOrg, fakeRepo, fakePullNumber, nil, fmt.Errorf("more than one comment on PR")},
-  }
+	gc := getFakeGithubClient()
+	cases := []struct {
+		client      *GithubClient
+		org, repo   string
+		pull        int
+		wantComment *github.IssueComment
+		wantErr     error
+	}{
+		{gc, fakeOrg, fakeRepo, fakePullNumber, nil, nil},
+		{gc, fakeOrg, fakeRepo, fakePullNumber, fakeOldComment, nil},
+		{gc, fakeOrg, fakeRepo, fakePullNumber, nil, fmt.Errorf("more than one comment on PR")},
+	}
 
-  for _, test := range cases {
-    actualComment, actualErr := test.client.getOldComment(test.org, test.repo, test.pull)
-    if actualComment != test.wantComment {
-      t.Errorf("get old comment: got comment %v, want comment %v", actualComment, test.wantComment)
-    }
-    if !reflect.DeepEqual(actualErr, test.wantErr) {
-      t.Errorf("get old comment: got err %v, want err %v", actualErr, test.wantErr)
-    }
-    // add a comment so we test 0, 1, and 2 comments on the PR respectively
-    test.client.CreateComment(test.org, test.repo, test.pull, fakeCommentBody)
-  }
+	for _, test := range cases {
+		actualComment, actualErr := test.client.getOldComment(test.org, test.repo, test.pull)
+		if actualComment != test.wantComment {
+			t.Errorf("get old comment: got comment %v, want comment %v", actualComment, test.wantComment)
+		}
+		if !reflect.DeepEqual(actualErr, test.wantErr) {
+			t.Errorf("get old comment: got err %v, want err %v", actualErr, test.wantErr)
+		}
+		// add a comment so we test 0, 1, and 2 comments on the PR respectively
+		test.client.CreateComment(test.org, test.repo, test.pull, fakeCommentBody)
+	}
 }
 
 func TestParseEntries(t *testing.T) {
-  cases := []struct{
-    input *github.IssueComment
-    want map[string]int
-  }{
-    {fakeOldComment, map[string]int{"fakejob":0, "fakejob2":1}},
-  }
-  for _, data := range cases {
-    actual, _ := parseEntries(data.input)
-    if !reflect.DeepEqual(data.want, actual) {
-      t.Fatalf("parse entries: got '%v', want '%v'", actual, data.want)
-    }
-  }
+	cases := []struct {
+		input *github.IssueComment
+		want  map[string]int
+	}{
+		{fakeOldComment, map[string]int{"fakejob": 0, "fakejob2": 1}},
+	}
+	for _, data := range cases {
+		actual, _ := parseEntries(data.input)
+		if !reflect.DeepEqual(data.want, actual) {
+			t.Fatalf("parse entries: got '%v', want '%v'", actual, data.want)
+		}
+	}
 }
 
 func TestBuildNewComment(t *testing.T) {
-  cases := []struct {
-    jd *JobData
-    entries map[string]int
-    outliers []string
-    want string
-  }{
-
-  }
+	cases := []struct {
+		jd       *JobData
+		entries  map[string]int
+		outliers []string
+		want     string
+	}{}
 }

--- a/tools/flaky-test-retryer/github_commenter_test.go
+++ b/tools/flaky-test-retryer/github_commenter_test.go
@@ -55,7 +55,7 @@ Test name | Retries
 fakejob0 | 3/3
 fakejob1 | 1/3
 
-`
+Job fakejob0 expended all 3 retries without success.`
 	failedShortCommentBody = `<!--AUTOMATED-FLAKY-RETRYER-->
 The following tests are currently flaky. Running them again to verify...
 
@@ -172,21 +172,17 @@ func TestBuildNewComment(t *testing.T) {
 		entries  map[string]int
 		outliers []string
 		wantBody string
-		wantBool bool
 	}{
-		{&fakeJob, map[string]int{"fakejob0": 0, "fakejob1": 1}, nil, retryCommentBody, true},
-		{&fakeJob, map[string]int{"fakejob0": 3, "fakejob1": 1}, nil, noMoreRetriesCommentBody, false},
-		{&fakeJob, map[string]int{"fakejob0": 0, "fakejob1": 1}, fakeFailedTests[:4], failedShortCommentBody, true},
-		{&fakeJob, map[string]int{"fakejob0": 0, "fakejob1": 1}, fakeFailedTests, failedLongCommentBody, true},
+		{&fakeJob, map[string]int{"fakejob0": 0, "fakejob1": 1}, nil, retryCommentBody},
+		{&fakeJob, map[string]int{"fakejob0": 3, "fakejob1": 1}, nil, noMoreRetriesCommentBody},
+		{&fakeJob, map[string]int{"fakejob0": 0, "fakejob1": 1}, fakeFailedTests[:4], failedShortCommentBody},
+		{&fakeJob, map[string]int{"fakejob0": 0, "fakejob1": 1}, fakeFailedTests, failedLongCommentBody},
 	}
 
 	for _, test := range cases {
-		gotBody, gotBool := buildNewComment(test.jd, test.entries, test.outliers)
+		gotBody := buildNewComment(test.jd, test.entries, test.outliers)
 		if gotBody != test.wantBody {
 			t.Fatalf("build new comment: got body \n'%v'\n, want \n'%v'", gotBody, test.wantBody)
-		}
-		if gotBool != test.wantBool {
-			t.Fatalf("build new comment: got bool '%v', want '%v'", gotBool, test.wantBool)
 		}
 	}
 }

--- a/tools/flaky-test-retryer/github_commenter_test.go
+++ b/tools/flaky-test-retryer/github_commenter_test.go
@@ -142,10 +142,10 @@ func TestGetOldComment(t *testing.T) {
 	for _, test := range cases {
 		actualComment, actualErr := test.client.getOldComment(test.org, test.repo, test.pull)
 		if !reflect.DeepEqual(actualComment, test.wantComment) {
-			t.Errorf("get old comment: got comment %v, want comment %v", actualComment, test.wantComment)
+			t.Errorf("get old comment: got comment '%v', want comment '%v'", actualComment, test.wantComment)
 		}
 		if !reflect.DeepEqual(actualErr, test.wantErr) {
-			t.Errorf("get old comment: got err %v, want err %v", actualErr, test.wantErr)
+			t.Errorf("get old comment: got err '%v', want err '%v'", actualErr, test.wantErr)
 		}
 		test.client.CreateComment(test.org, test.repo, test.pull, oldCommentBody)
 	}

--- a/tools/flaky-test-retryer/github_commenter_test.go
+++ b/tools/flaky-test-retryer/github_commenter_test.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+  "fmt"
+  "reflect"
+	"testing"
+
+	"github.com/google/go-github/github"
+	"github.com/TrevorFarrelly/test-infra/shared/ghutil/fakeghutil"
+  "github.com/knative/test-infra/tools/monitoring/prowapi"
+)
+
+var (
+  fakeCommentBody = `<!--AUTOMATED-FLAKY-RETRYER-->
+  The following tests are currently flaky. Running them again to verify...
+
+  Test name | Retries
+  --- | ---
+  fakejob | 0/3
+  fakejob2 | 1/3
+
+  /test fakejob2`
+  fakeOrg = "fakeorg"
+  fakeRepo = "fakerepo"
+  fakePullNumber = 127
+  fakeUserID = int64(99)
+  fakeUserLogin = "fakelogin"
+  fakeUser = &github.User{
+    ID: &fakeUserID,
+    Login: &fakeUserLogin,
+  }
+  fakeJob = JobData{
+   &prowapi.ReportMessage{
+     JobName: "test-job-2",
+     Refs: []prowapi.Refs{{
+       Org: fakeOrg,
+       Repo: fakeRepo,
+       Pulls: []prowapi.Pull{{
+         Number: fakePullNumber,
+       },},
+     },},
+   },
+   nil,
+   nil,
+  }
+  fakeOldComment = &github.IssueComment{
+    Body: &fakeCommentBody,
+    User: fakeUser,
+  }
+)
+
+
+func getFakeGithubClient() *GithubClient {
+  gc := fakeghutil.NewFakeGithubClient()
+  gc.Repos = []string{fakeRepo}
+	gc.User = fakeUser
+  return &GithubClient{
+    gc,
+    *gc.User.Login,
+    false,
+  }
+}
+
+func TestGetOldComment(t *testing.T) {
+  gc := getFakeGithubClient()
+  cases := []struct{
+    client *GithubClient
+    org, repo string
+    pull int
+    wantComment *github.IssueComment
+    wantErr error
+  }{
+    {gc, fakeOrg, fakeRepo, fakePullNumber, nil, nil},
+    {gc, fakeOrg, fakeRepo, fakePullNumber, fakeOldComment, nil},
+    {gc, fakeOrg, fakeRepo, fakePullNumber, nil, fmt.Errorf("more than one comment on PR")},
+  }
+
+  for _, test := range cases {
+    actualComment, actualErr := test.client.getOldComment(test.org, test.repo, test.pull)
+    if actualComment != test.wantComment {
+      t.Errorf("get old comment: got comment %v, want comment %v", actualComment, test.wantComment)
+    }
+    if !reflect.DeepEqual(actualErr, test.wantErr) {
+      t.Errorf("get old comment: got err %v, want err %v", actualErr, test.wantErr)
+    }
+    // add a comment so we test 0, 1, and 2 comments on the PR respectively
+    test.client.CreateComment(test.org, test.repo, test.pull, fakeCommentBody)
+  }
+}
+
+func TestParseEntries(t *testing.T) {
+  cases := []struct{
+    input *github.IssueComment
+    want map[string]int
+  }{
+    {fakeOldComment, map[string]int{"fakejob":0, "fakejob2":1}},
+  }
+  for _, data := range cases {
+    actual, _ := parseEntries(data.input)
+    if !reflect.DeepEqual(data.want, actual) {
+      t.Fatalf("parse entries: got '%v', want '%v'", actual, data.want)
+    }
+  }
+}
+
+func TestBuildNewComment(t *testing.T) {
+  cases := []struct {
+    jd *JobData
+    entries map[string]int
+    outliers []string
+    want string
+  }{
+
+  }
+}

--- a/tools/flaky-test-retryer/github_commenter_test.go
+++ b/tools/flaky-test-retryer/github_commenter_test.go
@@ -123,6 +123,8 @@ func getFakeGithubClient() *GithubClient {
 	}
 }
 
+// note: this test is not a standard table-driven test, each case depends on the previous. We add a comment
+// to the PR each iteration so we can cover the 0 comments, 1 comment, and 2 comments cases.
 func TestGetOldComment(t *testing.T) {
 	gc := getFakeGithubClient()
 	cases := []struct {
@@ -145,7 +147,6 @@ func TestGetOldComment(t *testing.T) {
 		if !reflect.DeepEqual(actualErr, test.wantErr) {
 			t.Errorf("get old comment: got err %v, want err %v", actualErr, test.wantErr)
 		}
-		// add a comment so we test 0, 1, and 2 comments on the PR respectively
 		test.client.CreateComment(test.org, test.repo, test.pull, oldCommentBody)
 	}
 }

--- a/tools/flaky-test-retryer/handler.go
+++ b/tools/flaky-test-retryer/handler.go
@@ -36,12 +36,11 @@ type HandlerClient struct {
 	context.Context
 	pubsub *subscriber.Client
 	github *GithubClient
-	dryrun bool
 }
 
 // NewHandlerClient gives us a handler where we can listen for Pubsub messages and
 // post comments on GitHub.
-func NewHandlerClient(githubAccount string, dryrun bool) (*HandlerClient, error) {
+func NewHandlerClient(githubAccount string) (*HandlerClient, error) {
 	ctx := context.Background()
 	githubClient, err := NewGithubClient(githubAccount)
 	if err != nil {
@@ -55,7 +54,6 @@ func NewHandlerClient(githubAccount string, dryrun bool) (*HandlerClient, error)
 		ctx,
 		pubsubClient,
 		githubClient,
-		dryrun,
 	}, nil
 }
 
@@ -97,7 +95,7 @@ func (hc *HandlerClient) HandleJob(jd *JobData) {
 	logWithPrefix(jd, "got %d flaky tests from today's report\n", len(flakyTests))
 
 	outliers := getNonFlakyTests(failedTests, flakyTests)
-	if err := hc.github.PostComment(jd, outliers, hc.dryrun); err != nil {
+	if err := hc.github.PostComment(jd, outliers); err != nil {
 		logWithPrefix(jd, "Could not post comment: %v", err)
 	}
 }

--- a/tools/flaky-test-retryer/handler.go
+++ b/tools/flaky-test-retryer/handler.go
@@ -40,9 +40,9 @@ type HandlerClient struct {
 
 // NewHandlerClient gives us a handler where we can listen for Pubsub messages and
 // post comments on GitHub.
-func NewHandlerClient(githubAccount string) (*HandlerClient, error) {
+func NewHandlerClient(githubAccount string, dryrun bool) (*HandlerClient, error) {
 	ctx := context.Background()
-	githubClient, err := NewGithubClient(githubAccount)
+	githubClient, err := NewGithubClient(githubAccount, dryrun)
 	if err != nil {
 		return nil, fmt.Errorf("Github client: %v", err)
 	}

--- a/tools/flaky-test-retryer/handler.go
+++ b/tools/flaky-test-retryer/handler.go
@@ -97,12 +97,6 @@ func (hc *HandlerClient) HandleJob(jd *JobData) {
 	logWithPrefix(jd, "got %d flaky tests from today's report\n", len(flakyTests))
 
 	outliers := getNonFlakyTests(failedTests, flakyTests)
-	if len(outliers) > 0 {
-		logWithPrefix(jd, "%d of %d failed tests are not flaky, cannot retry\n", len(outliers), len(failedTests))
-	} else {
-		logWithPrefix(jd, "all failed tests are flaky, triggering retry\n")
-	}
-
 	if err := hc.github.PostComment(jd, outliers, hc.dryrun); err != nil {
 		logWithPrefix(jd, "Could not post comment: %v", err)
 	}

--- a/tools/flaky-test-retryer/main.go
+++ b/tools/flaky-test-retryer/main.go
@@ -34,13 +34,14 @@ const (
 func main() {
 	serviceAccount := flag.String("service-account", os.Getenv("GOOGLE_APPLICATION_CREDENTIALS"), "JSON key file for GCS service account")
 	githubAccount := flag.String("github-account", "", "Token file for Github authentication")
+	dryrun := flag.Bool("dry-run", false, "dry run switch")
 	flag.Parse()
 
 	if err := InitLogParser(*serviceAccount); nil != err {
 		log.Fatalf("Failed authenticating GCS: '%v'", err)
 	}
 
-	handler, err := NewHandlerClient(*githubAccount)
+	handler, err := NewHandlerClient(*githubAccount, *dryrun)
 	if err != nil {
 		log.Fatalf("Coud not create handler: '%v'", err)
 	}

--- a/tools/flaky-test-retryer/main.go
+++ b/tools/flaky-test-retryer/main.go
@@ -31,21 +31,20 @@ const (
 	pubsubTopic = "knative-monitoring"
 )
 
-
 type EnvFlags struct {
-  ServiceAccount string // GCP service account file path
-  GithubAccount  string // github account file path
-  Dryrun bool           // dry run toggle
+	ServiceAccount string // GCP service account file path
+	GithubAccount  string // github account file path
+	Dryrun         bool   // dry run toggle
 }
 
 func initFlags() *EnvFlags {
-  var f EnvFlags
-  defaultServiceAccount := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")
-  flag.StringVar(&f.ServiceAccount, "service-account", defaultServiceAccount, "JSON key file for GCS service account")
+	var f EnvFlags
+	defaultServiceAccount := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")
+	flag.StringVar(&f.ServiceAccount, "service-account", defaultServiceAccount, "JSON key file for GCS service account")
 	flag.StringVar(&f.GithubAccount, "github-account", "", "Token file for Github authentication")
 	flag.BoolVar(&f.Dryrun, "dry-run", false, "dry run switch")
 	flag.Parse()
-  return &f
+	return &f
 }
 
 func main() {

--- a/tools/flaky-test-retryer/main.go
+++ b/tools/flaky-test-retryer/main.go
@@ -31,12 +31,11 @@ const (
 	pubsubTopic = "knative-monitoring"
 )
 
-var Flags = initFlags()
 
 type EnvFlags struct {
   ServiceAccount string // GCP service account file path
   GithubAccount  string // github account file path
-  DryRun bool           // dry run toggle
+  Dryrun bool           // dry run toggle
 }
 
 func initFlags() *EnvFlags {
@@ -44,22 +43,25 @@ func initFlags() *EnvFlags {
   defaultServiceAccount := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")
   flag.StringVar(&f.ServiceAccount, "service-account", defaultServiceAccount, "JSON key file for GCS service account")
 	flag.StringVar(&f.GithubAccount, "github-account", "", "Token file for Github authentication")
-	flag.BoolVar(&f.DryRun, "dry-run", false, "dry run switch")
-
+	flag.BoolVar(&f.Dryrun, "dry-run", false, "dry run switch")
+	flag.Parse()
   return &f
 }
 
 func main() {
+	flags := initFlags()
 
-	flag.Parse()
-
-	if err := InitLogParser(Flags.ServiceAccount); nil != err {
+	if err := InitLogParser(flags.ServiceAccount); nil != err {
 		log.Fatalf("Failed authenticating GCS: '%v'", err)
 	}
 
-	handler, err := NewHandlerClient(Flags.GithubAccount)
+	handler, err := NewHandlerClient(flags.GithubAccount, flags.Dryrun)
 	if err != nil {
 		log.Fatalf("Coud not create handler: '%v'", err)
+	}
+
+	if flags.Dryrun {
+		log.Println("running in [dry run] mode")
 	}
 
 	handler.Listen()

--- a/tools/flaky-test-retryer/main.go
+++ b/tools/flaky-test-retryer/main.go
@@ -31,17 +31,33 @@ const (
 	pubsubTopic = "knative-monitoring"
 )
 
+var Flags = initFlags()
+
+type EnvFlags struct {
+  ServiceAccount string // GCP service account file path
+  GithubAccount  string // github account file path
+  DryRun bool           // dry run toggle
+}
+
+func initFlags() *EnvFlags {
+  var f EnvFlags
+  defaultServiceAccount := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")
+  flag.StringVar(&f.ServiceAccount, "service-account", defaultServiceAccount, "JSON key file for GCS service account")
+	flag.StringVar(&f.GithubAccount, "github-account", "", "Token file for Github authentication")
+	flag.BoolVar(&f.DryRun, "dry-run", false, "dry run switch")
+
+  return &f
+}
+
 func main() {
-	serviceAccount := flag.String("service-account", os.Getenv("GOOGLE_APPLICATION_CREDENTIALS"), "JSON key file for GCS service account")
-	githubAccount := flag.String("github-account", "", "Token file for Github authentication")
-	dryrun := flag.Bool("dry-run", false, "dry run switch")
+
 	flag.Parse()
 
-	if err := InitLogParser(*serviceAccount); nil != err {
+	if err := InitLogParser(Flags.ServiceAccount); nil != err {
 		log.Fatalf("Failed authenticating GCS: '%v'", err)
 	}
 
-	handler, err := NewHandlerClient(*githubAccount, *dryrun)
+	handler, err := NewHandlerClient(Flags.GithubAccount)
 	if err != nil {
 		log.Fatalf("Coud not create handler: '%v'", err)
 	}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
This PR adds GitHub commenting functionality to the flaky-test-retryer. The comments feature a list of jobs, the number of retries, and either a list of tests that prevent the job from restarting or the command to restart the test. [Example](https://github.com/TrevorFarrelly/knative-testing/pull/30)

When we update a comment, we have to delete and re-post it so knative-prow robot detects a new `/test <job>` command. This does cause some GitHub email notification spam, and unfortunately I could not find another easy solution.

If any Knative devs have ideas for different comment formatting, or other ways to restart the jobs, I'd love for some input. The retryer is meant to help you after all, not spam your inbox any more than necessary :)
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #987 

**Special notes to reviewers**:

**User-visible changes in this PR**:

