### PR TITLE
Dump logs from all containers inside a pod

### DIFF
--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -257,7 +257,7 @@ function dump_app_logs() {
   for pod in $(get_app_pods "$1" "$2")
   do
     echo ">>> Pod: $pod"
-    kubectl -n "$2" logs "$pod" -c "$1"
+    kubectl -n "$2" logs "$pod" --all-containers
   done
 }
 


### PR DESCRIPTION
The script assumes the container name is the same as the deployment/app name.
This is not true for non Knative deployments (e.g. Istio): see https://github.com/knative/serving/pull/4816.
Let's just capture logs from all the containers.
