### PR TITLE
move -race option to go_test_e2e and default_unit_test_runner

### DIFF
--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -83,7 +83,7 @@ function go_test_e2e() {
   local go_options=""
   (( EMIT_METRICS )) && test_options="-emitmetrics"
   [[ ! " $@" == *" -tags="* ]] && go_options="-tags=e2e"
-  report_go_test -v -count=1 ${go_options} $@ ${test_options}
+  report_go_test -v -race -count=1 ${go_options} $@ ${test_options}
 }
 
 # Dump info about the test cluster. If dump_extra_cluster_info() is defined, calls it too.

--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -340,7 +340,7 @@ function report_go_test() {
   # Run tests in verbose mode to capture details.
   # go doesn't like repeating -v, so remove if passed.
   local args=" $@ "
-  local go_test="go test -race -v ${args/ -v / }"
+  local go_test="go test -v ${args/ -v / }"
   # Just run regular go tests if not on Prow.
   echo "Running tests with '${go_test}'"
   local report="$(mktemp)"

--- a/scripts/presubmit-tests.sh
+++ b/scripts/presubmit-tests.sh
@@ -224,7 +224,7 @@ function run_unit_tests() {
 
 # Default unit test runner that runs all go tests in the repo.
 function default_unit_test_runner() {
-  report_go_test ./...
+  report_go_test -race ./...
 }
 
 # Run integration tests. If there's no `integration_tests` function, run the


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
When vegeta generate test loads, it spawns workers without limit to achieve the desired request rate, see https://github.com/tsenart/vegeta/issues/344.
It causes our performance tests to fail with for `race: limit on 8128 simultaneously alive goroutines is exceeded, dying`, see https://prow.knative.dev/view/gcs/knative-prow/logs/ci-knative-serving-performance/1152413085785395200. So we'll need to remove the `-race` option from the `run test` command.

This PR moves the `-race` option from `report_go_test` to `go_test_e2e` and `default_unit_test_runner`, so that in `perf-test.sh` we can use `report_go_test` without `-race`.

Please LMK if you think there are other better solutions. 

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @adrcunha 
/cc @srinivashegde86 
