### PR TITLE
Store the build-log url instead of artifacts url

### DIFF
--- a/tools/monitoring/alert/alert.go
+++ b/tools/monitoring/alert/alert.go
@@ -99,9 +99,9 @@ func (c *Client) handleSingleError(config *config.Config, rmsg *prowapi.ReportMe
 	// Add the PR number if it is a pull request job
 	log.Println("Adding Error Log to the table")
 	if len(rmsg.Refs) <= 0 || len(rmsg.Refs[0].Pulls) <= 0 {
-		err = c.db.AddErrorLog(el.Pattern, el.Msg, rmsg.JobName, 0, rmsg.GCSPath)
+		err = c.db.AddErrorLog(el.Pattern, el.Msg, rmsg.JobName, 0, rmsg.URL)
 	} else {
-		err = c.db.AddErrorLog(el.Pattern, el.Msg, rmsg.JobName, rmsg.Refs[0].Pulls[0].Number, rmsg.GCSPath)
+		err = c.db.AddErrorLog(el.Pattern, el.Msg, rmsg.JobName, rmsg.Refs[0].Pulls[0].Number, rmsg.URL)
 	}
 	if err != nil {
 		log.Printf("Failed to insert error to db %+v\n", err)

--- a/tools/monitoring/alert/report.go
+++ b/tools/monitoring/alert/report.go
@@ -18,11 +18,9 @@ package alert
 
 import (
 	"fmt"
-	"log"
 	"sort"
 	"time"
 
-	"github.com/knative/test-infra/shared/gcs"
 	"github.com/knative/test-infra/tools/monitoring/config"
 	"github.com/knative/test-infra/tools/monitoring/mysql"
 )
@@ -66,13 +64,8 @@ func (c mailContent) body() string {
 func (r report) sprintLogs() string {
 	result := ""
 	for i, e := range r.logs {
-		if logURL, err := gcs.GetConsoleURL(e.BuildLogURL); err != nil {
-			log.Printf("Failed to getConsoleURL(%s): %v\n", e.String(), err)
-			result += fmt.Sprintf("%d. %s\n", i+1, e.String())
-		} else {
-			result += fmt.Sprintf("%d. [%v] %s (Job: %s, PR: %v, BuildLog: %s)\n",
-				i+1, e.TimeStamp, e.Msg, e.JobName, e.PRNumber, logURL)
-		}
+		result += fmt.Sprintf("%d. [%v] %s (Job: %s, PR: %v, BuildLog: %s)\n",
+			i+1, e.TimeStamp, e.Msg, e.JobName, e.PRNumber, e.BuildLogURL)
 	}
 	return result
 }

--- a/tools/monitoring/alert/report_test.go
+++ b/tools/monitoring/alert/report_test.go
@@ -39,7 +39,7 @@ func TestSprintLogs(t *testing.T) {
 						Msg:         "Knative test failed",
 						JobName:     "ci-knative-docs-continuous",
 						PRNumber:    0,
-						BuildLogURL: "gs://knative-prow/logs/ci-knative-docs-continuous/1132539579983728640/",
+						BuildLogURL: "https://prow.knative.dev/view/gcs/knative-prow/pr-logs/1153085516762058753",
 						TimeStamp:   testTime,
 					},
 					{
@@ -52,7 +52,7 @@ func TestSprintLogs(t *testing.T) {
 					},
 				},
 			},
-			want: "1. [2019-01-01 00:00:00 +0000 UTC] Knative test failed (Job: ci-knative-docs-continuous, PR: 0, BuildLog: https://console.cloud.google.com/storage/browser/knative-prow/logs/ci-knative-docs-continuous/1132539579983728640)\n" +
+			want: "1. [2019-01-01 00:00:00 +0000 UTC] Knative test failed (Job: ci-knative-docs-continuous, PR: 0, BuildLog: https://prow.knative.dev/view/gcs/knative-prow/pr-logs/1153085516762058753)\n" +
 				"2. [2019-01-01 00:00:00 +0000 UTC] Knative test failed (Job: ci-knative-docs-continuous, PR: 0, BuildLog: %zzzzz)\n",
 		},
 	}


### PR DESCRIPTION
In the monitoring email, we are linking to the artifacts URL in GCS as we store that instead of the prow status URL on spyglass. Store the status url instead, so we can link it directly in the alert.

We are still using the GCS path to read the build log and compare with the config to make sure we only alert, when needed. This only affects the db storage and reads. I verified that we are using this value for anything else.

Fixes #1167 