### PR TITLE
Migrate test-infra to use `knative.dev` import path

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -1777,6 +1777,7 @@ presubmits:
     rerun_command: "/test pull-knative-test-infra-build-tests"
     trigger: "(?m)^/test (all|pull-knative-test-infra-build-tests),?(\\s+|$)"
     decorate: true
+    path_alias: knative.dev/test-infra
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1806,6 +1807,7 @@ presubmits:
     rerun_command: "/test pull-knative-test-infra-unit-tests"
     trigger: "(?m)^/test (all|pull-knative-test-infra-unit-tests),?(\\s+|$)"
     decorate: true
+    path_alias: knative.dev/test-infra
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1839,6 +1841,7 @@ presubmits:
     rerun_command: "/test pull-knative-test-infra-integration-tests"
     trigger: "(?m)^/test (all|pull-knative-test-infra-integration-tests),?(\\s+|$)"
     decorate: true
+    path_alias: knative.dev/test-infra
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -4550,6 +4553,7 @@ periodics:
   - org: knative
     repo: test-infra
     base_ref: master
+    path_alias: knative.dev/test-infra
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable

--- a/ci/prow/config_knative.yaml
+++ b/ci/prow/config_knative.yaml
@@ -111,8 +111,11 @@ presubmits:
 
   knative/test-infra:
     - build-tests: true
+      dot-dev: true
     - unit-tests: true
+      dot-dev: true
     - integration-tests: true
+      dot-dev: true
 
   knative/caching:
     - build-tests: true
@@ -267,6 +270,7 @@ periodics:
 
   knative/test-infra:
     - continuous: true
+      dot-dev: true
 
   knative/serving-operator:
     - continuous: true

--- a/hack/update-test-infra.sh
+++ b/hack/update-test-infra.sh
@@ -23,10 +23,10 @@ echo "This script updates the vendored test-infra in all Knative repos,"
 echo "creating commits for each one of them. The PRs must still be created"
 echo "through GitHub UI (just open the link given at the end of the process)."
 echo "This script expects the Knative repositories to be located under"
-echo "\$GOPATH/src/github.com/knative (as instructed by the development docs)."
+echo "\$GOPATH/src/knative.dev (as instructed by the development docs)."
 
 cd ${GOPATH}
-cd src/github.com/knative
+cd src/knative.dev
 
 for repo in *; do
   [[ "${repo}" == "test-infra" ]] && continue
@@ -40,11 +40,11 @@ for repo in *; do
   needs_update=0
   if [[ -f "Gopkg.lock" ]]; then
     needs_update=1
-    dep ensure -update github.com/knative/test-infra
+    dep ensure -update knative.dev knative.dev/test-infra
     ./hack/update-deps.sh
   elif [[ -f "go.mod" ]]; then
     needs_update=1
-    GO111MODULE=on go get -u github.com/knative/test-infra/scripts
+    GO111MODULE=on go get -u knative.dev/test-infra/scripts
     GO111MODULE=on go mod vendor
   fi
   if (( needs_update )); then

--- a/images/clear-test-infra-alerts/Dockerfile
+++ b/images/clear-test-infra-alerts/Dockerfile
@@ -15,7 +15,7 @@
 FROM golang:1.12.5
 RUN apt-get update
 
-ENV TEMP_REPO_DIR /go/src/github.com/knative/test-infra
+ENV TEMP_REPO_DIR /go/src/knative.dev/test-infra
 ENV TOOL_NAME clearalerts
 
 # Temporarily add test-infra to the image to build custom tools

--- a/images/flaky-test-reporter/Dockerfile
+++ b/images/flaky-test-reporter/Dockerfile
@@ -16,7 +16,7 @@ FROM golang:1.10.2
 LABEL maintainer "Chao Dai <chaodai@google.com>"
 RUN apt-get update
 
-ENV TEMP_REPO_DIR /go/src/github.com/knative/test-infra
+ENV TEMP_REPO_DIR /go/src/knative.dev/test-infra
 ENV TOOL_NAME flaky-test-reporter
 
 # Temporarily add test-infra to the image to build custom tools

--- a/images/monitoring/Dockerfile
+++ b/images/monitoring/Dockerfile
@@ -15,7 +15,7 @@
 FROM golang:1.10.2
 RUN apt-get update
 
-ENV TEMP_REPO_DIR /go/src/github.com/knative/test-infra
+ENV TEMP_REPO_DIR /go/src/knative.dev/test-infra
 ENV TOOL_NAME monitoring
 
 # Temporarily add test-infra to the image to build custom tools

--- a/images/prow-auto-bumper/Dockerfile
+++ b/images/prow-auto-bumper/Dockerfile
@@ -16,7 +16,7 @@ FROM golang:1.10.2
 LABEL maintainer "Chao Dai <chaodai@google.com>"
 RUN apt-get update
 
-ENV TEMP_REPO_DIR /go/src/github.com/knative/test-infra
+ENV TEMP_REPO_DIR /go/src/knative.dev/test-infra
 ENV TOOL_NAME prow-auto-bumper
 
 # Temporarily add test-infra to the image to build custom tools

--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -63,7 +63,7 @@ RUN cp /go/src/knative.dev/test-infra/tools/githubhelper/githubhelper .
 
 # Use a local dep-collector that's a wrapper for building the tool
 # on-the-fly.
-# TODO(adrcunha): Remove once https://knative.dev/test-infra/pull/1019 is in all repos.
+# TODO(adrcunha): Remove once https://github.com/knative/test-infra/pull/1019 is in all repos.
 RUN cp /go/src/knative.dev/test-infra/images/prow-tests/dep-collector /usr/bin/dep-collector
 
 # Remove test-infra from the container

--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -55,16 +55,16 @@ RUN gem install mixlib-config -v 2.2.4  # required because ruby is 2.1
 RUN gem install mdl
 
 # Temporarily add test-infra to the image to build custom tools
-ADD . /go/src/github.com/knative/test-infra
+ADD . /go/src/knative.dev/test-infra
 
 # Build custom tools in the container
-RUN make -C /go/src/github.com/knative/test-infra/tools/githubhelper
-RUN cp /go/src/github.com/knative/test-infra/tools/githubhelper/githubhelper .
+RUN make -C /go/src/knative.dev/test-infra/tools/githubhelper
+RUN cp /go/src/knative.dev/test-infra/tools/githubhelper/githubhelper .
 
 # Use a local dep-collector that's a wrapper for building the tool
 # on-the-fly.
-# TODO(adrcunha): Remove once https://github.com/knative/test-infra/pull/1019 is in all repos.
-RUN cp /go/src/github.com/knative/test-infra/images/prow-tests/dep-collector /usr/bin/dep-collector
+# TODO(adrcunha): Remove once https://knative.dev/test-infra/pull/1019 is in all repos.
+RUN cp /go/src/knative.dev/test-infra/images/prow-tests/dep-collector /usr/bin/dep-collector
 
 # Remove test-infra from the container
-RUN rm -fr /go/src/github.com/knative/test-infra
+RUN rm -fr /go/src/knative.dev/test-infra

--- a/images/prow-tests/dep-collector
+++ b/images/prow-tests/dep-collector
@@ -17,10 +17,10 @@
 rm -fr ${GOPATH}/src/github.com/google/licenseclassifier
 rm -fr ${GOPATH}/bin/dep-collector
 go get -u github.com/google/licenseclassifier
-if [[ -d "${GOPATH}/src/github.com/knative/test-infra/tools/dep-collector" ]]; then
-  go install ${GOPATH}/src/github.com/knative/test-infra/tools/dep-collector
+if [[ -d "${GOPATH}/src/knative.dev/test-infra/tools/dep-collector" ]]; then
+  go install ${GOPATH}/src/knative.dev/test-infra/tools/dep-collector
 else
-  go get -u github.com/knative/test-infra/tools/dep-collector
+  go get -u knative.dev/test-infra/tools/dep-collector
 fi
 ${GOPATH}/bin/dep-collector $@
 err=$?

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -81,7 +81,7 @@ skipped.
 ### Sample presubmit test script
 
 ```bash
-source vendor/github.com/knative/test-infra/scripts/presubmit-tests.sh
+source vendor/knative.dev/test-infra/scripts/presubmit-tests.sh
 
 function post_build_tests() {
   echo "Cleaning up after build tests"
@@ -197,7 +197,7 @@ test cluster is created in a specific region, `us-west2`.
 # This test requires a cluster in LA
 E2E_CLUSTER_REGION=us-west2
 
-source vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
+source vendor/knative.dev/test-infra/scripts/e2e-tests.sh
 
 function knative_setup() {
   start_latest_knative_serving
@@ -281,7 +281,7 @@ This is a helper script for Knative release scripts. To use it:
 ### Sample release script
 
 ```bash
-source vendor/github.com/knative/test-infra/scripts/release.sh
+source vendor/knative.dev/test-infra/scripts/release.sh
 
 function build_release() {
   # config/ contains the manifests

--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -417,7 +417,7 @@ function update_licenses() {
   cd ${REPO_ROOT_DIR} || return 1
   local dst=$1
   shift
-  run_go_tool github.com/knative/test-infra/tools/dep-collector dep-collector $@ > ./${dst}
+  run_go_tool knative.dev/test-infra/tools/dep-collector dep-collector $@ > ./${dst}
 }
 
 # Run dep-collector to check for forbidden liceses.
@@ -427,7 +427,7 @@ function check_licenses() {
   rm -fr ${GOPATH}/src/github.com/google/licenseclassifier
   go get -u github.com/google/licenseclassifier
   # Check that we don't have any forbidden licenses in our images.
-  run_go_tool github.com/knative/test-infra/tools/dep-collector dep-collector -check $@
+  run_go_tool knative.dev/test-infra/tools/dep-collector dep-collector -check $@
 }
 
 # Run the given linter on the given files, checking it exists first.

--- a/shared/ghutil/fakeghutil/fakeghutil.go
+++ b/shared/ghutil/fakeghutil/fakeghutil.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 
 	"github.com/google/go-github/github"
-	"github.com/knative/test-infra/shared/ghutil"
+	"knative.dev/test-infra/shared/ghutil"
 )
 
 // FakeGithubClient is a faked client, implements all functions of ghutil.GithubOperations

--- a/shared/loadgenerator/loadgenerator.go
+++ b/shared/loadgenerator/loadgenerator.go
@@ -29,8 +29,8 @@ import (
 
 	"fortio.org/fortio/fhttp"
 	"fortio.org/fortio/periodic"
-	"github.com/knative/test-infra/shared/common"
-	"github.com/knative/test-infra/shared/prow"
+	"knative.dev/test-infra/shared/common"
+	"knative.dev/test-infra/shared/prow"
 )
 
 const (

--- a/shared/loadgenerator/loadgenerator_test.go
+++ b/shared/loadgenerator/loadgenerator_test.go
@@ -20,8 +20,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/knative/test-infra/shared/loadgenerator"
-	"github.com/knative/test-infra/shared/prow"
+	"knative.dev/test-infra/shared/loadgenerator"
+	"knative.dev/test-infra/shared/prow"
 )
 
 func TestSaveJSON(t *testing.T) {

--- a/shared/performance/performance.go
+++ b/shared/performance/performance.go
@@ -19,7 +19,7 @@ package performance
 import (
 	"fmt"
 
-	"github.com/knative/test-infra/shared/junit"
+	"knative.dev/test-infra/shared/junit"
 )
 
 const (

--- a/shared/prometheus/prometheus_test.go
+++ b/shared/prometheus/prometheus_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/knative/test-infra/shared/prometheus"
+	"knative.dev/test-infra/shared/prometheus"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 )

--- a/shared/prow/prow.go
+++ b/shared/prow/prow.go
@@ -30,7 +30,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/knative/test-infra/shared/gcs"
+	"knative.dev/test-infra/shared/gcs"
 )
 
 const (

--- a/shared/testgrid/testgrid.go
+++ b/shared/testgrid/testgrid.go
@@ -24,9 +24,9 @@ import (
 	"os"
 	"path"
 
-	"github.com/knative/test-infra/shared/common"
-	"github.com/knative/test-infra/shared/junit"
-	"github.com/knative/test-infra/shared/prow"
+	"knative.dev/test-infra/shared/common"
+	"knative.dev/test-infra/shared/junit"
+	"knative.dev/test-infra/shared/prow"
 )
 
 const (

--- a/shared/testgrid/testgrid_test.go
+++ b/shared/testgrid/testgrid_test.go
@@ -22,8 +22,8 @@ import (
 	"path"
 	"testing"
 
-	"github.com/knative/test-infra/shared/junit"
-	"github.com/knative/test-infra/shared/prow"
+	"knative.dev/test-infra/shared/junit"
+	"knative.dev/test-infra/shared/prow"
 )
 
 const (

--- a/shared/testgrid/yaml.go
+++ b/shared/testgrid/yaml.go
@@ -21,7 +21,7 @@ import (
 	"io/ioutil"
 	"path"
 
-	"github.com/knative/test-infra/shared/common"
+	"knative.dev/test-infra/shared/common"
 	yaml "gopkg.in/yaml.v2"
 )
 

--- a/test/e2e/load_generator_test.go
+++ b/test/e2e/load_generator_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/knative/test-infra/shared/loadgenerator"
+	"knative.dev/test-infra/shared/loadgenerator"
 )
 
 func loadTest(t *testing.T, factors bool, profiler bool) {

--- a/tools/coverage/artifacts/artsTest/artsTest.go
+++ b/tools/coverage/artifacts/artsTest/artsTest.go
@@ -17,8 +17,8 @@ limitations under the License.
 package artsTest
 
 import (
-	"github.com/knative/test-infra/tools/coverage/artifacts"
-	"github.com/knative/test-infra/tools/coverage/test"
+	"knative.dev/test-infra/tools/coverage/artifacts"
+	"knative.dev/test-infra/tools/coverage/test"
 )
 
 type LocalArtifacts = artifacts.LocalArtifacts

--- a/tools/coverage/artifacts/artsTest/artsTest_test.go
+++ b/tools/coverage/artifacts/artsTest/artsTest_test.go
@@ -19,7 +19,7 @@ package artsTest
 import (
 	"testing"
 
-	"github.com/knative/test-infra/tools/coverage/test"
+	"knative.dev/test-infra/tools/coverage/test"
 )
 
 func TestLocalInputArts(t *testing.T) {

--- a/tools/coverage/artifacts/local.go
+++ b/tools/coverage/artifacts/local.go
@@ -22,7 +22,7 @@ import (
 	"path"
 	"strings"
 
-	"github.com/knative/test-infra/tools/coverage/logUtil"
+	"knative.dev/test-infra/tools/coverage/logUtil"
 )
 
 type LocalArtifacts struct {

--- a/tools/coverage/artifacts/local_test.go
+++ b/tools/coverage/artifacts/local_test.go
@@ -21,8 +21,8 @@ import (
 	"log"
 	"testing"
 
-	"github.com/knative/test-infra/tools/coverage/logUtil"
-	"github.com/knative/test-infra/tools/coverage/test"
+	"knative.dev/test-infra/tools/coverage/logUtil"
+	"knative.dev/test-infra/tools/coverage/test"
 )
 
 // generates coverage profile by running go test on target package
@@ -41,7 +41,7 @@ func TestProfiling(t *testing.T) {
 
 	t.Logf("Verifying profile file...\n")
 	expectedFirstLine := "mode: count"
-	expectedLine := "github.com/knative/test-infra/tools/coverage/testTarget/subPkg1/common.go:19.19,21.2 0 2"
+	expectedLine := "knative.dev/test-infra/tools/coverage/testTarget/subPkg1/common.go:19.19,21.2 0 2"
 
 	scanner := bufio.NewScanner(arts.ProfileReader())
 	scanner.Scan()

--- a/tools/coverage/artifacts/profiling.go
+++ b/tools/coverage/artifacts/profiling.go
@@ -21,7 +21,7 @@ import (
 	"os"
 	"os/exec"
 
-	covIo "github.com/knative/test-infra/tools/coverage/io"
+	covIo "knative.dev/test-infra/tools/coverage/io"
 )
 
 type ProfileReader struct {

--- a/tools/coverage/calc/base.go
+++ b/tools/coverage/calc/base.go
@@ -24,9 +24,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/knative/test-infra/tools/coverage/git"
-	"github.com/knative/test-infra/tools/coverage/githubUtil"
-	"github.com/knative/test-infra/tools/coverage/str"
+	"knative.dev/test-infra/tools/coverage/git"
+	"knative.dev/test-infra/tools/coverage/githubUtil"
+	"knative.dev/test-infra/tools/coverage/str"
 )
 
 type codeBlock struct {

--- a/tools/coverage/calc/base_test.go
+++ b/tools/coverage/calc/base_test.go
@@ -18,7 +18,7 @@ package calc
 import (
 	"testing"
 
-	"github.com/knative/test-infra/tools/coverage/test"
+	"knative.dev/test-infra/tools/coverage/test"
 )
 
 func testCoverage() (c *Coverage) {

--- a/tools/coverage/calc/calc.go
+++ b/tools/coverage/calc/calc.go
@@ -24,7 +24,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/knative/test-infra/tools/coverage/artifacts"
+	"knative.dev/test-infra/tools/coverage/artifacts"
 )
 
 // CovList read profiling information from reader and constructs CoverageList.

--- a/tools/coverage/calc/calcTestExports/covList.go
+++ b/tools/coverage/calc/calcTestExports/covList.go
@@ -17,8 +17,8 @@ limitations under the License.
 package calcTestExports
 
 import (
-	"github.com/knative/test-infra/tools/coverage/artifacts/artsTest"
-	"github.com/knative/test-infra/tools/coverage/calc"
+	"knative.dev/test-infra/tools/coverage/artifacts/artsTest"
+	"knative.dev/test-infra/tools/coverage/calc"
 )
 
 func CovList() *calc.CoverageList {

--- a/tools/coverage/calc/calc_test.go
+++ b/tools/coverage/calc/calc_test.go
@@ -18,8 +18,8 @@ package calc
 import (
 	"testing"
 
-	"github.com/knative/test-infra/tools/coverage/artifacts/artsTest"
-	"github.com/knative/test-infra/tools/coverage/test"
+	"knative.dev/test-infra/tools/coverage/artifacts/artsTest"
+	"knative.dev/test-infra/tools/coverage/test"
 )
 
 func TestReadLocalProfile(t *testing.T) {

--- a/tools/coverage/calc/delta.go
+++ b/tools/coverage/calc/delta.go
@@ -23,8 +23,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/knative/test-infra/tools/coverage/githubUtil"
-	"github.com/knative/test-infra/tools/coverage/str"
+	"knative.dev/test-infra/tools/coverage/githubUtil"
+	"knative.dev/test-infra/tools/coverage/str"
 )
 
 type Incremental struct {

--- a/tools/coverage/calc/group.go
+++ b/tools/coverage/calc/group.go
@@ -22,7 +22,7 @@ import (
 	"path"
 	"strings"
 
-	"github.com/knative/test-infra/tools/coverage/str"
+	"knative.dev/test-infra/tools/coverage/str"
 )
 
 // CoverageList is a collection and summary over multiple file Coverage objects

--- a/tools/coverage/gcs/gcs.go
+++ b/tools/coverage/gcs/gcs.go
@@ -25,8 +25,8 @@ import (
 	"strconv"
 
 	"cloud.google.com/go/storage"
-	"github.com/knative/test-infra/tools/coverage/artifacts"
-	"github.com/knative/test-infra/tools/coverage/logUtil"
+	"knative.dev/test-infra/tools/coverage/artifacts"
+	"knative.dev/test-infra/tools/coverage/logUtil"
 	"google.golang.org/api/iterator"
 )
 

--- a/tools/coverage/gcs/gcsFakes/client.go
+++ b/tools/coverage/gcs/gcsFakes/client.go
@@ -5,8 +5,8 @@ import (
 	"log"
 
 	"cloud.google.com/go/storage"
-	"github.com/knative/test-infra/tools/coverage/artifacts"
-	"github.com/knative/test-infra/tools/coverage/artifacts/artsTest"
+	"knative.dev/test-infra/tools/coverage/artifacts"
+	"knative.dev/test-infra/tools/coverage/artifacts/artsTest"
 )
 
 type fakeStorageClient struct{}

--- a/tools/coverage/gcs/gcsPostsubmit.go
+++ b/tools/coverage/gcs/gcsPostsubmit.go
@@ -22,8 +22,8 @@ import (
 	"sort"
 	"strconv"
 
-	"github.com/knative/test-infra/tools/coverage/artifacts"
-	"github.com/knative/test-infra/tools/coverage/logUtil"
+	"knative.dev/test-infra/tools/coverage/artifacts"
+	"knative.dev/test-infra/tools/coverage/logUtil"
 )
 
 type PostSubmit struct {

--- a/tools/coverage/gcs/gcsPostsubmit_test.go
+++ b/tools/coverage/gcs/gcsPostsubmit_test.go
@@ -21,10 +21,10 @@ import (
 	"log"
 	"testing"
 
-	"github.com/knative/test-infra/tools/coverage/artifacts/artsTest"
-	"github.com/knative/test-infra/tools/coverage/gcs/gcsFakes"
-	"github.com/knative/test-infra/tools/coverage/logUtil"
-	"github.com/knative/test-infra/tools/coverage/test"
+	"knative.dev/test-infra/tools/coverage/artifacts/artsTest"
+	"knative.dev/test-infra/tools/coverage/gcs/gcsFakes"
+	"knative.dev/test-infra/tools/coverage/logUtil"
+	"knative.dev/test-infra/tools/coverage/test"
 )
 
 func testPostSubmit() (p *PostSubmit) {

--- a/tools/coverage/gcs/gcsPresubmit.go
+++ b/tools/coverage/gcs/gcsPresubmit.go
@@ -25,8 +25,8 @@ import (
 	"path"
 	"strconv"
 
-	"github.com/knative/test-infra/tools/coverage/artifacts"
-	"github.com/knative/test-infra/tools/coverage/githubUtil/githubPr"
+	"knative.dev/test-infra/tools/coverage/artifacts"
+	"knative.dev/test-infra/tools/coverage/githubUtil/githubPr"
 )
 
 const (

--- a/tools/coverage/git/git_test.go
+++ b/tools/coverage/git/git_test.go
@@ -21,7 +21,7 @@ import (
 	"path"
 	"testing"
 
-	"github.com/knative/test-infra/tools/coverage/test"
+	"knative.dev/test-infra/tools/coverage/test"
 )
 
 var (

--- a/tools/coverage/githubUtil/githubFakes/fake.go
+++ b/tools/coverage/githubUtil/githubFakes/fake.go
@@ -21,9 +21,9 @@ import (
 	"path"
 
 	"github.com/google/go-github/github"
-	"github.com/knative/test-infra/tools/coverage/githubUtil/githubClient"
-	"github.com/knative/test-infra/tools/coverage/githubUtil/githubPr"
-	"github.com/knative/test-infra/tools/coverage/test"
+	"knative.dev/test-infra/tools/coverage/githubUtil/githubClient"
+	"knative.dev/test-infra/tools/coverage/githubUtil/githubPr"
+	"knative.dev/test-infra/tools/coverage/test"
 )
 
 func FakeGithubClient() *githubClient.GithubClient {

--- a/tools/coverage/githubUtil/githubFiles.go
+++ b/tools/coverage/githubUtil/githubFiles.go
@@ -22,9 +22,9 @@ import (
 	"strings"
 
 	"github.com/google/go-github/github"
-	"github.com/knative/test-infra/tools/coverage/git"
-	"github.com/knative/test-infra/tools/coverage/githubUtil/githubPr"
-	"github.com/knative/test-infra/tools/coverage/logUtil"
+	"knative.dev/test-infra/tools/coverage/git"
+	"knative.dev/test-infra/tools/coverage/githubUtil/githubPr"
+	"knative.dev/test-infra/tools/coverage/logUtil"
 )
 
 // return corresponding source file path of given path (abc_test.go -> abc.go)

--- a/tools/coverage/githubUtil/githubFiles_test.go
+++ b/tools/coverage/githubUtil/githubFiles_test.go
@@ -19,8 +19,8 @@ import (
 	"path"
 	"testing"
 
-	"github.com/knative/test-infra/tools/coverage/githubUtil/githubFakes"
-	"github.com/knative/test-infra/tools/coverage/test"
+	"knative.dev/test-infra/tools/coverage/githubUtil/githubFakes"
+	"knative.dev/test-infra/tools/coverage/test"
 )
 
 func TestGetConcernedFiles(t *testing.T) {

--- a/tools/coverage/githubUtil/githubPr/githubRepo.go
+++ b/tools/coverage/githubUtil/githubPr/githubRepo.go
@@ -23,8 +23,8 @@ import (
 	"strconv"
 
 	"github.com/google/go-github/github"
-	"github.com/knative/test-infra/tools/coverage/githubUtil/githubClient"
-	"github.com/knative/test-infra/tools/coverage/logUtil"
+	"knative.dev/test-infra/tools/coverage/githubUtil/githubClient"
+	"knative.dev/test-infra/tools/coverage/logUtil"
 )
 
 type GithubPr struct {

--- a/tools/coverage/io/io.go
+++ b/tools/coverage/io/io.go
@@ -21,7 +21,7 @@ import (
 	"os"
 	"path"
 
-	"github.com/knative/test-infra/tools/coverage/logUtil"
+	"knative.dev/test-infra/tools/coverage/logUtil"
 )
 
 // CreateMarker produces empty file as marker

--- a/tools/coverage/io/io_test.go
+++ b/tools/coverage/io/io_test.go
@@ -21,7 +21,7 @@ import (
 	"path"
 	"testing"
 
-	"github.com/knative/test-infra/tools/coverage/test"
+	"knative.dev/test-infra/tools/coverage/test"
 )
 
 func TestWriteToArtifacts(t *testing.T) {

--- a/tools/coverage/line/line.go
+++ b/tools/coverage/line/line.go
@@ -21,9 +21,9 @@ import (
 	"log"
 	"os/exec"
 
-	"github.com/knative/test-infra/tools/coverage/artifacts"
-	"github.com/knative/test-infra/tools/coverage/calc"
-	"github.com/knative/test-infra/tools/coverage/gcs"
+	"knative.dev/test-infra/tools/coverage/artifacts"
+	"knative.dev/test-infra/tools/coverage/calc"
+	"knative.dev/test-infra/tools/coverage/gcs"
 )
 
 func CreateLineCovFile(arts *artifacts.LocalArtifacts) error {

--- a/tools/coverage/line/line_test.go
+++ b/tools/coverage/line/line_test.go
@@ -18,8 +18,8 @@ package line
 import (
 	"testing"
 
-	"github.com/knative/test-infra/tools/coverage/artifacts/artsTest"
-	"github.com/knative/test-infra/tools/coverage/test"
+	"knative.dev/test-infra/tools/coverage/artifacts/artsTest"
+	"knative.dev/test-infra/tools/coverage/test"
 )
 
 func TestCreateLineCovFile(t *testing.T) {

--- a/tools/coverage/main.go
+++ b/tools/coverage/main.go
@@ -22,11 +22,11 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/knative/test-infra/tools/coverage/artifacts"
-	"github.com/knative/test-infra/tools/coverage/gcs"
-	"github.com/knative/test-infra/tools/coverage/githubUtil/githubPr"
-	"github.com/knative/test-infra/tools/coverage/logUtil"
-	"github.com/knative/test-infra/tools/coverage/testgrid"
+	"knative.dev/test-infra/tools/coverage/artifacts"
+	"knative.dev/test-infra/tools/coverage/gcs"
+	"knative.dev/test-infra/tools/coverage/githubUtil/githubPr"
+	"knative.dev/test-infra/tools/coverage/logUtil"
+	"knative.dev/test-infra/tools/coverage/testgrid"
 )
 
 const (

--- a/tools/coverage/presubmit.go
+++ b/tools/coverage/presubmit.go
@@ -19,12 +19,12 @@ package main
 import (
 	"log"
 
-	"github.com/knative/test-infra/tools/coverage/artifacts"
-	"github.com/knative/test-infra/tools/coverage/calc"
-	"github.com/knative/test-infra/tools/coverage/gcs"
-	"github.com/knative/test-infra/tools/coverage/githubUtil"
-	"github.com/knative/test-infra/tools/coverage/io"
-	"github.com/knative/test-infra/tools/coverage/line"
+	"knative.dev/test-infra/tools/coverage/artifacts"
+	"knative.dev/test-infra/tools/coverage/calc"
+	"knative.dev/test-infra/tools/coverage/gcs"
+	"knative.dev/test-infra/tools/coverage/githubUtil"
+	"knative.dev/test-infra/tools/coverage/io"
+	"knative.dev/test-infra/tools/coverage/line"
 )
 
 func RunPresubmit(p *gcs.PreSubmit, arts *artifacts.LocalArtifacts) (isCoverageLow bool) {

--- a/tools/coverage/presubmit_test.go
+++ b/tools/coverage/presubmit_test.go
@@ -21,12 +21,12 @@ import (
 	"log"
 	"testing"
 
-	"github.com/knative/test-infra/tools/coverage/artifacts/artsTest"
-	"github.com/knative/test-infra/tools/coverage/gcs"
-	"github.com/knative/test-infra/tools/coverage/gcs/gcsFakes"
-	"github.com/knative/test-infra/tools/coverage/githubUtil/githubFakes"
-	"github.com/knative/test-infra/tools/coverage/githubUtil/githubPr"
-	"github.com/knative/test-infra/tools/coverage/test"
+	"knative.dev/test-infra/tools/coverage/artifacts/artsTest"
+	"knative.dev/test-infra/tools/coverage/gcs"
+	"knative.dev/test-infra/tools/coverage/gcs/gcsFakes"
+	"knative.dev/test-infra/tools/coverage/githubUtil/githubFakes"
+	"knative.dev/test-infra/tools/coverage/githubUtil/githubPr"
+	"knative.dev/test-infra/tools/coverage/test"
 )
 
 const (

--- a/tools/coverage/test/env.go
+++ b/tools/coverage/test/env.go
@@ -20,7 +20,7 @@ import (
 	"path"
 )
 
-const projectPathLessGoPath = "src/github.com/knative/test-infra/tools/coverage"
+const projectPathLessGoPath = "src/knative.dev/test-infra/tools/coverage"
 
 func ProjDir() string {
 	gopath := os.Getenv("GOPATH")

--- a/tools/coverage/testdata/artifacts/cov-profile.txt
+++ b/tools/coverage/testdata/artifacts/cov-profile.txt
@@ -1,12 +1,12 @@
 mode: count
-github.com/knative/test-infra/tools/coverage/testTarget/presubmit/newlyAddedFile.go:3.20,24.2 20 1
-github.com/knative/test-infra/tools/coverage/testTarget/presubmit/newlyAddedFile.go:26.20,35.2 7 0
-github.com/knative/test-infra/tools/coverage/testTarget/presubmit/onlySrcChange.go:5.20,8.2 2 1
-github.com/knative/test-infra/tools/coverage/testTarget/presubmit/onlySrcChange.go:10.20,12.2 1 0
-github.com/knative/test-infra/tools/coverage/testTarget/presubmit/onlyTestChange.go:5.18,8.2 2 1
-github.com/knative/test-infra/tools/coverage/testTarget/presubmit/onlyTestChange.go:10.18,12.2 1 0
-github.com/knative/test-infra/tools/coverage/testTarget/presubmit/common.go:3.19,5.2 0 35
-github.com/knative/test-infra/tools/coverage/testTarget/presubmit/cov-excl.go:3.26,14.2 10 0
-github.com/knative/test-infra/tools/coverage/testTarget/presubmit/cov-excl.go:16.26,21.2 4 1
-github.com/knative/test-infra/tools/coverage/testTarget/presubmit/ling-gen.go:3.26,11.2 7 1
-github.com/knative/test-infra/tools/coverage/testTarget/presubmit/ling-gen.go:13.26,22.2 8 0
+knative.dev/test-infra/tools/coverage/testTarget/presubmit/newlyAddedFile.go:3.20,24.2 20 1
+knative.dev/test-infra/tools/coverage/testTarget/presubmit/newlyAddedFile.go:26.20,35.2 7 0
+knative.dev/test-infra/tools/coverage/testTarget/presubmit/onlySrcChange.go:5.20,8.2 2 1
+knative.dev/test-infra/tools/coverage/testTarget/presubmit/onlySrcChange.go:10.20,12.2 1 0
+knative.dev/test-infra/tools/coverage/testTarget/presubmit/onlyTestChange.go:5.18,8.2 2 1
+knative.dev/test-infra/tools/coverage/testTarget/presubmit/onlyTestChange.go:10.18,12.2 1 0
+knative.dev/test-infra/tools/coverage/testTarget/presubmit/common.go:3.19,5.2 0 35
+knative.dev/test-infra/tools/coverage/testTarget/presubmit/cov-excl.go:3.26,14.2 10 0
+knative.dev/test-infra/tools/coverage/testTarget/presubmit/cov-excl.go:16.26,21.2 4 1
+knative.dev/test-infra/tools/coverage/testTarget/presubmit/ling-gen.go:3.26,11.2 7 1
+knative.dev/test-infra/tools/coverage/testTarget/presubmit/ling-gen.go:13.26,22.2 8 0

--- a/tools/coverage/testdata/artifacts/key-cov-profile.txt
+++ b/tools/coverage/testdata/artifacts/key-cov-profile.txt
@@ -1,8 +1,8 @@
 mode: count
-github.com/knative/test-infra/tools/coverage/testTarget/presubmit/onlySrcChange.go:4.20,7.2 2 1
-github.com/knative/test-infra/tools/coverage/testTarget/presubmit/onlySrcChange.go:9.20,11.2 1 0
-github.com/knative/test-infra/tools/coverage/testTarget/presubmit/onlyTestChange.go:4.18,7.2 2 1
-github.com/knative/test-infra/tools/coverage/testTarget/presubmit/onlyTestChange.go:9.18,11.2 1 0
-github.com/knative/test-infra/tools/coverage/testTarget/presubmit/common.go:3.19,5.2 0 35
-github.com/knative/test-infra/tools/coverage/testTarget/presubmit/newlyAddedFile.go:3.20,24.2 20 1
-github.com/knative/test-infra/tools/coverage/testTarget/presubmit/newlyAddedFile.go:26.20,35.2 7 0
+knative.dev/test-infra/tools/coverage/testTarget/presubmit/onlySrcChange.go:4.20,7.2 2 1
+knative.dev/test-infra/tools/coverage/testTarget/presubmit/onlySrcChange.go:9.20,11.2 1 0
+knative.dev/test-infra/tools/coverage/testTarget/presubmit/onlyTestChange.go:4.18,7.2 2 1
+knative.dev/test-infra/tools/coverage/testTarget/presubmit/onlyTestChange.go:9.18,11.2 1 0
+knative.dev/test-infra/tools/coverage/testTarget/presubmit/common.go:3.19,5.2 0 35
+knative.dev/test-infra/tools/coverage/testTarget/presubmit/newlyAddedFile.go:3.20,24.2 20 1
+knative.dev/test-infra/tools/coverage/testTarget/presubmit/newlyAddedFile.go:26.20,35.2 7 0

--- a/tools/coverage/testdata/artifacts/stdout.txt
+++ b/tools/coverage/testdata/artifacts/stdout.txt
@@ -1,1 +1,1 @@
-ok  	github.com/knative/test-infra/tools/coverage/testTarget/presubmit	0.012s	coverage: 56.5% of statements
+ok  	knative.dev/test-infra/tools/coverage/testTarget/presubmit	0.012s	coverage: 56.5% of statements

--- a/tools/coverage/testgrid/testsuiteXmlWriter.go
+++ b/tools/coverage/testgrid/testsuiteXmlWriter.go
@@ -21,10 +21,10 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/knative/test-infra/shared/junit"
-	"github.com/knative/test-infra/tools/coverage/artifacts"
-	"github.com/knative/test-infra/tools/coverage/calc"
-	"github.com/knative/test-infra/tools/coverage/logUtil"
+	"knative.dev/test-infra/shared/junit"
+	"knative.dev/test-infra/tools/coverage/artifacts"
+	"knative.dev/test-infra/tools/coverage/calc"
+	"knative.dev/test-infra/tools/coverage/logUtil"
 )
 
 // NewTestCase constructs the TestCase struct

--- a/tools/coverage/testgrid/testsuiteXmlWriter_test.go
+++ b/tools/coverage/testgrid/testsuiteXmlWriter_test.go
@@ -18,8 +18,8 @@ package testgrid
 import (
 	"testing"
 
-	"github.com/knative/test-infra/tools/coverage/artifacts/artsTest"
-	"github.com/knative/test-infra/tools/coverage/test"
+	"knative.dev/test-infra/tools/coverage/artifacts/artsTest"
+	"knative.dev/test-infra/tools/coverage/test"
 )
 
 const (

--- a/tools/flaky-test-reporter/github_issue.go
+++ b/tools/flaky-test-reporter/github_issue.go
@@ -27,8 +27,8 @@ import (
 
 	"github.com/google/go-github/github"
 
-	"github.com/knative/test-infra/shared/ghutil"
-	"github.com/knative/test-infra/shared/junit"
+	"knative.dev/test-infra/shared/ghutil"
+	"knative.dev/test-infra/shared/junit"
 )
 
 const (

--- a/tools/flaky-test-reporter/github_issue_test.go
+++ b/tools/flaky-test-reporter/github_issue_test.go
@@ -22,8 +22,8 @@ import (
 	"testing"
 
 	"github.com/google/go-github/github"
-	"github.com/knative/test-infra/shared/ghutil/fakeghutil"
-	"github.com/knative/test-infra/tools/flaky-test-reporter/config"
+	"knative.dev/test-infra/shared/ghutil/fakeghutil"
+	"knative.dev/test-infra/tools/flaky-test-reporter/config"
 )
 
 var testStatsMapForTest = map[string]TestStat{

--- a/tools/flaky-test-reporter/json_reporter.go
+++ b/tools/flaky-test-reporter/json_reporter.go
@@ -21,7 +21,7 @@ import (
 	"log"
 	"sync"
 
-	"github.com/knative/test-infra/tools/flaky-test-reporter/jsonreport"
+	"knative.dev/test-infra/tools/flaky-test-reporter/jsonreport"
 )
 
 // when reporting on all flaky tests in a repo, we want to eliminate the "job" layer, compressing all flaky

--- a/tools/flaky-test-reporter/jsonreport/jsonreport.go
+++ b/tools/flaky-test-reporter/jsonreport/jsonreport.go
@@ -25,8 +25,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/knative/test-infra/shared/common"
-	"github.com/knative/test-infra/shared/prow"
+	"knative.dev/test-infra/shared/common"
+	"knative.dev/test-infra/shared/prow"
 )
 
 const (

--- a/tools/flaky-test-reporter/main.go
+++ b/tools/flaky-test-reporter/main.go
@@ -27,8 +27,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/knative/test-infra/shared/prow"
-	"github.com/knative/test-infra/tools/flaky-test-reporter/config"
+	"knative.dev/test-infra/shared/prow"
+	"knative.dev/test-infra/tools/flaky-test-reporter/config"
 )
 
 func main() {

--- a/tools/flaky-test-reporter/result.go
+++ b/tools/flaky-test-reporter/result.go
@@ -28,10 +28,10 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/knative/test-infra/shared/common"
-	"github.com/knative/test-infra/shared/junit"
-	"github.com/knative/test-infra/shared/prow"
-	"github.com/knative/test-infra/tools/flaky-test-reporter/config"
+	"knative.dev/test-infra/shared/common"
+	"knative.dev/test-infra/shared/junit"
+	"knative.dev/test-infra/shared/prow"
+	"knative.dev/test-infra/tools/flaky-test-reporter/config"
 )
 
 const (

--- a/tools/flaky-test-reporter/slack_notification.go
+++ b/tools/flaky-test-reporter/slack_notification.go
@@ -30,7 +30,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/knative/test-infra/shared/testgrid"
+	"knative.dev/test-infra/shared/testgrid"
 )
 
 const (

--- a/tools/flaky-test-retryer/github_commenter.go
+++ b/tools/flaky-test-retryer/github_commenter.go
@@ -28,7 +28,7 @@ import (
 	"strings"
 
 	"github.com/google/go-github/github"
-	"github.com/knative/test-infra/shared/ghutil"
+	"knative.dev/test-infra/shared/ghutil"
 )
 
 const (

--- a/tools/flaky-test-retryer/github_commenter_test.go
+++ b/tools/flaky-test-retryer/github_commenter_test.go
@@ -22,8 +22,8 @@ import (
 	"testing"
 
 	"github.com/google/go-github/github"
-	"github.com/knative/test-infra/shared/ghutil/fakeghutil"
-	"github.com/knative/test-infra/tools/monitoring/prowapi"
+	"knative.dev/test-infra/shared/ghutil/fakeghutil"
+	"knative.dev/test-infra/tools/monitoring/prowapi"
 )
 
 var (

--- a/tools/flaky-test-retryer/handler.go
+++ b/tools/flaky-test-retryer/handler.go
@@ -25,10 +25,10 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/knative/test-infra/tools/monitoring/subscriber"
+	"knative.dev/test-infra/tools/monitoring/subscriber"
 	// TODO: remove this import once "k8s.io/test-infra" import problems are fixed
 	// https://github.com/test-infra/test-infra/issues/912
-	"github.com/knative/test-infra/tools/monitoring/prowapi"
+	"knative.dev/test-infra/tools/monitoring/prowapi"
 )
 
 // HandlerClient wraps the other clients we need when processing failed jobs.

--- a/tools/flaky-test-retryer/log_parser.go
+++ b/tools/flaky-test-retryer/log_parser.go
@@ -30,7 +30,7 @@ import (
 	"knative.dev/test-infra/tools/flaky-test-reporter/jsonreport"
 
 	// TODO: remove this import once "k8s.io/test-infra" import problems are fixed
-	// https://github.com/test-infra/test-infra/issues/912
+	// https://github.com/knative/test-infra/test-infra/issues/912
 	"knative.dev/test-infra/tools/monitoring/prowapi"
 )
 

--- a/tools/flaky-test-retryer/log_parser.go
+++ b/tools/flaky-test-retryer/log_parser.go
@@ -25,13 +25,13 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/knative/test-infra/shared/junit"
-	"github.com/knative/test-infra/shared/prow"
-	"github.com/knative/test-infra/tools/flaky-test-reporter/jsonreport"
+	"knative.dev/test-infra/shared/junit"
+	"knative.dev/test-infra/shared/prow"
+	"knative.dev/test-infra/tools/flaky-test-reporter/jsonreport"
 
 	// TODO: remove this import once "k8s.io/test-infra" import problems are fixed
 	// https://github.com/test-infra/test-infra/issues/912
-	"github.com/knative/test-infra/tools/monitoring/prowapi"
+	"knative.dev/test-infra/tools/monitoring/prowapi"
 )
 
 // InitLogParser configures jsonreport's dependencies.

--- a/tools/monitoring/alert/alert.go
+++ b/tools/monitoring/alert/alert.go
@@ -20,13 +20,13 @@ import (
 	"context"
 	"log"
 
-	"github.com/knative/test-infra/shared/gcs"
-	"github.com/knative/test-infra/tools/monitoring/config"
-	"github.com/knative/test-infra/tools/monitoring/log_parser"
-	"github.com/knative/test-infra/tools/monitoring/mail"
-	"github.com/knative/test-infra/tools/monitoring/mysql"
-	"github.com/knative/test-infra/tools/monitoring/prowapi"
-	"github.com/knative/test-infra/tools/monitoring/subscriber"
+	"knative.dev/test-infra/shared/gcs"
+	"knative.dev/test-infra/tools/monitoring/config"
+	"knative.dev/test-infra/tools/monitoring/log_parser"
+	"knative.dev/test-infra/tools/monitoring/mail"
+	"knative.dev/test-infra/tools/monitoring/mysql"
+	"knative.dev/test-infra/tools/monitoring/prowapi"
+	"knative.dev/test-infra/tools/monitoring/subscriber"
 )
 
 // Client holds all the resources required to run alerting

--- a/tools/monitoring/alert/report.go
+++ b/tools/monitoring/alert/report.go
@@ -21,8 +21,8 @@ import (
 	"sort"
 	"time"
 
-	"github.com/knative/test-infra/tools/monitoring/config"
-	"github.com/knative/test-infra/tools/monitoring/mysql"
+	"knative.dev/test-infra/tools/monitoring/config"
+	"knative.dev/test-infra/tools/monitoring/mysql"
 )
 
 const emailTemplate = `In the past %v, 

--- a/tools/monitoring/alert/report_test.go
+++ b/tools/monitoring/alert/report_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/knative/test-infra/tools/monitoring/mysql"
+	"knative.dev/test-infra/tools/monitoring/mysql"
 )
 
 func TestSprintLogs(t *testing.T) {

--- a/tools/monitoring/clearalerts/main.go
+++ b/tools/monitoring/clearalerts/main.go
@@ -21,9 +21,9 @@ import (
 	"log"
 	"time"
 
-	"github.com/knative/test-infra/shared/mysql"
-	"github.com/knative/test-infra/tools/monitoring/config"
-	msql "github.com/knative/test-infra/tools/monitoring/mysql"
+	"knative.dev/test-infra/shared/mysql"
+	"knative.dev/test-infra/tools/monitoring/config"
+	msql "knative.dev/test-infra/tools/monitoring/mysql"
 )
 
 func main() {

--- a/tools/monitoring/log_parser/log_parser.go
+++ b/tools/monitoring/log_parser/log_parser.go
@@ -20,8 +20,8 @@ import (
 	"log"
 	"regexp"
 
-	"github.com/knative/test-infra/tools/monitoring/config"
-	"github.com/knative/test-infra/tools/monitoring/mysql"
+	"knative.dev/test-infra/tools/monitoring/config"
+	"knative.dev/test-infra/tools/monitoring/mysql"
 )
 
 // collectMatches collects error messages that matches the patterns from text.

--- a/tools/monitoring/log_parser/log_parser_test.go
+++ b/tools/monitoring/log_parser/log_parser_test.go
@@ -21,7 +21,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/knative/test-infra/tools/monitoring/mysql"
+	"knative.dev/test-infra/tools/monitoring/mysql"
 )
 
 const (

--- a/tools/monitoring/main.go
+++ b/tools/monitoring/main.go
@@ -24,12 +24,12 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/knative/test-infra/shared/gcs"
-	"github.com/knative/test-infra/shared/mysql"
-	"github.com/knative/test-infra/tools/monitoring/alert"
-	"github.com/knative/test-infra/tools/monitoring/mail"
-	msql "github.com/knative/test-infra/tools/monitoring/mysql"
-	"github.com/knative/test-infra/tools/monitoring/subscriber"
+	"knative.dev/test-infra/shared/gcs"
+	"knative.dev/test-infra/shared/mysql"
+	"knative.dev/test-infra/tools/monitoring/alert"
+	"knative.dev/test-infra/tools/monitoring/mail"
+	msql "knative.dev/test-infra/tools/monitoring/mysql"
+	"knative.dev/test-infra/tools/monitoring/subscriber"
 )
 
 var (

--- a/tools/monitoring/mysql/database.go
+++ b/tools/monitoring/mysql/database.go
@@ -22,7 +22,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/knative/test-infra/shared/mysql"
+	"knative.dev/test-infra/shared/mysql"
 )
 
 const alertInsertStmt = `
@@ -35,7 +35,7 @@ type DB struct {
 }
 
 // ErrorLog stores a row in the "ErrorLogs" db table
-// Table schema: github.com/knative/test-infra/tools/monitoring/mysql/schema.sql
+// Table schema: knative.dev/test-infra/tools/monitoring/mysql/schema.sql
 type ErrorLog struct {
 	Pattern     string
 	Msg         string
@@ -46,7 +46,7 @@ type ErrorLog struct {
 }
 
 // Alert maps to the Alerts table
-// Table schema: github.com/knative/test-infra/tools/monitoring/mysql/schema.sql
+// Table schema: knative.dev/test-infra/tools/monitoring/mysql/schema.sql
 type Alert struct {
 	ErrorPattern string
 	Sent         time.Time

--- a/tools/monitoring/subscriber/subscriber.go
+++ b/tools/monitoring/subscriber/subscriber.go
@@ -22,7 +22,7 @@ import (
 	"log"
 
 	"cloud.google.com/go/pubsub"
-	"github.com/knative/test-infra/tools/monitoring/prowapi"
+	"knative.dev/test-infra/tools/monitoring/prowapi"
 )
 
 // Client is a wrapper on the subscriber Operation

--- a/tools/monitoring/subscriber/subscriber_test.go
+++ b/tools/monitoring/subscriber/subscriber_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 
 	"cloud.google.com/go/pubsub"
-	"github.com/knative/test-infra/tools/monitoring/prowapi"
+	"knative.dev/test-infra/tools/monitoring/prowapi"
 )
 
 type contextKey int

--- a/tools/prow-auto-bumper/config.go
+++ b/tools/prow-auto-bumper/config.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	"github.com/google/go-github/github"
-	"github.com/knative/test-infra/shared/ghutil"
+	"knative.dev/test-infra/shared/ghutil"
 )
 
 const (

--- a/tools/prow-auto-bumper/file.go
+++ b/tools/prow-auto-bumper/file.go
@@ -26,7 +26,7 @@ import (
 	"path/filepath"
 	"regexp"
 
-	"github.com/knative/test-infra/shared/common"
+	"knative.dev/test-infra/shared/common"
 )
 
 // Update all tags in a byte slice

--- a/tools/prow-auto-bumper/getversion_test.go
+++ b/tools/prow-auto-bumper/getversion_test.go
@@ -26,8 +26,8 @@ import (
 	"time"
 
 	"github.com/google/go-github/github"
-	"github.com/knative/test-infra/shared/ghutil"
-	"github.com/knative/test-infra/shared/ghutil/fakeghutil"
+	"knative.dev/test-infra/shared/ghutil"
+	"knative.dev/test-infra/shared/ghutil/fakeghutil"
 )
 
 func getFakeGitInfo() gitInfo {

--- a/tools/prow-auto-bumper/main.go
+++ b/tools/prow-auto-bumper/main.go
@@ -23,7 +23,7 @@ import (
 	"flag"
 	"log"
 
-	"github.com/knative/test-infra/shared/ghutil"
+	"knative.dev/test-infra/shared/ghutil"
 )
 
 func main() {

--- a/tools/prow-auto-bumper/parser.go
+++ b/tools/prow-auto-bumper/parser.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/knative/test-infra/shared/ghutil"
+	"knative.dev/test-infra/shared/ghutil"
 )
 
 // Tags could be in the form of: v[YYYYMMDD]-[GIT_HASH](-[VARIANT_PART]),

--- a/tools/prow-auto-bumper/pullrequest.go
+++ b/tools/prow-auto-bumper/pullrequest.go
@@ -28,7 +28,7 @@ import (
 	"strings"
 
 	"github.com/google/go-github/github"
-	"github.com/knative/test-infra/shared/ghutil"
+	"knative.dev/test-infra/shared/ghutil"
 )
 
 func call(cmd string, args ...string) error {

--- a/tools/webhook-apicoverage/resourcetree/resourceforest.go
+++ b/tools/webhook-apicoverage/resourcetree/resourceforest.go
@@ -20,7 +20,7 @@ import (
 	"container/list"
 	"reflect"
 
-	"github.com/knative/test-infra/tools/webhook-apicoverage/coveragecalculator"
+	"knative.dev/test-infra/tools/webhook-apicoverage/coveragecalculator"
 )
 
 // ResourceForest represents the top-level forest that contains individual resource trees for top-level resource types and all connected nodes across resource trees.

--- a/tools/webhook-apicoverage/resourcetree/resourcetree.go
+++ b/tools/webhook-apicoverage/resourcetree/resourcetree.go
@@ -20,7 +20,7 @@ import (
 	"container/list"
 	"reflect"
 
-	"github.com/knative/test-infra/tools/webhook-apicoverage/coveragecalculator"
+	"knative.dev/test-infra/tools/webhook-apicoverage/coveragecalculator"
 )
 
 // ResourceTree encapsulates a tree corresponding to a resource type.

--- a/tools/webhook-apicoverage/tools/tools.go
+++ b/tools/webhook-apicoverage/tools/tools.go
@@ -26,9 +26,9 @@ import (
 	"path"
 	"strings"
 
-	"github.com/knative/test-infra/tools/webhook-apicoverage/coveragecalculator"
-	"github.com/knative/test-infra/tools/webhook-apicoverage/view"
-	"github.com/knative/test-infra/tools/webhook-apicoverage/webhook"
+	"knative.dev/test-infra/tools/webhook-apicoverage/coveragecalculator"
+	"knative.dev/test-infra/tools/webhook-apicoverage/view"
+	"knative.dev/test-infra/tools/webhook-apicoverage/webhook"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"

--- a/tools/webhook-apicoverage/view/html_display.go
+++ b/tools/webhook-apicoverage/view/html_display.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/knative/test-infra/tools/webhook-apicoverage/coveragecalculator"
+	"knative.dev/test-infra/tools/webhook-apicoverage/coveragecalculator"
 )
 
 // HTMLHeader sets up an HTML page with the right style format

--- a/tools/webhook-apicoverage/view/rule.go
+++ b/tools/webhook-apicoverage/view/rule.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package view
 
-import "github.com/knative/test-infra/tools/webhook-apicoverage/coveragecalculator"
+import "knative.dev/test-infra/tools/webhook-apicoverage/coveragecalculator"
 
 // DisplayRules provides a mechanism for repos to define their own display rules.
 // DisplayHelper methods can use these rules to define how to display results.

--- a/tools/webhook-apicoverage/webhook/apicoverage_recorder.go
+++ b/tools/webhook-apicoverage/webhook/apicoverage_recorder.go
@@ -25,9 +25,9 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/knative/test-infra/tools/webhook-apicoverage/coveragecalculator"
-	"github.com/knative/test-infra/tools/webhook-apicoverage/resourcetree"
-	"github.com/knative/test-infra/tools/webhook-apicoverage/view"
+	"knative.dev/test-infra/tools/webhook-apicoverage/coveragecalculator"
+	"knative.dev/test-infra/tools/webhook-apicoverage/resourcetree"
+	"knative.dev/test-infra/tools/webhook-apicoverage/view"
 	"go.uber.org/zap"
 	"k8s.io/api/admission/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"


### PR DESCRIPTION
This is a BREAKING change for all contributors

After this has merged, the following changes are needed:
Move or recreate your knative/test-infra directory to ${GOPATH}/src/knative.dev/test-infra
Run the following sed command on any outstanding changes:
```
sed -i 's@github.com/knative/test-infra@knative.dev/test-infra@g' $(find -name '*.go' | xargs grep github.com/knative/test-infra | cut -d':' -f 1 | uniq)
```
This PR contains job changes that break any other PR before this PR merges once applied
/hold
Will merge it when quieter