### PR TITLE
Escape `<` and `>` in custom junit results

### DIFF
--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -320,7 +320,10 @@ function create_junit_xml() {
   local failure=""
   if [[ "$3" != "" ]]; then
     # Transform newlines into HTML code.
-    local msg="$(echo -n "$3" | sed 's/$/\&#xA;/g' | tr -d '\n')"
+    # Also escape `<` and `>` as here: https://github.com/golang/go/blob/50bd1c4d4eb4fac8ddeb5f063c099daccfb71b26/src/encoding/json/encode.go#L48, 
+    # this is temporary solution for fixing https://github.com/knative/test-infra/issues/1204,
+    # which should be obsolete once Test-infra 2.0 is in place
+    local msg="$(echo -n "$3" | sed 's/$/\&#xA;/g' | sed 's/</\\u003c/' | sed 's/>/\\u003e/' | tr -d '\n')"
     failure="<failure message=\"Failed\" type=\"\">${msg}</failure>"
   fi
   cat << EOF > "${xml}"


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**: fixes junit results parsing error in flaky test reporter, which was caused by `<autogenerated>` string in failure message.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #1204 

**Special notes to reviewers**:

**User-visible changes in this PR**:

/cc @adrcunha 
