### PR TITLE
Avoid runtime error when Flaky test reporter failed collecting result for one job

### DIFF
--- a/tools/flaky-test-reporter/main.go
+++ b/tools/flaky-test-reporter/main.go
@@ -78,6 +78,7 @@ func main() {
 			err = fmt.Errorf("WARNING: error collecting results for job '%s' in repo '%s': %v", jc.Name, jc.Repo, err)
 			log.Printf("%v", err)
 			jobErrs = append(jobErrs, err)
+			continue
 		}
 		if nil == rd.LastBuildStartTime {
 			log.Printf("WARNING: no build found, skipping '%s' in repo '%s'", jc.Name, jc.Repo)


### PR DESCRIPTION
Currently Flaky test reporter crashes due to runtime error when it failed collecting result for one job, at this line: https://github.com/knative/test-infra/blob/4f9e566a06beae2a61a1248a04159068899ad20a/tools/flaky-test-reporter/main.go#L82

This is not desired behavior, fixed by this PR