### PR TITLE
Format markdown

### DIFF
--- a/ci/prow_setup.md
+++ b/ci/prow_setup.md
@@ -6,9 +6,10 @@
    need to update [Makefile](./prow/Makefile). For details, see
    <https://github.com/kubernetes/test-infra/blob/master/prow/getting_started_deploy.md>.
 
-   **Note**: It's not advisable to turn on auto-scaling for the Prow cluster, as it can
-   cause temporary DNS errors when test jobs are scheduled to nodes that are not fully
-   initialized yet; for details see https://github.com/knative/test-infra/issues/1082.
+   **Note**: It's not advisable to turn on auto-scaling for the Prow cluster, as
+   it can cause temporary DNS errors when test jobs are scheduled to nodes that
+   are not fully initialized yet; for details see
+   https://github.com/knative/test-infra/issues/1082.
 
 1. Ensure the GCP projects listed in
    [resources.yaml](./prow/boskos/resources.yaml) are created.

--- a/tools/coverage/README.md
+++ b/tools/coverage/README.md
@@ -2,8 +2,13 @@
 
 The code coverage tool has two major features:
 
-1. As a pre-submit tool, it runs code coverage on every single commit to Github and reports coverage changes back to the PR as a comment by a robot account. If made a required job on the repository, it can be used to block a PR from merging if coverage falls below a certain threshold.
-1. As a periodic running job, it outputs a Junit XML that can be read from other tools like [TestGrid](http://testgrid.knative.dev/serving#coverage) to get overall coverage metrics.
+1. As a pre-submit tool, it runs code coverage on every single commit to Github
+   and reports coverage changes back to the PR as a comment by a robot account.
+   If made a required job on the repository, it can be used to block a PR from
+   merging if coverage falls below a certain threshold.
+1. As a periodic running job, it outputs a Junit XML that can be read from other
+   tools like [TestGrid](http://testgrid.knative.dev/serving#coverage) to get
+   overall coverage metrics.
 
 ## Design
 
@@ -11,12 +16,17 @@ See the [design document](design.md).
 
 ## Build and Release
 
-Run `make coverage-dev-image` to build and upload a staging version, intended for testing and debugging. The staging version can be triggered on a PR through the comment
-`/test pull-knative-serving-go-coverage-dev`. Note that staging version can only be tested against the serving repository because the staging jobs only exist in the serving repository.
+Run `make coverage-dev-image` to build and upload a staging version, intended
+for testing and debugging. The staging version can be triggered on a PR through
+the comment `/test pull-knative-serving-go-coverage-dev`. Note that staging
+version can only be tested against the serving repository because the staging
+jobs only exist in the serving repository.
 
 ### Validating the staging version
 
-- To run the pre-submit workflow, add the comment `/test pull-knative-serving-go-coverage-dev` to a PR.
-- To run the periodic workflow, (re)run a `post-knative-serving-go-coverage-dev` job.
+- To run the pre-submit workflow, add the comment
+  `/test pull-knative-serving-go-coverage-dev` to a PR.
+- To run the periodic workflow, (re)run a `post-knative-serving-go-coverage-dev`
+  job.
 
 To publish a new version of the code coverage tool, run `make coverage-image`.

--- a/tools/coverage/design.md
+++ b/tools/coverage/design.md
@@ -2,11 +2,15 @@
 
 ![design.svg](design.svg)
 
-We pack the test coverage tool in a container, that is triggered by Prow. It generates a test coverage profiling for the target repository. Afterward, it calculates the coverage change or summarizes the coverage data, depending on the workflow type, explained below.  
+We pack the test coverage tool in a container, that is triggered by Prow. It
+generates a test coverage profiling for the target repository. Afterward, it
+calculates the coverage change or summarizes the coverage data, depending on the
+workflow type, explained below.
 
 ## Post-submit workflow
 
-Produces and stores a coverage profile for the master branch, for later presubmit jobs to compare against.
+Produces and stores a coverage profile for the master branch, for later
+presubmit jobs to compare against.
 
 1. A PR is merged.
 1. Post-submit Prow job started.
@@ -15,21 +19,28 @@ Produces and stores a coverage profile for the master branch, for later presubmi
 ## Pre-submit workflow
 
 The pre-submit workflow is triggered when a pull request is created or updated.
-It runs the code coverage tool to report coverage changes through a comment by a robot GitHub account.
+It runs the code coverage tool to report coverage changes through a comment by a
+robot GitHub account.
 
 1. Developer submits a new commit to an open PR on GitHub.
 1. Matching pre-submit Prow job is started.
 1. Test coverage profile generated.
-1. Calculate coverage change against master branch. Compare the coverage file generated in this cycle against the coverage file in the master branch.
-1. Using the PR data from GitHub, `.gitattributes` file, as well as coverage change data calculated above, produce a list of files that we care about in the line-by-line coverage report. Produce line by line coverage HTML files and add links to them in the PR coverage report.
-1. The robot account posts the code coverage report on GitHub, as a comment in the PR.
+1. Calculate coverage change against master branch. Compare the coverage file
+   generated in this cycle against the coverage file in the master branch.
+1. Using the PR data from GitHub, `.gitattributes` file, as well as coverage
+   change data calculated above, produce a list of files that we care about in
+   the line-by-line coverage report. Produce line by line coverage HTML files
+   and add links to them in the PR coverage report.
+1. The robot account posts the code coverage report on GitHub, as a comment in
+   the PR.
 
 ## Periodic workflow
 
 Produces periodic code coverage results as input for TestGrid.
 
-1. Periodic Prow job starts.
-The frequency and start time can be configured in [the config file](../../ci/prow/testgrid_config.go)
+1. Periodic Prow job starts. The frequency and start time can be configured in
+   [the config file](../../ci/prow/testgrid_config.go)
 1. Test coverage profile and metadata generated.
 1. Generate and store per-file coverage data.
-  - Stores in the XML format that is used by TestGrid.
+
+- Stores in the XML format that is used by TestGrid.


### PR DESCRIPTION
Produced via:
  `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`
/assign @adrcunha
