### PR TITLE
make the subscriber client reusable

### DIFF
--- a/tools/flaky-test-retryer/handler.go
+++ b/tools/flaky-test-retryer/handler.go
@@ -46,7 +46,7 @@ func NewHandlerClient(githubAccount string, dryrun bool) (*HandlerClient, error)
 	if err != nil {
 		return nil, fmt.Errorf("Github client: %v", err)
 	}
-	pubsubClient, err := subscriber.NewSubscriberClient(ctx, projectName, pubsubTopic)
+	pubsubClient, err := subscriber.NewSubscriberClient(pubsubTopic)
 	if err != nil {
 		return nil, fmt.Errorf("Pubsub client: %v", err)
 	}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Reusing the pubsub client as needed. 

From [pubsub doc](https://godoc.org/cloud.google.com/go/pubsub#Client): 
```
// Client is a Google Pub/Sub client scoped to a single project.
//
// Clients should be reused rather than being created as needed.
// A Client may be shared by multiple goroutines.
```

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #

**Special notes to reviewers**:

**User-visible changes in this PR**:

