### PR TITLE
readonly and export E2E_PROJECT_ID in separate lines

### DIFF
--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -310,7 +310,8 @@ function setup_test_cluster() {
   # Set the actual project the test cluster resides in
   # It will be a project assigned by Boskos if test is running on Prow,
   # otherwise will be ${GCP_PROJECT} set up by user.
-  readonly export E2E_PROJECT_ID="$(gcloud config get-value project)"
+  export E2E_PROJECT_ID="$(gcloud config get-value project)"
+  readonly E2E_PROJECT_ID
 
   # Save some metadata about cluster creation for using in prow and testgrid
   save_metadata


### PR DESCRIPTION
It looks like `readonly export FOO=BAR` is equivalent to `readonly FOO=BAR`, and the `export` is not respected. Separate them so that `E2E_PROJECT_ID` is exported.

This is where the problem was discovered:
https://prow.knative.dev/view/gcs/knative-prow/pr-logs/pull/GoogleCloudPlatform_cloud-run-events/137/pull-googlecloudplatform-cloud-run-events-integration-tests/1158416917162102784
From this PR: 
https://github.com/GoogleCloudPlatform/cloud-run-events/pull/137

/cc @adrcunha 
FYI @n3wscott 