### PR TITLE
Update all Boskos related images base paths

### DIFF
--- a/ci/prow/boskos/deployments/janitor.yaml
+++ b/ci/prow/boskos/deployments/janitor.yaml
@@ -31,7 +31,7 @@ spec:
       terminationGracePeriodSeconds: 300
       containers:
       - name: boskos-janitor
-        image: gcr.io/k8s-testimages/janitor:v20190621-ff01381
+        image: gcr.io/k8s-prow/boskos/janitor:v20190723-99235c860
         args:
         - --resource-type=gke-project
         - --

--- a/ci/prow/boskos/deployments/metrics.yaml
+++ b/ci/prow/boskos/deployments/metrics.yaml
@@ -32,7 +32,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: metrics
-        image: gcr.io/k8s-testimages/metrics:v20190621-ff01381
+        image: gcr.io/k8s-prow/boskos/metrics:v20190723-99235c860
         args:
         - --resource-type=gke-project
         ports:

--- a/ci/prow/boskos/deployments/reaper.yaml
+++ b/ci/prow/boskos/deployments/reaper.yaml
@@ -31,6 +31,6 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: boskos-reaper
-        image: gcr.io/k8s-testimages/reaper:v20190621-ff01381
+        image: gcr.io/k8s-prow/boskos/reaper:v20190723-99235c860
         args:
         - --resource-type=gke-project

--- a/ci/prow/boskos/deployments/statefulset.yaml
+++ b/ci/prow/boskos/deployments/statefulset.yaml
@@ -31,7 +31,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: boskos
-        image: gcr.io/k8s-testimages/boskos:v20190621-ff01381
+        image: gcr.io/k8s-prow/boskos/boskos:v20190723-99235c860
         args:
         - --storage=/store/boskos.json
         - --config=/etc/config/config


### PR DESCRIPTION
k8s/test-infra had moved all Boskos related images from `gcr.io/k8s/testimages` to be under `gcr.io/k8s-prow/boskos`, update all images paths to the new ones as in this PR:
https://github.com/kubernetes/test-infra/pull/13559