### PR TITLE
use ID instead of login for flaky-test-retryer

### DIFF
--- a/tools/flaky-test-retryer/github_commenter.go
+++ b/tools/flaky-test-retryer/github_commenter.go
@@ -45,7 +45,7 @@ var (
 // GithubClient wraps the ghutil Github client
 type GithubClient struct {
 	ghutil.GithubOperations
-	Login  string
+	ID     int64
 	Dryrun bool
 }
 
@@ -59,7 +59,7 @@ func NewGithubClient(githubAccount string, dryrun bool) (*GithubClient, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &GithubClient{ghc, *user.Login, dryrun}, nil
+	return &GithubClient{ghc, user.GetID(), dryrun}, nil
 }
 
 // PostComment posts a new comment on the PR specified in JobData, retrying the job that triggered it.
@@ -104,7 +104,7 @@ func (gc *GithubClient) getOldComment(org, repo string, pull int) (*github.Issue
 		if err != nil {
 			return nil, err
 		}
-		if found && *comment.GetUser().Login == gc.Login {
+		if found && *comment.GetUser().ID == gc.ID {
 			if match == nil {
 				match = comment
 			} else {

--- a/tools/flaky-test-retryer/github_commenter_test.go
+++ b/tools/flaky-test-retryer/github_commenter_test.go
@@ -118,7 +118,7 @@ func getFakeGithubClient() *GithubClient {
 	gc.User = fakeUser
 	return &GithubClient{
 		gc,
-		*gc.User.Login,
+		*gc.User.ID,
 		false,
 	}
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
identify previous comments by user ID rather than login, so we can handle updates to the bot's display name and login info. Tested locally.
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #

**Special notes to reviewers**:

**User-visible changes in this PR**:

