### PR TITLE
flaky test retryer uses verioned tag instead of latest

### DIFF
--- a/tools/flaky-test-retryer/gke_deployment/retryer_service.yaml
+++ b/tools/flaky-test-retryer/gke_deployment/retryer_service.yaml
@@ -37,7 +37,7 @@ spec:
     spec:
       containers:
       - name: flaky-test-retry-bot
-        image: gcr.io/knative-tests/test-infra/flaky-test-retryer:latest
+        image: gcr.io/knative-tests/test-infra/flaky-test-retryer:v20190806-3ca0bfa
         imagePullPolicy: Always
         command: ["/flaky-test-retryer"]
         args:


### PR DESCRIPTION
See best practice here: https://kubernetes.io/docs/concepts/configuration/overview/#container-images