### PR TITLE
[coverage] add additional health check for a post-submit build

### DIFF
--- a/tools/coverage/gcs/gcsPostsubmit.go
+++ b/tools/coverage/gcs/gcsPostsubmit.go
@@ -95,7 +95,8 @@ func (p *PostSubmit) dirOfCompletionMarker(build int) (result string) {
 
 func (p *PostSubmit) isBuildHealthy(build int) bool {
 	return p.StorageClient.DoesObjectExist(p.Ctx, p.Bucket,
-		p.dirOfCompletionMarker(build))
+		p.dirOfCompletionMarker(build)) &&
+		p.StorageClient.DoesObjectExist(p.Ctx, p.Bucket, path.Join(p.dirOfArtifacts(build), p.covProfileName))
 }
 
 func (p *PostSubmit) pathToGoodCoverageArtifacts() (result string) {


### PR DESCRIPTION
Each pre-submit coverage job looks for coverage profile for the latest healthy master build. We add the check of profile existence to the health check so that master build without a coverage profile will be ignored.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #1242

**Special notes to reviewers**:

**User-visible changes in this PR**:

