### PR TITLE
Restrict issue tracker bot to only test-infra

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -5528,6 +5528,7 @@ periodics:
       args:
       - "|-
         --query=org:knative
+        repo:test-infra
         -label:lifecycle/frozen
         -label:lifecycle/stale
         -label:lifecycle/rotten"
@@ -5567,6 +5568,7 @@ periodics:
       args:
       - "|-
         --query=org:knative
+        repo:test-infra
         -label:lifecycle/frozen
         label:lifecycle/stale
         -label:lifecycle/rotten"
@@ -5606,6 +5608,7 @@ periodics:
       args:
       - "|-
         --query=org:knative
+        repo:test-infra
         -label:lifecycle/frozen
         label:lifecycle/rotten"
       - "--updated=720h"

--- a/ci/prow/periodic_config.go
+++ b/ci/prow/periodic_config.go
@@ -382,9 +382,11 @@ func generateIssueTrackerPeriodicJob(jobName, labelFilter, updatedTime, comment 
 	data.CronString = issueTrackerPeriodicJobCron
 	data.Base.Command = "/app/robots/commenter/app.binary"
 
+	// TODO(Fredy-Z): remove "repo:test-infra" after syncing up with the WGs.
 	data.Base.Args = []string{
 		`|-
         --query=org:knative
+        repo:test-infra
         ` + labelFilter,
 		"--updated=" + updatedTime,
 		"--token=/etc/housekeeping-github-token/token",


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Restrict the issue tracker bot to only test-infra before we sync up with the WGs.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @adrcunha 