### PR TITLE
flaky test retryer: add Spyglass links, update grammar

### DIFF
--- a/tools/flaky-test-retryer/github_commenter.go
+++ b/tools/flaky-test-retryer/github_commenter.go
@@ -173,17 +173,17 @@ func buildNewComment(jd *JobData, entries map[string]*entry, outliers []string) 
 	}
 	sort.Strings(keys)
 	for _, test := range keys {
-		entryString = append(entryString, fmt.Sprintf("%s | %s | %d/%d", test, buildLinks(entries[test].oldLinks, jd.URL), entries[test].retries, maxRetries))
+		entryString = append(entryString, fmt.Sprintf("%s | %s | %d/%d", test, buildLinks(entries[test].oldLinks, jd.URL, jd.RunID), entries[test].retries, maxRetries))
 	}
 	return fmt.Sprintf(commentTemplate, identifier, strings.Join(entryString, "\n"), cmd)
 }
 
 // buildLinks constructs a Markdown-formatted list of URLs
-func buildLinks(oldLinks string, newLink string) string {
+func buildLinks(oldLinks, newLink, id string) string {
 	if oldLinks == "" {
-		return fmt.Sprintf("[link](%s)", newLink)
+		return fmt.Sprintf("[%s](%s)", id, newLink)
 	}
-	return fmt.Sprintf("%s<br>[link](%s)", oldLinks, newLink)
+	return fmt.Sprintf("%s<br>[%s](%s)", oldLinks, id, newLink)
 }
 
 // buildRetryString increments the retry counter and generates a /test string if we have

--- a/tools/flaky-test-retryer/github_commenter.go
+++ b/tools/flaky-test-retryer/github_commenter.go
@@ -134,9 +134,10 @@ func parseEntries(comment *github.IssueComment) (map[string]*entry, error) {
 		fields := strings.Split(string(e), " | ")
 		// support old comments with 2 columns, before links were added
 		var links string
-		if len(fields) == 2 {
-			links = ""
-		} else {
+		if len(fields) < 2 || len(fields) > 3 {
+			return nil, fmt.Errorf("invalid number of table entries")
+		}
+		if len(fields) != 2 {
 			links = fields[1]
 		}
 		retry, err := strconv.Atoi(strings.Split(fields[len(fields)-1], "/")[0])

--- a/tools/flaky-test-retryer/github_commenter.go
+++ b/tools/flaky-test-retryer/github_commenter.go
@@ -37,8 +37,6 @@ const (
 )
 
 var (
-	gcsPrefix       = "gs://"
-	spyglassPrefix  = "https://prow.knative.dev/view/gcs/"
 	identifier      = "<!--AUTOMATED-FLAKY-RETRYER-->"
 	commentTemplate = "%s\nThe following jobs failed due to test flakiness:\n\nTest name | Triggers | Retries\n--- | --- | ---\n%s\n\n%s"
 )

--- a/tools/flaky-test-retryer/github_commenter_test.go
+++ b/tools/flaky-test-retryer/github_commenter_test.go
@@ -33,7 +33,7 @@ The following jobs failed due to test flakiness:
 Test name | Triggers | Retries
 --- | --- | ---
 fakejob0 |  | 0/3
-fakejob1 | [link]() | 1/3
+fakejob1 | []() | 1/3
 
 Automatically retrying...
 /test fakejob1`
@@ -42,8 +42,8 @@ The following jobs failed due to test flakiness:
 
 Test name | Triggers | Retries
 --- | --- | ---
-fakejob0 | [link]() | 1/3
-fakejob1 | [link]() | 1/3
+fakejob0 | []() | 1/3
+fakejob1 | []() | 1/3
 
 Automatically retrying...
 /test fakejob0`
@@ -52,8 +52,8 @@ The following jobs failed due to test flakiness:
 
 Test name | Triggers | Retries
 --- | --- | ---
-fakejob0 | [link]()<br>[link]()<br>[link]()<br>[link]() | 3/3
-fakejob1 | [link]() | 1/3
+fakejob0 | []()<br>[]()<br>[]()<br>[]() | 3/3
+fakejob1 | []() | 1/3
 
 Job fakejob0 expended all 3 retries without success.`
 	failedShortCommentBody = `<!--AUTOMATED-FLAKY-RETRYER-->
@@ -61,8 +61,8 @@ The following jobs failed due to test flakiness:
 
 Test name | Triggers | Retries
 --- | --- | ---
-fakejob0 | [link]() | 0/3
-fakejob1 | [link]() | 1/3
+fakejob0 | []() | 0/3
+fakejob1 | []() | 1/3
 
 Failed non-flaky tests preventing automatic retry of fakejob0:
 
@@ -72,8 +72,8 @@ The following jobs failed due to test flakiness:
 
 Test name | Triggers | Retries
 --- | --- | ---
-fakejob0 | [link]() | 0/3
-fakejob1 | [link]() | 1/3
+fakejob0 | []() | 0/3
+fakejob1 | []() | 1/3
 
 Failed non-flaky tests preventing automatic retry of fakejob0:
 
@@ -166,7 +166,7 @@ func TestParseEntries(t *testing.T) {
 		input *github.IssueComment
 		want  map[string]*entry
 	}{
-		{fakeOldComment, map[string]*entry{"fakejob0": &entry{"", 0}, "fakejob1": &entry{"[link]()", 1}}},
+		{fakeOldComment, map[string]*entry{"fakejob0": &entry{"", 0}, "fakejob1": &entry{"[]()", 1}}},
 	}
 	for _, data := range cases {
 		actual, _ := parseEntries(data.input)
@@ -184,7 +184,7 @@ func TestBuildNewComment(t *testing.T) {
 		wantBody string
 	}{
 		{&fakeJob, map[string]*entry{"fakejob0": &entry{"", 0}, "fakejob1": &entry{"", 1}}, nil, retryCommentBody},
-		{&fakeJob, map[string]*entry{"fakejob0": &entry{"[link]()<br>[link]()<br>[link]()", 3}, "fakejob1": &entry{"", 1}}, nil, noMoreRetriesCommentBody},
+		{&fakeJob, map[string]*entry{"fakejob0": &entry{"[]()<br>[]()<br>[]()", 3}, "fakejob1": &entry{"", 1}}, nil, noMoreRetriesCommentBody},
 		{&fakeJob, map[string]*entry{"fakejob0": &entry{"", 0}, "fakejob1": &entry{"", 1}}, fakeFailedTests[:4], failedShortCommentBody},
 		{&fakeJob, map[string]*entry{"fakejob0": &entry{"", 0}, "fakejob1": &entry{"", 1}}, fakeFailedTests, failedLongCommentBody},
 	}

--- a/tools/flaky-test-retryer/log_parser.go
+++ b/tools/flaky-test-retryer/log_parser.go
@@ -68,7 +68,7 @@ func (jd *JobData) IsSupported() bool {
 	}
 	// check repo
 	if len(jd.Refs) == 0 {
-		log.Printf("%s: mesasge does not contain any repository references\n", prefix)
+		log.Printf("%s: message does not contain any repository references\n", prefix)
 		return false
 	}
 	repos, err := jd.getReportRepos()


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Some of the wording in the first deployment didn't really make sense, and now the table of retries shows a history of the builds that triggered it. [Example](https://github.com/TrevorFarrelly/test-infra/pull/2)

also fixed a typo in a log message
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #1249 

**Special notes to reviewers**:

**User-visible changes in this PR**:

