### PR TITLE
Enable project plugin for eventing and eventing-contrib

### DIFF
--- a/ci/prow/plugins.yaml
+++ b/ci/prow/plugins.yaml
@@ -40,7 +40,7 @@ project_config:
       # TODO(Fredy-Z): Enable this plugin for other repos when needed.
       project_repo_configs:
         eventing:
-          repo_maintainers_team_id: 3058996 # eventing-admins
+          repo_maintainers_team_id: 3012514 # knative-milestone-maintainers
           repo_default_column_map:
             "Performance: Measurement":
               To do
@@ -51,7 +51,7 @@ project_config:
             Eventing Usability:
               To do
         eventing-contrib:
-          repo_maintainers_team_id: 2967132 # eventing-sources-admins
+          repo_maintainers_team_id: 3012514 # knative-milestone-maintainers
 
 plugins:
   knative:

--- a/ci/prow/plugins.yaml
+++ b/ci/prow/plugins.yaml
@@ -40,6 +40,7 @@ project_config:
       # TODO(Fredy-Z): Enable this plugin for other repos when needed.
       project_repo_configs:
         eventing:
+          # TODO(grantr): replace with a new team eventing-project-maintainers
           repo_maintainers_team_id: 3012514 # knative-milestone-maintainers
           repo_default_column_map:
             "Performance: Measurement":
@@ -51,6 +52,7 @@ project_config:
             Eventing Usability:
               To do
         eventing-contrib:
+          # TODO(grantr): replace with a new team eventing-contrib-project-maintainers
           repo_maintainers_team_id: 3012514 # knative-milestone-maintainers
 
 plugins:

--- a/ci/prow/plugins.yaml
+++ b/ci/prow/plugins.yaml
@@ -33,6 +33,26 @@ repo_milestone:
     maintainers_id: 3012514
     maintainers_team: knative-milestone-maintainers
 
+project_config:
+  project_org_configs:
+    knative:
+      org_maintainers_team_id: 2652083 # knative-admin
+      # TODO(Fredy-Z): Enable this plugin for other repos when needed.
+      project_repo_configs:
+        eventing:
+          repo_maintainers_team_id: 3058996 # eventing-admins
+          repo_default_column_map:
+            "Performance: Measurement":
+              To do
+            Delivery Reliability:
+              To do
+            Delivery Efficiency:
+              To do
+            Eventing Usability:
+              To do
+        eventing-contrib:
+          repo_maintainers_team_id: 2967132 # eventing-sources-admins
+
 plugins:
   knative:
   - approve


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

FIX #1240 

**What this PR does, why we need it**:
Enable project plugin for `eventing` and `eventing-contrib` repo.

NOTE:
1. Only developers in the configured team can use this plugin
2. Example usage for this plugin:
i. `/project Delivery Reliability To do` to add this issue/pr to the `To do` column of `Delivery Reliability` dashboard.
ii. `/project Delivery Efficiency` to add this issue/pr to the `Delivery Efficiency` dashboard, and add it to `To do` column by default as configured here.
iii. `/project clear Delivery Efficiency` to remove this issue/pr from `Delivery Efficiency` dashboard.

/cc @adrcunha 
/cc @grantr 

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
