### PR TITLE
Add prow jobs to update clusters running serving benchmarks

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -5630,6 +5630,54 @@ periodics:
     - name: housekeeping-github-token
       secret:
         secretName: housekeeping-github-token
+- cron: "30 07 * * *"
+  name: ci-knative-serving-recreate-clusters
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: test-infra
+  spec:
+    containers:
+    - image: gcr.io/knative-performance/update-serving:v20190809-c290f606fc20
+      imagePullPolicy: Always
+      command:
+      - "/workspace/tools/recreate-serving/recreate.sh"
+      volumeMounts:
+      - name: performance-test
+        mountPath: /etc/performance-test
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/performance-test/service-account.json
+    volumes:
+    - name: performance-test
+      secret:
+        secretName: performance-test
+- cron: "0 * * * *"
+  name: ci-knative-serving-update-clusters
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: test-infra
+  spec:
+    containers:
+    - image: gcr.io/knative-performance/update-serving:v20190809-c290f606fc20
+      imagePullPolicy: Always
+      command:
+      - "/workspace/tools/update-serving/update.sh"
+      volumeMounts:
+      - name: performance-test
+        mountPath: /etc/performance-test
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/performance-test/service-account.json
+    volumes:
+    - name: performance-test
+      secret:
+        secretName: performance-test
 postsubmits:
   knative/serving:
   - name: post-knative-serving-go-coverage

--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -5519,6 +5519,7 @@ periodics:
   extra_refs:
   - org: knative
     repo: test-infra
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/k8s-prow/commenter:v20190731-e3f7b9853
@@ -5526,19 +5527,18 @@ periodics:
       command:
       - "/app/robots/commenter/app.binary"
       args:
-      - "|-
-        --query=org:knative
-        repo:test-infra
+      - "--query=repo:knative/test-infra
+        is:issue
+        is:open
         -label:lifecycle/frozen
         -label:lifecycle/stale
         -label:lifecycle/rotten"
       - "--updated=2160h"
       - "--token=/etc/housekeeping-github-token/token"
-      - "|-
-        --comment=Issues go stale after 90d of inactivity.
+      - "--comment=Issues go stale after 90d of inactivity.
         Mark the issue as fresh with /remove-lifecycle stale.
-        Stale issues rot after an additional 30d of inactivity and eventually close.\n
-        If this issue is safe to close now please do so with /close.\n
+        Stale issues rot after an additional 30d of inactivity and eventually close.
+        If this issue is safe to close now please do so with /close.
         Send feedback to Knative Productivity Slack channel or knative/test-infra.
         /lifecycle stale"
       - "--template"
@@ -5559,6 +5559,7 @@ periodics:
   extra_refs:
   - org: knative
     repo: test-infra
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/k8s-prow/commenter:v20190731-e3f7b9853
@@ -5566,20 +5567,19 @@ periodics:
       command:
       - "/app/robots/commenter/app.binary"
       args:
-      - "|-
-        --query=org:knative
-        repo:test-infra
+      - "--query=repo:knative/test-infra
+        is:issue
+        is:open
         -label:lifecycle/frozen
         label:lifecycle/stale
         -label:lifecycle/rotten"
       - "--updated=720h"
       - "--token=/etc/housekeeping-github-token/token"
-      - "|-
-        --comment=Stale issues rot after 30d of inactivity.
+      - "--comment=Stale issues rot after 30d of inactivity.
         Mark the issue as fresh with /remove-lifecycle rotten.
-        Rotten issues close after an additional 30d of inactivity.\n
-        If this issue is safe to close now please do so with /close.\n
-        Send feedback to Knative Productivity Slack channel or knative/test-infra.
+        Rotten issues close after an additional 30d of inactivity.
+		If this issue is safe to close now please do so with /close.
+		Send feedback to Knative Productivity Slack channel or knative/test-infra.
         /lifecycle rotten"
       - "--template"
       - "--ceiling=10"
@@ -5599,6 +5599,7 @@ periodics:
   extra_refs:
   - org: knative
     repo: test-infra
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/k8s-prow/commenter:v20190731-e3f7b9853
@@ -5606,17 +5607,16 @@ periodics:
       command:
       - "/app/robots/commenter/app.binary"
       args:
-      - "|-
-        --query=org:knative
-        repo:test-infra
+      - "--query=repo:knative/test-infra
+        is:issue
+        is:open
         -label:lifecycle/frozen
         label:lifecycle/rotten"
       - "--updated=720h"
       - "--token=/etc/housekeeping-github-token/token"
-      - "|-
-        --comment=Rotten issues close after 30d of inactivity.
+      - "--comment=Rotten issues close after 30d of inactivity.
         Reopen the issue with /reopen.
-        Mark the issue as fresh with /remove-lifecycle rotten.\n
+        Mark the issue as fresh with /remove-lifecycle rotten.
         Send feedback to Knative Productivity Slack channel or knative/test-infra.
         /close"
       - "--template"
@@ -5636,13 +5636,14 @@ periodics:
   decorate: true
   extra_refs:
   - org: knative
-    repo: test-infra
+    repo: serving
+    base_ref: master
   spec:
     containers:
-    - image: gcr.io/knative-performance/update-serving:v20190809-c290f606fc20
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
       command:
-      - "/workspace/tools/recreate-serving/recreate.sh"
+      - "/test/performance/tools/recreate-serving/recreate.sh"
       volumeMounts:
       - name: performance-test
         mountPath: /etc/performance-test
@@ -5660,13 +5661,14 @@ periodics:
   decorate: true
   extra_refs:
   - org: knative
-    repo: test-infra
+    repo: serving
+    base_ref: master
   spec:
     containers:
-    - image: gcr.io/knative-performance/update-serving:v20190809-c290f606fc20
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
       command:
-      - "/workspace/tools/update-serving/update.sh"
+      - "/test/performance/tools/update-serving/update.sh"
       volumeMounts:
       - name: performance-test
         mountPath: /etc/performance-test

--- a/ci/prow/make_config.go
+++ b/ci/prow/make_config.go
@@ -133,24 +133,25 @@ type stringArrayFlag []string
 
 var (
 	// Values used in the jobs that can be changed through command-line flags.
-	output                       *os.File
-	gcsBucket                    string
-	logsDir                      string
-	presubmitLogsDir             string
-	testAccount                  string
-	nightlyAccount               string
-	releaseAccount               string
-	flakesreporterDockerImage    string
-	prowversionbumperDockerImage string
-	githubCommenterDockerImage   string
-	coverageDockerImage          string
-	clearalertsDockerImage       string
-	prowTestsDockerImage         string
-	presubmitScript              string
-	releaseScript                string
-	performanceScript            string
-	webhookAPICoverageScript     string
-	cleanupScript                string
+	output                          *os.File
+	gcsBucket                       string
+	logsDir                         string
+	presubmitLogsDir                string
+	testAccount                     string
+	nightlyAccount                  string
+	releaseAccount                  string
+	flakesreporterDockerImage       string
+	prowversionbumperDockerImage    string
+	githubCommenterDockerImage      string
+	servingClusterUpdateDockerImage string
+	coverageDockerImage             string
+	clearalertsDockerImage          string
+	prowTestsDockerImage            string
+	presubmitScript                 string
+	releaseScript                   string
+	performanceScript               string
+	webhookAPICoverageScript        string
+	cleanupScript                   string
 
 	// #########################################################################
 	// ############## data used for generating prow configuration ##############
@@ -1045,6 +1046,7 @@ func main() {
 	flag.StringVar(&clearalertsDockerImage, "clear-alerts", "gcr.io/knative-tests/test-infra/monitoring/clear-alerts:latest", "Docker image for clearing alerts in test-infra monitoring")
 	flag.StringVar(&prowTestsDockerImage, "prow-tests-docker", "gcr.io/knative-tests/test-infra/prow-tests:stable", "prow-tests docker image")
 	flag.StringVar(&githubCommenterDockerImage, "github-commenter-docker", "gcr.io/k8s-prow/commenter:v20190731-e3f7b9853", "github commenter docker image")
+	flag.StringVar(&servingClusterUpdateDockerImage, "serving-cluster-update-docker", "gcr.io/knative-performance/update-serving:v20190809-c290f606fc20", "serving cluster update docker image")
 	flag.StringVar(&presubmitScript, "presubmit-script", "./test/presubmit-tests.sh", "Executable for running presubmit tests")
 	flag.StringVar(&releaseScript, "release-script", "./hack/release.sh", "Executable for creating releases")
 	flag.StringVar(&performanceScript, "performance-script", "./test/performance-tests.sh", "Executable for running performance tests")
@@ -1094,6 +1096,7 @@ func main() {
 		generateVersionBumpertoolPeriodicJob()
 		generateBackupPeriodicJob()
 		generateIssueTrackerPeriodicJobs()
+		generateServingClusterUpdatePeriodicJobs()
 		generateOtherJobConfigs("postsubmits", func(repo repositoryData) bool {
 			return repo.EnableGoCoverage
 		}, generateGoCoveragePostsubmit)

--- a/ci/prow/make_config.go
+++ b/ci/prow/make_config.go
@@ -133,25 +133,24 @@ type stringArrayFlag []string
 
 var (
 	// Values used in the jobs that can be changed through command-line flags.
-	output                          *os.File
-	gcsBucket                       string
-	logsDir                         string
-	presubmitLogsDir                string
-	testAccount                     string
-	nightlyAccount                  string
-	releaseAccount                  string
-	flakesreporterDockerImage       string
-	prowversionbumperDockerImage    string
-	githubCommenterDockerImage      string
-	servingClusterUpdateDockerImage string
-	coverageDockerImage             string
-	clearalertsDockerImage          string
-	prowTestsDockerImage            string
-	presubmitScript                 string
-	releaseScript                   string
-	performanceScript               string
-	webhookAPICoverageScript        string
-	cleanupScript                   string
+	output                       *os.File
+	gcsBucket                    string
+	logsDir                      string
+	presubmitLogsDir             string
+	testAccount                  string
+	nightlyAccount               string
+	releaseAccount               string
+	flakesreporterDockerImage    string
+	prowversionbumperDockerImage string
+	githubCommenterDockerImage   string
+	coverageDockerImage          string
+	clearalertsDockerImage       string
+	prowTestsDockerImage         string
+	presubmitScript              string
+	releaseScript                string
+	performanceScript            string
+	webhookAPICoverageScript     string
+	cleanupScript                string
 
 	// #########################################################################
 	// ############## data used for generating prow configuration ##############
@@ -761,8 +760,7 @@ func indentMap(indentation int, mp map[string]string) string {
 
 // outputConfig outputs the given line, if not empty, to stdout.
 func outputConfig(line string) {
-	s := strings.TrimSpace(line)
-	if s != "" {
+	if strings.TrimSpace(line) != "" {
 		fmt.Fprintln(output, line)
 	}
 }
@@ -1046,7 +1044,6 @@ func main() {
 	flag.StringVar(&clearalertsDockerImage, "clear-alerts", "gcr.io/knative-tests/test-infra/monitoring/clear-alerts:latest", "Docker image for clearing alerts in test-infra monitoring")
 	flag.StringVar(&prowTestsDockerImage, "prow-tests-docker", "gcr.io/knative-tests/test-infra/prow-tests:stable", "prow-tests docker image")
 	flag.StringVar(&githubCommenterDockerImage, "github-commenter-docker", "gcr.io/k8s-prow/commenter:v20190731-e3f7b9853", "github commenter docker image")
-	flag.StringVar(&servingClusterUpdateDockerImage, "serving-cluster-update-docker", "gcr.io/knative-performance/update-serving:v20190809-c290f606fc20", "serving cluster update docker image")
 	flag.StringVar(&presubmitScript, "presubmit-script", "./test/presubmit-tests.sh", "Executable for running presubmit tests")
 	flag.StringVar(&releaseScript, "release-script", "./hack/release.sh", "Executable for creating releases")
 	flag.StringVar(&performanceScript, "performance-script", "./test/performance-tests.sh", "Executable for running performance tests")

--- a/ci/prow/periodic_config.go
+++ b/ci/prow/periodic_config.go
@@ -340,11 +340,10 @@ func generateIssueTrackerPeriodicJobs() {
         -label:lifecycle/stale
         -label:lifecycle/rotten`
 	staleUpdatedTime := "2160h"
-	staleComment := `|-
-        --comment=Issues go stale after 90d of inactivity.
+	staleComment := `--comment=Issues go stale after 90d of inactivity.
         Mark the issue as fresh with /remove-lifecycle stale.
-        Stale issues rot after an additional 30d of inactivity and eventually close.\n
-        If this issue is safe to close now please do so with /close.\n
+        Stale issues rot after an additional 30d of inactivity and eventually close.
+        If this issue is safe to close now please do so with /close.
         Send feedback to Knative Productivity Slack channel or knative/test-infra.
         /lifecycle stale`
 	generateIssueTrackerPeriodicJob(staleJobName, staleLabelFilter, staleUpdatedTime, staleComment)
@@ -355,12 +354,13 @@ func generateIssueTrackerPeriodicJobs() {
         label:lifecycle/stale
         -label:lifecycle/rotten`
 	rottenUpdatedTime := "720h"
-	rottenComment := `|-
-        --comment=Stale issues rot after 30d of inactivity.
+	rottenComment := `--comment=Stale issues rot after 30d of inactivity.
         Mark the issue as fresh with /remove-lifecycle rotten.
-        Rotten issues close after an additional 30d of inactivity.\n
-        If this issue is safe to close now please do so with /close.\n
-        Send feedback to Knative Productivity Slack channel or knative/test-infra.
+        Rotten issues close after an additional 30d of inactivity.
+		If this issue is safe to close now please do so with /close.
+		
+		Send feedback to Knative Productivity Slack channel or knative/test-infra.
+		
         /lifecycle rotten`
 	generateIssueTrackerPeriodicJob(rottenJobName, rottenLabelFilter, rottenUpdatedTime, rottenComment)
 
@@ -369,10 +369,9 @@ func generateIssueTrackerPeriodicJobs() {
         -label:lifecycle/frozen
         label:lifecycle/rotten`
 	closeUpdatedTime := "720h"
-	closeComment := `|-
-        --comment=Rotten issues close after 30d of inactivity.
+	closeComment := `--comment=Rotten issues close after 30d of inactivity.
         Reopen the issue with /reopen.
-        Mark the issue as fresh with /remove-lifecycle rotten.\n
+        Mark the issue as fresh with /remove-lifecycle rotten.
         Send feedback to Knative Productivity Slack channel or knative/test-infra.
         /close`
 	generateIssueTrackerPeriodicJob(closeJobName, closeLabelFilter, closeUpdatedTime, closeComment)
@@ -381,6 +380,7 @@ func generateIssueTrackerPeriodicJobs() {
 func generateIssueTrackerPeriodicJob(jobName, labelFilter, updatedTime, comment string) {
 	var data periodicJobTemplateData
 	data.Base = newbaseProwJobTemplateData("knative/test-infra")
+	data.Base.ExtraRefs = append(data.Base.ExtraRefs, "  base_ref: "+data.Base.RepoBranch)
 	data.Base.Image = githubCommenterDockerImage
 	data.PeriodicJobName = jobName
 	data.CronString = issueTrackerPeriodicJobCron
@@ -388,9 +388,9 @@ func generateIssueTrackerPeriodicJob(jobName, labelFilter, updatedTime, comment 
 
 	// TODO(Fredy-Z): remove "repo:test-infra" after syncing up with the WGs.
 	data.Base.Args = []string{
-		`|-
-        --query=org:knative
-        repo:test-infra
+		`--query=repo:knative/test-infra
+        is:issue
+        is:open
         ` + labelFilter,
 		"--updated=" + updatedTime,
 		"--token=/etc/housekeeping-github-token/token",
@@ -408,7 +408,7 @@ func generateIssueTrackerPeriodicJob(jobName, labelFilter, updatedTime, comment 
 func generateServingClusterUpdatePeriodicJobs() {
 	recreateServingClustersJobName := "ci-knative-serving-recreate-clusters"
 	recreateServingClustersCronString := recreateServingPerfClusterPeriodicJobCron
-	recreateServingClustersCommand := "/workspace/tools/recreate-serving/recreate.sh"
+	recreateServingClustersCommand := "/test/performance/tools/recreate-serving/recreate.sh"
 	generateServingClusterUpdatePeriodicJob(
 		recreateServingClustersJobName,
 		recreateServingClustersCronString,
@@ -417,7 +417,7 @@ func generateServingClusterUpdatePeriodicJobs() {
 
 	updateServingClustersJobName := "ci-knative-serving-update-clusters"
 	updateServingClustersCronString := updateServingPerfClusterPeriodicJobCron
-	updateServingClustersCommand := "/workspace/tools/update-serving/update.sh"
+	updateServingClustersCommand := "/test/performance/tools/update-serving/update.sh"
 	generateServingClusterUpdatePeriodicJob(
 		updateServingClustersJobName,
 		updateServingClustersCronString,
@@ -427,8 +427,8 @@ func generateServingClusterUpdatePeriodicJobs() {
 
 func generateServingClusterUpdatePeriodicJob(jobName, cronString, command string) {
 	var data periodicJobTemplateData
-	data.Base = newbaseProwJobTemplateData("knative/test-infra")
-	data.Base.Image = servingClusterUpdateDockerImage
+	data.Base = newbaseProwJobTemplateData("knative/serving")
+	data.Base.ExtraRefs = append(data.Base.ExtraRefs, "  base_ref: "+data.Base.RepoBranch)
 	data.PeriodicJobName = jobName
 	data.CronString = cronString
 	data.Base.Command = command


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Add prow jobs to update clusters running serving benchmarks, to replace the cronjobs we are running now:
https://github.com/knative/serving/blob/master/test/performance/tools/update-serving/update.yaml
https://github.com/knative/serving/blob/master/test/performance/tools/recreate-serving/recreate.yaml

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

**Special notes to reviewers**:
This PR serves as the first step to migrate the performance testing infra in `serving` to `test-infra`, a few following steps will be:
1. Migrate common part in https://github.com/knative/serving/tree/master/test/performance/tools to `test-infra` (also rewrite them with `Go` for test-infra 2.0)
2. Use the above common code to setup the environment in `serving`, `eventing`, etc., and install project-related components for running the benchmarks

As a few design decisions related to `Mako` haven't been made, we haven't come out an end-to-end solution for performance testing infra. We should be able to have something new in next week's meeting. After the decision is made, I will write a detailed design proposal for it.

/cc @srinivashegde86 
/cc @adrcunha 
/cc @chaodaiG 