### PR TITLE
Make ingress tests optional for PRs

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -630,6 +630,7 @@ presubmits:
     rerun_command: "/test pull-knative-serving-istio-1.1-mesh"
     trigger: "(?m)^/test (all|pull-knative-serving-istio-1.1-mesh),?(\\s+|$)"
     decorate: true
+    optional: true
     branches:
     - "release-0.4"
     - "release-0.5"
@@ -666,6 +667,7 @@ presubmits:
     rerun_command: "/test pull-knative-serving-istio-1.1-mesh"
     trigger: "(?m)^/test (all|pull-knative-serving-istio-1.1-mesh),?(\\s+|$)"
     decorate: true
+    optional: true
     path_alias: knative.dev/serving
     skip_branches:
     - "release-0.4"
@@ -703,6 +705,7 @@ presubmits:
     rerun_command: "/test pull-knative-serving-istio-1.1-no-mesh"
     trigger: "(?m)^/test (all|pull-knative-serving-istio-1.1-no-mesh),?(\\s+|$)"
     decorate: true
+    optional: true
     branches:
     - "release-0.4"
     - "release-0.5"
@@ -739,6 +742,7 @@ presubmits:
     rerun_command: "/test pull-knative-serving-istio-1.1-no-mesh"
     trigger: "(?m)^/test (all|pull-knative-serving-istio-1.1-no-mesh),?(\\s+|$)"
     decorate: true
+    optional: true
     path_alias: knative.dev/serving
     skip_branches:
     - "release-0.4"
@@ -776,6 +780,7 @@ presubmits:
     rerun_command: "/test pull-knative-serving-istio-1.2-mesh"
     trigger: "(?m)^/test (all|pull-knative-serving-istio-1.2-mesh),?(\\s+|$)"
     decorate: true
+    optional: true
     branches:
     - "release-0.4"
     - "release-0.5"
@@ -812,6 +817,7 @@ presubmits:
     rerun_command: "/test pull-knative-serving-istio-1.2-mesh"
     trigger: "(?m)^/test (all|pull-knative-serving-istio-1.2-mesh),?(\\s+|$)"
     decorate: true
+    optional: true
     path_alias: knative.dev/serving
     skip_branches:
     - "release-0.4"
@@ -849,6 +855,7 @@ presubmits:
     rerun_command: "/test pull-knative-serving-istio-1.2-no-mesh"
     trigger: "(?m)^/test (all|pull-knative-serving-istio-1.2-no-mesh),?(\\s+|$)"
     decorate: true
+    optional: true
     branches:
     - "release-0.4"
     - "release-0.5"
@@ -885,6 +892,7 @@ presubmits:
     rerun_command: "/test pull-knative-serving-istio-1.2-no-mesh"
     trigger: "(?m)^/test (all|pull-knative-serving-istio-1.2-no-mesh),?(\\s+|$)"
     decorate: true
+    optional: true
     path_alias: knative.dev/serving
     skip_branches:
     - "release-0.4"
@@ -922,6 +930,7 @@ presubmits:
     rerun_command: "/test pull-knative-serving-gloo-0.17.1"
     trigger: "(?m)^/test (all|pull-knative-serving-gloo-0.17.1),?(\\s+|$)"
     decorate: true
+    optional: true
     branches:
     - "release-0.4"
     - "release-0.5"
@@ -957,6 +966,7 @@ presubmits:
     rerun_command: "/test pull-knative-serving-gloo-0.17.1"
     trigger: "(?m)^/test (all|pull-knative-serving-gloo-0.17.1),?(\\s+|$)"
     decorate: true
+    optional: true
     path_alias: knative.dev/serving
     skip_branches:
     - "release-0.4"

--- a/ci/prow/config_knative.yaml
+++ b/ci/prow/config_knative.yaml
@@ -46,18 +46,23 @@ presubmits:
       - "./test/performance-tests.sh"
     - custom-test: istio-1.1-mesh
       always_run: false
+      optional: true
       full-command: "./test/e2e-tests.sh --istio-version 1.1-latest --mesh"
     - custom-test: istio-1.1-no-mesh
       always_run: false
+      optional: true
       full-command: "./test/e2e-tests.sh --istio-version 1.1-latest --no-mesh"
     - custom-test: istio-1.2-mesh
       always_run: false
+      optional: true
       full-command: "./test/e2e-tests.sh --istio-version 1.2-latest --mesh"
     - custom-test: istio-1.2-no-mesh
       always_run: false
+      optional: true
       full-command: "./test/e2e-tests.sh --istio-version 1.2-latest --no-mesh"
     - custom-test: gloo-0.17.1
       always_run: false
+      optional: true
       full-command: "./test/e2e-tests.sh --gloo-version 0.17.1"
 
   knative/build:

--- a/ci/prow/make_config.go
+++ b/ci/prow/make_config.go
@@ -102,6 +102,7 @@ type baseProwJobTemplateData struct {
 	Year                int
 	Labels              []string
 	PathAlias           string
+	Optional            string
 }
 
 // ####################################################################################################
@@ -373,6 +374,7 @@ func newbaseProwJobTemplateData(repo string) baseProwJobTemplateData {
 	data.Env = make([]string, 0)
 	data.ExtraRefs = []string{"- org: " + data.OrgName, "  repo: " + data.RepoName}
 	data.Labels = make([]string, 0)
+	data.Optional = ""
 	return data
 }
 
@@ -501,6 +503,8 @@ func parseBasicJobConfigOverrides(data *baseProwJobTemplateData, config yaml.Map
 			}
 		case "env-vars":
 			addExtraEnvVarsToJob(getStringArray(item.Value), data)
+		case "optional":
+			(*data).Optional = "optional: true"
 		case nil: // already processed
 			continue
 		default:

--- a/ci/prow/templates/prow_presubmit_job.yaml
+++ b/ci/prow/templates/prow_presubmit_job.yaml
@@ -6,6 +6,7 @@
     rerun_command: "/test [[.PresubmitPullJobName]]"
     trigger: "(?m)^/test (all|[[.PresubmitPullJobName]]),?(\\s+|$)"
     decorate: true
+    [[.Base.Optional]]
     [[.Base.PathAlias]]
     [[indent_array_section 4 "branches" .Base.Branches]]
     [[indent_array_section 4 "skip_branches" .Base.SkipBranches]]


### PR DESCRIPTION
Ingress tests in PRs were created for debugging purpose, they were set up without the options of "optional", which made them PR blockers if being triggered in PRs. An example is here: https://github.com/knative/serving/pull/5003

This PR fixes the problem so they are not PR blockers

/cc @adrcunha 
/cc @Fredy-Z 