### PR TITLE
refactor jsonreport into client and interface

### DIFF
--- a/tools/flaky-test-reporter/json_reporter.go
+++ b/tools/flaky-test-reporter/json_reporter.go
@@ -24,12 +24,12 @@ import (
 	"knative.dev/test-infra/tools/flaky-test-reporter/jsonreport"
 )
 
-type ReportClient struct {
+type reportClient struct {
 	jsonreport.JSONClient
 }
 
-func newJSONClient() *ReportClient {
-	return &ReportClient{jsonreport.NewClient()}
+func newJSONClient() *reportClient {
+	return &reportClient{jsonreport.NewClient()}
 }
 
 // when reporting on all flaky tests in a repo, we want to eliminate the "job" layer, compressing all flaky
@@ -49,7 +49,7 @@ func getFlakyTestSet(repoDataAll []*RepoData) map[string]map[string]bool {
 	return flakyTestSet
 }
 
-func (rc *ReportClient) writeFlakyTestsToJSON(repoDataAll []*RepoData, dryrun bool) error {
+func (rc *reportClient) writeFlakyTestsToJSON(repoDataAll []*RepoData, dryrun bool) error {
 	var allErrs []error
 	flakyTestSets := getFlakyTestSet(repoDataAll)
 	ch := make(chan bool, len(flakyTestSets))

--- a/tools/flaky-test-reporter/json_reporter.go
+++ b/tools/flaky-test-reporter/json_reporter.go
@@ -24,6 +24,14 @@ import (
 	"knative.dev/test-infra/tools/flaky-test-reporter/jsonreport"
 )
 
+type ReportClient struct {
+	jsonreport.JSONClient
+}
+
+func newJSONClient() *ReportClient {
+	return &ReportClient{jsonreport.NewClient()}
+}
+
 // when reporting on all flaky tests in a repo, we want to eliminate the "job" layer, compressing all flaky
 // tests in that repo into a single list. There can be duplicate tests across jobs, though, so we store tests
 // in a nested map first to eliminate those duplicates.
@@ -41,7 +49,7 @@ func getFlakyTestSet(repoDataAll []*RepoData) map[string]map[string]bool {
 	return flakyTestSet
 }
 
-func writeFlakyTestsToJSON(repoDataAll []*RepoData, dryrun bool) error {
+func (rc *ReportClient) writeFlakyTestsToJSON(repoDataAll []*RepoData, dryrun bool) error {
 	var allErrs []error
 	flakyTestSets := getFlakyTestSet(repoDataAll)
 	ch := make(chan bool, len(flakyTestSets))
@@ -57,7 +65,7 @@ func writeFlakyTestsToJSON(repoDataAll []*RepoData, dryrun bool) error {
 			if err := run(
 				fmt.Sprintf("writing JSON report for repo '%s'", repo),
 				func() error {
-					_, err := jsonreport.CreateReportForRepo(repo, testList, true)
+					_, err := rc.CreateReportForRepo(repo, testList, true)
 					return err
 				},
 				dryrun); nil != err {

--- a/tools/flaky-test-reporter/json_reporter.go
+++ b/tools/flaky-test-reporter/json_reporter.go
@@ -25,7 +25,7 @@ import (
 )
 
 type reportClient struct {
-	jsonreport.JSONClient
+	jsonreport.Client
 }
 
 func newJSONClient() *reportClient {

--- a/tools/flaky-test-reporter/json_reporter.go
+++ b/tools/flaky-test-reporter/json_reporter.go
@@ -42,7 +42,7 @@ func getFlakyTestSet(repoDataAll []*RepoData) map[string]map[string]bool {
 }
 
 func writeFlakyTestsToJSON(repoDataAll []*RepoData, dryrun bool) error {
-	client := jsonreport.NewClient()
+	client := &jsonreport.JSONClient{}
 	var allErrs []error
 	flakyTestSets := getFlakyTestSet(repoDataAll)
 	ch := make(chan bool, len(flakyTestSets))
@@ -58,7 +58,7 @@ func writeFlakyTestsToJSON(repoDataAll []*RepoData, dryrun bool) error {
 			if err := run(
 				fmt.Sprintf("writing JSON report for repo '%s'", repo),
 				func() error {
-					_, err := client.CreateReportForRepo(repo, testList, true)
+					_, err := client.CreateReport(repo, testList, true)
 					return err
 				},
 				dryrun); nil != err {

--- a/tools/flaky-test-reporter/json_reporter.go
+++ b/tools/flaky-test-reporter/json_reporter.go
@@ -24,14 +24,6 @@ import (
 	"knative.dev/test-infra/tools/flaky-test-reporter/jsonreport"
 )
 
-type reportClient struct {
-	jsonreport.Client
-}
-
-func newJSONClient() *reportClient {
-	return &reportClient{jsonreport.NewClient()}
-}
-
 // when reporting on all flaky tests in a repo, we want to eliminate the "job" layer, compressing all flaky
 // tests in that repo into a single list. There can be duplicate tests across jobs, though, so we store tests
 // in a nested map first to eliminate those duplicates.
@@ -49,7 +41,8 @@ func getFlakyTestSet(repoDataAll []*RepoData) map[string]map[string]bool {
 	return flakyTestSet
 }
 
-func (rc *reportClient) writeFlakyTestsToJSON(repoDataAll []*RepoData, dryrun bool) error {
+func writeFlakyTestsToJSON(repoDataAll []*RepoData, dryrun bool) error {
+	client := jsonreport.NewClient()
 	var allErrs []error
 	flakyTestSets := getFlakyTestSet(repoDataAll)
 	ch := make(chan bool, len(flakyTestSets))
@@ -65,7 +58,7 @@ func (rc *reportClient) writeFlakyTestsToJSON(repoDataAll []*RepoData, dryrun bo
 			if err := run(
 				fmt.Sprintf("writing JSON report for repo '%s'", repo),
 				func() error {
-					_, err := rc.CreateReportForRepo(repo, testList, true)
+					_, err := client.CreateReportForRepo(repo, testList, true)
 					return err
 				},
 				dryrun); nil != err {

--- a/tools/flaky-test-reporter/jsonreport/jsonreport.go
+++ b/tools/flaky-test-reporter/jsonreport/jsonreport.go
@@ -41,6 +41,7 @@ type Report struct {
 	Flaky []string `json:"flaky"`
 }
 
+// JSONClient contains the set of operations a JSON reporter needs
 type JSONClient interface {
 	CreateReportForRepo(repo string, flaky []string, writeFile bool) (*Report, error)
 	ParseFlakyLog(repo string, buildID int, f func(report Report, result *[]string)) ([]Report, []string, error)
@@ -55,7 +56,7 @@ func Initialize(serviceAccount string) (*Client, error) {
 	return NewClient(), prow.Initialize(serviceAccount)
 }
 
-// newClient gives us a new Client struct, without initializing Prow
+// NewClient gives us a new Client struct, without initializing Prow
 func NewClient() *Client {
 	return &Client{}
 }
@@ -74,7 +75,7 @@ func (c *Client) writeToArtifactsDir(r *Report) error {
 	return ioutil.WriteFile(outFilePath, contents, 0644)
 }
 
-// parseFlakyLog reads the latest flaky test report and returns filtered results based
+// ParseFlakyLog reads the latest flaky test report and returns filtered results based
 // on the function the caller passes in.
 func (c *Client) ParseFlakyLog(repo string, buildID int, f func(report Report, result *[]string)) ([]Report, []string, error) {
 	var parsedResults []string

--- a/tools/flaky-test-reporter/jsonreport/jsonreport.go
+++ b/tools/flaky-test-reporter/jsonreport/jsonreport.go
@@ -41,13 +41,27 @@ type Report struct {
 	Flaky []string `json:"flaky"`
 }
 
+type JSONClient interface {
+	CreateReportForRepo(repo string, flaky []string, writeFile bool) (*Report, error)
+	ParseFlakyLog(repo string, buildID int, f func(report Report, result *[]string)) ([]Report, []string, error)
+	GetFlakyTestReport(repo string, buildID int) ([]Report, error)
+}
+
+// Client is simply a way to call methods, it does not contain any data itself
+type Client struct{}
+
 // Initialize wraps prow's init, which must be called before any other prow functions are used.
-func Initialize(serviceAccount string) error {
-	return prow.Initialize(serviceAccount)
+func Initialize(serviceAccount string) (*Client, error) {
+	return NewClient(), prow.Initialize(serviceAccount)
+}
+
+// newClient gives us a new Client struct, without initializing Prow
+func NewClient() *Client {
+	return &Client{}
 }
 
 // writeToArtifactsDir writes the flaky test data for this repo to disk.
-func (r *Report) writeToArtifactsDir() error {
+func (c *Client) writeToArtifactsDir(r *Report) error {
 	artifactsDir := prow.GetLocalArtifactsDir()
 	if err := common.CreateDir(path.Join(artifactsDir, r.Repo)); nil != err {
 		return err
@@ -60,22 +74,35 @@ func (r *Report) writeToArtifactsDir() error {
 	return ioutil.WriteFile(outFilePath, contents, 0644)
 }
 
+// parseFlakyLog reads the latest flaky test report and returns filtered results based
+// on the function the caller passes in.
+func (c *Client) ParseFlakyLog(repo string, buildID int, f func(report Report, result *[]string)) ([]Report, []string, error) {
+	var parsedResults []string
+	results, err := c.GetFlakyTestReport(repo, buildID)
+	if err == nil && len(results) > 0 {
+		for _, r := range results {
+			f(r, &parsedResults)
+		}
+	}
+	return results, parsedResults, err
+}
+
 // GetFlakyTestReport collects flaky test reports from the given buildID and repo.
 // Use repo = "" to get reports from all repositories, and buildID = -1 to get the
 // most recent report
-func GetFlakyTestReport(repo string, buildID int) ([]Report, error) {
+func (c *Client) GetFlakyTestReport(repo string, buildID int) ([]Report, error) {
 	job := prow.NewJob(jobName, prow.PeriodicJob, "", 0)
 	var err error
 	if buildID == -1 {
-		buildID, err = getLatestValidBuild(job, repo)
+		buildID, err = c.getLatestValidBuild(job, repo)
 		if err != nil {
 			return nil, err
 		}
 	}
 	build := job.NewBuild(buildID)
 	var reports []Report
-	for _, filepath := range getReportPaths(build, repo) {
-		report, err := readJSONReport(build, filepath)
+	for _, filepath := range c.getReportPaths(build, repo) {
+		report, err := c.readJSONReport(build, filepath)
 		if err != nil {
 			return nil, err
 		}
@@ -86,11 +113,11 @@ func GetFlakyTestReport(repo string, buildID int) ([]Report, error) {
 
 // getLatestValidBuild inexpensively sorts and finds the most recent JSON report.
 // Assumes sequential build IDs are sequential in time.
-func getLatestValidBuild(job *prow.Job, repo string) (int, error) {
+func (c *Client) getLatestValidBuild(job *prow.Job, repo string) (int, error) {
 	// check latest build first, before looking to older builds
 	if buildID, err := job.GetLatestBuildNumber(); err == nil {
 		build := job.NewBuild(buildID)
-		if reports := getReportPaths(build, repo); len(reports) != 0 {
+		if reports := c.getReportPaths(build, repo); len(reports) != 0 {
 			return buildID, nil
 		}
 	}
@@ -101,7 +128,7 @@ func getLatestValidBuild(job *prow.Job, repo string) (int, error) {
 	for _, buildID := range buildIDs {
 		build := job.NewBuild(buildID)
 		// check if reports exist for this build
-		if reports := getReportPaths(build, repo); len(reports) == 0 {
+		if reports := c.getReportPaths(build, repo); len(reports) == 0 {
 			continue
 		}
 		// check if this report is too old
@@ -120,7 +147,7 @@ func getLatestValidBuild(job *prow.Job, repo string) (int, error) {
 
 // getReportPaths searches build artifacts for reports from the given repo, returning
 // the path to any matching files. Use repo = "" to get all reports from all repos.
-func getReportPaths(build *prow.Build, repo string) []string {
+func (c *Client) getReportPaths(build *prow.Build, repo string) []string {
 	var matches []string
 	suffix := path.Join(repo, filename)
 	for _, artifact := range build.GetArtifacts() {
@@ -132,7 +159,7 @@ func getReportPaths(build *prow.Build, repo string) []string {
 }
 
 // readJSONReport builds a repo-specific report object from a given json file path.
-func readJSONReport(build *prow.Build, filename string) (*Report, error) {
+func (c *Client) readJSONReport(build *prow.Build, filename string) (*Report, error) {
 	report := &Report{}
 	contents, err := build.ReadFile(filename)
 	if err != nil {
@@ -146,13 +173,13 @@ func readJSONReport(build *prow.Build, filename string) (*Report, error) {
 
 // CreateReportForRepo generates a flaky report for a given repository, and optionally
 // writes it to disk.
-func CreateReportForRepo(repo string, flaky []string, writeFile bool) (*Report, error) {
+func (c *Client) CreateReportForRepo(repo string, flaky []string, writeFile bool) (*Report, error) {
 	report := &Report{
 		Repo:  repo,
 		Flaky: flaky,
 	}
 	if writeFile {
-		return report, report.writeToArtifactsDir()
+		return report, c.writeToArtifactsDir(report)
 	}
 	return report, nil
 }

--- a/tools/flaky-test-reporter/jsonreport/jsonreport.go
+++ b/tools/flaky-test-reporter/jsonreport/jsonreport.go
@@ -58,7 +58,7 @@ func Initialize(serviceAccount string) (Client, error) {
 	return &JSONClient{}, prow.Initialize(serviceAccount)
 }
 
-// CreateReportForRepo generates a flaky report for a given repository, and optionally
+// CreateReport generates a flaky report for a given repository, and optionally
 // writes it to disk.
 func (c *JSONClient) CreateReport(repo string, flaky []string, writeFile bool) (*Report, error) {
 	report := &Report{
@@ -85,7 +85,7 @@ func (c *JSONClient) writeToArtifactsDir(r *Report) error {
 	return ioutil.WriteFile(outFilePath, contents, 0644)
 }
 
-// getFlakyTests gets the latest flaky tests from the given repo
+// GetFlakyTests gets the latest flaky tests from the given repo
 func (c *JSONClient) GetFlakyTests(repo string) ([]string, error) {
 	reports, err := c.GetFlakyTestReport(repo, -1)
 	if err != nil {
@@ -97,7 +97,7 @@ func (c *JSONClient) GetFlakyTests(repo string) ([]string, error) {
 	return reports[0].Flaky, nil
 }
 
-// getReportRepos gets all of the repositories where we collect flaky tests.
+// GetReportRepos gets all of the repositories where we collect flaky tests.
 func (c *JSONClient) GetReportRepos() ([]string, error) {
 	reports, err := c.GetFlakyTestReport("", -1)
 	if err != nil {

--- a/tools/flaky-test-reporter/main.go
+++ b/tools/flaky-test-reporter/main.go
@@ -63,7 +63,6 @@ func main() {
 	if nil != err {
 		log.Fatalf("Failed authenticating Slack: '%v'", err)
 	}
-	jsonClient := newJSONClient()
 
 	var repoDataAll []*RepoData
 	// Clean up local artifacts directory, this will be used later for artifacts uploads
@@ -97,7 +96,7 @@ func main() {
 	jobErr := combineErrors(jobErrs)
 	githubErr := gih.processGithubIssues(repoDataAll, *dryrun)
 	slackErr := sendSlackNotifications(repoDataAll, slackClient, gih, *dryrun)
-	jsonErr := jsonClient.writeFlakyTestsToJSON(repoDataAll, *dryrun)
+	jsonErr := writeFlakyTestsToJSON(repoDataAll, *dryrun)
 	if nil != jobErr {
 		log.Printf("Job step failures:\n%v", jobErr)
 	}

--- a/tools/flaky-test-reporter/main.go
+++ b/tools/flaky-test-reporter/main.go
@@ -63,6 +63,7 @@ func main() {
 	if nil != err {
 		log.Fatalf("Failed authenticating Slack: '%v'", err)
 	}
+	jsonClient := newJSONClient()
 
 	var repoDataAll []*RepoData
 	// Clean up local artifacts directory, this will be used later for artifacts uploads
@@ -96,7 +97,7 @@ func main() {
 	jobErr := combineErrors(jobErrs)
 	githubErr := gih.processGithubIssues(repoDataAll, *dryrun)
 	slackErr := sendSlackNotifications(repoDataAll, slackClient, gih, *dryrun)
-	jsonErr := writeFlakyTestsToJSON(repoDataAll, *dryrun)
+	jsonErr := jsonClient.writeFlakyTestsToJSON(repoDataAll, *dryrun)
 	if nil != jobErr {
 		log.Printf("Job step failures:\n%v", jobErr)
 	}

--- a/tools/flaky-test-retryer/handler.go
+++ b/tools/flaky-test-retryer/handler.go
@@ -36,7 +36,7 @@ const pubsubTopic = "flaky-test-retryer"
 // HandlerClient wraps the other clients we need when processing failed jobs.
 type HandlerClient struct {
 	context.Context
-	logs   *LogClient
+	logs *reportClient
 	pubsub *subscriber.Client
 	github *GithubClient
 }

--- a/tools/flaky-test-retryer/main.go
+++ b/tools/flaky-test-retryer/main.go
@@ -45,11 +45,7 @@ func initFlags() *EnvFlags {
 func main() {
 	flags := initFlags()
 
-	if err := InitLogParser(flags.ServiceAccount); nil != err {
-		log.Fatalf("Failed authenticating GCS: '%v'", err)
-	}
-
-	handler, err := NewHandlerClient(flags.GithubAccount, flags.Dryrun)
+	handler, err := NewHandlerClient(flags.ServiceAccount, flags.GithubAccount, flags.Dryrun)
 	if err != nil {
 		log.Fatalf("Coud not create handler: '%v'", err)
 	}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Unit testing elements that use jsonreport would be a hassle without this. Now we can write a fake jsonreport to use when unit testing, which will be ready soon.
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Part of #1251 

**Special notes to reviewers**:

**User-visible changes in this PR**:

