### PR TITLE
Fix update-full command in Prow's Makefile

### DIFF
--- a/ci/prow/Makefile
+++ b/ci/prow/Makefile
@@ -81,7 +81,8 @@ update-single-cluster-deployment:
 	kubectl apply -f deployments/$(NAME).yaml
 	$(UNSET_CONTEXT)
 
-update-full: update-cluster-deployments update-config update-boskos-deployments
+# Update all resources on Prow cluster except boskos resource
+update-full: update-all-cluster-deployments update-all-boskos-deployments update-plugins update-config
 
 test:
 	@echo "*** Checking config generator for prow and testgrid"


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
The current `make update-full` will throw some error, this PR fixes it.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @adrcunha 
/cc @chaodaiG 