### PR TITLE
revert postsubmit coverage job back to only run on master branch

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -5625,31 +5625,7 @@ postsubmits:
     - master
     agent: kubernetes
     decorate: true
-    branches:
-    - "release-0.4"
-    - "release-0.5"
-    - "release-0.6"
-    - "release-0.7"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/coverage:latest
-        imagePullPolicy: Always
-        command:
-        - "/coverage"
-        args:
-        - "--artifacts=$(ARTIFACTS)"
-        - "--cov-threshold-percentage=0"
-  - name: post-knative-serving-go-coverage
-    branches:
-    - master
-    agent: kubernetes
-    decorate: true
     path_alias: knative.dev/serving
-    skip_branches:
-    - "release-0.4"
-    - "release-0.5"
-    - "release-0.6"
-    - "release-0.7"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/coverage:latest
@@ -5665,11 +5641,6 @@ postsubmits:
     agent: kubernetes
     decorate: true
     path_alias: knative.dev/serving
-    skip_branches:
-    - "release-0.4"
-    - "release-0.5"
-    - "release-0.6"
-    - "release-0.7"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/coverage-dev:latest-dev
@@ -5715,33 +5686,7 @@ postsubmits:
     - master
     agent: kubernetes
     decorate: true
-    branches:
-    - "release-0.4"
-    - "release-0.5"
-    - "release-0.6"
-    - "release-0.7"
-    - "release-0.8"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/coverage:latest
-        imagePullPolicy: Always
-        command:
-        - "/coverage"
-        args:
-        - "--artifacts=$(ARTIFACTS)"
-        - "--cov-threshold-percentage=0"
-  - name: post-knative-eventing-go-coverage
-    branches:
-    - master
-    agent: kubernetes
-    decorate: true
     path_alias: knative.dev/eventing
-    skip_branches:
-    - "release-0.4"
-    - "release-0.5"
-    - "release-0.6"
-    - "release-0.7"
-    - "release-0.8"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/coverage:latest
@@ -5757,33 +5702,7 @@ postsubmits:
     - master
     agent: kubernetes
     decorate: true
-    branches:
-    - "release-0.4"
-    - "release-0.5"
-    - "release-0.6"
-    - "release-0.7"
-    - "release-0.8"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/coverage:latest
-        imagePullPolicy: Always
-        command:
-        - "/coverage"
-        args:
-        - "--artifacts=$(ARTIFACTS)"
-        - "--cov-threshold-percentage=0"
-  - name: post-knative-eventing-contrib-go-coverage
-    branches:
-    - master
-    agent: kubernetes
-    decorate: true
     path_alias: knative.dev/eventing-contrib
-    skip_branches:
-    - "release-0.4"
-    - "release-0.5"
-    - "release-0.6"
-    - "release-0.7"
-    - "release-0.8"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/coverage:latest

--- a/ci/prow/make_config.go
+++ b/ci/prow/make_config.go
@@ -801,6 +801,10 @@ func executeJobTemplateWrapper(repoName string, data interface{}, generateOneJob
 		case *presubmitJobTemplateData:
 			base = &data.(*presubmitJobTemplateData).Base
 		case *postsubmitJobTemplateData:
+			if strings.HasSuffix(data.(*postsubmitJobTemplateData).PostsubmitJobName, "go-coverage") {
+				generateOneJob(data)
+				return
+			}
 			base = &data.(*postsubmitJobTemplateData).Base
 		default:
 			log.Fatalf("Unrecognized job template type: '%v'", v)

--- a/ci/prow/templates/prow_postsubmit_gocoverage_job.yaml
+++ b/ci/prow/templates/prow_postsubmit_gocoverage_job.yaml
@@ -5,8 +5,6 @@
     [[indent_section 8 "labels" .Base.Labels]]
     decorate: true
     [[.Base.PathAlias]]
-    [[indent_array_section 4 "branches" .Base.Branches]]
-    [[indent_array_section 4 "skip_branches" .Base.SkipBranches]]
     spec:
       containers:
       - image: [[.Base.Image]]


### PR DESCRIPTION
Currently postsubmit coverage jobs run on both master and release branches in repos migrated to `knative.dev` importing paths, under the same job name, which is a bug since presubmit coverage runs only look for latest result in postsubmit coverage jobs. This PR fixes the problem by only allowing  postsubmit coverage jobs run on master branch.

FYI @Fredy-Z since he discovered this problem
/cc @adrcunha 
/cc @steuhs 