### PR TITLE
Add skip reporting mode to flaky-test-reporter, add a job runs with this mode

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -5586,6 +5586,45 @@ periodics:
     - name: flaky-test-reporter-slack-token
       secret:
         secretName: flaky-test-reporter-slack-token
+- cron: "0 * * * *"
+  name: ci-knaitve-flakes-resultsrecorder
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: test-infra
+    base_ref: master
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/flaky-test-reporter:latest
+      imagePullPolicy: Always
+      command:
+      - "/flaky-test-reporter"
+      args:
+      - "--service-account=/etc/test-account/service-account.json"
+      - "--github-account=/etc/flaky-test-reporter-github-token/token"
+      - "--slack-account=/etc/flaky-test-reporter-slack-token/token"
+      - "--skip-report"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      - name: flaky-test-reporter-github-token
+        mountPath: /etc/flaky-test-reporter-github-token
+        readOnly: true
+      - name: flaky-test-reporter-slack-token
+        mountPath: /etc/flaky-test-reporter-slack-token
+        readOnly: true
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
+    - name: flaky-test-reporter-github-token
+      secret:
+        secretName: flaky-test-reporter-github-token
+    - name: flaky-test-reporter-slack-token
+      secret:
+        secretName: flaky-test-reporter-slack-token
 - cron: "0 20 * * 1"
   name: ci-knative-prow-auto-bumper
   agent: kubernetes

--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -5587,7 +5587,7 @@ periodics:
       secret:
         secretName: flaky-test-reporter-slack-token
 - cron: "0 * * * *"
-  name: ci-knaitve-flakes-resultsrecorder
+  name: ci-knative-flakes-resultsrecorder
   agent: kubernetes
   decorate: true
   extra_refs:
@@ -5839,7 +5839,7 @@ periodics:
     - name: performance-test
       secret:
         secretName: performance-test
-- cron: "0 * * * *"
+- cron: "5 * * * *"
   name: ci-knative-serving-update-clusters
   agent: kubernetes
   decorate: true

--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -5605,6 +5605,7 @@ periodics:
       - "--github-account=/etc/flaky-test-reporter-github-token/token"
       - "--slack-account=/etc/flaky-test-reporter-slack-token/token"
       - "--skip-report"
+      - "--build-count=20"
       volumeMounts:
       - name: test-account
         mountPath: /etc/test-account

--- a/ci/prow/periodic_config.go
+++ b/ci/prow/periodic_config.go
@@ -44,7 +44,7 @@ const (
 	perfPeriodicJobCron                       = "0 */3 * * *"  // Run every 3 hours
 	clearAlertsPeriodicJobCron                = "0,30 * * * *" // Run every 30 minutes
 	recreateServingPerfClusterPeriodicJobCron = "30 07 * * *"  // Run at 00:30PST every day (07:30 UTC)
-	updateServingPerfClusterPeriodicJobCron   = "0 * * * *"    // Run every an hour
+	updateServingPerfClusterPeriodicJobCron   = "5 * * * *"    // Run every an hour
 
 	// Perf job constants
 	perfTimeout = 120 // Job timeout in minutes
@@ -253,7 +253,7 @@ func generateFlakytoolPeriodicJob() {
 
 	// Generate another job that runs more frequently but not reporting to
 	// Github or Slack
-	data.PeriodicJobName = "ci-knaitve-flakes-resultsrecorder"
+	data.PeriodicJobName = "ci-knative-flakes-resultsrecorder"
 	data.CronString = flakesResultRecorderPeriodicJobCron
 	data.Base.Args = append(data.Base.Args, "--skip-report")
 	executeJobTemplate("periodic flakesresultrecorder", readTemplate(periodicCustomJob), "presubmits", "", data.PeriodicJobName, false, data)

--- a/ci/prow/periodic_config.go
+++ b/ci/prow/periodic_config.go
@@ -256,6 +256,7 @@ func generateFlakytoolPeriodicJob() {
 	data.PeriodicJobName = "ci-knative-flakes-resultsrecorder"
 	data.CronString = flakesResultRecorderPeriodicJobCron
 	data.Base.Args = append(data.Base.Args, "--skip-report")
+	data.Base.Args = append(data.Base.Args, "--build-count=20")
 	executeJobTemplate("periodic flakesresultrecorder", readTemplate(periodicCustomJob), "presubmits", "", data.PeriodicJobName, false, data)
 }
 

--- a/tools/flaky-test-reporter/constants.go
+++ b/tools/flaky-test-reporter/constants.go
@@ -19,10 +19,8 @@ limitations under the License.
 package main
 
 const (
-	// Builds to be analyzed, this is an arbitrary number
-	buildsCount = 10
-	// Minimal number of results to be counted as valid results for each testcase, this is an arbitrary number
-	requiredCount = 8
+	// Minimal ratio of results to be counted as valid results for each testcase, this is an arbitrary number
+	requiredRatio = 0.8
 	// Don't do anything if found more than 5 tests flaky, or 1% tests flaky, whichever comes first
 	countThreshold   = 5
 	percentThreshold = 0.01

--- a/tools/flaky-test-reporter/main.go
+++ b/tools/flaky-test-reporter/main.go
@@ -36,6 +36,7 @@ func main() {
 	githubAccount := flag.String("github-account", "", "Token file for Github authentication")
 	slackAccount := flag.String("slack-account", "", "slack secret file for authenticating with Slack")
 	configPath := flag.String("configfile", "./config.yaml", "Config file for overriding default config file")
+	skipReport := flag.Bool("skip-report", false, "skip Github and Slack report")
 	dryrun := flag.Bool("dry-run", false, "dry run switch")
 	flag.Parse()
 
@@ -48,19 +49,22 @@ func main() {
 		log.Fatalf("config cannot be created: '%v'", err)
 	}
 
-	if nil != dryrun && true == *dryrun {
+	if true == *dryrun {
 		log.Printf("running in [dry run mode]")
+	}
+	if true == *skipReport {
+		log.Printf("--skip-report provided, skipping Github and Slack report")
 	}
 
 	if err := prow.Initialize(*serviceAccount); nil != err { // Explicit authenticate with gcs Client
 		log.Fatalf("Failed authenticating GCS: '%v'", err)
 	}
 	gih, err := Setup(*githubAccount)
-	if err != nil {
+	if err != nil && !*skipReport {
 		log.Fatalf("Cannot setup github: %v", err)
 	}
 	slackClient, err := newSlackClient(*slackAccount)
-	if nil != err {
+	if nil != err && !*skipReport {
 		log.Fatalf("Failed authenticating Slack: '%v'", err)
 	}
 
@@ -93,23 +97,27 @@ func main() {
 	// Errors that could result in inaccuracy reporting would be treated with fast fail by processGithubIssues,
 	// so any errors returned are github opeations error, which in most cases wouldn't happen, but in case it
 	// happens, it should fail the job after Slack notification
-	jobErr := combineErrors(jobErrs)
-	githubErr := gih.processGithubIssues(repoDataAll, *dryrun)
-	slackErr := sendSlackNotifications(repoDataAll, slackClient, gih, *dryrun)
-	jsonErr := writeFlakyTestsToJSON(repoDataAll, *dryrun)
+	var jobErr, githubErr, slackErr, jsonErr error
+	jobErr = combineErrors(jobErrs)
+	if !*skipReport {
+		githubErr = gih.processGithubIssues(repoDataAll, *dryrun)
+		slackErr = sendSlackNotifications(repoDataAll, slackClient, gih, *dryrun)
+	}
+	jsonErr = writeFlakyTestsToJSON(repoDataAll, *dryrun)
 	if nil != jobErr {
 		log.Printf("Job step failures:\n%v", jobErr)
 	}
-	if nil != githubErr {
+	if nil != githubErr && !*skipReport {
 		log.Printf("Github step failures:\n%v", githubErr)
 	}
-	if nil != slackErr {
+	if nil != slackErr && !*skipReport {
 		log.Printf("Slack step failures:\n%v", slackErr)
 	}
 	if nil != jsonErr {
 		log.Printf("JSON step failures:\n%v", jsonErr)
 	}
-	if nil != jobErr || nil != githubErr || nil != slackErr || nil != jsonErr { // Fail this job if there is any error
+	if nil != jobErr || nil != jsonErr ||
+		(!*skipReport && (nil != githubErr || nil != slackErr)) { // Fail this job if there is any error
 		os.Exit(1)
 	}
 }

--- a/tools/flaky-test-reporter/main.go
+++ b/tools/flaky-test-reporter/main.go
@@ -52,20 +52,23 @@ func main() {
 	if true == *dryrun {
 		log.Printf("running in [dry run mode]")
 	}
-	if true == *skipReport {
-		log.Printf("--skip-report provided, skipping Github and Slack report")
-	}
-
-	if err := prow.Initialize(*serviceAccount); nil != err { // Explicit authenticate with gcs Client
+	if err = prow.Initialize(*serviceAccount); nil != err { // Explicit authenticate with gcs Client
 		log.Fatalf("Failed authenticating GCS: '%v'", err)
 	}
-	gih, err := Setup(*githubAccount)
-	if err != nil && !*skipReport {
-		log.Fatalf("Cannot setup github: %v", err)
-	}
-	slackClient, err := newSlackClient(*slackAccount)
-	if nil != err && !*skipReport {
-		log.Fatalf("Failed authenticating Slack: '%v'", err)
+
+	var gih *GithubIssueHandler
+	var slackClient *SlackClient
+	if true == *skipReport {
+		log.Printf("--skip-report provided, skipping Github and Slack report")
+	} else {
+		gih, err = Setup(*githubAccount)
+		if err != nil {
+			log.Fatalf("Cannot setup github: %v", err)
+		}
+		slackClient, err = newSlackClient(*slackAccount)
+		if nil != err {
+			log.Fatalf("Failed authenticating Slack: '%v'", err)
+		}
 	}
 
 	var repoDataAll []*RepoData

--- a/tools/flaky-test-reporter/main.go
+++ b/tools/flaky-test-reporter/main.go
@@ -31,15 +31,26 @@ import (
 	"knative.dev/test-infra/tools/flaky-test-reporter/config"
 )
 
+var (
+	// Builds to be analyzed, this is determined by flag
+	buildsCount int
+	// Minimal number of results to be counted as valid results for each
+	// testcase, this is derived from buildsCount and requiredRatio
+	requiredCount float32
+)
+
 func main() {
 	serviceAccount := flag.String("service-account", os.Getenv("GOOGLE_APPLICATION_CREDENTIALS"), "JSON key file for GCS service account")
 	githubAccount := flag.String("github-account", "", "Token file for Github authentication")
 	slackAccount := flag.String("slack-account", "", "slack secret file for authenticating with Slack")
 	configPath := flag.String("configfile", "./config.yaml", "Config file for overriding default config file")
+	buildsCountOverride := flag.Int("build-count", 10, "count of builds to scan")
 	skipReport := flag.Bool("skip-report", false, "skip Github and Slack report")
 	dryrun := flag.Bool("dry-run", false, "dry run switch")
 	flag.Parse()
 
+	buildsCount = *buildsCountOverride
+	requiredCount = requiredRatio * float32(buildsCount)
 	if isAbs := filepath.IsAbs(*configPath); !isAbs {
 		// Relative path works strangely in docker, transform it to absolute path
 		*configPath = filepath.Join(filepath.Dir(os.Args[0]), *configPath)

--- a/tools/flaky-test-reporter/result.go
+++ b/tools/flaky-test-reporter/result.go
@@ -73,7 +73,7 @@ func (ts *TestStat) isPassed() bool {
 }
 
 func (ts *TestStat) hasEnoughRuns() bool {
-	return len(ts.Passed)+len(ts.Failed) >= requiredCount
+	return float32(len(ts.Passed)+len(ts.Failed)) >= requiredCount
 }
 
 func (ts *TestStat) getTestStatus() string {


### PR DESCRIPTION
Flaky test report runs once a day, the results recorded by it can be stale especially at the end of the day. Add a skip reporting mode to this tool, create another tool runs at this mode and more frequently, so that the latest result is more reliable, which makes flaky-test-retryer more reliable too as it depends on the results collected by flaky-test-reporter

Part of: #1250 

/cc @adrcunha 
/cc @srinivashegde86 

fyi @TrevorFarrelly 
