### PR TITLE
golang format tools

### DIFF
--- a/tools/flaky-test-retryer/github_commenter_test.go
+++ b/tools/flaky-test-retryer/github_commenter_test.go
@@ -208,10 +208,10 @@ func TestBuildNewComment(t *testing.T) {
 		outliers []string
 		wantBody string
 	}{
-		{&fakeJob, map[string]*entry{"fakejob0": &entry{"", 0}, "fakejob1": &entry{"[]()", 1}}, nil, retryCommentBody},
-		{&fakeJob, map[string]*entry{"fakejob0": &entry{"[]()<br>[]()<br>[]()", 3}, "fakejob1": &entry{"[]()", 1}}, nil, noMoreRetriesCommentBody},
-		{&fakeJob, map[string]*entry{"fakejob0": &entry{"", 0}, "fakejob1": &entry{"[]()", 1}}, fakeFailedTests[:4], failedShortCommentBody},
-		{&fakeJob, map[string]*entry{"fakejob0": &entry{"", 0}, "fakejob1": &entry{"[]()", 1}}, fakeFailedTests, failedLongCommentBody},
+		{&fakeJob, map[string]*entry{"fakejob0": {"", 0}, "fakejob1": {"[]()", 1}}, nil, retryCommentBody},
+		{&fakeJob, map[string]*entry{"fakejob0": {"[]()<br>[]()<br>[]()", 3}, "fakejob1": {"[]()", 1}}, nil, noMoreRetriesCommentBody},
+		{&fakeJob, map[string]*entry{"fakejob0": {"", 0}, "fakejob1": {"[]()", 1}}, fakeFailedTests[:4], failedShortCommentBody},
+		{&fakeJob, map[string]*entry{"fakejob0": {"", 0}, "fakejob1": {"[]()", 1}}, fakeFailedTests, failedLongCommentBody},
 	}
 
 	for _, test := range cases {


### PR DESCRIPTION
<!--golang format tools-->
<!---->
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
/assign adrcunha
