### PR TITLE
[coverage] update string mapper to accommodate knative repo structure change

### DIFF
--- a/tools/coverage/githubUtil/github.go
+++ b/tools/coverage/githubUtil/github.go
@@ -21,13 +21,13 @@ import (
 )
 
 // convert filepath from profile format to github format
-// (github.com/$REPO_OWNER/$REPO_NAME/pkg/... -> pkg/...)
+// (knative.dev/$REPO_NAME/pkg/... -> pkg/...)
 func FilePathProfileToGithub(filePath string) string {
-	slice := strings.SplitN(filePath, "/", 4)
-	if len(slice) < 4 {
-		log.Printf("FilePath string cannot be splitted into 4 parts: [sep=%s] %s; "+
+	slice := strings.SplitN(filePath, "/", 3)
+	if len(slice) < 3 {
+		log.Printf("FilePath string cannot be splitted into 3 parts: [sep=%s] %s; "+
 			"Original string is returned\n", "/", filePath)
 		return filePath
 	}
-	return slice[3]
+	return slice[2]
 }


### PR DESCRIPTION
The change of repo structure from github.com/$REPO_OWNER/$REPO_NAME to knative.dev/$REPO_NAME/ breaks the function FilePathProfileToGithub, because the function is based on the repo structure. This change is to fix the issue.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #

**Special notes to reviewers**:

**User-visible changes in this PR**:

