### PR TITLE
Revert "retry cluster creation when it failed due to nodes unhealthy"

### DIFF
--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -288,14 +288,10 @@ function create_test_cluster_with_retries() {
       [[ "$(get_test_return_code)" == "0" ]] && return 0
       # Retry if cluster creation failed because of:
       # - stockout (https://github.com/knative/test-infra/issues/592)
-      # - latest GKE not available in this region/zone yet
-      #   (https://github.com/knative/test-infra/issues/694)
-      # - cluster created but some nodes are unhealthy
-      #   (https://github.com/knative/test-infra/issues/1291)
+      # - latest GKE not available in this region/zone yet (https://github.com/knative/test-infra/issues/694)
       [[ -z "$(grep -Fo 'does not have enough resources available to fulfill' ${cluster_creation_log})" \
           && -z "$(grep -Fo 'ResponseError: code=400, message=No valid versions with the prefix' ${cluster_creation_log})" \
           && -z "$(grep -Po 'ResponseError: code=400, message=Master version "[0-9a-z\-\.]+" is unsupported' ${cluster_creation_log})" ]] \
-          && -z "$(grep -Po '[0-9]+ nodes out of [0-9]+ are unhealthy' ${cluster_creation_log})" ]] \
           && return 1
     done
   done


### PR DESCRIPTION
Reverts knative/test-infra#1292

This condition somehow caused a serving PR retrying on test failures, reverting it for now
https://prow.knative.dev/view/gcs/knative-prow/pr-logs/pull/knative_serving/5237/pull-knative-serving-integration-tests/1164179840731975680

/cc @adrcunha 
/cc @srinivashegde86 