### PR TITLE
flaky test retryer uses flaky test recorder results

### DIFF
--- a/tools/flaky-test-reporter/jsonreport/fakejsonreport/fakejsonreport.go
+++ b/tools/flaky-test-reporter/jsonreport/fakejsonreport/fakejsonreport.go
@@ -51,8 +51,8 @@ func (c *FakeClient) CreateReport(repo string, flaky []string, writeFile bool) (
 }
 
 // GetFlakyTests gets the latest flaky tests from the given repo
-func (c *FakeClient) GetFlakyTests(repo string) ([]string, error) {
-	reports, err := c.GetFlakyTestReport(repo, -1)
+func (c *FakeClient) GetFlakyTests(jobName, repo string) ([]string, error) {
+	reports, err := c.GetFlakyTestReport("", repo, -1)
 	if err != nil {
 		return nil, err
 	}
@@ -63,8 +63,8 @@ func (c *FakeClient) GetFlakyTests(repo string) ([]string, error) {
 }
 
 // GetReportRepos gets all of the repositories where we collect flaky tests.
-func (c *FakeClient) GetReportRepos() ([]string, error) {
-	reports, err := c.GetFlakyTestReport("", -1)
+func (c *FakeClient) GetReportRepos(jobName string) ([]string, error) {
+	reports, err := c.GetFlakyTestReport("", "", -1)
 	if err != nil {
 		return nil, err
 	}
@@ -78,7 +78,7 @@ func (c *FakeClient) GetReportRepos() ([]string, error) {
 // GetFlakyTestReport collects flaky test reports from the given buildID and repo.
 // Use repo = "" to get reports from all repositories, and buildID = -1 to get the
 // most recent report
-func (c *FakeClient) GetFlakyTestReport(repo string, buildID int) ([]jsonreport.Report, error) {
+func (c *FakeClient) GetFlakyTestReport(jobName, repo string, buildID int) ([]jsonreport.Report, error) {
 	report := jsonreport.Report{}
 	if err := json.Unmarshal(c.data, &report); err != nil {
 		return nil, err

--- a/tools/flaky-test-retryer/log_parser.go
+++ b/tools/flaky-test-retryer/log_parser.go
@@ -69,7 +69,7 @@ func (jd *JobData) IsSupported() bool {
 		log.Printf("%s: message does not contain any repository references\n", prefix)
 		return false
 	}
-	repos, err := client.GetReportRepos()
+	repos, err := client.GetReportRepos(flakesRecorderJobName)
 	if err != nil {
 		log.Printf("%s: error getting reporter's repositories: %v\n", prefix, err)
 		return false
@@ -151,7 +151,7 @@ func GetCombinedResultsForBuild(build *prow.Build) ([]*junit.TestSuites, error) 
 
 // getFlakyTests gets the current flaky tests from the repo JobData originated from
 func (jd *JobData) getFlakyTests() ([]string, error) {
-	return client.GetFlakyTests(jd.Refs[0].Repo)
+	return client.GetFlakyTests(flakesRecorderJobName, jd.Refs[0].Repo)
 }
 
 // compareTests compares lists of failed and flaky tests, and returns any outlying failed

--- a/tools/flaky-test-retryer/main.go
+++ b/tools/flaky-test-retryer/main.go
@@ -26,6 +26,10 @@ import (
 	"os"
 )
 
+const (
+	flakesRecorderJobName = "ci-knative-flakes-resultsrecorder"
+)
+
 type EnvFlags struct {
 	ServiceAccount string // GCP service account file path
 	GithubAccount  string // github account file path


### PR DESCRIPTION
`ci-knative-flakes-resultsrecorder` runs more frequently with broader spectrum than `ci-knative-flakes-reporter`, use it as data source for retryer to improve the accuracy

joblink: https://prow.knative.dev/?job=ci-knative-flakes-resultsrecorder

Fixes #1250 

/cc @adrcunha 
/cc @srinivashegde86 

