### PR TITLE
Set serving build test requests/limits both to 16Gb memory

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -132,6 +132,11 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-central1
+        resources:
+          requests:
+            memory: 12Gi
+          limits:
+            memory: 16Gi
       volumes:
       - name: test-account
         secret:
@@ -167,6 +172,11 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-central1
+        resources:
+          requests:
+            memory: 12Gi
+          limits:
+            memory: 16Gi
       volumes:
       - name: test-account
         secret:
@@ -2841,6 +2851,11 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
+      resources:
+        requests:
+          memory: 12Gi
+        limits:
+          memory: 16Gi
     volumes:
     - name: test-account
       secret:

--- a/ci/prow/config_knative.yaml
+++ b/ci/prow/config_knative.yaml
@@ -21,6 +21,11 @@ presubmits:
       - release-0.6
       - release-0.7
     - build-tests: true
+      resources:
+        requests:
+          memory: 12Gi # Real request for this pod is 16 as sidecar requests 4
+        limits:
+          memory: 16Gi
     - unit-tests: true
     - integration-tests: true
       args:
@@ -186,6 +191,11 @@ periodics:
     - continuous: true
       timeout: 100
       dot-dev: true
+      resources:
+        requests:
+          memory: 12Gi
+        limits:
+          memory: 16Gi
     - branch-ci: true
       release: "0.4"
     - branch-ci: true

--- a/ci/prow/templates/prow_periodic_test_job.yaml
+++ b/ci/prow/templates/prow_periodic_test_job.yaml
@@ -17,4 +17,5 @@
       [[indent_section 8 "securityContext" .Base.SecurityContext]]
       [[indent_section 6 "volumeMounts" .Base.VolumeMounts]]
       [[indent_section 6 "env" .Base.Env]]
+      [[indent_section 6 "resources" .Base.Resources]]
     [[indent_section 4 "volumes" .Base.Volumes]]

--- a/ci/prow/templates/prow_presubmit_job.yaml
+++ b/ci/prow/templates/prow_presubmit_job.yaml
@@ -21,4 +21,5 @@
         [[indent_section 10 "securityContext" .Base.SecurityContext]]
         [[indent_section 8 "volumeMounts" .Base.VolumeMounts]]
         [[indent_section 8 "env" .Base.Env]]
+        [[indent_section 8 "resources" .Base.Resources]]
       [[indent_section 6 "volumes" .Base.Volumes]]


### PR DESCRIPTION
Serving build tests are killed OOM sometimes, increase the limit from 8Gb to 16Gb to help alleviate the problem. 
Example: https://prow.knative.dev/view/gcs/knative-prow/logs/ci-knative-serving-continuous/1163966682885001216

/cc @mattmoor 
/cc @adrcunha 
/cc @yt3liu 

/hold
May not be needed if #1300 solves the problem by building sequentially