### PR TITLE
Fix flaky-test-retryer: scan current run instead of latest

### DIFF
--- a/tools/flaky-test-retryer/log_parser.go
+++ b/tools/flaky-test-retryer/log_parser.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"log"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"knative.dev/test-infra/shared/junit"
@@ -96,13 +97,13 @@ func (jd *JobData) IsSupported() bool {
 // getFailedTests gets all the tests that failed in the given job.
 func (jd *JobData) getFailedTests() ([]string, error) {
 	// use cache if it is populated
-	if jd.failedTests != nil {
+	if len(jd.failedTests) > 0 {
 		return jd.failedTests, nil
 	}
 	job := prow.NewJob(jd.JobName, string(jd.JobType), jd.Refs[0].Repo, jd.Refs[0].Pulls[0].Number)
-	buildID, err := job.GetLatestBuildNumber()
+	buildID, err := strconv.Atoi(jd.RunID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("cannot convert RunID '%s' to int", jd.RunID)
 	}
 	build := job.NewBuild(buildID)
 	results, err := GetCombinedResultsForBuild(build)


### PR DESCRIPTION
Retryer skipped retrying one of failed tests in serving, the log says there is no test failed. The reason could be it's scanning latest build, and this is not reliable if someone manually triggered rerun. Using RunID instead of latest

Example: https://prow.knative.dev/view/gcs/knative-prow/pr-logs/pull/knative_serving/5249/pull-knative-serving-integration-tests/1164571049820426240

/cc @srinivashegde86 

/hold
let me test it first