### PR TITLE
Add comment explaining why retryer scans latest build instead of current build

### DIFF
--- a/tools/flaky-test-retryer/log_parser.go
+++ b/tools/flaky-test-retryer/log_parser.go
@@ -96,10 +96,14 @@ func (jd *JobData) IsSupported() bool {
 // getFailedTests gets all the tests that failed in the given job.
 func (jd *JobData) getFailedTests() ([]string, error) {
 	// use cache if it is populated
-	if jd.failedTests != nil {
+	if len(jd.failedTests) > 0 {
 		return jd.failedTests, nil
 	}
 	job := prow.NewJob(jd.JobName, string(jd.JobType), jd.Refs[0].Repo, jd.Refs[0].Pulls[0].Number)
+	// Check latest build instead of using jd.RunID, as there are times where
+	// devs initiated retry manually before retryer gets to it, and in this case
+	// scaning latest build can help retryer avoid initiating another retry
+	// since latest build has no test failure yet
 	buildID, err := job.GetLatestBuildNumber()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
There is an implicit logic in flaky test retryer that needs to be better documented

/cc @srinivashegde86 