### PR TITLE
[WIP]Move performance test scripts to test-infra

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -230,11 +230,22 @@ This is a helper script for Knative performance test scripts. To use it:
 
 1. Source the script.
 
+1. [optional] Customize path of the benchmark folder. This folder should
+   contains and only contains all benchmarks controlled by Prow periodic jobs:
+
+   - `BENCHMARK_ROOT_PATH`: Benchmark root path, defaults to `"test/performance/benchmarks`.
+   - `CLUSTER_REGION`: Cluster region for a new benchmark if not specified
+   in its `cluster.properties` file, defaults to `us-central1`.
+   - `CLUSTER_NODES`: Number of nodes in the cluster for a new benchmark if
+   not specified in its `cluster.properties` file, defaults to `1`.
+
 1. [optional] Write the `update_knative()` function, which will update your
    system under test (e.g., Knative Serving).
 
-1. [optional] Write the `update_benchmark benchmark_name` function, which
-   will update the benchmark (usually Knative services + Kubernetes cronjobs).
+1. [optional] Write the `update_benchmark(benchmark_path)` function, which
+   will update the underlying resources for the benchmark (usually Knative
+   resources and Kubernetes cronjobs for benchmarking). This function accepts
+   a parameter, which is the benchmark path in the current repo.
 
 1. Call the `main()` function passing `$@` (without quotes).
 
@@ -246,9 +257,6 @@ This script will update `Knative serving` and the given benchmark.
 source vendor/knative.dev/test-infra/scripts/performance-tests.sh
 
 function update_knative() {
-  echo ">> Updating istio"
-  kubectl apply -f third_party/$istio_version/istio-crds.yaml || abort "failed to apply istio-crds"
-  kubectl apply -f third_party/$istio_version/istio-lean.yaml || abort "failed to apply istio-lean"
   echo ">> Updating serving"
   ko apply -f config/ -f config/v1beta1 || abort "failed to apply serving"
 }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -226,7 +226,9 @@ success
 
 ## Using the `performance-tests.sh` helper script
 
-This is a helper script for Knative performance test scripts. To use it:
+This is a helper script for Knative performance test scripts. In combination
+with specific Prow jobs, it can automatically manage the environment for running
+benchmarks jobs for each repo. To use it:
 
 1. Source the script.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -224,6 +224,43 @@ kubectl get pods || fail_test
 success
 ```
 
+## Using the `performance-tests.sh` helper script
+
+This is a helper script for Knative performance test scripts. To use it:
+
+1. Source the script.
+
+1. [optional] Write the `update_knative()` function, which will update your
+   system under test (e.g., Knative Serving).
+
+1. [optional] Write the `update_benchmark benchmark_name` function, which
+   will update the benchmark (usually Knative services + Kubernetes cronjobs).
+
+1. Call the `main()` function passing `$@` (without quotes).
+
+### Sample performance test script
+
+This script will update `Knative serving` and the given benchmark.
+
+```bash
+source vendor/knative.dev/test-infra/scripts/performance-tests.sh
+
+function update_knative() {
+  echo ">> Updating istio"
+  kubectl apply -f third_party/$istio_version/istio-crds.yaml || abort "failed to apply istio-crds"
+  kubectl apply -f third_party/$istio_version/istio-lean.yaml || abort "failed to apply istio-lean"
+  echo ">> Updating serving"
+  ko apply -f config/ -f config/v1beta1 || abort "failed to apply serving"
+}
+
+function update_benchmark() {
+  echo ">> Updating benchmark $1"
+  ko apply -f ${TEST_ROOT_PATH}/$1 || abort "failed to apply benchmark $1"
+}
+
+main $@
+```
+
 ## Using the `release.sh` helper script
 
 This is a helper script for Knative release scripts. To use it:

--- a/scripts/performance-tests.sh
+++ b/scripts/performance-tests.sh
@@ -1,0 +1,194 @@
+#!/bin/bash
+
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is a helper script for Knative performance test scripts.
+# See README.md for instructions on how to use it.
+
+source $(dirname ${BASH_SOURCE})/library.sh
+
+# Setup env vars
+export PROJECT_NAME="knative-performance"
+export USER_NAME="mako-job@knative-performance.iam.gserviceaccount.com"
+export TEST_ROOT_PATH="$GOPATH/src/knative.dev/${REPO_NAME}/test/performance"
+export KO_DOCKER_REPO="gcr.io/knative-performance"
+
+# Creates a new cluster.
+# $1 -> name, $2 -> zone/region, $3 -> num_nodes
+function create_cluster() {
+  header "Creating cluster $1 with $3 nodes in $2"
+  gcloud beta container clusters create ${1} \
+    --addons=HorizontalPodAutoscaling,HttpLoadBalancing \
+    --machine-type=n1-standard-4 \
+    --cluster-version=latest --region=${2} \
+    --enable-stackdriver-kubernetes --enable-ip-alias \
+    --num-nodes=${3} \
+    --enable-autorepair \
+    --scopes cloud-platform
+}
+
+# Create serice account secret on the cluster.
+# $1 -> cluster_name, $2 -> cluster_zone
+function create_secret() {
+  echo "Create service account on cluster $1 in zone $2"
+  gcloud container clusters get-credentials $1 --zone=$2 --project=${PROJECT_NAME} || abort "Failed to get cluster creds"
+  kubectl create secret generic service-account --from-file=robot.json=${PERF_TEST_GOOGLE_APPLICATION_CREDENTIALS}
+}
+
+# Set up the user credentials for cluster operations.
+function setup_user() {
+  header "Setup User"
+
+  gcloud config set core/account ${USER_NAME}
+  gcloud auth activate-service-account ${USER_NAME} --key-file=${PERF_TEST_GOOGLE_APPLICATION_CREDENTIALS}
+  gcloud config set core/project ${PROJECT_NAME}
+
+  echo "gcloud user is $(gcloud config get-value core/account)"
+  echo "Using secret defined in ${PERF_TEST_GOOGLE_APPLICATION_CREDENTIALS}"
+}
+
+# Update resources installed on the cluster.
+# $1 -> cluster_name, $2 -> cluster_zone
+function update_cluster() {
+  local cluster_name=$1
+  local cluster_zone=$2
+  gcloud container clusters get-credentials $cluster_name --zone=$cluster_zone --project=${PROJECT_NAME} || abort "Failed to get cluster creds"
+  echo ">> Setting up 'prod' config-mako"
+  cat | kubectl apply -f - <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-mako
+data:
+  # This should only be used by our performance automation.
+  environment: prod
+EOF
+
+  if function_exists update_knative; then
+    update_knative || fail_test "failed to update knative"
+  fi
+  local benchmark_name=${cluster_name#$REPO_NAME"-"}
+  if function_exists update_benchmark; then
+    update_benchmark ${benchmark_name} || fail_test "failed to update benchmark"
+  fi
+}
+
+# Create a new cluster and install serving components and apply benchmark yamls.
+# $1 -> cluster_name, $2 -> cluster_zone, $3 -> node_count
+function create_new_cluster() {
+  # create a new cluster
+  create_cluster $1 $2 $3 || abort "Failed to create the new cluster $1"
+  
+  # create the secret on the new cluster
+  create_secret $1 $2 || abort "Failed to create secrets on the new cluster"
+
+  # update components on the cluster, e.g. serving and istio
+  update_cluster $1 $2 || abort "Failed to update the cluster"
+}
+
+function recreate_clusters() {
+  # set up the user credentials for cluster operations
+  setup_user
+
+  header "Recreating all clusters"
+  for cluster in $(gcloud container clusters list --project="${PROJECT_NAME}" --format="csv[no-heading](name,zone,currentNodeCount)"); do
+    [[ ! ${PROJECT_NAME} =~ ^${REPO_NAME} ]] && continue
+    name=$(echo $cluster | cut -f1 -d",")
+    zone=$(echo $cluster | cut -f2 -d",")
+    node_count=$(echo $cluster | cut -f3 -d",")
+    (( node_count=node_count/3 ))
+
+    # delete the old cluster
+    gcloud container clusters delete ${name} --zone ${zone} --quiet
+
+    # create a new cluster and update all the components
+    create_new_cluster ${name} ${zone} ${node_count}
+  done
+
+  header "Done recreating all clusters"
+}
+
+function update_clusters() {
+  # set up the credential for cluster operations
+  setup_user
+
+  # Get all clusters to update and ko apply config. Use newline to split
+  header "Update all clusters"
+  IFS=$'\n'
+  for cluster in $(gcloud container clusters list --project="${PROJECT_NAME}" --format="csv[no-heading](name,zone)"); do
+    [[ ! ${PROJECT_NAME} =~ ^${REPO_NAME} ]] && continue
+    name=$(echo $cluster | cut -f1 -d",")
+    zone=$(echo $cluster | cut -f2 -d",")
+
+    update_cluster ${name} ${zone}
+  done
+
+  header "Done updating all clusters"
+}
+
+NUM_NODES=1
+CLUSTER_NAME=""
+CLUSTER_REGION="us-central1"
+RECREATE_CLUSTERS=0
+UPDATE_CLUSTERS=0
+CREATE_CLUSTER_BENCHMARK=0
+
+# Parse flags and excute the command.
+function main() {
+  if (( ! IS_PROW )); then
+    abort "this script should only be run by Prow since it needs secrets created on Prow cluster"
+  fi
+
+  local command=$1
+  # Try parsing the first flag as a command.  
+  case ${command} in
+    --recreate_clusters) RECREATE_CLUSTERS=1 ;;
+    --update_clusters) UPDATE_CLUSTERS=1 ;;
+    --create_cluster_benchmark) CREATE_CLUSTER_BENCHMARK=1 ;;
+    *) abort "unknown command ${command}, must be --recreate_clusters / --update_clusters / --create_cluster_benchmark"
+  esac
+  shift
+
+  while [[ $# -ne 0 ]]; do
+    [[ $# -ge 2 ]] || abort "missing parameter after $1"
+    local parameter=$1
+    # Try parsing the options.
+    case ${parameter} in
+      --num_nodes) NUM_NODES=$2 ;;
+      --name) CLUSTER_NAME=$2 ;;
+      --region) CLUSTER_REGION=$2 ;;
+      *) abort "unknown option ${parameter}" ;;
+    esac
+    shift
+    shift
+  done
+
+  readonly NUM_NODES
+  readonly CLUSTER_NAME
+  readonly CLUSTER_REGION
+  readonly RECREATE_CLUSTERS
+  readonly UPDATE_CLUSTERS
+  readonly CREATE_CLUSTER_BENCHMARK
+
+  if (( RECREATE_CLUSTERS )); then
+    create_test_cluster
+  elif (( UPDATE_CLUSTERS )); then
+    setup_test_cluster
+  else
+    create_cluster_benchmark
+  fi
+}
+
+main $@

--- a/scripts/performance-tests.sh
+++ b/scripts/performance-tests.sh
@@ -123,15 +123,17 @@ function create_new_cluster() {
 function create_new_benchmark_cluster() {
   local benchmark_path="${BENCHMARK_ROOT_PATH}/$1"
   [ ! -d ${benchmark_path} ] && abort "benchmark $1 does not exist"
+  local prod_config_path="${benchmark_path}/prod.config"
+  [ ! -f ${prod_config_path} ] && echo "prod.config is not found, no cluster will be created" && return 0
   local cluster_name=$(get_cluster_name $1)
   local cluster_region="${CLUSTER_REGION}"
   local node_count="${CLUSTER_NODES}"
-  local config_file_path="${benchmark_path}/${CLUSTER_CONFIG_FILE}"
-  if [ ! -f ${config_file_path} ]; then
+  local cluster_config_path="${benchmark_path}/${CLUSTER_CONFIG_FILE}"
+  if [ ! -f ${cluster_config_path} ]; then
     echo "cluster.config is not found in benchmark $1, using the default config to create the cluster"
   else
-    cluster_region=$(get_config_value ${config_file_path} ${CLUSTER_REGION_CONFIG_NAME} ${CLUSTER_REGION})
-    node_count=$(get_config_value ${config_file_path} ${CLUSTER_NODES_CONFIG_NAME} ${CLUSTER_NODES})
+    cluster_region=$(get_config_value ${cluster_config_path} ${CLUSTER_REGION_CONFIG_NAME} ${CLUSTER_REGION})
+    node_count=$(get_config_value ${cluster_config_path} ${CLUSTER_NODES_CONFIG_NAME} ${CLUSTER_NODES})
   fi
 
   echo ">> Creating new cluster for benchmark $1 in ${REPO_NAME}"

--- a/scripts/performance-tests.sh
+++ b/scripts/performance-tests.sh
@@ -64,7 +64,7 @@ function create_cluster() {
     --scopes cloud-platform
 }
 
-# Create service account, github & slack token secrets on the cluster.
+# Create service account, Github and Slack token secrets on the cluster.
 # Parameters: $1 - cluster name
 #             $2 - cluster zone/region
 function create_secrets() {
@@ -123,7 +123,6 @@ function create_new_cluster() {
 function create_new_benchmark_cluster() {
   local benchmark_path="${BENCHMARK_ROOT_PATH}/$1"
   [ ! -d ${benchmark_path} ] && abort "benchmark $1 does not exist"
-  #   
   local cluster_name=$(get_cluster_name $1)
   local cluster_region="${CLUSTER_REGION}"
   local node_count="${CLUSTER_NODES}"
@@ -166,8 +165,7 @@ function get_cluster_name() {
 function recreate_clusters() {
   header "Recreating all clusters for ${REPO_NAME}"
   local all_clusters=$(gcloud container clusters list --project="${PROJECT_NAME}" --format="csv[no-heading](name,zone,currentNodeCount)")
-  echo ">> Listing all clusters:"
-  echo "${all_clusters}"
+  echo ">> Project contains clusters:" ${all_clusters}
   for cluster in ${all_clusters}; do
     local name=$(echo "${cluster}" | cut -f1 -d",")
     # the cluster name is prefixed with repo name, here we should only handle clusters related to the current repo
@@ -191,8 +189,7 @@ function recreate_clusters() {
 function update_clusters() {
   header "Updating all clusters for ${REPO_NAME}"
   local all_clusters=$(gcloud container clusters list --project="${PROJECT_NAME}" --format="csv[no-heading](name,zone)")
-  echo ">> Listing all clusters:"
-  echo "${all_clusters}"
+  echo ">> Project contains clusters:" ${all_clusters}
   for cluster in ${all_clusters}; do
     local name=$(echo "${cluster}" | cut -f1 -d",")
     # the cluster name is prefixed with repo name, here we should only handle clusters related to the current repo
@@ -206,15 +203,15 @@ function update_clusters() {
 }
 
 # Try to reset clusters for benchmarks in the current repo.
-# There can be three cases:
+# There can be 4 cases:
 # 1. If a new benchmark is added, create a new cluster for it;
 # 2. If a benchmark is deleted, delete its corresponding cluster;
 # 3. If a benchmark is renamed, delete the old cluster and create a new one.
+# 4. TODO(Fredy-Z): If the cluster.properties file is changed, delete the old cluster and create a new one.
 # This function will be run as postsubmit jobs.
 function reset_benchmark_clusters() {
   local all_clusters=$(gcloud container clusters list --project="${PROJECT_NAME}" --format="csv[no-heading](name,zone)")
-  echo ">> Listing all clusters:"
-  echo "${all_clusters}"
+  echo ">> Project contains clusters:" ${all_clusters}
   header "Trying to delete unused clusters for ${REPO_NAME}"
   for cluster in ${all_clusters}; do
     local name=$(echo "${cluster}" | cut -f1 -d",")

--- a/scripts/performance-tests.sh
+++ b/scripts/performance-tests.sh
@@ -19,6 +19,11 @@
 
 source $(dirname ${BASH_SOURCE})/library.sh
 
+# Configurable parameters.
+readonly CLUSTER_REGION=${CLUSTER_REGION:-us-central1}
+readonly CLUSTER_NODES=${CLUSTER_NODES:-1}
+readonly BENCHMARK_ROOT_PATH=${BENCHMARK_ROOT_PATH:-test/performance/benchmarks}
+
 # Setup env vars.
 readonly PROJECT_NAME="knative-performance"
 readonly USER_NAME="mako-job@knative-performance.iam.gserviceaccount.com"
@@ -26,25 +31,27 @@ readonly KO_DOCKER_REPO="gcr.io/${PROJECT_NAME}/${REPO_NAME}"
 readonly PERF_TEST_GOOGLE_APPLICATION_CREDENTIALS="/etc/performance-test/service-account.json"
 readonly PERF_TEST_GITHUB_TOKEN="/etc/performance-test/github-token"
 readonly PERF_TEST_SLACK_TOKEN="/etc/performance-test/slack-token"
-export TEST_ROOT_PATH="${GOPATH}/src/knative.dev/${REPO_NAME}/test/performance"
+readonly CLUSTER_CONFIG_FILE="cluster.properties"
+readonly CLUSTER_REGION_CONFIG_NAME="cluster_region"
+readonly CLUSTER_NODES_CONFIG_NAME="cluster_nodes"
 
 # Set up the user credentials for cluster operations.
 function setup_user() {
-  header "Setup User"
-
+  echo ">> Setup User"
   echo "Using gcloud user ${USER_NAME}"
   gcloud config set core/account ${USER_NAME}
   echo "Using secret defined in ${PERF_TEST_GOOGLE_APPLICATION_CREDENTIALS}"
   gcloud auth activate-service-account ${USER_NAME} --key-file=${PERF_TEST_GOOGLE_APPLICATION_CREDENTIALS}
+  echo "Using gcloud project ${PROJECT_NAME}"
   gcloud config set core/project ${PROJECT_NAME}
 }
 
 # Creates a new cluster.
 # Parameters: $1 - cluster name
 #             $2 - cluster zone/region
-#             $3 - cluster node num
+#             $3 - number of nodes in the cluster
 function create_cluster() {
-  header "Creating cluster $1 with $3 nodes in $2"
+  echo ">> Creating cluster $1 with $3 nodes in $2"
   gcloud beta container clusters create $1 \
     --addons=HorizontalPodAutoscaling,HttpLoadBalancing \
     --cluster-version=latest \
@@ -61,10 +68,10 @@ function create_cluster() {
 # Parameters: $1 - cluster name
 #             $2 - cluster zone/region
 function create_secrets() {
-  echo "Creating service account on cluster $1 in zone $2"
+  echo ">> Creating service account on cluster $1 in zone $2"
   gcloud container clusters get-credentials $1 --zone=$2 --project=${PROJECT_NAME} || abort "failed to get cluster creds"
   kubectl create secret generic service-account --from-file=robot.json=${PERF_TEST_GOOGLE_APPLICATION_CREDENTIALS}
-  kubectl create secret generic tokens --from-file=github-token=${PERF_TEST_GITHUB_TOKEN} --from-file=slack-token=${PERF_TEST_SLACK_TOKEN}
+  kubectl create secret generic tokens --from-file=github=${PERF_TEST_GITHUB_TOKEN} --from-file=slack=${PERF_TEST_SLACK_TOKEN}
 }
 
 # Update resources installed on the cluster.
@@ -83,24 +90,23 @@ data:
   environment: prod
 EOF
 
-  echo ">> Deleting all benchmark jobs to avoid noise"
+  echo ">> Deleting all benchmark jobs to avoid noise in the update process"
   kubectl delete cronjob --all
   kubectl delete job --all
   
   if function_exists update_knative; then
     update_knative || abort "failed to update knative"
   fi
-  # get benchmark_name by removing the prefix from cluster name, e.g. get "load-test" from "serving-load-test"
-  local benchmark_name=${1#$REPO_NAME"-"}
+  local benchmark_name=$(get_benchmark_name $1)
   if function_exists update_benchmark; then
-    update_benchmark ${TEST_ROOT_PATH}/${benchmark_name} || abort "failed to update benchmark"
+    update_benchmark ${BENCHMARK_ROOT_PATH}/${benchmark_name} || abort "failed to update benchmark"
   fi
 }
 
-# Create a new cluster and create required secrets on it.
+# Create a new cluster and do necessary setups.
 # Parameters: $1 - cluster name
 #             $2 - cluster zone/region
-#             $3 - cluster node num
+#             $3 - number of nodes in the cluster
 function create_new_cluster() {
   # create a new cluster
   create_cluster $1 $2 $3 || abort "failed to create the new cluster $1"
@@ -112,10 +118,55 @@ function create_new_cluster() {
   update_cluster $1 $2 || abort "failed to update the cluster"
 }
 
+# Create a new cluster for the benchmark and do necessary setups.
+# Parameters: $1 - benchmark name
+function create_new_benchmark_cluster() {
+  local benchmark_path="${BENCHMARK_ROOT_PATH}/$1"
+  [ ! -d ${benchmark_path} ] && abort "benchmark $1 does not exist"
+  #   
+  local cluster_name=$(get_cluster_name $1)
+  local cluster_region="${CLUSTER_REGION}"
+  local node_count="${CLUSTER_NODES}"
+  local config_file_path="${benchmark_path}/${CLUSTER_CONFIG_FILE}"
+  if [ ! -f ${config_file_path} ]; then
+    echo "cluster.config is not found in benchmark $1, using the default config to create the cluster"
+  else
+    cluster_region=$(get_config_value ${config_file_path} ${CLUSTER_REGION_CONFIG_NAME} ${CLUSTER_REGION})
+    node_count=$(get_config_value ${config_file_path} ${CLUSTER_NODES_CONFIG_NAME} ${CLUSTER_NODES})
+  fi
+
+  echo ">> Creating new cluster for benchmark $1 in ${REPO_NAME}"
+  create_new_cluster ${cluster_name} ${cluster_region} ${node_count}
+}
+
+# Get the value for the given key from the config file, return default value if not found.
+# Parameters: $1 - config file path
+#             $2 - config name
+#             $3 - default value
+function get_config_value() {
+  local value=$(grep $2 $1 | cut -d'=' -f2)
+  echo ${value:-$3}
+}
+
+# Get benchmark name from the cluster name.
+# Parameters: $1 - cluster name
+function get_benchmark_name() {
+  # get benchmark_name by removing the prefix from cluster name, e.g. get "load-test" from "serving-load-test"
+  echo ${1#$REPO_NAME"-"}
+}
+
+# Get cluster name from the benchmark name.
+# Parameters: $1 - benchmark name
+function get_cluster_name() {
+  # cluster_name is [repo_name]-[benchmark_name], e.g. serving-load-test
+  echo "${REPO_NAME}-$1"
+}
+
 # Delete the old clusters related to the current repo, and recreate them with the same configuration.
 function recreate_clusters() {
-  header "Recreating all clusters"
+  header "Recreating all clusters for ${REPO_NAME}"
   local all_clusters=$(gcloud container clusters list --project="${PROJECT_NAME}" --format="csv[no-heading](name,zone,currentNodeCount)")
+  echo ">> Listing all clusters:"
   echo "${all_clusters}"
   for cluster in ${all_clusters}; do
     local name=$(echo "${cluster}" | cut -f1 -d",")
@@ -123,6 +174,8 @@ function recreate_clusters() {
     [[ ! ${name} =~ ^${REPO_NAME} ]] && continue
     local zone=$(echo "${cluster}" | cut -f2 -d",")
     local node_count=$(echo "${cluster}" | cut -f3 -d",")
+    # we create regional clusters, it will create nodes in all its 3 zones. The node_count we get here is 
+    # the total node count, so we'll need to divide with 3 to get the actual regional node count
     (( node_count=node_count/3 ))
 
     # delete the old cluster
@@ -131,14 +184,14 @@ function recreate_clusters() {
     # create a new cluster and install required resources
     create_new_cluster ${name} ${zone} ${node_count}
   done
-
   header "Done recreating all clusters"
 }
 
 # Update the clusters related to the current repo.
 function update_clusters() {
-  header "Update all clusters"
+  header "Updating all clusters for ${REPO_NAME}"
   local all_clusters=$(gcloud container clusters list --project="${PROJECT_NAME}" --format="csv[no-heading](name,zone)")
+  echo ">> Listing all clusters:"
   echo "${all_clusters}"
   for cluster in ${all_clusters}; do
     local name=$(echo "${cluster}" | cut -f1 -d",")
@@ -149,51 +202,66 @@ function update_clusters() {
     # update all resources installed on the cluster
     update_cluster ${name} ${zone}
   done
-
   header "Done updating all clusters"
 }
 
-CREATE_CLUSTER_BENCHMARK=0
+# Try to reset clusters for benchmarks in the current repo.
+# There can be three cases:
+# 1. If a new benchmark is added, create a new cluster for it;
+# 2. If a benchmark is deleted, delete its corresponding cluster;
+# 3. If a benchmark is renamed, delete the old cluster and create a new one.
+# This function will be run as postsubmit jobs.
+function reset_benchmark_clusters() {
+  local all_clusters=$(gcloud container clusters list --project="${PROJECT_NAME}" --format="csv[no-heading](name,zone)")
+  echo ">> Listing all clusters:"
+  echo "${all_clusters}"
+  header "Trying to delete unused clusters for ${REPO_NAME}"
+  for cluster in ${all_clusters}; do
+    local name=$(echo "${cluster}" | cut -f1 -d",")
+    # the cluster name is prefixed with repo name, here we should only handle clusters related to the current repo
+    [[ ! ${name} =~ ^${REPO_NAME} ]] && continue
+    local zone=$(echo "${cluster}" | cut -f2 -d",")
+    local cluster_being_used=0
+    for benchmark_dir in ${BENCHMARK_ROOT_PATH}/*/; do
+      local benchmark_name=$(basename ${benchmark_dir})
+      [[ $(get_cluster_name ${benchmark_name}) == ${name} ]] && cluster_being_used=1 && break
+    done
+    if (( ! cluster_being_used )); then
+      gcloud container clusters delete ${name} --zone ${zone} --quiet
+    fi
+  done
+  header "Done deleting unused clusters"
+
+  local all_cluster_names=$(gcloud container clusters list --project="${PROJECT_NAME}" --format="value(name)")
+  header "Trying to create new clusters for ${REPO_NAME}"
+  for benchmark_dir in ${BENCHMARK_ROOT_PATH}/*/; do
+    local benchmark_name=$(basename ${benchmark_dir})
+    local cluster_exists=0
+    for name in ${all_cluster_names}; do
+      [[ $(get_cluster_name ${benchmark_name}) == ${name} ]] && cluster_exists=1 && break
+    done
+    if (( ! cluster_exists )); then
+      create_new_benchmark_cluster ${benchmark_name} || abort "failed to create cluster for the new benchmark ${benchmark_name}"
+    fi
+  done
+  header "Done creating new clusters"
+}
 
 # Parse flags and excute the command.
 function main() {
+  if (( ! IS_PROW )); then
+    abort "this script should only be run by Prow since it needs secrets created on Prow cluster"
+  fi
+
   # set up the user credentials for cluster operations
   setup_user || echo "failed to set up user"
 
-  local create_cluster_benchmark=0
-
-  local command=$1
   # Try parsing the first flag as a command.  
-  case ${command} in
-    --recreate_clusters) recreate_clusters ;;
-    --update_clusters) update_clusters ;;
-    --create_cluster_benchmark) create_cluster_benchmark=1 ;;
-    *) abort "unknown command ${command}, must be --recreate_clusters / --update_clusters / --create_cluster_benchmark"
+  case $1 in
+    --recreate-clusters) recreate_clusters ;;
+    --update-clusters) update_clusters ;;
+    --reset-benchmark-clusters) reset_benchmark_clusters ;;
+    *) abort "unknown command $1, must be --recreate-clusters, --update-clusters or --reset-benchmark-clusters"
   esac
   shift
-
-  local num_nodes=1
-  local cluster_name="" 
-  local cluster_region="us-central1"
-  while [[ $# -ne 0 ]]; do
-    [[ $# -ge 2 ]] || abort "missing parameter after $1"
-    local parameter=$1
-    # Try parsing the options.
-    case ${parameter} in
-      --name) cluster_name=$2 ;;
-      --region) cluster_region=$2 ;;
-      --num_nodes) num_nodes=$2 ;;
-      *) abort "unknown option ${parameter}" ;;
-    esac
-    shift
-    shift
-  done
-
-  if (( create_cluster_benchmark )); then
-    [[ ! -z "$cluster_name" ]] || abort "cluster name must be set when creating a new cluster"
-    [[ ! -z "$cluster_region" ]] || abort "cluster region must be set when creating a new cluster"
-    [[ ! -z "$num_nodes" ]] || abort "number of nodes must be set when creating a new cluster"
-
-    create_new_cluster "${REPO_NAME}-${cluster_name}" "${cluster_region}" "${num_nodes}"
-  fi
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Move scripts for performance testing from `serving` to `test-infra`, so `eventing` can also use it.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/hold