### PR TITLE
flaky-test-retryer: comment makes more sense

### DIFF
--- a/tools/flaky-test-retryer/README.md
+++ b/tools/flaky-test-retryer/README.md
@@ -79,7 +79,7 @@ tests and existing retry comments. They all follow a similar format:
 and have different footers, depending on the cross-reference result and the
 number of attempted retries:
 
-> Automatically retrying... /test presubmitJobName
+> Automatically retrying due to test flakiness... /test presubmitJobName
 
 if all tests that failed are currently flaky, triggering a retry.
 

--- a/tools/flaky-test-retryer/github_commenter.go
+++ b/tools/flaky-test-retryer/github_commenter.go
@@ -44,7 +44,7 @@ var (
 	testIdentifierPattern = fmt.Sprintf("<!--[%[1]s]%%s[%[1]s]-->", testIdentifierToken)
 	// reTestIdentifier is regex matching pattern for capturing testname
 	reTestIdentifier = regexp.MustCompile(fmt.Sprintf(`\[%[1]s\](.*?)\[%[1]s\]`, testIdentifierToken))
-	commentTemplate  = "%s\nThe following jobs failed due to test flakiness:\n\nTest name | Triggers | Retries\n--- | --- | ---\n%s\n\n%s"
+	commentTemplate  = "%s\nThe following jobs failed:\n\nTest name | Triggers | Retries\n--- | --- | ---\n%s\n\n%s"
 )
 
 // GithubClient wraps the ghutil Github client
@@ -231,7 +231,7 @@ func buildNewComment(jd *JobData, entries map[string]*entry, outliers []string) 
 // more retries available.
 func buildRetryString(job string, entries map[string]*entry) string {
 	if entries[job].retries++; entries[job].retries <= maxRetries {
-		return fmt.Sprintf("Automatically retrying...\n/test %s", job)
+		return fmt.Sprintf("Automatically retrying due to test flakiness...\n/test %s", job)
 	}
 	return ""
 }

--- a/tools/flaky-test-retryer/github_commenter_test.go
+++ b/tools/flaky-test-retryer/github_commenter_test.go
@@ -28,55 +28,55 @@ import (
 
 var (
 	legacyCommentBody = `<!--AUTOMATED-FLAKY-RETRYER-->
-The following jobs failed due to test flakiness:
+The following jobs failed:
 
 Test name | Retries
 --- | ---
 fakejob0 | 0/3
 fakejob1 | 1/3
 
-Automatically retrying...
+Automatically retrying due to test flakiness...
 /test fakejob1`
 	backwardCompatibleRetryCommentBody = `<!--[AUTOMATED-FLAKY-RETRYER]fakeSha[AUTOMATED-FLAKY-RETRYER]-->
-The following jobs failed due to test flakiness:
+The following jobs failed:
 
 Test name | Triggers | Retries
 --- | --- | ---
 fakejob0 | []() | 1/3
 
-Automatically retrying...
+Automatically retrying due to test flakiness...
 /test fakejob0`
 	resetCountRetryCommentBody = `<!--[AUTOMATED-FLAKY-RETRYER]fakeShafakeSha[AUTOMATED-FLAKY-RETRYER]-->
-The following jobs failed due to test flakiness:
+The following jobs failed:
 
 Test name | Triggers | Retries
 --- | --- | ---
 fakejob0 | []() | 1/3
 
-Automatically retrying...
+Automatically retrying due to test flakiness...
 /test fakejob0`
 	oldCommentBody = `<!--[AUTOMATED-FLAKY-RETRYER]fakeSha[AUTOMATED-FLAKY-RETRYER]-->
-The following jobs failed due to test flakiness:
+The following jobs failed:
 
 Test name | Triggers | Retries
 --- | --- | ---
 fakejob0 |  | 0/3
 fakejob1 | []() | 1/3
 
-Automatically retrying...
+Automatically retrying due to test flakiness...
 /test fakejob1`
 	retryCommentBody = `<!--[AUTOMATED-FLAKY-RETRYER]fakeSha[AUTOMATED-FLAKY-RETRYER]-->
-The following jobs failed due to test flakiness:
+The following jobs failed:
 
 Test name | Triggers | Retries
 --- | --- | ---
 fakejob0 | []() | 1/3
 fakejob1 | []() | 1/3
 
-Automatically retrying...
+Automatically retrying due to test flakiness...
 /test fakejob0`
 	noMoreRetriesCommentBody = `<!--[AUTOMATED-FLAKY-RETRYER]fakeSha[AUTOMATED-FLAKY-RETRYER]-->
-The following jobs failed due to test flakiness:
+The following jobs failed:
 
 Test name | Triggers | Retries
 --- | --- | ---
@@ -85,7 +85,7 @@ fakejob1 | []() | 1/3
 
 Job fakejob0 expended all 3 retries without success.`
 	failedShortCommentBody = `<!--[AUTOMATED-FLAKY-RETRYER]fakeSha[AUTOMATED-FLAKY-RETRYER]-->
-The following jobs failed due to test flakiness:
+The following jobs failed:
 
 Test name | Triggers | Retries
 --- | --- | ---
@@ -96,7 +96,7 @@ Failed non-flaky tests preventing automatic retry of fakejob0:
 
 ` + "```\ntest0\ntest1\ntest2\ntest3\n```"
 	failedLongCommentBody = `<!--[AUTOMATED-FLAKY-RETRYER]fakeSha[AUTOMATED-FLAKY-RETRYER]-->
-The following jobs failed due to test flakiness:
+The following jobs failed:
 
 Test name | Triggers | Retries
 --- | --- | ---


### PR DESCRIPTION
As discovered by @Fredy-Z  that the retryer comments are a bit confusing to users when a job failed with both flaky and non-flaky tests, change it to make it more accurate

/cc @Fredy-Z 