### PR TITLE
Make temp files creation work across OSes

### DIFF
--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -311,12 +311,26 @@ function capture_output() {
   return ${failed}
 }
 
+# Create a temporary file with the given extension in a way that works on both Linux and macOS.
+# Parameters: $1 - file name without extension (e.g. 'myfile_XXXX')
+#             $2 - file extension (e.g. 'xml')
+function mktemp_with_extension() {
+  local nameprefix
+  local fullname
+
+  nameprefix="$(mktemp $1)"
+  fullname="${nameprefix}.$2"
+  mv ${nameprefix} ${fullname}
+
+  echo ${fullname}
+}
+
 # Create a JUnit XML for a test.
 # Parameters: $1 - check class name as an identifier (e.g. BuildTests)
 #             $2 - check name as an identifier (e.g., GoBuild)
 #             $3 - failure message (can contain newlines), optional (means success)
 function create_junit_xml() {
-  local xml="$(mktemp ${ARTIFACTS}/junit_XXXXXXXX.xml)"
+  local xml="$(mktemp_with_extension ${ARTIFACTS}/junit_XXXXXXXX xml)"
   local failure=""
   if [[ "$3" != "" ]]; then
     # Transform newlines into HTML code.
@@ -352,7 +366,7 @@ function report_go_test() {
   echo "Finished run, return code is ${failed}"
   # Install go-junit-report if necessary.
   run_go_tool github.com/jstemmer/go-junit-report go-junit-report --help > /dev/null 2>&1
-  local xml=$(mktemp ${ARTIFACTS}/junit_XXXXXXXX.xml)
+  local xml="$(mktemp_with_extension ${ARTIFACTS}/junit_XXXXXXXX xml)"
   cat ${report} \
       | go-junit-report \
       | sed -e "s#\"\(github\.com/knative\|knative\.dev\)/${REPO_NAME}/#\"#g" \


### PR DESCRIPTION
**What this PR does, why we need it**:

The `file_XXXXX` pattern only works with files that do not have an extension on macOS, so temporal XML files are currently created with the literal and conflicting name `junit_XXXXXXXX.xml`.

**Special notes to reviewers**:

**User-visible changes in this PR**:

