### PR TITLE
Added monitoring for code coverage post-submit

### DIFF
--- a/tools/coverage/artifacts/local.go
+++ b/tools/coverage/artifacts/local.go
@@ -68,7 +68,7 @@ func (arts *LocalArtifacts) KeyProfileCreator() *os.File {
 
 // ProduceProfileFile produce coverage profile (&its stdout) by running go test on target package
 // for periodic job, produce junit xml for testgrid in addition
-func (arts *LocalArtifacts) ProduceProfileFile(covTargetsStr string) {
+func (arts *LocalArtifacts) ProduceProfileFile(covTargetsStr string) error {
 	// creates artifacts directory
 	log.Printf("mkdir -p %s\n", arts.directory)
 	cmd := exec.Command("mkdir", "-p", arts.directory)
@@ -82,5 +82,5 @@ func (arts *LocalArtifacts) ProduceProfileFile(covTargetsStr string) {
 	}
 	log.Printf("covTargets = %v\n", covTargets)
 
-	runProfiling(covTargets, arts)
+	return runProfiling(covTargets, arts)
 }

--- a/tools/coverage/artifacts/local_test.go
+++ b/tools/coverage/artifacts/local_test.go
@@ -36,8 +36,12 @@ func TestProfiling(t *testing.T) {
 			"key-cov-profile.txt",
 			"stdout.txt"),
 	}
-	arts.ProduceProfileFile(fmt.Sprintf("../%s/subPkg1/ "+
+	err := arts.ProduceProfileFile(fmt.Sprintf("../%s/subPkg1/ "+
 		"../%s/subPkg2/", test.CovTargetRootRel, test.CovTargetRootRel))
+
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	t.Logf("Verifying profile file...\n")
 	expectedFirstLine := "mode: count"

--- a/tools/coverage/artifacts/profiling.go
+++ b/tools/coverage/artifacts/profiling.go
@@ -16,6 +16,7 @@ limitations under the License.
 package artifacts
 
 import (
+	"fmt"
 	"io"
 	"log"
 	"os"
@@ -34,7 +35,7 @@ func NewProfileReader(reader io.ReadCloser) *ProfileReader {
 
 // runProfiling writes coverage profile (&its stdout) by running go test on
 // target package
-func runProfiling(covTargets []string, localArts *LocalArtifacts) {
+func runProfiling(covTargets []string, localArts *LocalArtifacts) (err error) {
 	log.Println("\nStarts calc.runProfiling(...)")
 
 	cmdArgs := []string{"test"}
@@ -49,8 +50,9 @@ func runProfiling(covTargets []string, localArts *LocalArtifacts) {
 	output, errCmdOutput := cmd.CombinedOutput()
 
 	if errCmdOutput != nil {
-		log.Printf("Error running 'go test -coverprofile ': error='%v'; combined output='%s'\n",
+		err = fmt.Errorf("Error running 'go test -coverprofile ': error='%v'; combined output='%s'\n",
 			errCmdOutput, output)
+		log.Printf(err.Error())
 	}
 
 	log.Printf("coverage profile created @ '%s'", localArts.ProfilePath())

--- a/tools/coverage/artifacts/profiling.go
+++ b/tools/coverage/artifacts/profiling.go
@@ -50,7 +50,7 @@ func runProfiling(covTargets []string, localArts *LocalArtifacts) (err error) {
 	output, errCmdOutput := cmd.CombinedOutput()
 
 	if errCmdOutput != nil {
-		err = fmt.Errorf("Error running 'go test -coverprofile ': error='%v'; combined output='%s'\n",
+		err = fmt.Errorf("error running 'go test -coverprofile ': error='%v'; combined output='%s'\n",
 			errCmdOutput, output)
 		log.Printf(err.Error())
 	}

--- a/tools/coverage/main.go
+++ b/tools/coverage/main.go
@@ -77,7 +77,11 @@ func main() {
 		defaultStdoutRedirect,
 	)
 
-	localArtifacts.ProduceProfileFile(*coverageTargetDir)
+	if err := localArtifacts.ProduceProfileFile(*coverageTargetDir); err != nil {
+		if jobType == "postsubmit" {
+			defer log.Fatalf("Profile production failed: %v", err)
+		}
+	}
 
 	switch jobType {
 	case "presubmit":

--- a/tools/coverage/presubmit_test.go
+++ b/tools/coverage/presubmit_test.go
@@ -80,7 +80,9 @@ func preSubmitForTest() (data *gcs.PreSubmit) {
 func TestRunPresubmit(t *testing.T) {
 	log.Println("Starting TestRunPresubmit")
 	arts := artsTest.LocalArtsForTest("TestRunPresubmit")
-	arts.ProduceProfileFile("./" + test.CovTargetRelPath)
+	if err := arts.ProduceProfileFile("./" + test.CovTargetRelPath); err != nil {
+		t.Fatal(err)
+	}
 	p := preSubmitForTest()
 	RunPresubmit(p, arts)
 	if !test.FileOrDirExists(arts.LineCovFilePath()) {

--- a/tools/monitoring/config/config.yaml
+++ b/tools/monitoring/config/config.yaml
@@ -162,7 +162,7 @@ spec:
         prs-affected: 0
         period: 1440
 
-  - error-pattern: "Error running 'go test -coverprofile '"
+  - error-pattern: "error running 'go test -coverprofile '"
     hint: 'Check build file and see why go test failed. Continuous failure of this test will cause
     outdated comparison base for pre-submit code coverage check.'
     alerts:

--- a/tools/monitoring/config/config.yaml
+++ b/tools/monitoring/config/config.yaml
@@ -161,3 +161,14 @@ spec:
         jobs-affected: 1
         prs-affected: 0
         period: 1440
+
+  - error-pattern: "Error running 'go test -coverprofile '"
+    hint: 'Check build file and see why go test failed. Continuous failure of this test will cause
+    outdated comparison base for pre-submit code coverage check.'
+    alerts:
+      - job-name-regex: 'post.*'
+        occurrences: 2
+        jobs-affected: 1
+        prs-affected: 0
+        period: 1440
+


### PR DESCRIPTION
`go test -coverprofile` returns a non-zero return code if any of the unit test fails.
While occasional such failure may be caused by flakiness, consistent failures in post-submit workflow of code coverage is likely caused by bad configuration or running environment. We want to be able to monitor on these failures with pre-set thresholds.
1. make post-submit job fail at the end, if the `go test` has a non-zero return code
2. Add the error pattern to monitoring so that alert will be sent if threshold is met

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #

**Special notes to reviewers**:

**User-visible changes in this PR**:

