### PR TITLE
Build flaky-test-reporter using go1.12

### DIFF
--- a/images/flaky-test-reporter/Dockerfile
+++ b/images/flaky-test-reporter/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.10.2
+FROM golang:1.12
 LABEL maintainer "Chao Dai <chaodai@google.com>"
 RUN apt-get update
 


### PR DESCRIPTION
Building docker image failed due to go version being too old, update it to use 1.12

/cc @adrcunha 