### PR TITLE
Fix latency and coverage Makefiles

### DIFF
--- a/images/coverage/Dockerfile
+++ b/images/coverage/Dockerfile
@@ -32,4 +32,4 @@ RUN cp $TEMP_REPO_DIR/tools/$TOOL_NAME/$TOOL_NAME /$TOOL_NAME
 # Remove test-infra from the container
 RUN rm -fr $TEMP_REPO_DIR
 
-ENTRYPOINT ["/metrics"]
+ENTRYPOINT ["/coverage"]

--- a/images/coverage/Dockerfile
+++ b/images/coverage/Dockerfile
@@ -12,5 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-all:
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build .
+FROM golang:1.12.1
+LABEL maintainer "Stephen Lu <syzf@google.com>"
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    git
+
+ENV TEMP_REPO_DIR /go/src/knative.dev/test-infra
+ENV TOOL_NAME coverage
+
+# Temporarily add test-infra to the image to build custom tools
+ADD . $TEMP_REPO_DIR
+
+# Build tool in the container
+RUN make -C $TEMP_REPO_DIR/tools/$TOOL_NAME/
+RUN cp $TEMP_REPO_DIR/tools/$TOOL_NAME/$TOOL_NAME /$TOOL_NAME
+
+# Remove test-infra from the container
+RUN rm -fr $TEMP_REPO_DIR
+
+ENTRYPOINT ["/metrics"]

--- a/images/coverage/Makefile
+++ b/images/coverage/Makefile
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-all:
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build .
+IMAGE_NAME ?= coverage
+include ../../shared/Makefile.simple-image

--- a/images/latency/Dockerfile
+++ b/images/latency/Dockerfile
@@ -12,13 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.10.2
-
-LABEL maintainer="adrcunha@google.com"
-
+FROM golang:1.12
+LABEL maintainer "Adriano Cunha <adrcunha@google.com>"
 RUN apt-get update && apt-get install -y --no-install-recommends
 
-COPY tools/latency/latency /metrics
+ENV TEMP_REPO_DIR /go/src/knative.dev/test-infra
+ENV TOOL_NAME latency
+
+# Temporarily add test-infra to the image to build custom tools
+ADD . $TEMP_REPO_DIR
+
+# Build tool in the container
+RUN make -C $TEMP_REPO_DIR/tools/$TOOL_NAME/
+RUN cp $TEMP_REPO_DIR/tools/$TOOL_NAME/$TOOL_NAME /metrics
+
+# Remove test-infra from the container
+RUN rm -fr $TEMP_REPO_DIR
 
 ENTRYPOINT ["/metrics"]
-

--- a/images/latency/Makefile
+++ b/images/latency/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2019 The OSS Authors.
+# Copyright 2019 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,13 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.12.1
-LABEL maintainer="kubernetes-test-infra-coverage-feature-owner@google.com"
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates \
-    git
-
-COPY coverage /coverage
-ENTRYPOINT ["/coverage"]
-
+IMAGE_NAME = metrics
+include ../../shared/Makefile.simple-image

--- a/shared/Makefile.simple-image
+++ b/shared/Makefile.simple-image
@@ -15,8 +15,8 @@
 # Rules for creating simple docker images.
 
 # This is not a real Makefile. It should be included by another Makefile,
-# and IMAGE_NAME set appropriately. Set BINARY_DIR to `go build` a binary,
-# if desired. You must also provide a Dockerfile together with the Makefile.
+# and IMAGE_NAME set appropriately. You must also provide a Dockerfile
+# together with the Makefile.
 
 REGISTRY ?= gcr.io
 PROJECT  ?= knative-tests
@@ -27,9 +27,6 @@ TAG := $(shell date +v%Y%m%d)-$(shell git describe --always --dirty --match '^$$
 all: build
 
 build:
-ifdef BINARY_DIR
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build $(BINARY_DIR)
-endif
 	docker build -t $(IMG):$(TAG) -f Dockerfile ../..
 	docker tag $(IMG):$(TAG) $(IMG):latest
 

--- a/tools/coverage/README.md
+++ b/tools/coverage/README.md
@@ -16,11 +16,12 @@ See the [design document](design.md).
 
 ## Build and Release
 
-Run `make IMAGE_NAME=coverage-dev push` to build and upload a staging version,
-intended for testing and debugging. The staging version can be triggered on a PR
-through the comment `/test pull-knative-serving-go-coverage-dev`. Note that
-staging version can only be tested against the serving repository because the
-staging jobs only exist in the serving repository.
+In the `/images/coverage` directory, run `make IMAGE_NAME=coverage-dev push` to
+build and upload a staging version, intended for testing and debugging. The
+staging version can be triggered on a PR through the comment
+`/test pull-knative-serving-go-coverage-dev`. Note that staging version can only
+be tested against the serving repository because the staging jobs only exist in
+the serving repository.
 
 ### Validating the staging version
 

--- a/tools/latency/Makefile
+++ b/tools/latency/Makefile
@@ -12,6 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-IMAGE_NAME = metrics
-BINARY_DIR = .
-include ../../shared/Makefile.simple-image
+all:
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build .


### PR DESCRIPTION
Build the tools in the container for compatibility sake.

Remove the support from building a binary in the shared Makefile, since this is now unused.