### PR TITLE
Hide error when gcp isn't being used

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -485,7 +485,9 @@ function main() {
   parse_flags $@
   # Log what will be done and where.
   banner "Release configuration"
-  echo "- gcloud user: $(gcloud config get-value core/account)"
+  if which gcloud &>/dev/null ; then
+    echo "- gcloud user: $(gcloud config get-value core/account)"
+  fi
   echo "- Go path: ${GOPATH}"
   echo "- Repository root: ${REPO_ROOT_DIR}"
   echo "- Destination GCR: ${KO_DOCKER_REPO}"


### PR DESCRIPTION
When running `hack/release.sh --skip-tests` I see this:
```
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@@@@ Mon Sep  9 10:02:40 PDT 2019
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
hack/../vendor/knative.dev/test-infra/scripts/release.sh: line 488: gcloud: command not found
- gcloud user:
- Go path: /home/travis/gopath
- Repository root: /home/travis/gopath/src/knative.dev/eventing
- Destination GCR: ko.local
- Tests will NOT be run
- Artifacts WILL NOT be tagged
- Release will not be published
- Release will be BUILT FROM SOURCE
```
Notice the error after the banner.

This will hide that.

Signed-off-by: Doug Davis <dug@us.ibm.com>

/lint