### PR TITLE
Acquire cluster admin role for only GKE

### DIFF
--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -326,7 +326,6 @@ function setup_test_cluster() {
   # Setup the admin role and also KO_DOCKER_REPO if it is a GKE cluster
   if [[ -z "$(kubectl get clusterrolebinding cluster-admin-binding 2> /dev/null)" && "${k8s_cluster}" =~ ^gke_.* ]]; then
     acquire_cluster_admin_role ${k8s_user} ${E2E_CLUSTER_NAME} ${E2E_CLUSTER_REGION} ${E2E_CLUSTER_ZONE}
-    kubectl config set-context ${k8s_cluster} --namespace=default
     # Incorporate an element of randomness to ensure that each run properly publishes images.
     export KO_DOCKER_REPO=gcr.io/${E2E_PROJECT_ID}/${E2E_BASE_NAME}-e2e-img/${RANDOM}
   fi
@@ -334,6 +333,9 @@ function setup_test_cluster() {
   # Safety checks
   is_protected_gcr ${KO_DOCKER_REPO} && \
     abort "\$KO_DOCKER_REPO set to ${KO_DOCKER_REPO}, which is forbidden"
+
+  # Use default namespace for all subsequent kubectl commands in this context
+  kubectl config set-context ${k8s_cluster} --namespace=default
 
   echo "- gcloud project is ${E2E_PROJECT_ID}"
   echo "- gcloud user is ${k8s_user}"

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -323,7 +323,7 @@ function setup_test_cluster() {
     abort "kubeconfig context set to ${k8s_cluster}, which is forbidden"
 
   # If cluster admin role isn't set, this is a brand new cluster
-  # Setup the admin role and also KO_DOCKER_REPO
+  # Setup the admin role and also KO_DOCKER_REPO if it is a GKE cluster
   if [[ -z "$(kubectl get clusterrolebinding cluster-admin-binding 2> /dev/null)" && "${k8s_cluster}" =~ ^gke_.* ]]; then
     acquire_cluster_admin_role ${k8s_user} ${E2E_CLUSTER_NAME} ${E2E_CLUSTER_REGION} ${E2E_CLUSTER_ZONE}
     kubectl config set-context ${k8s_cluster} --namespace=default

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -324,7 +324,7 @@ function setup_test_cluster() {
 
   # If cluster admin role isn't set, this is a brand new cluster
   # Setup the admin role and also KO_DOCKER_REPO
-  if [[ -z "$(kubectl get clusterrolebinding cluster-admin-binding 2> /dev/null)" ]]; then
+  if [[ -z "$(kubectl get clusterrolebinding cluster-admin-binding 2> /dev/null)" && "${k8s_cluster}" =~ ^gke_.* ]]; then
     acquire_cluster_admin_role ${k8s_user} ${E2E_CLUSTER_NAME} ${E2E_CLUSTER_REGION} ${E2E_CLUSTER_ZONE}
     kubectl config set-context ${k8s_cluster} --namespace=default
     # Incorporate an element of randomness to ensure that each run properly publishes images.

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -335,9 +335,9 @@ function setup_test_cluster() {
   is_protected_gcr ${KO_DOCKER_REPO} && \
     abort "\$KO_DOCKER_REPO set to ${KO_DOCKER_REPO}, which is forbidden"
 
-  echo "- Project is ${E2E_PROJECT_ID}"
+  echo "- gcloud project is ${E2E_PROJECT_ID}"
+  echo "- gcloud user is ${k8s_user}"
   echo "- Cluster is ${k8s_cluster}"
-  echo "- User is ${k8s_user}"
   echo "- Docker is ${KO_DOCKER_REPO}"
 
   export KO_DATA_PATH="${REPO_ROOT_DIR}/.git"


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
According to the documents under https://knative.dev/docs/install/, cluster admin role is only required for GKE, so in `e2e-tests.sh`, only acquire cluster admin role for GKE clusters.

This can potentially make `e2e-tests.sh --run-tests` works with other Kubernetes vendors as long as the clusters and other environments are properly set up.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @adrcunha 
/cc @chaodaiG 