### PR TITLE
add env vars for tokens

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -5861,6 +5861,12 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: PERF_TEST_GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/performance-test/service-account.json
+      - name: GITHUB_TOKEN
+        value: /etc/performance-test/github-token
+      - name: SLACK_READ_TOKEN
+        value: /etc/performance-test/slack-read-token
+      - name: SLACK_WRITE_TOKEN
+        value: /etc/performance-test/slack-write-token
     volumes:
     - name: test-account
       secret:
@@ -5897,6 +5903,12 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: PERF_TEST_GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/performance-test/service-account.json
+      - name: GITHUB_TOKEN
+        value: /etc/performance-test/github-token
+      - name: SLACK_READ_TOKEN
+        value: /etc/performance-test/slack-read-token
+      - name: SLACK_WRITE_TOKEN
+        value: /etc/performance-test/slack-write-token
     volumes:
     - name: test-account
       secret:
@@ -5933,6 +5945,12 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: PERF_TEST_GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/performance-test/service-account.json
+      - name: GITHUB_TOKEN
+        value: /etc/performance-test/github-token
+      - name: SLACK_READ_TOKEN
+        value: /etc/performance-test/slack-read-token
+      - name: SLACK_WRITE_TOKEN
+        value: /etc/performance-test/slack-write-token
     volumes:
     - name: test-account
       secret:
@@ -5969,6 +5987,12 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: PERF_TEST_GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/performance-test/service-account.json
+      - name: GITHUB_TOKEN
+        value: /etc/performance-test/github-token
+      - name: SLACK_READ_TOKEN
+        value: /etc/performance-test/slack-read-token
+      - name: SLACK_WRITE_TOKEN
+        value: /etc/performance-test/slack-write-token
     volumes:
     - name: test-account
       secret:

--- a/ci/prow/periodic_config.go
+++ b/ci/prow/periodic_config.go
@@ -448,5 +448,8 @@ func perfClusterUpdatePeriodicJob(jobName, cronString, command, repo, sa string)
 	addEnvToJob(&data.Base, "GOOGLE_APPLICATION_CREDENTIALS", data.Base.ServiceAccount)
 	addVolumeToJob(&data.Base, "/etc/performance-test", sa, true, "")
 	addEnvToJob(&data.Base, "PERF_TEST_GOOGLE_APPLICATION_CREDENTIALS", "/etc/performance-test/service-account.json")
+	addEnvToJob(&data.Base, "GITHUB_TOKEN", "/etc/performance-test/github-token")
+	addEnvToJob(&data.Base, "SLACK_READ_TOKEN", "/etc/performance-test/slack-read-token")
+	addEnvToJob(&data.Base, "SLACK_WRITE_TOKEN", "/etc/performance-test/slack-write-token")
 	executeJobTemplate(jobName, readTemplate(periodicTestJob), "presubmits", "", data.PeriodicJobName, false, data)
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Add the github token and slack tokens as env vars for performance test related jobs

Note:
@chaodaiG We haven't add the tokens in secret `eventing-performance-test`, but it won't cause any error since we haven't set up eventing to use them now.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @chaodaiG @srinivashegde86 