### PR TITLE
golang format tools

### DIFF
--- a/tools/coverage/githubUtil/github_test.go
+++ b/tools/coverage/githubUtil/github_test.go
@@ -50,9 +50,9 @@ func TestFilePathProfileToGithub(t *testing.T) {
 			getRepoRoot = func() (string, error) {
 				return tt.args.repoRoot, nil
 			}
-			defer func(){
-			    os.Setenv("GOPATH", gopath)
-			    getRepoRoot = getRepoRootSaved
+			defer func() {
+				os.Setenv("GOPATH", gopath)
+				getRepoRoot = getRepoRootSaved
 			}()
 			if got := FilePathProfileToGithub(tt.args.file); got != tt.want {
 				t.Errorf("FilePathProfileToGithub(%v) = %v, want %v", tt.args.file, got, tt.want)


### PR DESCRIPTION
<!--golang format tools-->
<!---->
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
/assign adrcunha
