### PR TITLE
Convert all 'nil =='style to '== nil' style

### DIFF
--- a/ci/prow/make_config.go
+++ b/ci/prow/make_config.go
@@ -232,7 +232,7 @@ func generateCron(jobType, jobName string, timeout int) string {
 func readTemplate(fp string) string {
 	if _, ok := templatesCache[fp]; !ok {
 		content, err := ioutil.ReadFile(path.Join(templateDir, fp))
-		if nil != err {
+		if err != nil {
 			log.Fatalf("Failed read file '%s': '%v'", fp, err)
 		}
 		templatesCache[fp] = string(content)

--- a/shared/common/common.go
+++ b/shared/common/common.go
@@ -55,7 +55,7 @@ func GetRootDir() (string, error) {
 // CDToRootDir change directory to git root dir
 func CDToRootDir() error {
 	d, err := GetRootDir()
-	if nil != err {
+	if err != nil {
 		return err
 	}
 	return os.Chdir(d)

--- a/shared/junit/junit.go
+++ b/shared/junit/junit.go
@@ -110,7 +110,7 @@ func (testSuites *TestSuites) GetTestSuite(suiteName string) (*TestSuite, error)
 
 // AddTestSuite adds TestSuite to TestSuites
 func (testSuites *TestSuites) AddTestSuite(testSuite *TestSuite) error {
-	if _, err := testSuites.GetTestSuite(testSuite.Name); nil == err {
+	if _, err := testSuites.GetTestSuite(testSuite.Name); err == nil {
 		return fmt.Errorf("Test suite '%s' already exists", testSuite.Name)
 	}
 	testSuites.Suites = append(testSuites.Suites, *testSuite)
@@ -129,13 +129,13 @@ func (testSuites *TestSuites) ToBytes(prefix, indent string) ([]byte, error) {
 // the input Suite
 func UnMarshal(buf []byte) (*TestSuites, error) {
 	var testSuites TestSuites
-	if err := xml.Unmarshal(buf, &testSuites); nil == err {
+	if err := xml.Unmarshal(buf, &testSuites); err == nil {
 		return &testSuites, nil
 	}
 
 	// The input might be a TestSuite if reach here, try parsing with TestSuite
 	testSuites.Suites = append([]TestSuite(nil), TestSuite{})
-	if err := xml.Unmarshal(buf, &testSuites.Suites[0]); nil != err {
+	if err := xml.Unmarshal(buf, &testSuites.Suites[0]); err != nil {
 		return nil, err
 	}
 	return &testSuites, nil

--- a/shared/junit/junit_test.go
+++ b/shared/junit/junit_test.go
@@ -91,25 +91,25 @@ func newTestCase(name string, status TestStatusEnum) *TestCase {
 }
 
 func TestUnmarshalEmptySuites(t *testing.T) {
-	if _, err := UnMarshal([]byte(emptySuites)); nil != err {
+	if _, err := UnMarshal([]byte(emptySuites)); err != nil {
 		t.Errorf("Expected 'succeed', actual: 'failed parsing empty suites, '%s'", err)
 	}
 }
 
 func TestUnmarshalMalFormed(t *testing.T) {
-	if _, err := UnMarshal([]byte(malSuitesString)); nil == err {
+	if _, err := UnMarshal([]byte(malSuitesString)); err == nil {
 		t.Errorf("Expected: failed, actual: succeeded parsing malformed xml, '%s'", err)
 	}
 }
 
 func TestUnmarshalSuites(t *testing.T) {
-	if _, err := UnMarshal([]byte(validSuitesString)); nil != err {
+	if _, err := UnMarshal([]byte(validSuitesString)); err != nil {
 		t.Errorf("Expected: succeed, actual: failed parsing suites result, '%s'", err)
 	}
 }
 
 func TestUnmarshalSuite(t *testing.T) {
-	if _, err := UnMarshal([]byte(validSuiteString)); nil != err {
+	if _, err := UnMarshal([]byte(validSuiteString)); err != nil {
 		t.Errorf("Expected: succeed, actual: failed parsing suite result, '%s'", err)
 	}
 }
@@ -136,7 +136,7 @@ func TestAddTestSuite(t *testing.T) {
 	}
 
 	expectedErrString := "Test suite 'suite_0' already exists"
-	if err := testSuites.AddTestSuite(&testSuite0); nil == err || err.Error() != expectedErrString {
+	if err := testSuites.AddTestSuite(&testSuite0); err == nil || err.Error() != expectedErrString {
 		t.Fatalf("Expected: '%s', actual: '%v'", expectedErrString, err)
 	}
 

--- a/shared/testgrid/testgrid.go
+++ b/shared/testgrid/testgrid.go
@@ -65,7 +65,7 @@ func CreateXMLOutput(tc []junit.TestCase, testName string) error {
 
 	// ensure artifactsDir exist, in case not invoked from this script
 	artifactsDir := prow.GetLocalArtifactsDir()
-	if err := common.CreateDir(artifactsDir); nil != err {
+	if err := common.CreateDir(artifactsDir); err != nil {
 		return err
 	}
 	op, err := ts.ToBytes("", "  ")

--- a/shared/testgrid/testgrid_test.go
+++ b/shared/testgrid/testgrid_test.go
@@ -63,7 +63,7 @@ func TestXMLOutput(t *testing.T) {
 }
 
 func TestConfigPath(t *testing.T) {
-	if _, err := NewConfig(); nil != err {
+	if _, err := NewConfig(); err != nil {
 		t.Fatalf("Testing default config file, want: no err, got: %v", err)
 	}
 }

--- a/shared/testgrid/yaml.go
+++ b/shared/testgrid/yaml.go
@@ -47,7 +47,7 @@ type Tab struct {
 // NewConfig loads from default config
 func NewConfig() (*Config, error) {
 	root, err := common.GetRootDir()
-	if nil != err {
+	if err != nil {
 		return nil, err
 	}
 	return NewConfigFromFile(path.Join(root, configPath))
@@ -57,10 +57,10 @@ func NewConfig() (*Config, error) {
 func NewConfigFromFile(fp string) (*Config, error) {
 	ac := &Config{}
 	contents, err := ioutil.ReadFile(fp)
-	if nil == err {
+	if err == nil {
 		err = yaml.Unmarshal(contents, ac)
 	}
-	if nil != err {
+	if err != nil {
 		return nil, err
 	}
 	return ac, err

--- a/tools/flaky-test-reporter/config/config.go
+++ b/tools/flaky-test-reporter/config/config.go
@@ -54,19 +54,19 @@ type SlackChannel struct {
 
 func init() {
 	contents, err := ioutil.ReadFile(configFile)
-	if nil != err {
+	if err != nil {
 		// If running in container the relative path would not work,
 		// get current file dir and try to resolve it with Abs path
 		dir, _ := filepath.Abs(filepath.Dir(os.Args[0]))
 		contents, err = ioutil.ReadFile(filepath.Join(dir, configFile))
 	}
-	if nil != err {
+	if err != nil {
 		log.Printf("Failed to load the config file: %v", err)
 		return
 	}
 
 	config := &Config{}
-	if err = yaml.Unmarshal(contents, config); nil != err {
+	if err = yaml.Unmarshal(contents, config); err != nil {
 		log.Printf("Failed to unmarshal %v", contents)
 	} else {
 		JobConfigs = config.JobConfigs

--- a/tools/flaky-test-reporter/github_issue_test.go
+++ b/tools/flaky-test-reporter/github_issue_test.go
@@ -192,8 +192,8 @@ func TestUpdateIssue(t *testing.T) {
 		}
 
 		gotErr := fgih.updateIssue(&fi, "new", &data.ts, dryrun)
-		if nil == data.wantErr {
-			if nil != gotErr {
+		if data.wantErr == nil {
+			if gotErr != nil {
 				t.Fatalf("update %v, got err: '%v', want err: '%v'", data, gotErr, data.wantErr)
 			}
 		} else {

--- a/tools/flaky-test-reporter/json_reporter.go
+++ b/tools/flaky-test-reporter/json_reporter.go
@@ -62,7 +62,7 @@ func writeFlakyTestsToJSON(repoDataAll []RepoData, dryrun bool) error {
 					_, err := client.CreateReport(repo, testList, true)
 					return err
 				},
-				dryrun); nil != err {
+				dryrun); err != nil {
 				allErrs = append(allErrs, err)
 				log.Printf("failed writing JSON report for repo '%s': '%v'", repo, err)
 			}

--- a/tools/flaky-test-reporter/jsonreport/jsonreport.go
+++ b/tools/flaky-test-reporter/jsonreport/jsonreport.go
@@ -75,12 +75,12 @@ func (c *JSONClient) CreateReport(repo string, flaky []string, writeFile bool) (
 // writeToArtifactsDir writes the flaky test data for this repo to disk.
 func (c *JSONClient) writeToArtifactsDir(r *Report) error {
 	artifactsDir := prow.GetLocalArtifactsDir()
-	if err := common.CreateDir(path.Join(artifactsDir, r.Repo)); nil != err {
+	if err := common.CreateDir(path.Join(artifactsDir, r.Repo)); err != nil {
 		return err
 	}
 	outFilePath := path.Join(artifactsDir, r.Repo, filename)
 	contents, err := json.Marshal(r)
-	if nil != err {
+	if err != nil {
 		return err
 	}
 	return ioutil.WriteFile(outFilePath, contents, 0644)
@@ -115,7 +115,7 @@ func (c *JSONClient) GetReportRepos(jobName string) ([]string, error) {
 // Use repo = "" to get reports from all repositories, and buildID = -1 to get the
 // most recent report
 func (c *JSONClient) GetFlakyTestReport(jobName, repo string, buildID int) ([]Report, error) {
-	if "" == jobName {
+	if jobName == "" {
 		jobName = defaultJobName
 	}
 	job := prow.NewJob(jobName, prow.PeriodicJob, "", 0)

--- a/tools/flaky-test-reporter/main.go
+++ b/tools/flaky-test-reporter/main.go
@@ -56,31 +56,31 @@ func main() {
 		log.Printf("running in [dry run mode]")
 	}
 
-	if err := prow.Initialize(*serviceAccount); nil != err { // Explicit authenticate with gcs Client
+	if err := prow.Initialize(*serviceAccount); err != nil { // Explicit authenticate with gcs Client
 		log.Fatalf("Failed authenticating GCS: '%v'", err)
 	}
 
 	var repoDataAll []RepoData
 	// Clean up local artifacts directory, this will be used later for artifacts uploads
 	err := os.RemoveAll(prow.GetLocalArtifactsDir()) // this function returns nil if path not found
-	if nil != err {
+	if err != nil {
 		log.Fatalf("Failed removing local artifacts directory: %v", err)
 	}
 	var jobErrs []error
 	for _, jc := range config.JobConfigs {
 		log.Printf("collecting results for job '%s' in repo '%s'\n", jc.Name, jc.Repo)
 		rd, err := collectTestResultsForRepo(jc)
-		if nil != err {
+		if err != nil {
 			err = fmt.Errorf("WARNING: error collecting results for job '%s' in repo '%s': %v", jc.Name, jc.Repo, err)
 			log.Printf("%v", err)
 			jobErrs = append(jobErrs, err)
 			continue
 		}
-		if nil == rd.LastBuildStartTime {
+		if rd.LastBuildStartTime == nil {
 			log.Printf("WARNING: no build found, skipping '%s' in repo '%s'", jc.Name, jc.Repo)
 			continue
 		}
-		if err = createArtifactForRepo(*rd); nil != err {
+		if err = createArtifactForRepo(*rd); err != nil {
 			log.Fatalf("Error creating artifacts for job '%s' in repo '%s': %v", jc.Name, jc.Repo, err)
 		}
 		repoDataAll = append(repoDataAll, *rd)
@@ -102,18 +102,17 @@ func main() {
 		slackErr = slackOperations(*slackAccount, repoDataAll, flakyIssues, *dryrun)
 	}
 
-	if nil != jobErr {
+	if jobErr != nil {
 		log.Printf("Job step failures:\n%v", jobErr)
 	}
-
-	if nil != slackErr {
+	if slackErr != nil {
 		log.Printf("Slack step failures:\n%v", slackErr)
 	}
-	if nil != jsonErr {
+	if jsonErr != nil {
 		log.Printf("JSON step failures:\n%v", jsonErr)
 	}
 	// Fail this job if there is any error
-	if nil != jobErr || nil != jsonErr || nil != ghErr || nil != slackErr {
+	if jobErr != nil || jsonErr != nil || ghErr != nil || slackErr != nil {
 		os.Exit(1)
 	}
 }
@@ -134,7 +133,7 @@ func slackOperations(slackToken string, repoData []RepoData, flakyIssues map[str
 	}
 
 	client, err := slackutil.NewWriteClient(knativeBotName, slackToken)
-	if nil != err {
+	if err != nil {
 		return err
 	}
 

--- a/tools/flaky-test-reporter/result.go
+++ b/tools/flaky-test-reporter/result.go
@@ -126,12 +126,12 @@ func flakyRateAboveThreshold(rd RepoData) bool {
 func createArtifactForRepo(rd RepoData) error {
 	artifactsDir := prow.GetLocalArtifactsDir()
 	err := common.CreateDir(path.Join(artifactsDir, rd.Config.Repo))
-	if nil != err {
+	if err != nil {
 		return err
 	}
 	outFilePath := path.Join(artifactsDir, rd.Config.Repo, rd.Config.Name+".json")
 	contents, err := json.Marshal(rd)
-	if nil != err {
+	if err != nil {
 		return err
 	}
 	return ioutil.WriteFile(outFilePath, contents, 0644)
@@ -139,7 +139,7 @@ func createArtifactForRepo(rd RepoData) error {
 
 // addSuiteToRepoData adds all testCase from suite into RepoData
 func addSuiteToRepoData(suite *junit.TestSuite, buildID int, rd *RepoData) {
-	if nil == rd.TestStats {
+	if rd.TestStats == nil {
 		rd.TestStats = make(map[string]*TestStat)
 	}
 	for _, testCase := range suite.TestCases {
@@ -172,10 +172,10 @@ func getCombinedResultsForBuild(build *prow.Build) ([]*junit.TestSuites, error) 
 		}
 		relPath, _ := filepath.Rel(build.StoragePath, artifact)
 		contents, err := build.ReadFile(relPath)
-		if nil != err {
+		if err != nil {
 			return nil, err
 		}
-		if suites, err := junit.UnMarshal(contents); nil != err {
+		if suites, err := junit.UnMarshal(contents); err != nil {
 			return nil, err
 		} else {
 			allSuites = append(allSuites, suites)
@@ -202,7 +202,7 @@ func collectTestResultsForRepo(jc config.JobConfig) (*RepoData, error) {
 			rd.LastBuildStartTime = build.StartTime
 		}
 		combinedResults, err := getCombinedResultsForBuild(&build)
-		if nil != err {
+		if err != nil {
 			return nil, err
 		}
 		for _, suites := range combinedResults {
@@ -219,9 +219,9 @@ func (rd *RepoData) getResultSliceForTest(testName string) []junit.TestStatusEnu
 	ts := rd.TestStats[testName]
 	for i, buildID := range rd.BuildIDs {
 		switch {
-		case true == intSliceContains(ts.Failed, buildID):
+		case intSliceContains(ts.Failed, buildID):
 			res[i] = junit.Failed
-		case true == intSliceContains(ts.Passed, buildID):
+		case intSliceContains(ts.Passed, buildID):
 			res[i] = junit.Passed
 		default:
 			res[i] = junit.Skipped
@@ -251,8 +251,8 @@ func getLatestFinishedBuilds(job *prow.Job, count int) []prow.Build {
 			break
 		}
 		build := job.NewBuild(buildID)
-		if nil != build.FinishTime {
-			if nil == build.StartTime {
+		if build.FinishTime != nil {
+			if build.StartTime == nil {
 				log.Fatalf("Failed parsing start time for finished build '%s'", build.StoragePath)
 			}
 			builds = append(builds, *build)

--- a/tools/flaky-test-reporter/slack_notification.go
+++ b/tools/flaky-test-reporter/slack_notification.go
@@ -40,13 +40,13 @@ func createSlackMessageForRepo(rd RepoData, flakyIssuesMap map[string][]*flakyIs
 	flakyTests := getFlakyTests(rd)
 	message := fmt.Sprintf("As of %s, there are %d flaky tests in '%s' from repo '%s'",
 		time.Unix(*rd.LastBuildStartTime, 0).String(), len(flakyTests), rd.Config.Name, rd.Config.Repo)
-	if "" == rd.Config.IssueRepo {
+	if rd.Config.IssueRepo == "" {
 		message += fmt.Sprintf("\n(Job is marked to not create GitHub issues)")
 	}
 	if flakyRateAboveThreshold(rd) { // Don't list each test as this can be huge
 		flakyRate := getFlakyRate(rd)
 		message += fmt.Sprintf("\n>- skip displaying all tests as flaky rate above threshold")
-		if flakyIssues, ok := flakyIssuesMap[getBulkIssueIdentity(rd, flakyRate)]; ok && "" != rd.Config.IssueRepo {
+		if flakyIssues, ok := flakyIssuesMap[getBulkIssueIdentity(rd, flakyRate)]; ok && rd.Config.IssueRepo != "" {
 			// When flaky rate is above threshold, there is only one issue created,
 			// so there is only one element in flakyIssues
 			for _, fi := range flakyIssues {
@@ -56,7 +56,7 @@ func createSlackMessageForRepo(rd RepoData, flakyIssuesMap map[string][]*flakyIs
 	} else {
 		for _, testFullName := range flakyTests {
 			message += fmt.Sprintf("\n>- %s", testFullName)
-			if flakyIssues, ok := flakyIssuesMap[getIdentityForTest(testFullName, rd.Config.Repo)]; ok && "" != rd.Config.IssueRepo {
+			if flakyIssues, ok := flakyIssuesMap[getIdentityForTest(testFullName, rd.Config.Repo)]; ok && rd.Config.IssueRepo != "" {
 				for _, fi := range flakyIssues {
 					message += fmt.Sprintf("\t%s", fi.issue.GetHTMLURL())
 				}
@@ -64,7 +64,7 @@ func createSlackMessageForRepo(rd RepoData, flakyIssuesMap map[string][]*flakyIs
 		}
 	}
 
-	if testgridTabURL, err := testgrid.GetTestgridTabURL(rd.Config.Name, []string{testgridFilter}); nil != err {
+	if testgridTabURL, err := testgrid.GetTestgridTabURL(rd.Config.Name, []string{testgridFilter}); err != nil {
 		log.Println(err) // don't fail as this could be optional
 	} else {
 		message += fmt.Sprintf("\nSee Testgrid for up-to-date flaky tests information: %s", testgridTabURL)
@@ -94,7 +94,7 @@ func sendSlackNotifications(repoDataAll []RepoData, c slackutil.WriteOperations,
 						return c.Post(message, channel.Identity)
 					},
 					dryrun,
-				); nil != err {
+				); err != nil {
 					allErrs = append(allErrs, err)
 					log.Printf("failed sending notification to Slack channel '%s': '%v'", channel.Name, err)
 				}

--- a/tools/flaky-test-retryer/github_commenter.go
+++ b/tools/flaky-test-retryer/github_commenter.go
@@ -69,7 +69,7 @@ func (e *entry) toString() string {
 // only keep latest 3 links
 func (e *entry) addLink(newLink string) {
 	var oldLinks []string
-	if "" != e.links {
+	if e.links != "" {
 		oldLinks = strings.Split(e.links, "<br>")
 	}
 	if len(oldLinks) >= maxRetries { // only keep last 2 if more than 2
@@ -186,7 +186,7 @@ func parseEntries(body string) (map[string]*entry, error) {
 	entryStrings := re.FindAllString(body, -1)
 	for _, e := range entryStrings {
 		en, err := stringToEntry(e)
-		if nil != err {
+		if err != nil {
 			return nil, err
 		}
 		entries[en.name] = en

--- a/tools/flaky-test-retryer/github_commenter_test.go
+++ b/tools/flaky-test-retryer/github_commenter_test.go
@@ -285,7 +285,7 @@ func TestAppendComment(t *testing.T) {
 		fj.Refs[0].Pulls[0].SHA = test.commitSHA
 		fgc.PostComment(&fj, test.outliers)
 		actualComment, actualErr := fgc.getOldComment(fakeOrg, fakeRepo, fakePullID)
-		if nil != actualErr {
+		if actualErr != nil {
 			t.Fatalf("testing appending existing comment, with:\nold comment:\n%s\nfailed tests:'%v'\nwant: no error\ngot: %v",
 				test.oldCommentBody, test.outliers, actualErr)
 		}

--- a/tools/flaky-test-retryer/log_parser.go
+++ b/tools/flaky-test-retryer/log_parser.go
@@ -141,10 +141,10 @@ func GetCombinedResultsForBuild(build *prow.Build) ([]*junit.TestSuites, error) 
 		}
 		relPath, _ := filepath.Rel(build.StoragePath, artifact)
 		contents, err := build.ReadFile(relPath)
-		if nil != err {
+		if err != nil {
 			return nil, err
 		}
-		if suites, err := junit.UnMarshal(contents); nil != err {
+		if suites, err := junit.UnMarshal(contents); err != nil {
 			return nil, err
 		} else {
 			allSuites = append(allSuites, suites)

--- a/tools/githubhelper/githubhelper.go
+++ b/tools/githubhelper/githubhelper.go
@@ -48,7 +48,7 @@ var (
 // otherwise it falls back to use an anonymous client
 func authenticate(githubTokenPath *string) {
 	client = github.NewClient(nil)
-	if nil == githubTokenPath || "" == *githubTokenPath {
+	if githubTokenPath == nil || *githubTokenPath == "" {
 		return
 	}
 

--- a/tools/prow-auto-bumper/file.go
+++ b/tools/prow-auto-bumper/file.go
@@ -52,7 +52,7 @@ func (pv *PRVersions) updateAllTags(content []byte, imageFilter *regexp.Regexp) 
 		lastIndex = m[1]
 
 		iv := pv.getIndex(image, tag)
-		if "" != pv.images[image][iv].newVersion {
+		if pv.images[image][iv].newVersion != "" {
 			res += pv.images[image][iv].newVersion
 			msg += fmt.Sprintf("\nImage: %s\nOld Tag: %s\nNew Tag: %s", image, tag, pv.images[image][iv].newVersion)
 		} else {

--- a/tools/prow-auto-bumper/getversion_test.go
+++ b/tools/prow-auto-bumper/getversion_test.go
@@ -43,7 +43,7 @@ func getFakeGitInfo() gitInfo {
 
 func createPullRequest(t *testing.T, fgc *fakeghutil.FakeGithubClient, fakeGi gitInfo) *github.PullRequest {
 	PR, err := fgc.CreatePullRequest(fakeGi.org, fakeGi.repo, fakeGi.getHeadRef(), fakeGi.base, "title", "body")
-	if nil != err {
+	if err != nil {
 		t.Fatalf("Create PR in %s/%s, want: no error, got: '%v'", fakeGi.org, fakeGi.org, err)
 	}
 	return PR
@@ -345,11 +345,11 @@ func TestGetBestVersion(t *testing.T) {
 		}
 
 		pv, err := getBestVersion(fcw, fakeGi)
-		if nil != err {
+		if err != nil {
 			t.Fatalf("get best versions with PRs '%v', want: no error, got: '%v'", data.PRInfos, err)
 		}
-		if nil == data.dominantVersions {
-			if nil != pv && nil != pv.dominantVersions {
+		if data.dominantVersions == nil {
+			if pv != nil && pv.dominantVersions != nil {
 				t.Fatalf("get best versions with PRs '%v', want: nil, got: '%v'", data.PRInfos, pv.getDominantVersions())
 			}
 		} else if eq := reflect.DeepEqual(*data.dominantVersions, pv.getDominantVersions()); !eq {
@@ -365,7 +365,7 @@ func TestRetryGetBestVersion(t *testing.T) {
 
 	// only the error case exercises all the code in the function
 	_, err := retryGetBestVersion(fcw, fakeGi)
-	if nil == err || !strings.Contains(err.Error(), "failed list pull request") {
+	if err == nil || !strings.Contains(err.Error(), "failed list pull request") {
 		t.Fatalf("retry get best version with no PRs, want error: 'failed list pull request', got: '%v'", err)
 	}
 }

--- a/tools/prow-auto-bumper/main.go
+++ b/tools/prow-auto-bumper/main.go
@@ -34,12 +34,12 @@ func main() {
 	dryrun := flag.Bool("dry-run", false, "dry run switch")
 	flag.Parse()
 
-	if nil != dryrun && true == *dryrun {
+	if dryrun != nil && *dryrun {
 		log.Println("Running in [dry run mode]")
 	}
 
 	gc, err := ghutil.NewGithubClient(*githubAccount)
-	if nil != err {
+	if err != nil {
 		log.Fatalf("cannot authenticate to github: %v", err)
 	}
 
@@ -63,18 +63,18 @@ func main() {
 
 	gcw := &GHClientWrapper{gc}
 	bestVersion, err := retryGetBestVersion(gcw, srcGI)
-	if nil != err {
+	if err != nil {
 		log.Fatalf("cannot get best version from %s/%s: '%v'", srcGI.org, srcGI.repo, err)
 	}
 	log.Printf("Found version to update. Old Version: '%s', New Version: '%s'",
 		bestVersion.dominantVersions.oldVersion, bestVersion.dominantVersions.newVersion)
 
 	msgs, err := bestVersion.updateAllFiles(fileFilters, imageRegexp, *dryrun)
-	if nil != err {
+	if err != nil {
 		log.Fatalf("failed updating files: '%v'", err)
 	}
 
-	if err = createOrUpdatePR(gcw, bestVersion, targetGI, msgs, *dryrun); nil != err {
+	if err = createOrUpdatePR(gcw, bestVersion, targetGI, msgs, *dryrun); err != nil {
 		log.Fatalf("failed creating pullrequest: '%v'", err)
 	}
 }

--- a/tools/prow-auto-bumper/parser.go
+++ b/tools/prow-auto-bumper/parser.go
@@ -47,7 +47,7 @@ func deconstructTag(in string) (string, string) {
 func getDominantKey(m map[string]int) string {
 	var res string
 	for key, v := range m {
-		if "" == res || v > m[res] {
+		if res == "" || v > m[res] {
 			res = key
 		}
 	}
@@ -57,7 +57,7 @@ func getDominantKey(m map[string]int) string {
 // The way k8s updates versions doesn't guarantee the same version tag across all images,
 // dominantVersions is the version that appears most times
 func (pv *PRVersions) getDominantVersions() versions {
-	if nil != pv.dominantVersions {
+	if pv.dominantVersions != nil {
 		return *pv.dominantVersions
 	}
 
@@ -83,11 +83,11 @@ func (pv *PRVersions) getDominantVersions() versions {
 // Parse changelist, find all version changes, and store them in image name: versions map
 func (pv *PRVersions) parseChangelist(gcw *GHClientWrapper, gi gitInfo) error {
 	fs, err := gcw.ListFiles(gi.org, gi.repo, *pv.PR.Number)
-	if nil != err {
+	if err != nil {
 		return err
 	}
 	for _, f := range fs {
-		if nil == f.Patch {
+		if f.Patch == nil {
 			continue
 		}
 		minuses := imageMinusRegexp.FindAllStringSubmatch(*f.Patch, -1)
@@ -114,12 +114,12 @@ func getBestVersion(gcw *GHClientWrapper, gi gitInfo) (*PRVersions, error) {
 	var overallErr error
 	var bestDelta float64 = maxDelta + 1
 	PRs, err := gcw.ListPullRequests(gi.org, gi.repo, gi.getHeadRef(), gi.base)
-	if nil != err {
+	if err != nil {
 		return bestPv, fmt.Errorf("failed list pull request: '%v'", err)
 	}
 
 	for _, PR := range PRs {
-		if nil == PR.State || string(ghutil.PullRequestCloseState) != *PR.State {
+		if PR.State == nil || string(ghutil.PullRequestCloseState) != *PR.State {
 			continue
 		}
 		delta := targetTime.Sub(*PR.CreatedAt).Hours()
@@ -130,12 +130,12 @@ func getBestVersion(gcw *GHClientWrapper, gi gitInfo) (*PRVersions, error) {
 			images: make(map[string][]versions),
 			PR:     PR,
 		}
-		if err := pv.parseChangelist(gcw, gi); nil != err {
+		if err := pv.parseChangelist(gcw, gi); err != nil {
 			overallErr = fmt.Errorf("failed listing files from PR '%d': '%v'", *PR.Number, err)
 			break
 		}
 		vs := pv.getDominantVersions()
-		if "" == vs.oldVersion || "" == vs.newVersion {
+		if vs.oldVersion == "" || vs.newVersion == "" {
 			log.Printf("Warning: found PR misses version change '%d'", *PR.Number)
 			continue
 		}
@@ -155,7 +155,7 @@ func getBestVersion(gcw *GHClientWrapper, gi gitInfo) (*PRVersions, error) {
 				continue
 			}
 		}
-		if nil == bestPv || math.Abs(delta) < math.Abs(bestDelta) {
+		if bestPv == nil || math.Abs(delta) < math.Abs(bestDelta) {
 			bestDelta = delta
 			bestPv = &pv
 		}
@@ -169,7 +169,7 @@ func retryGetBestVersion(gcw *GHClientWrapper, gi gitInfo) (*PRVersions, error) 
 	// retry if there is github related error
 	for retryCount := 0; retryCount < maxRetry; retryCount++ {
 		bestPv, overallErr = getBestVersion(gcw, gi)
-		if nil == overallErr {
+		if overallErr == nil {
 			break
 		}
 		log.Println(overallErr)


### PR DESCRIPTION
Currently there is a mixture of `nil == err` and `err == nil` styles, and the former one was mainly introduced by me, the primary purpose was to avoid accidental variable assignment like
```
if err = nil {
}
```
Which is always true in some other languages. This is not the case in go as it would complain `syntax error: assignment err = nil used as value`. This change convert all `nil == err` usages to `err == nil` to ensure consistency