### PR TITLE
Use var for regexp.mustCompile

### DIFF
--- a/ci/prow/make_config.go
+++ b/ci/prow/make_config.go
@@ -173,6 +173,8 @@ var (
 
 	// Map which sections of the config.yaml were written to stdout.
 	sectionMap map[string]bool
+
+	projNameRegex = regexp.MustCompile(`.+-[0-9\.]+$`)
 )
 
 // Generate cron string based on job type, offset generated from jobname
@@ -1028,7 +1030,7 @@ func buildProjRepoStr(projName string, repoName string) string {
 
 // isReleased returns true for project name that has version
 func isReleased(projName string) bool {
-	return regexp.MustCompile(`.+-[0-9\.]+$`).FindString(projName) != ""
+	return projNameRegex.FindString(projName) != ""
 }
 
 // setOutput set the given file as the output target, then all the output will be written to this file

--- a/ci/prow/testgrid_config.go
+++ b/ci/prow/testgrid_config.go
@@ -60,6 +60,8 @@ var (
 
 	// templatesCache caches templates in memory to avoid I/O
 	templatesCache = make(map[string]string)
+
+	contRegex = regexp.MustCompile(`-[0-9\.]+-continuous`)
 )
 
 // baseTestgridTemplateData contains basic data about the testgrid config file.
@@ -128,7 +130,7 @@ func generateTestGroup(projName string, repoName string, jobNames []string) {
 		extras := make(map[string]string)
 		switch jobName {
 		case "continuous", "dot-release", "auto-release", "performance", "performance-mesh", "latency", "nightly":
-			isDailyBranch := regexp.MustCompile(`-[0-9\.]+-continuous`).FindString(testGroupName) != ""
+			isDailyBranch := contRegex.FindString(testGroupName) != ""
 			if !isDailyBranch && (jobName == "continuous" || jobName == "auto-release") {
 				// TODO(Fredy-Z): this value should be derived from the cron string
 				extras["alert_stale_results_hours"] = "3"

--- a/tools/flaky-test-reporter/github_issue.go
+++ b/tools/flaky-test-reporter/github_issue.go
@@ -73,9 +73,8 @@ var (
 	// testIdentifierPattern is used for formatting test identifier,
 	// expect an argument of test identifier
 	testIdentifierPattern = fmt.Sprintf("[%[1]s]%%s[%[1]s]", testIdentifierToken)
-	// reTestIdentifier is regex matching pattern for capturing testname
-	reTestIdentifier      = fmt.Sprintf(`\[%[1]s\](.*?)\[%[1]s\]`, testIdentifierToken)
-	reTestIdentifierRegex = regexp.MustCompile(reTestIdentifier)
+	// regex matching pattern for capturing testname
+	reTestIdentifierRegex = regexp.MustCompile(fmt.Sprintf(`\[%[1]s\](.*?)\[%[1]s\]`, testIdentifierToken))
 
 	// historyPattern is for creating history section in commment,
 	// expect an argument of history Unicode from previous comment
@@ -83,17 +82,15 @@ var (
 		beforeHistoryToken, afterHistoryToken, passedUnicode, failedUnicode, skippedUnicode)
 	// reHistory is for identifying history from comment
 	reHistory = fmt.Sprintf("(?s)%s(.*?)%s", beforeHistoryToken, afterHistoryToken)
-	// reSingleRecord is for identifying each single record
-	reSingleRecord      = `[0-9]{4}\-[0-9]{2}\-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} [+\-][0-9]{4} [A-Z]{3}:.*`
-	reSingleRecordRegex = regexp.MustCompile(reSingleRecord)
+	// regex for identifying each single record
+	reSingleRecordRegex = regexp.MustCompile(`[0-9]{4}\-[0-9]{2}\-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} [+\-][0-9]{4} [A-Z]{3}:.*`)
 
 	// latestStatusPattern is for creating latest test result line in comment,
 	// expect an argument of test status as defined in result.go
 	latestStatusPattern = fmt.Sprintf(`%s%%s`, latestStatusToken)
 
-	// reLastestStatus is for identifying latest test result from comment
-	reLastestStatus     = fmt.Sprintf(`%s([a-zA-Z]*)`, latestStatusToken)
-	reLatestStatusRegex = regexp.MustCompile(reLastestStatus)
+	// regex for identifying latest test result from comment
+	reLatestStatusRegex = regexp.MustCompile(fmt.Sprintf(`%s([a-zA-Z]*)`, latestStatusToken))
 
 	// Precompute timeConsiderOld so that the same standard used everywhere
 	timeConsiderOld = time.Now().AddDate(0, 0, -daysConsiderOld)

--- a/tools/flaky-test-retryer/github_commenter.go
+++ b/tools/flaky-test-retryer/github_commenter.go
@@ -45,6 +45,7 @@ var (
 	// reTestIdentifier is regex matching pattern for capturing testname
 	reTestIdentifier = regexp.MustCompile(fmt.Sprintf(`\[%[1]s\](.*?)\[%[1]s\]`, testIdentifierToken))
 	commentTemplate  = "%s\nThe following jobs failed:\n\nTest name | Triggers | Retries\n--- | --- | ---\n%s\n\n%s"
+	entriesRegex     = regexp.MustCompile(`.* \| \d/\d`)
 )
 
 // GithubClient wraps the ghutil Github client
@@ -182,8 +183,7 @@ func (gc *GithubClient) getOldComment(org, repo string, pull int) (*github.Issue
 // a new comment.
 func parseEntries(body string) (map[string]*entry, error) {
 	entries := make(map[string]*entry)
-	re := regexp.MustCompile(`.* \| \d/\d`)
-	entryStrings := re.FindAllString(body, -1)
+	entryStrings := entriesRegex.FindAllString(body, -1)
 	for _, e := range entryStrings {
 		en, err := stringToEntry(e)
 		if err != nil {

--- a/tools/latency/main.go
+++ b/tools/latency/main.go
@@ -38,10 +38,13 @@ import (
 	"google.golang.org/api/option"
 )
 
-var ctx = context.Background()
-var client *storage.Client
-var e2eDuration = regexp.MustCompile("\\((\\d+\\.\\d+)s\\)")
-var sourceDir string
+var (
+	ctx         = context.Background()
+	e2eDuration = regexp.MustCompile("\\((\\d+\\.\\d+)s\\)")
+
+	client    *storage.Client
+	sourceDir string
+)
 
 type Metric struct {
 	values        []int


### PR DESCRIPTION
regexp.MustCompile panics when the compile fails. We should do this only during packga init and not later when defining vars as that will execute everything and panic at runtime when calling MustCompile instead of failing at the start before executing anything
