### PR TITLE
Add `kail` to the Prow testing image.

### DIFF
--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -61,6 +61,9 @@ ADD . /go/src/knative.dev/test-infra
 RUN make -C /go/src/knative.dev/test-infra/tools/githubhelper
 RUN cp /go/src/knative.dev/test-infra/tools/githubhelper/githubhelper .
 
+# We would prefer to install with go get -u github.com/boz/kail, but it is broken
+RUN /go/src/knative.dev/test-infra/images/prow-tests/install-kail.sh
+
 # Use a local dep-collector that's a wrapper for building the tool
 # on-the-fly.
 # TODO(adrcunha): Remove once https://github.com/knative/test-infra/pull/1019 is in all repos.

--- a/images/prow-tests/install-kail.sh
+++ b/images/prow-tests/install-kail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+bash <( curl -sfL https://raw.githubusercontent.com/boz/kail/master/godownloader.sh) -b "$GOPATH/bin"

--- a/images/prow-tests/install-kail.sh
+++ b/images/prow-tests/install-kail.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 bash <( curl -sfL https://raw.githubusercontent.com/boz/kail/master/godownloader.sh) -b "$GOPATH/bin"


### PR DESCRIPTION
The `go get -u` command for it is broken, so using the recommended download command from the repo.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

First half of solving https://github.com/knative/serving/issues/5459

Have not pushed image yet.