### PR TITLE
Remove some ununsed vars

### DIFF
--- a/tools/monitoring/subscriber/subscriber.go
+++ b/tools/monitoring/subscriber/subscriber.go
@@ -38,7 +38,6 @@ type Client struct {
 // Operation defines a list of methods for subscribing messages
 type Operation interface {
 	Receive(ctx context.Context, f func(context.Context, *pubsub.Message)) error
-	String() string
 }
 
 // NewSubscriberClient returns a new SubscriberClient used to read crier pubsub messages

--- a/tools/monitoring/subscriber/subscriber_test.go
+++ b/tools/monitoring/subscriber/subscriber_test.go
@@ -28,17 +28,12 @@ import (
 
 type contextKey int
 
-const (
-	keyError contextKey = iota
-)
+const keyError contextKey = iota
 
-type fakeSubscriber struct {
-	Operation
-	name string
-}
+type fakeSubscriber struct{}
 
 func getFakeSubscriber(n string) *Client {
-	return &Client{&fakeSubscriber{name: n}}
+	return &Client{&fakeSubscriber{}}
 }
 
 func (fs *fakeSubscriber) Receive(ctx context.Context, f func(context.Context, *pubsub.Message)) error {
@@ -46,10 +41,6 @@ func (fs *fakeSubscriber) Receive(ctx context.Context, f func(context.Context, *
 		return err.(error)
 	}
 	return nil
-}
-
-func (fs *fakeSubscriber) String() string {
-	return fs.name
 }
 
 func TestSubscriberClient_ReceiveMessageAckAll(t *testing.T) {


### PR DESCRIPTION
We have some ununsed vars initially intended for testing, but we dont really use them. Delete them instead.