### PR TITLE
Add instruction for verifying flaky-test-report locally + fix a small…

### DIFF
--- a/tools/flaky-test-reporter/README.md
+++ b/tools/flaky-test-reporter/README.md
@@ -23,16 +23,14 @@ Flags for this tool are:
 ## How To Debug/Verify Changes
 
 For debugging purpose it's highly recommended to start with `--dry-run` flag, by
-passing this flag it will only collect information from GCS/Github, and
-all the manipulations of Github/Slack resources are omitted.
+passing this flag it will only **read** information from GCS/Github, and
+all the **writes** of Github/Slack resources are omitted.
 
 ### Requirement
 
-- `GCP token`: Create a service account by visiting
-  `https://pantheon.corp.google.com/iam-admin/serviceaccounts?project=[YOUR_PROJECT]`,
-  navigate to newly created service account, and click `CREATE KEY` button and
-  select `JSON`. Download generated json key file and save it securely on your
-  system.
+- `GCP token`: Create a GCP service account following this
+  [instruction](https://cloud.google.com/iam/docs/creating-managing-service-account-keys).
+  Download generated json key file and save it securely on your system.
 - `Github token`: Create a github token by visiting
   `https://github.com/settings/tokens`, click `Generate new token` and select at
   least `repo:status` and `public_repo` permissions before generate the token.
@@ -48,12 +46,14 @@ go run [REPO_ROOT]/tools/flaky-test-reporter --service-account "[PATH_OF_GCP_TOK
  --github-account "[PATH_OF_GITHUB_TOKEN]" --dry-run
 ``` 
 
-## Prow Job
+## Prow Jobs
 
-There is a prow job(ci-knative-flakes-reporter) that triggers this tool at 4:00/5:00AM(Day light saving)
-everyday, which does Github/Slack reporting. Another prow
-job(ci-knative-flakes-resultsrecorder) that runs every hour, which does only
-data collection part by passing `--skip-report` flag, the data it collected can be used like [this](https://github.com/knative/test-infra/blob/11c44d69473c167f76da249625d67431b6fe90df/tools/flaky-test-reporter/jsonreport/jsonreport.go#L117)
+1. `ci-knative-flakes-reporter`: triggers this tool at 4:00/5:00AM(Day light saving)
+everyday, which does Github/Slack reporting.
+1. `ci-knative-flakes-resultsrecorder`: runs every hour, does only data
+   collection part by passing `--skip-report` flag, the data it collected can be
+   used like
+   [this](https://github.com/knative/test-infra/blob/11c44d69473c167f76da249625d67431b6fe90df/tools/flaky-test-reporter/jsonreport/jsonreport.go#L117)
 
 ## Considerations
 

--- a/tools/flaky-test-reporter/README.md
+++ b/tools/flaky-test-reporter/README.md
@@ -14,18 +14,46 @@ Flags for this tool are:
   Github API calls.
 - `--slack-account` specifies the path of file containing Slack token for Slack
   web API calls.
+- `skip-report` skips all Github/Slack activities. This is used for the
+  purpose of data collection.
 - `--dry-run` enables dry-run mode.
 
 ### IMPORTANT: This tool is _NOT_ intended to run locally, as this could interfere with real Github issues and potentially flood Knative Slack channels
 
+## How To Debug/Verify Changes
+
 For debugging purpose it's highly recommended to start with `--dry-run` flag, by
-passing this flag it will only collect information from GCS/Github/Slack, and
+passing this flag it will only collect information from GCS/Github, and
 all the manipulations of Github/Slack resources are omitted.
+
+### Requirement
+
+- `GCP token`: Create a service account by visiting
+  `https://pantheon.corp.google.com/iam-admin/serviceaccounts?project=[YOUR_PROJECT]`,
+  navigate to newly created service account, and click `CREATE KEY` button and
+  select `JSON`. Download generated json key file and save it securely on your
+  system.
+- `Github token`: Create a github token by visiting
+  `https://github.com/settings/tokens`, click `Generate new token` and select at
+  least `repo:status` and `public_repo` permissions before generate the token.
+  Save generated token in a file securely on your system.
+
+### Debug Command
+
+### IMPORTANT: Please DO pass in _--dry-run_ for debugging purpose, as it's good enough for debugging majority of the cases.
+
+Command for debugging:
+```
+go run [REPO_ROOT]/tools/flaky-test-reporter --service-account "[PATH_OF_GCP_TOKEN]" \
+ --github-account "[PATH_OF_GITHUB_TOKEN]" --dry-run
+``` 
 
 ## Prow Job
 
-There is a prow job that triggers this tool at 4:00/5:00AM(Day light saving)
-everyday.
+There is a prow job(ci-knative-flakes-reporter) that triggers this tool at 4:00/5:00AM(Day light saving)
+everyday, which does Github/Slack reporting. Another prow
+job(ci-knative-flakes-resultsrecorder) that runs every hour, which does only
+data collection part by passing `--skip-report` flag, the data it collected can be used like [this](https://github.com/knative/test-infra/blob/11c44d69473c167f76da249625d67431b6fe90df/tools/flaky-test-reporter/jsonreport/jsonreport.go#L117)
 
 ## Considerations
 

--- a/tools/flaky-test-reporter/github_issue.go
+++ b/tools/flaky-test-reporter/github_issue.go
@@ -361,7 +361,8 @@ func (gih *GithubIssueHandler) findExistingComment(issue *github.Issue, issueIde
 		// Double check to make sure the comment contains beforeHistoryToken as
 		// it's expected from auto-comment. Check reTestIdentifierRegex for bulk
 		// issue since it doesn't have beforeHistoryToken
-		if testNameFromComment := reTestIdentifierRegex.FindStringSubmatch(*comment.Body); (len(testNameFromComment) >= 2 && issueIdentity == testNameFromComment[1]) ||
+		testNameFromComment := reTestIdentifierRegex.FindStringSubmatch(*comment.Body)
+		if (len(testNameFromComment) >= 2 && issueIdentity == testNameFromComment[1]) ||
 			strings.Contains(*comment.Body, beforeHistoryToken) {
 			targetComment = comments[i]
 			break

--- a/tools/flaky-test-reporter/github_issue.go
+++ b/tools/flaky-test-reporter/github_issue.go
@@ -358,7 +358,11 @@ func (gih *GithubIssueHandler) findExistingComment(issue *github.Issue, issueIde
 		if *comment.User.ID != *gih.user.ID {
 			continue
 		}
-		if strings.Contains(*comment.Body, beforeHistoryToken) {
+		// Double check to make sure the comment contains beforeHistoryToken as
+		// it's expected from auto-comment. Check reTestIdentifierRegex for bulk
+		// issue since it doesn't have beforeHistoryToken
+		if testNameFromComment := reTestIdentifierRegex.FindStringSubmatch(*comment.Body); (len(testNameFromComment) >= 2 && issueIdentity == testNameFromComment[1]) ||
+			strings.Contains(*comment.Body, beforeHistoryToken) {
 			targetComment = comments[i]
 			break
 		}

--- a/tools/flaky-test-reporter/main.go
+++ b/tools/flaky-test-reporter/main.go
@@ -133,7 +133,7 @@ func slackOperations(slackToken string, repoData []RepoData, flakyIssues map[str
 	}
 
 	client, err := slackutil.NewWriteClient(knativeBotName, slackToken)
-	if err != nil {
+	if err != nil && !dryrun { // Dryrun doesn't do any Slack operation
 		return err
 	}
 


### PR DESCRIPTION
Update flaky-test-reporter instruction so that devs can verify their changes locally before pushing. By the way fixing a bug which was unfortunately not caught before PR merging since they were not able to verify it without this instruction

/cc @srinivashegde86 
/cc @Fredy-Z 