### PR TITLE
Sort release versions/tags properly so we can release 0.10 and beyond

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -165,8 +165,8 @@ function prepare_auto_release() {
   PUBLISH_RELEASE=1
 
   git fetch --all || abort "error fetching branches/tags from remote"
-  local tags="$(git tag | cut -d 'v' -f2 | cut -d '.' -f1-2 | sort | uniq)"
-  local branches="$( { (git branch -r | grep upstream/release-) ; (git branch | grep release-); } | cut -d '-' -f2 | sort | uniq)"
+  local tags="$(git tag | cut -d 'v' -f2 | cut -d '.' -f1-2 | sort -V | uniq)"
+  local branches="$( { (git branch -r | grep upstream/release-) ; (git branch | grep release-); } | cut -d '-' -f2 | sort -V | uniq)"
 
   echo "Versions released (from tags): [" ${tags} "]"
   echo "Versions released (from branches): [" ${branches} "]"


### PR DESCRIPTION
current implementation would sort "0.2, 0.1, 0.10" as "0.1, 0.10, 0.2", which would fail release if 0.10 is cut. Fix it with proper sorting

/cc @adrcunha 
/cc @Fredy-Z 