### PR TITLE
Add kail and update ko install in prow-tests

### DIFF
--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -38,7 +38,8 @@ RUN rm -rf /usr/local/go && \
     rm "${GO_TARBALL}"
 
 # Extra tools through go get
-RUN go get -u github.com/google/ko/cmd/ko
+RUN GO111MODULE=on go get github.com/google/ko/cmd/ko
+RUN GO111MODULE=on go get github.com/boz/kail/cmd/kail
 RUN go get -u github.com/golang/dep/cmd/dep
 RUN go get -u github.com/jstemmer/go-junit-report
 RUN go get -u github.com/raviqqe/liche

--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -49,7 +49,7 @@ RUN bazel version > /bazel_version
 RUN bazel shutdown
 
 # Extract ko version
-RUN git ls-remote https://github.com/google/ko HEAD | cut -f1 > /ko_version
+RUN ko version > /ko_version
 
 # Extra tools through gem
 RUN gem install mixlib-config -v 2.2.4  # required because ruby is 2.1

--- a/scripts/presubmit-tests.sh
+++ b/scripts/presubmit-tests.sh
@@ -304,7 +304,7 @@ function main() {
     go version
     echo ">> git version"
     git version
-    echo ">> ko built from commit"
+    echo ">> ko version"
     [[ -f /ko_version ]] && cat /ko_version || echo "unknown"
     echo ">> bazel version"
     [[ -f /bazel_version ]] && cat /bazel_version || echo "unknown"


### PR DESCRIPTION
`ko` now needs to be installed with module support.
Install `kail` as a bonus; part of knative/serving#5459.