### PR TITLE
Remove the check of GOOGLE_APPLICATION_CREDENTIALS in make update-config for testgrid

### DIFF
--- a/ci/testgrid/Makefile
+++ b/ci/testgrid/Makefile
@@ -22,9 +22,6 @@ test:
 	make -C $(PROW_DIR) test
 
 update-config:
-ifndef GOOGLE_APPLICATION_CREDENTIALS
-	$(error GOOGLE_APPLICATION_CREDENTIALS not set)
-endif
 	bazel run @k8s//testgrid/cmd/configurator -- \
 		--yaml=$(TESTGRID_DIR)/config.yaml \
 		--output=gs://knative-testgrid/config \


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
We don't need to set `GOOGLE_APPLICATION_CREDENTIALS` when we update testgrid config.

A few investigation steps:
The `README` in https://github.com/kubernetes/test-infra/blob/master/testgrid/cmd/configurator/README.md does not mention the `GOOGLE_APPLICATION_CREDENTIALS`, I failed to find any historic changes for it since the file was added in July, 2019.
The code says it will use the local creds if empty - https://github.com/kubernetes/test-infra/blob/0674bf7a88536cdff7dea09bd20fdf87a6042c0f/testgrid/cmd/configurator/main.go#L69, so I believe it will use the activated gcloud account if we don't provide the credential, which can be found by running `gcloud auth list`. It must have been set as the correct one by default.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @adrcunha 
/cc @chaodaiG 