### PR TITLE
update istio to 1.13 and remove 1.11

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -678,156 +678,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-serving-istio-1.1-mesh
-    agent: kubernetes
-    context: pull-knative-serving-istio-1.1-mesh
-    always_run: false
-    rerun_command: "/test pull-knative-serving-istio-1.1-mesh"
-    trigger: "(?m)^/test (all|pull-knative-serving-istio-1.1-mesh),?(\\s+|$)"
-    decorate: true
-    optional: true
-    branches:
-    - "release-0.4"
-    - "release-0.5"
-    - "release-0.6"
-    - "release-0.7"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/e2e-tests.sh"
-        - "--istio-version"
-        - "1.1-latest"
-        - "--mesh"
-        volumeMounts:
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-      volumes:
-      - name: test-account
-        secret:
-          secretName: test-account
-  - name: pull-knative-serving-istio-1.1-mesh
-    agent: kubernetes
-    context: pull-knative-serving-istio-1.1-mesh
-    always_run: false
-    rerun_command: "/test pull-knative-serving-istio-1.1-mesh"
-    trigger: "(?m)^/test (all|pull-knative-serving-istio-1.1-mesh),?(\\s+|$)"
-    decorate: true
-    optional: true
-    path_alias: knative.dev/serving
-    skip_branches:
-    - "release-0.4"
-    - "release-0.5"
-    - "release-0.6"
-    - "release-0.7"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/e2e-tests.sh"
-        - "--istio-version"
-        - "1.1-latest"
-        - "--mesh"
-        volumeMounts:
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-      volumes:
-      - name: test-account
-        secret:
-          secretName: test-account
-  - name: pull-knative-serving-istio-1.1-no-mesh
-    agent: kubernetes
-    context: pull-knative-serving-istio-1.1-no-mesh
-    always_run: false
-    rerun_command: "/test pull-knative-serving-istio-1.1-no-mesh"
-    trigger: "(?m)^/test (all|pull-knative-serving-istio-1.1-no-mesh),?(\\s+|$)"
-    decorate: true
-    optional: true
-    branches:
-    - "release-0.4"
-    - "release-0.5"
-    - "release-0.6"
-    - "release-0.7"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/e2e-tests.sh"
-        - "--istio-version"
-        - "1.1-latest"
-        - "--no-mesh"
-        volumeMounts:
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-      volumes:
-      - name: test-account
-        secret:
-          secretName: test-account
-  - name: pull-knative-serving-istio-1.1-no-mesh
-    agent: kubernetes
-    context: pull-knative-serving-istio-1.1-no-mesh
-    always_run: false
-    rerun_command: "/test pull-knative-serving-istio-1.1-no-mesh"
-    trigger: "(?m)^/test (all|pull-knative-serving-istio-1.1-no-mesh),?(\\s+|$)"
-    decorate: true
-    optional: true
-    path_alias: knative.dev/serving
-    skip_branches:
-    - "release-0.4"
-    - "release-0.5"
-    - "release-0.6"
-    - "release-0.7"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/e2e-tests.sh"
-        - "--istio-version"
-        - "1.1-latest"
-        - "--no-mesh"
-        volumeMounts:
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-      volumes:
-      - name: test-account
-        secret:
-          secretName: test-account
   - name: pull-knative-serving-istio-1.2-mesh
     agent: kubernetes
     context: pull-knative-serving-istio-1.2-mesh
@@ -964,6 +814,156 @@ presubmits:
         - "./test/e2e-tests.sh"
         - "--istio-version"
         - "1.2-latest"
+        - "--no-mesh"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-serving-istio-1.3-mesh
+    agent: kubernetes
+    context: pull-knative-serving-istio-1.3-mesh
+    always_run: false
+    rerun_command: "/test pull-knative-serving-istio-1.3-mesh"
+    trigger: "(?m)^/test (all|pull-knative-serving-istio-1.3-mesh),?(\\s+|$)"
+    decorate: true
+    optional: true
+    branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/e2e-tests.sh"
+        - "--istio-version"
+        - "1.3-latest"
+        - "--mesh"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-serving-istio-1.3-mesh
+    agent: kubernetes
+    context: pull-knative-serving-istio-1.3-mesh
+    always_run: false
+    rerun_command: "/test pull-knative-serving-istio-1.3-mesh"
+    trigger: "(?m)^/test (all|pull-knative-serving-istio-1.3-mesh),?(\\s+|$)"
+    decorate: true
+    optional: true
+    path_alias: knative.dev/serving
+    skip_branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/e2e-tests.sh"
+        - "--istio-version"
+        - "1.3-latest"
+        - "--mesh"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-serving-istio-1.3-no-mesh
+    agent: kubernetes
+    context: pull-knative-serving-istio-1.3-no-mesh
+    always_run: false
+    rerun_command: "/test pull-knative-serving-istio-1.3-no-mesh"
+    trigger: "(?m)^/test (all|pull-knative-serving-istio-1.3-no-mesh),?(\\s+|$)"
+    decorate: true
+    optional: true
+    branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/e2e-tests.sh"
+        - "--istio-version"
+        - "1.3-latest"
+        - "--no-mesh"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-serving-istio-1.3-no-mesh
+    agent: kubernetes
+    context: pull-knative-serving-istio-1.3-no-mesh
+    always_run: false
+    rerun_command: "/test pull-knative-serving-istio-1.3-no-mesh"
+    trigger: "(?m)^/test (all|pull-knative-serving-istio-1.3-no-mesh),?(\\s+|$)"
+    decorate: true
+    optional: true
+    path_alias: knative.dev/serving
+    skip_branches:
+    - "release-0.4"
+    - "release-0.5"
+    - "release-0.6"
+    - "release-0.7"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/e2e-tests.sh"
+        - "--istio-version"
+        - "1.3-latest"
         - "--no-mesh"
         volumeMounts:
         - name: test-account
@@ -3337,72 +3337,6 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "39 */2 * * *"
-  name: ci-knative-serving-istio-1.1-mesh
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: knative
-    repo: serving
-    base_ref: master
-    path_alias: knative.dev/serving
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./test/e2e-tests.sh"
-      - "--istio-version"
-      - "1.1-latest"
-      - "--mesh"
-      volumeMounts:
-      - name: test-account
-        mountPath: /etc/test-account
-        readOnly: true
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/test-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-    volumes:
-    - name: test-account
-      secret:
-        secretName: test-account
-- cron: "50 */2 * * *"
-  name: ci-knative-serving-istio-1.1-no-mesh
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: knative
-    repo: serving
-    base_ref: master
-    path_alias: knative.dev/serving
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./test/e2e-tests.sh"
-      - "--istio-version"
-      - "1.1-latest"
-      - "--no-mesh"
-      volumeMounts:
-      - name: test-account
-        mountPath: /etc/test-account
-        readOnly: true
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/test-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-    volumes:
-    - name: test-account
-      secret:
-        secretName: test-account
 - cron: "40 */2 * * *"
   name: ci-knative-serving-istio-1.2-mesh
   agent: kubernetes
@@ -3455,6 +3389,72 @@ periodics:
       - "./test/e2e-tests.sh"
       - "--istio-version"
       - "1.2-latest"
+      - "--no-mesh"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "50 */2 * * *"
+  name: ci-knative-serving-istio-1.3-mesh
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: master
+    path_alias: knative.dev/serving
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./test/e2e-tests.sh"
+      - "--istio-version"
+      - "1.3-latest"
+      - "--mesh"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "12 */2 * * *"
+  name: ci-knative-serving-istio-1.3-no-mesh
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: master
+    path_alias: knative.dev/serving
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./test/e2e-tests.sh"
+      - "--istio-version"
+      - "1.3-latest"
       - "--no-mesh"
       volumeMounts:
       - name: test-account

--- a/ci/prow/config_knative.yaml
+++ b/ci/prow/config_knative.yaml
@@ -49,14 +49,6 @@ presubmits:
       always_run: false
       command:
       - "./test/performance-tests.sh"
-    - custom-test: istio-1.1-mesh
-      always_run: false
-      optional: true
-      full-command: "./test/e2e-tests.sh --istio-version 1.1-latest --mesh"
-    - custom-test: istio-1.1-no-mesh
-      always_run: false
-      optional: true
-      full-command: "./test/e2e-tests.sh --istio-version 1.1-latest --no-mesh"
     - custom-test: istio-1.2-mesh
       always_run: false
       optional: true
@@ -65,6 +57,14 @@ presubmits:
       always_run: false
       optional: true
       full-command: "./test/e2e-tests.sh --istio-version 1.2-latest --no-mesh"
+    - custom-test: istio-1.3-mesh
+      always_run: false
+      optional: true
+      full-command: "./test/e2e-tests.sh --istio-version 1.3-latest --mesh"
+    - custom-test: istio-1.3-no-mesh
+      always_run: false
+      optional: true
+      full-command: "./test/e2e-tests.sh --istio-version 1.3-latest --no-mesh"
     - custom-test: gloo-0.17.1
       always_run: false
       optional: true
@@ -203,17 +203,17 @@ periodics:
       release: "0.7"
     - branch-ci: true
       release: "0.8"
-    - custom-job: istio-1.1-mesh
-      full-command: "./test/e2e-tests.sh --istio-version 1.1-latest --mesh"
-      dot-dev: true
-    - custom-job: istio-1.1-no-mesh
-      full-command: "./test/e2e-tests.sh --istio-version 1.1-latest --no-mesh"
-      dot-dev: true
     - custom-job: istio-1.2-mesh
       full-command: "./test/e2e-tests.sh --istio-version 1.2-latest --mesh"
       dot-dev: true
     - custom-job: istio-1.2-no-mesh
       full-command: "./test/e2e-tests.sh --istio-version 1.2-latest --no-mesh"
+      dot-dev: true
+    - custom-job: istio-1.3-mesh
+      full-command: "./test/e2e-tests.sh --istio-version 1.3-latest --mesh"
+      dot-dev: true
+    - custom-job: istio-1.3-no-mesh
+      full-command: "./test/e2e-tests.sh --istio-version 1.3-latest --no-mesh"
       dot-dev: true
     - custom-job: gloo-0.17.1
       full-command: "./test/e2e-tests.sh --gloo-version 0.17.1"

--- a/ci/prow/testgrid_config.go
+++ b/ci/prow/testgrid_config.go
@@ -159,7 +159,7 @@ func generateTestGroup(projName string, repoName string, jobNames []string) {
 			extras["short_text_metric"] = "coverage"
 			// Do not alert on coverage failures (i.e., coverage below threshold)
 			extras["num_failures_to_alert"] = "9999"
-		case "istio-1.1-mesh", "istio-1.1-no-mesh", "istio-1.2-mesh", "istio-1.2-no-mesh", "gloo-0.17.1":
+		case "istio-1.2-mesh", "istio-1.2-no-mesh", "istio-1.3-mesh", "istio-1.3-no-mesh", "gloo-0.17.1":
 			extras["alert_stale_results_hours"] = "3"
 			extras["num_failures_to_alert"] = "3"
 		default:
@@ -208,7 +208,7 @@ func generateDashboard(projName string, repoName string, jobNames []string) {
 			executeDashboardTabTemplate("nightly", testGroupName, testgridTabSortByName, noExtras)
 		case "test-coverage":
 			executeDashboardTabTemplate("coverage", testGroupName, testgridTabGroupByDir, noExtras)
-		case "istio-1.1-mesh", "istio-1.1-no-mesh", "istio-1.2-mesh", "istio-1.2-no-mesh", "gloo-0.17.1":
+		case "istio-1.2-mesh", "istio-1.2-no-mesh", "istio-1.3-mesh", "istio-1.3-no-mesh", "gloo-0.17.1":
 			executeDashboardTabTemplate(jobName, testGroupName, testgridTabSortByName, noExtras)
 		default:
 			log.Fatalf("Unknown job name %q", jobName)
@@ -236,7 +236,7 @@ func getTestGroupName(repoName string, jobName string) string {
 		return strings.ToLower(fmt.Sprintf("ci-%s-%s-release", repoName, jobName))
 	case "test-coverage":
 		return strings.ToLower(fmt.Sprintf("pull-%s-%s", repoName, jobName))
-	case "istio-1.1-mesh", "istio-1.1-no-mesh", "istio-1.2-mesh", "istio-1.2-no-mesh", "gloo-0.17.1":
+	case "istio-1.2-mesh", "istio-1.2-no-mesh", "istio-1.3-mesh", "istio-1.3-no-mesh", "gloo-0.17.1":
 		return strings.ToLower(fmt.Sprintf("ci-%s-%s", repoName, jobName))
 	}
 	log.Fatalf("Unknown jobName for getTestGroupName: %s", jobName)

--- a/ci/testgrid/config.yaml
+++ b/ci/testgrid/config.yaml
@@ -60,20 +60,20 @@ test_groups:
   gcs_prefix: knative-prow/logs/ci-knative-serving-continuous
   alert_stale_results_hours: 3
   num_failures_to_alert: 3
-- name: ci-knative-serving-istio-1.1-mesh
-  gcs_prefix: knative-prow/logs/ci-knative-serving-istio-1.1-mesh
-  alert_stale_results_hours: 3
-  num_failures_to_alert: 3
-- name: ci-knative-serving-istio-1.1-no-mesh
-  gcs_prefix: knative-prow/logs/ci-knative-serving-istio-1.1-no-mesh
-  alert_stale_results_hours: 3
-  num_failures_to_alert: 3
 - name: ci-knative-serving-istio-1.2-mesh
   gcs_prefix: knative-prow/logs/ci-knative-serving-istio-1.2-mesh
   alert_stale_results_hours: 3
   num_failures_to_alert: 3
 - name: ci-knative-serving-istio-1.2-no-mesh
   gcs_prefix: knative-prow/logs/ci-knative-serving-istio-1.2-no-mesh
+  alert_stale_results_hours: 3
+  num_failures_to_alert: 3
+- name: ci-knative-serving-istio-1.3-mesh
+  gcs_prefix: knative-prow/logs/ci-knative-serving-istio-1.3-mesh
+  alert_stale_results_hours: 3
+  num_failures_to_alert: 3
+- name: ci-knative-serving-istio-1.3-no-mesh
+  gcs_prefix: knative-prow/logs/ci-knative-serving-istio-1.3-no-mesh
   alert_stale_results_hours: 3
   num_failures_to_alert: 3
 - name: ci-knative-serving-gloo-0.17.1
@@ -275,17 +275,17 @@ dashboards:
   - name: conformance
     test_group_name: ci-knative-serving-continuous
     base_options: "include-filter-by-regex=test/conformance/&sort-by-name="
-  - name: istio-1.1-mesh
-    test_group_name: ci-knative-serving-istio-1.1-mesh
-    base_options: "sort-by-name="
-  - name: istio-1.1-no-mesh
-    test_group_name: ci-knative-serving-istio-1.1-no-mesh
-    base_options: "sort-by-name="
   - name: istio-1.2-mesh
     test_group_name: ci-knative-serving-istio-1.2-mesh
     base_options: "sort-by-name="
   - name: istio-1.2-no-mesh
     test_group_name: ci-knative-serving-istio-1.2-no-mesh
+    base_options: "sort-by-name="
+  - name: istio-1.3-mesh
+    test_group_name: ci-knative-serving-istio-1.3-mesh
+    base_options: "sort-by-name="
+  - name: istio-1.3-no-mesh
+    test_group_name: ci-knative-serving-istio-1.3-no-mesh
     base_options: "sort-by-name="
   - name: gloo-0.17.1
     test_group_name: ci-knative-serving-gloo-0.17.1

--- a/shared/testgrid/testgrid.go
+++ b/shared/testgrid/testgrid.go
@@ -39,10 +39,10 @@ const (
 // jobNameTestgridURLMap contains harded coded mapping of job name: Testgrid tab URL relative to base URL
 var jobNameTestgridURLMap = map[string]string{
 	"ci-knative-serving-continuous":        "serving#continuous",
-	"ci-knative-serving-istio-1.1-mesh":    "serving#istio-1.1-mesh",
-	"ci-knative-serving-istio-1.1-no-mesh": "serving#istio-1.1-no-mesh",
 	"ci-knative-serving-istio-1.2-mesh":    "serving#istio-1.2-mesh",
 	"ci-knative-serving-istio-1.2-no-mesh": "serving#istio-1.2-no-mesh",
+	"ci-knative-serving-istio-1.3-mesh":    "serving#istio-1.3-mesh",
+	"ci-knative-serving-istio-1.3-no-mesh": "serving#istio-1.3-no-mesh",
 	"ci-knative-serving-gloo-0.17.1":       "serving#gloo-0.17.1",
 }
 

--- a/tools/flaky-test-reporter/config/config.yaml
+++ b/tools/flaky-test-reporter/config/config.yaml
@@ -20,18 +20,6 @@ jobConfigs:
     slackChannels:
       - name: serving-api
         identity: CA4DNJ9A4
-  - name: ci-knative-serving-istio-1.1-mesh
-    repo: serving
-    type: postsubmit
-    slackChannels:
-      - name: networking
-        identity: CA9RHBGJX
-  - name: ci-knative-serving-istio-1.1-no-mesh
-    repo: serving
-    type: postsubmit
-    slackChannels:
-      - name: networking
-        identity: CA9RHBGJX
   - name: ci-knative-serving-istio-1.2-mesh
     repo: serving
     type: postsubmit
@@ -39,6 +27,18 @@ jobConfigs:
       - name: networking
         identity: CA9RHBGJX
   - name: ci-knative-serving-istio-1.2-no-mesh
+    repo: serving
+    type: postsubmit
+    slackChannels:
+      - name: networking
+        identity: CA9RHBGJX
+  - name: ci-knative-serving-istio-1.3-mesh
+    repo: serving
+    type: postsubmit
+    slackChannels:
+      - name: networking
+        identity: CA9RHBGJX
+  - name: ci-knative-serving-istio-1.3-no-mesh
     repo: serving
     type: postsubmit
     slackChannels:


### PR DESCRIPTION
As requested by @tcnghia , testing istio1.13 instead of istio1.11, as istio1.13 is already enabled in serving, and 1.11 is EoL.

Fixes https://github.com/knative/serving/issues/5656

/cc @yt3liu 
/cc @adrcunha 
/cc @tcnghia 

/hold
The Prow/testgrid config will need to be applied before flaky-test-reporter image