### PR TITLE
Fix flaky-test-reporter dryrun mode

### DIFF
--- a/tools/flaky-test-reporter/github_issue.go
+++ b/tools/flaky-test-reporter/github_issue.go
@@ -537,7 +537,7 @@ func (gih *GithubIssueHandler) processGithubIssuesForRepo(rd RepoData, flakyIssu
 			} else {
 				if fi, err := gih.githubToFlakyIssue(issue, dryrun); err != nil {
 					errs = append(errs, err)
-				} else {
+				} else if !dryrun { // fi is nil as issue is not created in dryrun mode
 					issues = append(issues, *fi)
 				}
 			}


### PR DESCRIPTION
There is a nil pointer error in dryrun mode when referencing newly created Github issue, as issues creation step is skipped in dryrun mode. Add a check to make sure dryrun doesn't fail due to this

/cc @srinivashegde86 
/cc @Fredy-Z 