### PR TITLE
Extend cleanup job timeout to 120 hours

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -5588,7 +5588,7 @@ periodics:
   agent: kubernetes
   decorate: true
   decoration_config:
-    timeout: 86400000000000
+    timeout: 432000000000000
   extra_refs:
   - org: knative
     repo: test-infra

--- a/ci/prow/periodic_config.go
+++ b/ci/prow/periodic_config.go
@@ -219,7 +219,7 @@ func generateCleanupPeriodicJob() {
 	data.Base = newbaseProwJobTemplateData("knative/test-infra")
 	data.PeriodicJobName = "ci-knative-cleanup"
 	data.CronString = cleanupPeriodicJobCron
-	data.Base.DecorationConfig = []string{"timeout: 86400000000000"} // 24 hours
+	data.Base.DecorationConfig = []string{"timeout: 432000000000000"} // 120 hours
 	data.Base.Command = cleanupScript
 	data.Base.Args = []string{
 		"--project-resource-yaml ci/prow/boskos/resources.yaml",


### PR DESCRIPTION
Test resources(i.e. test images) cleanup is handled by a weekly cleanup job, which has been failing due to timeout consistently. Extend the timeout so that it can clean up more(Might still not be sufficient to make it succeed as we have 75 Boskos projects now).

In the long run, we should address this problem with a better solution: https://github.com/knative/test-infra/issues/1399

/cc @adrcunha 