### PR TITLE
Parameterize Prow host and TestGrid bucket

### DIFF
--- a/ci/prow/make_config.go
+++ b/ci/prow/make_config.go
@@ -74,6 +74,10 @@ type baseProwJobTemplateData struct {
 	OrgName             string
 	RepoName            string
 	RepoNameForJob      string
+	ProwHost            string
+	TestGridHost        string
+	GubernatorHost      string
+	TestGridGcsBucket   string
 	GcsBucket           string
 	GcsLogDir           string
 	GcsPresubmitLogDir  string
@@ -136,7 +140,11 @@ type stringArrayFlag []string
 var (
 	// Values used in the jobs that can be changed through command-line flags.
 	output                       *os.File
+	prowHost                     string
+	testGridHost                 string
+	gubernatorHost               string
 	gcsBucket                    string
+	testGridGcsBucket            string
 	logsDir                      string
 	presubmitLogsDir             string
 	testAccount                  string
@@ -358,7 +366,11 @@ func newbaseProwJobTemplateData(repo string) baseProwJobTemplateData {
 	data.RepoName = strings.Replace(repo, data.OrgName+"/", "", 1)
 	data.RepoNameForJob = strings.ToLower(strings.Replace(repo, "/", "-", -1))
 	data.RepoBranch = "master" // Default to be master, will override later for other branches
+	data.ProwHost = prowHost
+	data.TestGridHost = testGridHost
+	data.GubernatorHost = gubernatorHost
 	data.GcsBucket = gcsBucket
+	data.TestGridGcsBucket = testGridGcsBucket
 	data.RepoURI = "github.com/" + repo
 	data.CloneURI = fmt.Sprintf("\"https://%s.git\"", data.RepoURI)
 	data.GcsLogDir = fmt.Sprintf("gs://%s/%s", gcsBucket, logsDir)
@@ -1057,7 +1069,11 @@ func main() {
 	flag.StringVar(&testgridConfigOutput, "testgrid-config-output", "", "The destination for the testgrid config output, default to be stdout")
 
 	var includeConfig = flag.Bool("include-config", true, "Whether to include general configuration (e.g., plank) in the generated config")
+	flag.StringVar(&prowHost, "prow-host", "https://prow.knative.dev", "Prow host, including HTTP protocol")
+	flag.StringVar(&testGridHost, "testgrid-host", "https://testgrid.knative.dev", "TestGrid host, including HTTP protocol")
+	flag.StringVar(&gubernatorHost, "gubernator-host", "https://gubernator.knative.dev", "Gubernator host, including HTTP protocol")
 	flag.StringVar(&gcsBucket, "gcs-bucket", "knative-prow", "GCS bucket to upload the logs to")
+	flag.StringVar(&testGridGcsBucket, "testgrid-gcs-bucket", "knative-testgrid", "TestGrid GCS bucket")
 	flag.StringVar(&logsDir, "logs-dir", "logs", "Path in the GCS bucket to upload logs of periodic and post-submit jobs")
 	flag.StringVar(&presubmitLogsDir, "presubmit-logs-dir", "pr-logs", "Path in the GCS bucket to upload logs of pre-submit jobs")
 	flag.StringVar(&testAccount, "test-account", "/etc/test-account/service-account.json", "Path to the service account JSON for test jobs")

--- a/ci/prow/templates/prow_config_header.yaml
+++ b/ci/prow/templates/prow_config_header.yaml
@@ -21,10 +21,10 @@
 # FROM COMMIT: ((COMMIT_HASH_TOKEN))
 
 plank:
-  job_url_template: 'https://prow.knative.dev/view/gcs/[[.GcsBucket]]/{{if or (eq .Spec.Type "presubmit") (eq .Spec.Type "batch")}}[[.PresubmitLogsDir]]/pull{{with .Spec.Refs}}/{{.Org}}_{{.Repo}}{{end}}{{else}}[[.LogsDir]]{{end}}{{if eq .Spec.Type "presubmit"}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}{{else if eq .Spec.Type "batch"}}/batch{{end}}/{{.Spec.Job}}/{{.Status.BuildID}}/'
-  report_template: '[Full PR test history](https://gubernator.knative.dev/pr/{{.Spec.Refs.Org}}_{{.Spec.Refs.Repo}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}). [Your PR dashboard](https://gubernator.knative.dev/pr/{{with index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}).'
+  job_url_template: '[[.ProwHost]]/view/gcs/[[.GcsBucket]]/{{if or (eq .Spec.Type "presubmit") (eq .Spec.Type "batch")}}[[.PresubmitLogsDir]]/pull{{with .Spec.Refs}}/{{.Org}}_{{.Repo}}{{end}}{{else}}[[.LogsDir]]{{end}}{{if eq .Spec.Type "presubmit"}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}{{else if eq .Spec.Type "batch"}}/batch{{end}}/{{.Spec.Job}}/{{.Status.BuildID}}/'
+  report_template: '[Full PR test history]([[.GubernatorHost]]/pr/{{.Spec.Refs.Org}}_{{.Spec.Refs.Repo}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}). [Your PR dashboard]([[.GubernatorHost]]/pr/{{with index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}).'
   job_url_prefix_config: 
-    "*": "https://prow.knative.dev/view/gcs/"
+    "*": "[[.ProwHost]]/view/gcs/"
   pod_pending_timeout: 60m
   default_decoration_config:
     timeout: 7200000000000 # 2h
@@ -44,8 +44,8 @@ deck:
   spyglass:
     size_limit: 500000000 # 500MB
     gcs_browser_prefix: https://console.cloud.google.com/storage/browser/
-    testgrid_config: gs://knative-testgrid/config
-    testgrid_root: https://testgrid.knative.dev/
+    testgrid_config: gs://[[.TestGridGcsBucket]]/config
+    testgrid_root: [[.TestGridHost]]/
     viewers:
       "started.json|finished.json":
       - "metadata"
@@ -53,7 +53,7 @@ deck:
       - "buildlog"
       "artifacts/junit.*\\.xml":
       - "junit"
-    announcement: "The old job viewer, Gubernator, has been deprecated in favour of this page, Spyglass.{{if .ArtifactPath}} For now, the old page is <a href='https://gubernator.knative.dev/build/{{.ArtifactPath}}'>still available</a>.{{end}} Please send feedback to Knative productivity."
+    announcement: "The old job viewer, Gubernator, has been deprecated in favour of this page, Spyglass.{{if .ArtifactPath}} For now, the old page is <a href='[[.GubernatorHost]]/build/{{.ArtifactPath}}'>still available</a>.{{end}} Please send feedback to Knative productivity."
   tide_update_period: 1s
 
 prowjob_namespace: default
@@ -105,8 +105,8 @@ tide:
   merge_method:
     knative: squash
     google/knative-gcp: squash
-  target_url: https://prow.knative.dev/tide
-  pr_status_base_url: https://prow.knative.dev/pr
+  target_url: [[.ProwHost]]/tide
+  pr_status_base_url: [[.ProwHost]]/pr
   blocker_label: tide/merge-blocker
   squash_label: tide/merge-method-squash
   rebase_label: tide/merge-method-rebase

--- a/ci/prow/templates/testgrid_config_header.yaml
+++ b/ci/prow/templates/testgrid_config_header.yaml
@@ -36,7 +36,7 @@ default_test_group:
 
 default_dashboard_tab:
   open_test_template:            # The URL template to visit after clicking on a cell
-    url: https://prow.knative.dev/view/gcs/<gcs_prefix>/<changelist>
+    url: [[.ProwHost]]/view/gcs/<gcs_prefix>/<changelist>
   file_bug_template:             # The URL template to visit when filing a bug
     url: https://github.com/knative/serving/issues/new
     options:
@@ -50,7 +50,7 @@ default_dashboard_tab:
   # Text to show in the about menu as a link to another view of the results
   results_text: See these results on Prow
   results_url_template:          # The URL template to visit after clicking
-    url: https://prow.knative.dev/job-history/<gcs_prefix>
+    url: [[.ProwHost]]/job-history/<gcs_prefix>
   # URL for regression search links.
   code_search_path: github.com/knative/serving/search
   num_columns_recent: 10

--- a/ci/prow/testgrid_config.go
+++ b/ci/prow/testgrid_config.go
@@ -67,8 +67,12 @@ var (
 // baseTestgridTemplateData contains basic data about the testgrid config file.
 // TODO(Fredy-Z): remove this structure and use baseProwJobTemplateData instead
 type baseTestgridTemplateData struct {
-	TestGroupName string
-	Year          int
+	ProwHost          string
+	TestGridHost      string
+	GubernatorHost    string
+	TestGridGcsBucket string
+	TestGroupName     string
+	Year              int
 }
 
 // testGroupTemplateData contains data about a test group
@@ -100,6 +104,10 @@ type testgridEntityGenerator func(string, string, []string)
 func newBaseTestgridTemplateData(testGroupName string) baseTestgridTemplateData {
 	var data baseTestgridTemplateData
 	data.Year = time.Now().Year()
+	data.ProwHost = prowHost
+	data.TestGridHost = testGridHost
+	data.GubernatorHost = gubernatorHost
+	data.TestGridGcsBucket = testGridGcsBucket
 	data.TestGroupName = testGroupName
 	return data
 }


### PR DESCRIPTION
Allow these to be set through command-line flags in `make_config.go`.