### PR TITLE
Fix issue tracker jobs

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -5784,12 +5784,7 @@ periodics:
         -label:lifecycle/rotten"
       - "--updated=2160h"
       - "--token=/etc/housekeeping-github-token/token"
-      - "--comment=Issues go stale after 90 days of inactivity.\n
-        Mark the issue as fresh by adding the comment `/remove-lifecycle stale`.\n
-        Stale issues rot after an additional 30 days of inactivity and eventually close.\n
-        If this issue is safe to close now please do so by adding the comment `/close`.\n\n
-        Send feedback to [Knative Productivity Slack channel](https://knative.slack.com/messages/CCSNR4FCH) or file an issue in [knative/test-infra](https://github.com/knative/test-infra/issues/new).\n\n
-        /lifecycle stale"
+      - "--comment=Issues go stale after 90 days of inactivity.\nMark the issue as fresh by adding the comment `/remove-lifecycle stale`.\nStale issues rot after an additional 30 days of inactivity and eventually close.\nIf this issue is safe to close now please do so by adding the comment `/close`.\n\nSend feedback to [Knative Productivity Slack channel](https://knative.slack.com/messages/CCSNR4FCH) or file an issue in [knative/test-infra](https://github.com/knative/test-infra/issues/new).\n\n/lifecycle stale"
       - "--template"
       - "--ceiling=10"
       - "--confirm"
@@ -5824,12 +5819,7 @@ periodics:
         -label:lifecycle/rotten"
       - "--updated=720h"
       - "--token=/etc/housekeeping-github-token/token"
-      - "--comment=Stale issues rot after 30 days of inactivity.\n
-        Mark the issue as fresh by adding the comment `/remove-lifecycle rotten`.\n
-        Rotten issues close after an additional 30 days of inactivity.\n
-        If this issue is safe to close now please do so by adding the comment `/close`.\n\n
-        Send feedback to [Knative Productivity Slack channel](https://knative.slack.com/messages/CCSNR4FCH) or file an issue in [knative/test-infra](https://github.com/knative/test-infra/issues/new).\n\n
-        /lifecycle rotten"
+      - "--comment=Stale issues rot after 30 days of inactivity.\nMark the issue as fresh by adding the comment `/remove-lifecycle rotten`.\nRotten issues close after an additional 30 days of inactivity.\nIf this issue is safe to close now please do so by adding the comment `/close`.\n\nSend feedback to [Knative Productivity Slack channel](https://knative.slack.com/messages/CCSNR4FCH) or file an issue in [knative/test-infra](https://github.com/knative/test-infra/issues/new).\n\n/lifecycle rotten"
       - "--template"
       - "--ceiling=10"
       - "--confirm"
@@ -5864,11 +5854,7 @@ periodics:
         label:lifecycle/rotten"
       - "--updated=720h"
       - "--token=/etc/housekeeping-github-token/token"
-      - "--comment=Rotten issues close after 30 days of inactivity.\n
-        Reopen the issue with `/reopen`.\n
-        Mark the issue as fresh by adding the comment `/remove-lifecycle rotten`.\n\n
-        Send feedback to [Knative Productivity Slack channel](https://knative.slack.com/messages/CCSNR4FCH) or file an issue in [knative/test-infra](https://github.com/knative/test-infra/issues/new).\n\n
-        /close"
+      - "--comment=Rotten issues close after 30 days of inactivity.\nReopen the issue with `/reopen`.\nMark the issue as fresh by adding the comment `/remove-lifecycle rotten`.\n\nSend feedback to [Knative Productivity Slack channel](https://knative.slack.com/messages/CCSNR4FCH) or file an issue in [knative/test-infra](https://github.com/knative/test-infra/issues/new).\n\n/close"
       - "--template"
       - "--ceiling=10"
       - "--confirm"
@@ -5903,12 +5889,7 @@ periodics:
         -label:lifecycle/rotten"
       - "--updated=2160h"
       - "--token=/etc/housekeeping-github-token/token"
-      - "--comment=Issues go stale after 90 days of inactivity.\n
-        Mark the issue as fresh by adding the comment `/remove-lifecycle stale`.\n
-        Stale issues rot after an additional 30 days of inactivity and eventually close.\n
-        If this issue is safe to close now please do so by adding the comment `/close`.\n\n
-        Send feedback to [Knative Productivity Slack channel](https://knative.slack.com/messages/CCSNR4FCH) or file an issue in [knative/test-infra](https://github.com/knative/test-infra/issues/new).\n\n
-        /lifecycle stale"
+      - "--comment=Issues go stale after 90 days of inactivity.\nMark the issue as fresh by adding the comment `/remove-lifecycle stale`.\nStale issues rot after an additional 30 days of inactivity and eventually close.\nIf this issue is safe to close now please do so by adding the comment `/close`.\n\nSend feedback to [Knative Productivity Slack channel](https://knative.slack.com/messages/CCSNR4FCH) or file an issue in [knative/test-infra](https://github.com/knative/test-infra/issues/new).\n\n/lifecycle stale"
       - "--template"
       - "--ceiling=10"
       - "--confirm"
@@ -5943,12 +5924,7 @@ periodics:
         -label:lifecycle/rotten"
       - "--updated=720h"
       - "--token=/etc/housekeeping-github-token/token"
-      - "--comment=Stale issues rot after 30 days of inactivity.\n
-        Mark the issue as fresh by adding the comment `/remove-lifecycle rotten`.\n
-        Rotten issues close after an additional 30 days of inactivity.\n
-        If this issue is safe to close now please do so by adding the comment `/close`.\n\n
-        Send feedback to [Knative Productivity Slack channel](https://knative.slack.com/messages/CCSNR4FCH) or file an issue in [knative/test-infra](https://github.com/knative/test-infra/issues/new).\n\n
-        /lifecycle rotten"
+      - "--comment=Stale issues rot after 30 days of inactivity.\nMark the issue as fresh by adding the comment `/remove-lifecycle rotten`.\nRotten issues close after an additional 30 days of inactivity.\nIf this issue is safe to close now please do so by adding the comment `/close`.\n\nSend feedback to [Knative Productivity Slack channel](https://knative.slack.com/messages/CCSNR4FCH) or file an issue in [knative/test-infra](https://github.com/knative/test-infra/issues/new).\n\n/lifecycle rotten"
       - "--template"
       - "--ceiling=10"
       - "--confirm"
@@ -5983,11 +5959,7 @@ periodics:
         label:lifecycle/rotten"
       - "--updated=720h"
       - "--token=/etc/housekeeping-github-token/token"
-      - "--comment=Rotten issues close after 30 days of inactivity.\n
-        Reopen the issue with `/reopen`.\n
-        Mark the issue as fresh by adding the comment `/remove-lifecycle rotten`.\n\n
-        Send feedback to [Knative Productivity Slack channel](https://knative.slack.com/messages/CCSNR4FCH) or file an issue in [knative/test-infra](https://github.com/knative/test-infra/issues/new).\n\n
-        /close"
+      - "--comment=Rotten issues close after 30 days of inactivity.\nReopen the issue with `/reopen`.\nMark the issue as fresh by adding the comment `/remove-lifecycle rotten`.\n\nSend feedback to [Knative Productivity Slack channel](https://knative.slack.com/messages/CCSNR4FCH) or file an issue in [knative/test-infra](https://github.com/knative/test-infra/issues/new).\n\n/close"
       - "--template"
       - "--ceiling=10"
       - "--confirm"

--- a/ci/prow/issue_tracker_config.go
+++ b/ci/prow/issue_tracker_config.go
@@ -75,12 +75,12 @@ func (r repoIssue) generateJobs() {
         -label:lifecycle/stale
         -label:lifecycle/rotten`
 	updatedTime := fmt.Sprintf("%dh", r.daysToStale*24)
-	comment := fmt.Sprintf("--comment=Issues go stale after %d days of inactivity.\\n\n"+
-		"        Mark the issue as fresh by adding the comment `/remove-lifecycle stale`.\\n\n"+
-		"        Stale issues rot after an additional %d days of inactivity and eventually close.\\n\n"+
-		"        If this issue is safe to close now please do so by adding the comment `/close`.\\n\\n\n"+
-		"        %s\\n\\n\n"+
-		"        /lifecycle stale", r.daysToStale, r.daysToRot, feedbackNote)
+	comment := fmt.Sprintf("--comment=Issues go stale after %d days of inactivity.\\n"+
+		"Mark the issue as fresh by adding the comment `/remove-lifecycle stale`.\\n"+
+		"Stale issues rot after an additional %d days of inactivity and eventually close.\\n"+
+		"If this issue is safe to close now please do so by adding the comment `/close`.\\n\\n"+
+		"%s\\n\\n"+
+		"/lifecycle stale", r.daysToStale, r.daysToRot, feedbackNote)
 	r.generateJob(jobName, filter, updatedTime, comment)
 
 	jobName = fmt.Sprintf("ci-%s-issue-tracker-rotten", repoForJob)
@@ -90,12 +90,12 @@ func (r repoIssue) generateJobs() {
         label:lifecycle/stale
         -label:lifecycle/rotten`
 	updatedTime = fmt.Sprintf("%dh", r.daysToRot*24)
-	comment = fmt.Sprintf("--comment=Stale issues rot after %d days of inactivity.\\n\n"+
-		"        Mark the issue as fresh by adding the comment `/remove-lifecycle rotten`.\\n\n"+
-		"        Rotten issues close after an additional %d days of inactivity.\\n\n"+
-		"        If this issue is safe to close now please do so by adding the comment `/close`.\\n\\n\n"+
-		"        %s\\n\\n\n"+
-		"        /lifecycle rotten", r.daysToRot, r.daysToClose, feedbackNote)
+	comment = fmt.Sprintf("--comment=Stale issues rot after %d days of inactivity.\\n"+
+		"Mark the issue as fresh by adding the comment `/remove-lifecycle rotten`.\\n"+
+		"Rotten issues close after an additional %d days of inactivity.\\n"+
+		"If this issue is safe to close now please do so by adding the comment `/close`.\\n\\n"+
+		"%s\\n\\n"+
+		"/lifecycle rotten", r.daysToRot, r.daysToClose, feedbackNote)
 	r.generateJob(jobName, filter, updatedTime, comment)
 
 	jobName = fmt.Sprintf("ci-%s-issue-tracker-close", repoForJob)
@@ -105,11 +105,11 @@ func (r repoIssue) generateJobs() {
         -label:lifecycle/stale
         label:lifecycle/rotten`
 	updatedTime = fmt.Sprintf("%dh", r.daysToClose*24)
-	comment = fmt.Sprintf("--comment=Rotten issues close after %d days of inactivity.\\n\n"+
-		"        Reopen the issue with `/reopen`.\\n\n"+
-		"        Mark the issue as fresh by adding the comment `/remove-lifecycle rotten`.\\n\\n\n"+
-		"        %s\\n\\n\n"+
-		"        /close", r.daysToClose, feedbackNote)
+	comment = fmt.Sprintf("--comment=Rotten issues close after %d days of inactivity.\\n"+
+		"Reopen the issue with `/reopen`.\\n"+
+		"Mark the issue as fresh by adding the comment `/remove-lifecycle rotten`.\\n\\n"+
+		"%s\\n\\n"+
+		"/close", r.daysToClose, feedbackNote)
 	r.generateJob(jobName, filter, updatedTime, comment)
 }
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Fix the issue tracker jobs, specifically the `lifecycle` label is not added after the Github comment.

The reason for this issue is, if a string in the yaml is quoted with `"`, the new lines within it will be converted to spaces, see https://stackoverflow.com/a/21699210, so the last line of our Github comment becomes " /lifecycle stale" (`Markdown` hides the leading spaces so the comment "looks" correct..)

This PR makes the comments one-liner in the yaml file, which is harder to read but is the easiest fix. If we really want to break it into multiple lines, we can use `|-`, but we will not be able to use `\n`
for the line break.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @adrcunha 