### PR TITLE
Remove test account for performance test jobs

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -6459,16 +6459,11 @@ periodics:
       args:
       - "./test/performance/tools/recreate_clusters.sh"
       volumeMounts:
-      - name: test-account
-        mountPath: /etc/test-account
-        readOnly: true
       - name: performance-test
         mountPath: /etc/performance-test
         readOnly: true
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/test-account/service-account.json
-      - name: PERF_TEST_GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/performance-test/service-account.json
       - name: GITHUB_TOKEN
         value: /etc/performance-test/github-token
@@ -6477,9 +6472,6 @@ periodics:
       - name: SLACK_WRITE_TOKEN
         value: /etc/performance-test/slack-write-token
     volumes:
-    - name: test-account
-      secret:
-        secretName: test-account
     - name: performance-test
       secret:
         secretName: performance-test
@@ -6505,16 +6497,11 @@ periodics:
       args:
       - "./test/performance/tools/update_clusters.sh"
       volumeMounts:
-      - name: test-account
-        mountPath: /etc/test-account
-        readOnly: true
       - name: performance-test
         mountPath: /etc/performance-test
         readOnly: true
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/test-account/service-account.json
-      - name: PERF_TEST_GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/performance-test/service-account.json
       - name: GITHUB_TOKEN
         value: /etc/performance-test/github-token
@@ -6523,9 +6510,6 @@ periodics:
       - name: SLACK_WRITE_TOKEN
         value: /etc/performance-test/slack-write-token
     volumes:
-    - name: test-account
-      secret:
-        secretName: test-account
     - name: performance-test
       secret:
         secretName: performance-test
@@ -6551,16 +6535,11 @@ periodics:
       args:
       - "./test/performance/tools/recreate_clusters.sh"
       volumeMounts:
-      - name: test-account
-        mountPath: /etc/test-account
-        readOnly: true
       - name: eventing-performance-test
         mountPath: /etc/performance-test
         readOnly: true
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/test-account/service-account.json
-      - name: PERF_TEST_GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/performance-test/service-account.json
       - name: GITHUB_TOKEN
         value: /etc/performance-test/github-token
@@ -6569,9 +6548,6 @@ periodics:
       - name: SLACK_WRITE_TOKEN
         value: /etc/performance-test/slack-write-token
     volumes:
-    - name: test-account
-      secret:
-        secretName: test-account
     - name: eventing-performance-test
       secret:
         secretName: eventing-performance-test
@@ -6597,16 +6573,11 @@ periodics:
       args:
       - "./test/performance/tools/update_clusters.sh"
       volumeMounts:
-      - name: test-account
-        mountPath: /etc/test-account
-        readOnly: true
       - name: eventing-performance-test
         mountPath: /etc/performance-test
         readOnly: true
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/test-account/service-account.json
-      - name: PERF_TEST_GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/performance-test/service-account.json
       - name: GITHUB_TOKEN
         value: /etc/performance-test/github-token
@@ -6615,9 +6586,6 @@ periodics:
       - name: SLACK_WRITE_TOKEN
         value: /etc/performance-test/slack-write-token
     volumes:
-    - name: test-account
-      secret:
-        secretName: test-account
     - name: eventing-performance-test
       secret:
         secretName: eventing-performance-test

--- a/ci/prow/periodic_config.go
+++ b/ci/prow/periodic_config.go
@@ -378,10 +378,8 @@ func perfClusterUpdatePeriodicJob(jobName, cronString, command, repo, sa string)
 	data.PeriodicJobName = jobName
 	data.CronString = cronString
 	data.PeriodicCommand = createCommand(data.Base)
-	configureServiceAccountForJob(&data.Base)
-	addEnvToJob(&data.Base, "GOOGLE_APPLICATION_CREDENTIALS", data.Base.ServiceAccount)
 	addVolumeToJob(&data.Base, "/etc/performance-test", sa, true, "")
-	addEnvToJob(&data.Base, "PERF_TEST_GOOGLE_APPLICATION_CREDENTIALS", "/etc/performance-test/service-account.json")
+	addEnvToJob(&data.Base, "GOOGLE_APPLICATION_CREDENTIALS", "/etc/performance-test/service-account.json")
 	addEnvToJob(&data.Base, "GITHUB_TOKEN", "/etc/performance-test/github-token")
 	addEnvToJob(&data.Base, "SLACK_READ_TOKEN", "/etc/performance-test/slack-read-token")
 	addEnvToJob(&data.Base, "SLACK_WRITE_TOKEN", "/etc/performance-test/slack-write-token")


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
We do not need the test account for performance test jobs. This PR removes it, and set `GOOGLE_APPLICATION_CREDENTIALS` to the service account key that is specific to that project.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

This change will need to be coordinated with other changes.

/hold

