### PR TITLE
Update and add missing roles to plank initial config

### DIFF
--- a/ci/prow/config_start.yaml
+++ b/ci/prow/config_start.yaml
@@ -202,6 +202,24 @@ metadata:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
+  namespace: default
+  name: "plank"
+rules:
+  - apiGroups:
+      - "prow.k8s.io"
+    resources:
+      - prowjobs
+    verbs:
+      - get
+      - create
+      - list
+      - update
+      - patch
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  namespace: test-pods
   name: "plank"
 rules:
   - apiGroups:
@@ -212,19 +230,24 @@ rules:
       - create
       - delete
       - list
-  - apiGroups:
-      - "prow.k8s.io"
-    resources:
-      - prowjobs
-    verbs:
-      - get
-      - create
-      - list
-      - update
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
+  namespace: default
+  name: "plank"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "plank"
+subjects:
+- kind: ServiceAccount
+  name: "plank"
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  namespace: test-pods
   name: "plank"
 roleRef:
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
A new instance, if created from scratch, won't start since these roles will be wrong or missing.

Shamelessly copied from k8s Prow config.