### PR TITLE
Install liche with module support on

### DIFF
--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -46,7 +46,7 @@ RUN GO111MODULE=on go get github.com/google/ko/cmd/ko
 RUN GO111MODULE=on go get github.com/boz/kail/cmd/kail
 RUN go get -u github.com/golang/dep/cmd/dep
 RUN go get -u github.com/jstemmer/go-junit-report
-RUN go get -u github.com/raviqqe/liche
+RUN GO111MODULE=on go get -u github.com/raviqqe/liche
 
 # Extract bazel version
 RUN bazel version > /bazel_version


### PR DESCRIPTION
Otherwise you'll now get:

```
Step 17/26 : RUN go get -u github.com/raviqqe/liche
 ---> Running in 69195fcf78f7
package github.com/russross/blackfriday/v2: cannot find package "github.com/russross/blackfriday/v2" in any of:
        /usr/local/go/src/github.com/russross/blackfriday/v2 (from $GOROOT)
        /go/src/github.com/russross/blackfriday/v2 (from $GOPATH)
```