### PR TITLE
Retire eventing perf test

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -4859,44 +4859,6 @@ periodics:
     - name: release-account
       secret:
         secretName: release-account
-- cron: "0 */3 * * *"
-  name: ci-knative-eventing-performance
-  agent: kubernetes
-  labels:
-    prow.k8s.io/pubsub.project: knative-tests
-    prow.k8s.io/pubsub.topic: knative-monitoring
-    prow.k8s.io/pubsub.runID: ci-knative-eventing-performance
-  decorate: true
-  extra_refs:
-  - org: knative
-    repo: eventing
-    base_ref: master
-    path_alias: knative.dev/eventing
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./test/performance-tests.sh"
-      volumeMounts:
-      - name: test-account
-        mountPath: /etc/test-account
-        readOnly: true
-      env:
-      - name: E2E_MIN_CLUSTER_NODES
-        value: "4"
-      - name: E2E_MAX_CLUSTER_NODES
-        value: "4"
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/test-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-    volumes:
-    - name: test-account
-      secret:
-        secretName: test-account
 - cron: "0 1 * * *"
   name: ci-knative-eventing-go-coverage
   labels:

--- a/ci/prow/config_knative.yaml
+++ b/ci/prow/config_knative.yaml
@@ -304,8 +304,6 @@ periodics:
       dot-dev: true
     - auto-release: true
       dot-dev: true
-    - performance: true
-      dot-dev: true
 
   knative/eventing-contrib:
     - continuous: true

--- a/ci/testgrid/config.yaml
+++ b/ci/testgrid/config.yaml
@@ -141,9 +141,6 @@ test_groups:
 - name: ci-knative-eventing-auto-release
   gcs_prefix: knative-prow/logs/ci-knative-eventing-auto-release
   alert_stale_results_hours: 3
-- name: ci-knative-eventing-performance
-  gcs_prefix: knative-prow/logs/ci-knative-eventing-performance
-  short_text_metric: "perf_latency"
 - name: pull-knative-eventing-test-coverage
   gcs_prefix: knative-prow/logs/ci-knative-eventing-go-coverage
   num_failures_to_alert: 9999
@@ -354,9 +351,6 @@ dashboards:
   - name: auto-release
     test_group_name: ci-knative-eventing-auto-release
     base_options: "sort-by-name="
-  - name: performance
-    test_group_name: ci-knative-eventing-performance
-    base_options: "exclude-filter-by-regex=Overall$&group-by-target=&expand-groups=&sort-by-name="
   - name: coverage
     test_group_name: pull-knative-eventing-test-coverage
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Eventing has converted the old perf test case to running with Mako, retire the corresponding Prow jobs.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @adrcunha 
/cc @chaodaiG 

