### PR TITLE
added a no-cache version in image Makefile

### DIFF
--- a/images/prow-tests/README.md
+++ b/images/prow-tests/README.md
@@ -11,6 +11,10 @@ To build and push a new image, just run `make push`.
 For testing purposes you can build an image but not push it; to do so, run
 `make build`.
 
+`make build_no_cache` is similar to `make build` except it does not use the cache
+when building images with docker. This ensures the image is built with the latest
+version of each tool.
+
 The Prow jobs are configured to use the `prow-tests` image tagged with `stable`.
 This tag must be manually set in GCR using the Cloud Console.
 

--- a/shared/Makefile.simple-image
+++ b/shared/Makefile.simple-image
@@ -39,10 +39,10 @@ build:
 build_no_cache:
 	$(call build_helper,--no-cache)
 
-push_versioned: build
+push_versioned: build_no_cache
 	docker push $(IMG):$(TAG)
 
-push_latest: build
+push_latest: build_no_cache
 	docker push $(IMG):latest
 
 push: push_versioned push_latest

--- a/shared/Makefile.simple-image
+++ b/shared/Makefile.simple-image
@@ -24,11 +24,20 @@ PROJECT  ?= knative-tests
 IMG = $(REGISTRY)/$(PROJECT)/test-infra/$(IMAGE_NAME)
 TAG := $(shell date +v%Y%m%d)-$(shell git describe --always --dirty --match '^$$')
 
+# build_helper: build the image with docker
+#	$1 = [optional] additional flags to be applied to the build
+define build_helper
+	docker build $(1) -t $(IMG):$(TAG) -f Dockerfile ../..
+endef
+
 all: build
 
 build:
-	docker build -t $(IMG):$(TAG) -f Dockerfile ../..
+	$(call build_helper)
 	docker tag $(IMG):$(TAG) $(IMG):latest
+
+build_no_cache:
+	$(call build_helper,--no-cache)
 
 push_versioned: build
 	docker push $(IMG):$(TAG)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:

When I'm trying to update tools used in prow-test image, it is not picking up the latest gcloud SDK  due to the step already cached in docker build.

**Testing**

Confirmed running `make build_no_cache` has an updated gcloud SDK version. 

```
# Ran with `make build`
$ docker run --entrypoint=""  gcr.io/joyceyu-test/test-infra/prow-tests:v20191007-0a634c8-dirty  gcloud version  
Google Cloud SDK 257.0.0
alpha 2019.05.17
beta 2019.05.17
bq 2.0.46
core 2019.08.02
docker-credential-gcr 
gsutil 4.41
kubectl 2019.08.02


# Ran with `make build_no_cache`
$ docker run --entrypoint=""  gcr.io/joyceyu-test/test-infra/prow-tests:v20191007-0a634c8-dirty  gcloud version  
Google Cloud SDK 265.0.0
alpha 2019.05.17
beta 2019.05.17
bq 2.0.48
core 2019.09.27
docker-credential-gcr 
gsutil 4.43
kubectl 2019.09.22
```

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #

**Special notes to reviewers**:

**User-visible changes in this PR**:

