### PR TITLE
Add Prow release notes to auto-bumper PR body, fixing duplicate entries bug

### DIFF
--- a/tools/prow-auto-bumper/pullrequest.go
+++ b/tools/prow-auto-bumper/pullrequest.go
@@ -44,11 +44,15 @@ func generatePRBody(extraMsgs []string) string {
 	var body string
 	if len(extraMsgs) > 0 {
 		body += "Info:\n"
-		for _, msg := range sets.NewString(extraMsgs).List() {
+		for _, msg := range sets.NewString(extraMsgs...).List() {
 			body += fmt.Sprintf("%s\n", msg)
 		}
 		body += "\n"
 	}
+
+	body += "\nPlease check [Prow release notes]" +
+		"(https://github.com/kubernetes/test-infra/blob/master/prow/ANNOUNCEMENTS.md)" +
+		"to make sure there is no breaking changes\n"
 
 	oncaller, err := getOncaller()
 	var assignment string

--- a/tools/prow-auto-bumper/pullrequest.go
+++ b/tools/prow-auto-bumper/pullrequest.go
@@ -27,6 +27,8 @@ import (
 	"os/exec"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	"github.com/google/go-github/github"
 	"knative.dev/pkg/test/ghutil"
 )
@@ -42,7 +44,7 @@ func generatePRBody(extraMsgs []string) string {
 	var body string
 	if len(extraMsgs) > 0 {
 		body += "Info:\n"
-		for _, msg := range extraMsgs {
+		for _, msg := range sets.NewString(extraMsgs).List() {
 			body += fmt.Sprintf("%s\n", msg)
 		}
 		body += "\n"


### PR DESCRIPTION
Prow auto-bumper tool only updates images, but not configs, i.e. RBAC changes etc., adding Prow release notes link in it's PR body for oncall to check before applying to avoid breaking changes.

By the way fixing the bug of duplicate entries in PR body. Current behavior is when the same image is used multiple times then the PR body would contain multiple copies of the same message, see this example: https://github.com/knative/test-infra/pull/1421. Dedup the entries so the same message appear only once

/cc @adrcunha 
/cc @chizhg 