### PR TITLE
support publish to azure

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -315,5 +315,4 @@ Example command to publish Knative Serving to Azure:
 ```sh
 foo@trantor:~/go/src/knative.dev/serving
 $ ./hack/release.sh --test-args "--unit-tests" --release-acr MYACR --release-azblob https://MYBLOB.blob.core.windows.net/MYCONTAINER --publish --tag-release
-
 ```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -313,6 +313,5 @@ Automated azure support for running integration tests (ie AKS setup etc.) has no
 
 Example command to publish Knative Serving to Azure:
 ```sh
-foo@trantor:~/go/src/knative.dev/serving
 $ ./hack/release.sh --test-args "--unit-tests" --release-acr MYACR --release-azblob https://MYBLOB.blob.core.windows.net/MYCONTAINER --publish --tag-release
 ```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -263,7 +263,7 @@ This is a helper script for Knative release scripts. To use it:
    - `SKIP_TESTS`: true if `--skip-tests` was passed. This is handled
      automatically.
    - `VALIDATION_TESTS`: set to the test script file to run if `--validation-tests` was passed, otherwise the default value `./test/presubmit-tests.sh` will be used. 
-   - `VALIDATION_TEST_ARGS`: set if `--test-args` was passed. This is used to set command line arguments to `VALIDATION_TESTS`
+   - `VALIDATION_TEST_ARGS`: set if `--test-args` was passed. This is used to set command line arguments to `VALIDATION_TESTS`. Defaults to no arguments.
    - `TAG_RELEASE`: true if `--tag-release` was passed. In this case, the
      environment variable `TAG` will contain the release tag in the form
      `v$BUILD_TAG`.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -262,6 +262,8 @@ This is a helper script for Knative release scripts. To use it:
      used. It is set to `ko.local` if `--publish` was not passed.
    - `SKIP_TESTS`: true if `--skip-tests` was passed. This is handled
      automatically.
+   - `VALIDATION_TESTS`: set to the test script file to run if `--validation-tests` was passed, otherwise the default value `./test/presubmit-tests.sh` will be used. 
+   - `VALIDATION_TEST_ARGS`: set if `--test-args` was passed. This is used to set command line arguments to `VALIDATION_TESTS`
    - `TAG_RELEASE`: true if `--tag-release` was passed. In this case, the
      environment variable `TAG` will contain the release tag in the form
      `v$BUILD_TAG`.
@@ -293,18 +295,18 @@ main $@
 ```
 ### Using release.sh to publish to Azure
 To run release.sh to publish to Azure Contianer Registery and Azure Blob, the following pre-requisites need to be configured/setup:
-#### A. Install Tools
-1. Install `az` command line tool, see [here] (https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest)
-2. Install `azcopy` tool, see [here](https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-v10)
+1. Install Tools
+    - Install `az` [command line tool](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest)
+    - Install `azcopy` [command line tool](https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-v10)
 
-#### B. Create ACR
-1. Create an Azure Container Registry.
-2. Get the and save the admin key locally, see [here](https://docs.microsoft.com/en-us/azure/container-registry/container-registry-authentication).
+1. Create ACR
+    - Create an Azure Container Registry.
+    - Get the and save the admin key locally, see [here](https://docs.microsoft.com/en-us/azure/container-registry/container-registry-authentication).
 
-#### C. Create Azure BLOB
-1. Create an Azure Storage account
-2. Create a "Container" in the blob, instructions [here](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-portal).
-3. Assign read/write permissions to the user/Service Principle that will be used, see [here](https://docs.microsoft.com/en-us/azure/storage/common/storage-auth). If you see 404s when you run the release script, you likely havent set permissions correctly.
+1. Create Azure BLOB
+    - Create an Azure Storage account
+    - Create a "Container" in the blob, instructions [here](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-portal).
+    - Assign read/write permissions to the user/Service Principle that will be used, see [here](https://docs.microsoft.com/en-us/azure/storage/common/storage-auth). If you see 404s when you run the release script, you likely havent set permissions correctly.
 
 #### Configure tests
 Automated azure support for running integration tests (ie AKS setup etc.) has not tested. The `--test-args` flag can be used to restrict presubmit testing to unit and build tests only.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -291,3 +291,27 @@ function build_release() {
 
 main $@
 ```
+### Using release.sh to publish to Azure
+To run release.sh to publish to Azure Contianer Registery and Azure Blob, the following pre-requisites need to be configured/setup:
+#### A. Install Tools
+1. Install `az` command line tool, see [here] (https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest)
+2. Install `azcopy` tool, see [here](https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-v10)
+
+#### B. Create ACR
+1. Create an Azure Container Registry.
+2. Get the and save the admin key locally, see [here](https://docs.microsoft.com/en-us/azure/container-registry/container-registry-authentication).
+
+#### C. Create Azure BLOB
+1. Create an Azure Storage account
+2. Create a "Container" in the blob, instructions [here](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-portal).
+3. Assign read/write permissions to the user/Service Principle that will be used, see [here](https://docs.microsoft.com/en-us/azure/storage/common/storage-auth). If you see 404s when you run the release script, you likely havent set permissions correctly.
+
+#### Configure tests
+Automated azure support for running integration tests (ie AKS setup etc.) has not tested. The `--test-args` flag can be used to restrict presubmit testing to unit and build tests only.
+
+Example command to publish KNative Serving to Azure:
+```
+foo@trantor:~/go/src/knative.dev/serving
+$ ./hack/release.sh --test-args "--unit-tests" --release-acr MYACR --release-azblob https://MYBLOB.blob.core.windows.net/MYCONTAINER --publish --tag-release
+
+```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -312,7 +312,7 @@ To run release.sh to publish to Azure Contianer Registery and Azure Blob, the fo
 Automated azure support for running integration tests (ie AKS setup etc.) has not tested. The `--test-args` flag can be used to restrict presubmit testing to unit and build tests only. Or `--skip-test` can be used to skip all tests.
 
 Example command to publish Knative Serving to Azure:
-```
+```sh
 foo@trantor:~/go/src/knative.dev/serving
 $ ./hack/release.sh --test-args "--unit-tests" --release-acr MYACR --release-azblob https://MYBLOB.blob.core.windows.net/MYCONTAINER --publish --tag-release
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -309,7 +309,7 @@ To run release.sh to publish to Azure Contianer Registery and Azure Blob, the fo
     - Assign read/write permissions to the user/Service Principle that will be used, see [here](https://docs.microsoft.com/en-us/azure/storage/common/storage-auth). If you see 404s when you run the release script, you likely havent set permissions correctly.
 
 #### Configure tests
-Automated azure support for running integration tests (ie AKS setup etc.) has not tested. The `--test-args` flag can be used to restrict presubmit testing to unit and build tests only.
+Automated azure support for running integration tests (ie AKS setup etc.) has not tested. The `--test-args` flag can be used to restrict presubmit testing to unit and build tests only. Or `--skip-test` can be used to skip all tests.
 
 Example command to publish Knative Serving to Azure:
 ```

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -436,8 +436,7 @@ function parse_flags() {
             VALIDATION_TEST=$1
             ;;
           --test-args)
-            # multiple args can be passed as a|b
-            VALIDATION_TEST_ARGS="$(tr '|' ' ' <<<$1)"
+            VALIDATION_TEST_ARGS=$1
             ;;
           --version)
             [[ $1 =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || abort "version format must be '[0-9].[0-9].[0-9]'"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -436,7 +436,7 @@ function parse_flags() {
             VALIDATION_TEST=$1
             ;;
           --test-args)
-            VALIDATION_TEST_ARGS=$1
+            VALIDATION_TEST_ARGS="$1"
             ;;
           --version)
             [[ $1 =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || abort "version format must be '[0-9].[0-9].[0-9]'"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -528,16 +528,14 @@ function parse_flags() {
 }
 
 # Run tests (unless --skip-tests was passed). Conveniently displays a banner indicating so.
-# Parameters: $1 - executable that runs the tests.
+# Parameters: $1... - executable (and arguments) that runs the tests.
 function run_validation_tests() {
   if (( ! SKIP_TESTS )); then
-    _VALIDATION_COMMAND=$1
-    shift
-    _VALIDATION_ARGS=$@
     banner "Running release validation tests"
-    banner "${_VALIDATION_COMMAND} with args: ${_VALIDATION_ARGS}"
+    banner "Running release validation tests"
+    echo "Running '$@'"
     # Run tests.
-    if ! ${_VALIDATION_COMMAND} ${_VALIDATION_ARGS}; then
+    if ! $@; then
       banner "Release validation tests failed, aborting"
       exit 1
     fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -421,7 +421,7 @@ function parse_flags() {
             ;;
           --release-acr)
             AZ_ACR_NAME=$1
-            KO_DOCKER_REPO="${1}.azurecr.io"
+            KO_DOCKER_REPO="${AZ_ACR_NAME}.azurecr.io"
             has_registry_flag=1
             ;;
           --release-azblob)

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -432,6 +432,9 @@ function parse_flags() {
             RELEASE_GCS_BUCKET=$1
             has_storage_flag=1
             ;;
+          --validation-tests)
+            VALIDATION_TEST=$1
+            ;;
           --test-args)
             # multiple args can be passed as a|b
             VALIDATION_TEST_ARGS="$(tr '|' ' ' <<<$1)"

--- a/test/unit/dummy.yaml
+++ b/test/unit/dummy.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: caching.internal.knative.dev/v1alpha1
+kind: Image
+metadata:
+  labels:
+    serving.knative.dev/release: devel
+  name: queue-proxy
+  namespace: knative-serving
+spec:
+  image: foo.azurecr.io/queue-39be6f1d08a095bd076a71d288d295b6@sha256:13c56ba9592ee63d0c675008930b099d9cd1eb638ce747fa03ff52a74e1398da

--- a/test/unit/release-tests.sh
+++ b/test/unit/release-tests.sh
@@ -87,6 +87,7 @@ test_function ${FAILURE} "error: cannot have both --branch and --auto-release se
 test_function ${FAILURE} "error: missing parameter" parse_flags --from-nightly
 test_function ${FAILURE} "error: nightly tag" parse_flags --from-nightly aaa
 
+test_function ${FAILURE} "error: missing parameter" parse_flags --validation-tests
 test_function ${FAILURE} "error: missing parameter" parse_flags --test-args
 
 token_file=$(mktemp)

--- a/test/unit/release-tests.sh
+++ b/test/unit/release-tests.sh
@@ -19,6 +19,27 @@ source $(dirname $0)/../../scripts/release.sh
 
 set -e
 
+function mock_tag_images_in_yamls_acr() {
+  set -e
+  AZ_ACR_NAME=foo
+  KO_DOCKER_REPO="${AZ_ACR_NAME}.azurecr.io"
+  TAG=sometag
+  function az() {
+	echo $@
+  }
+  tag_images_in_yamls_acr "$@" 2>&1
+}
+
+function mock_publish_to_azblob() {
+  set -e
+  RELEASE_AZ_BLOB_URL=https://foo.blob.core.windows.net
+  TAG=sometag
+  function azcopy() {
+	echo $@
+  }
+  publish_to_azblob "$@" 2>&1
+}
+
 function mock_publish_to_github() {
   set -e
   PUBLISH_TO_GITHUB=1
@@ -112,6 +133,8 @@ echo ">> Testing ACR/BLOB values"
 
 test_function ${SUCCESS} "Not publishing the release, GCR/ACR flags ignored" parse_flags --release-acr foo
 test_function ${SUCCESS} "Not publishing the release, GCS/BLOB flags ignored" parse_flags --release-azblob foo
+test_function ${SUCCESS} "copy somefile https://foo.blob.core.windows.net/previous/sometag/" mock_publish_to_azblob somefile
+test_function ${SUCCESS} "acr import -n foo --source foo.azurecr.io/queue-39be6f1d08a095bd076a71d288d295b6@sha256:13c56ba9592ee63d0c675008930b099d9cd1eb638ce747fa03ff52a74e1398da -t queue-39be6f1d08a095bd076a71d288d295b6:sometag" mock_tag_images_in_yamls_acr dummy.yaml
 
 echo ">> Testing publishing to GitHub"
 

--- a/test/unit/release-tests.sh
+++ b/test/unit/release-tests.sh
@@ -87,14 +87,16 @@ test_function ${FAILURE} "error: cannot have both --branch and --auto-release se
 test_function ${FAILURE} "error: missing parameter" parse_flags --from-nightly
 test_function ${FAILURE} "error: nightly tag" parse_flags --from-nightly aaa
 
+test_function ${FAILURE} "error: missing parameter" parse_flags --test-args
+
 token_file=$(mktemp)
 echo -e "abc " > ${token_file}
 test_function ${SUCCESS} ":abc:" call_function_post "echo :\$GITHUB_TOKEN:" parse_flags --github-token ${token_file}
 
 echo ">> Testing GCR/GCS values"
 
-test_function ${SUCCESS} "GCR flag is ignored" parse_flags --release-gcr foo
-test_function ${SUCCESS} "GCS flag is ignored" parse_flags --release-gcs foo
+test_function ${SUCCESS} "Not publishing the release, GCR/ACR flags ignored" parse_flags --release-gcr foo
+test_function ${SUCCESS} "Not publishing the release, GCS/BLOB flags ignored" parse_flags --release-gcs foo
 
 test_function ${SUCCESS} ":ko.local:" call_function_post "echo :\$KO_DOCKER_REPO:" parse_flags
 test_function ${SUCCESS} "::" call_function_post "echo :\$RELEASE_GCS_BUCKET:" parse_flags
@@ -104,6 +106,11 @@ test_function ${SUCCESS} ":knative-nightly/test-infra:" call_function_post "echo
 
 test_function ${SUCCESS} ":foo:" call_function_post "echo :\$KO_DOCKER_REPO:" parse_flags --release-gcr foo --publish
 test_function ${SUCCESS} ":foo:" call_function_post "echo :\$RELEASE_GCS_BUCKET:" parse_flags --release-gcs foo --publish
+
+echo ">> Testing ACR/BLOB values"
+
+test_function ${SUCCESS} "Not publishing the release, GCR/ACR flags ignored" parse_flags --release-acr foo
+test_function ${SUCCESS} "Not publishing the release, GCS/BLOB flags ignored" parse_flags --release-azblob foo
 
 echo ">> Testing publishing to GitHub"
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Support publishing build artifacts to azure (acr, azure blob) so that we can build and consume knative serving on azure

Also adds a validation_args param to skip integration tests via a command line option

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #
#1451 

**Special notes to reviewers**:
No changes made to gcp logic :)

**User-visible changes in this PR**:

