### PR TITLE
Configure knative/website for tide

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -85,6 +85,7 @@ tide:
     - "knative/serving"
     - "knative/serving-operator"
     - "knative/test-infra"
+    - "knative/website"
     labels:
     - lgtm
     - approved

--- a/ci/prow/config_knative.yaml
+++ b/ci/prow/config_knative.yaml
@@ -190,6 +190,13 @@ presubmits:
     - go-coverage: true
       dot-dev: true
 
+  knative/website:
+    # This repo only uses Tide
+    - build-tests: false
+    - unit-tests: false
+    - integration-tests: false
+    - go-coverage: false
+
 periodics:
   knative/serving:
     - continuous: true


### PR DESCRIPTION
knative/website only uses tide, but a presubmit entry is required to generate the config. Thus, add a presubmit entry with no presubmit tests enabled.

Part of #1454