### PR TITLE
Allow using cleanup.sh on arbitrary projects and GCR

### DIFF
--- a/test/unit/cleanup-tests.sh
+++ b/test/unit/cleanup-tests.sh
@@ -40,6 +40,7 @@ test_function ${FAILURE} "error: expecting value following" cleanup_script --art
 test_function ${FAILURE} "error: expecting value following" cleanup_script --project --dry-run
 test_function ${FAILURE} "error: expecting value following" cleanup_script --gcr --dry-run
 test_function ${FAILURE} "error: provide a project or resource" cleanup_script --dry-run
+test_function ${FAILURE} "error: provide a project or resource" cleanup_script --project a --project-resource-yaml b
 
 test_function ${FAILURE} "error: days to keep" cleanup_script --days-to-keep-images "a" --dry-run
 test_function ${FAILURE} "error: hours to keep" cleanup_script --hours-to-keep-clusters "a" --dry-run

--- a/test/unit/cleanup-tests.sh
+++ b/test/unit/cleanup-tests.sh
@@ -17,11 +17,6 @@
 source $(dirname $0)/test-helper.sh
 source $(dirname $0)/../../tools/cleanup/cleanup-functions.sh
 
-readonly _FAKE_NIGHTLY_PROJECT_NAME="gcr.io/knative-nightly"
-readonly _FAKE_BOSKOS_PROJECT_NAME="gcr.io/fake-boskos-project"
-readonly _PROJECT_RESOURCE_YAML="ci/prow/boskos_resources.yaml"
-readonly _RE_PROJECT_NAME="knative-boskos-[a-zA-Z0-9]+"
-
 # Call "cleanup.sh" function with given parameters
 # Parameters: $1..$n - parameters passed to "cleanup.sh" script
 function cleanup_script() {
@@ -42,6 +37,9 @@ test_function ${FAILURE} "error: expecting value following" cleanup_script --gcr
 test_function ${FAILURE} "error: expecting value following" cleanup_script --days-to-keep-images --dry-run
 test_function ${FAILURE} "error: expecting value following" cleanup_script --hours-to-keep-clusters --dry-run
 test_function ${FAILURE} "error: expecting value following" cleanup_script --artifacts --dry-run
+test_function ${FAILURE} "error: expecting value following" cleanup_script --project --dry-run
+test_function ${FAILURE} "error: expecting value following" cleanup_script --gcr --dry-run
+test_function ${FAILURE} "error: provide a project or resource" cleanup_script --dry-run
 
 test_function ${FAILURE} "error: days to keep" cleanup_script --days-to-keep-images "a" --dry-run
 test_function ${FAILURE} "error: hours to keep" cleanup_script --hours-to-keep-clusters "a" --dry-run
@@ -50,19 +48,20 @@ test_function ${FAILURE} "error: hours to keep" cleanup_script --hours-to-keep-c
 echo ">> Testing deleting images from single project"
 
 test_function ${FAILURE} "error: missing gcr" delete_old_images_from_gcr
-test_function ${FAILURE} "error: missing days" delete_old_images_from_gcr ${_FAKE_BOSKOS_PROJECT_NAME}
-test_function ${SUCCESS} "" mock_gcloud_function delete_old_images_from_gcr ${_FAKE_BOSKOS_PROJECT_NAME} 1
+test_function ${FAILURE} "error: missing days" delete_old_images_from_gcr p1
+test_function ${SUCCESS} "" mock_gcloud_function delete_old_images_from_gcr p1 1
 
 echo ">> Testing deleting images from multiple projects"
 
 test_function ${FAILURE} "error: missing project names" delete_old_gcr_images
-test_function ${FAILURE} "error: missing days" delete_old_gcr_images "${_FAKE_BOSKOS_PROJECT_NAME}1"
-test_function ${SUCCESS} "Start" mock_gcloud_function delete_old_gcr_images "${_PROJECT_RESOURCE_YAML}1 ${_PROJECT_RESOURCE_YAML}2" 99
+test_function ${FAILURE} "error: missing days" delete_old_gcr_images p1
+test_function ${SUCCESS} "Start" mock_gcloud_function delete_old_gcr_images "p1 p2" 99
+test_function ${SUCCESS} "Start" mock_gcloud_function delete_old_gcr_images "p1 p2" 99 foo.gcr
 
 echo ">> Testing deleting clusters from multiple projects"
 
 test_function ${FAILURE} "error: missing project names" delete_old_test_clusters
-test_function ${FAILURE} "error: missing hours" delete_old_test_clusters "${_FAKE_BOSKOS_PROJECT_NAME}1"
-test_function ${SUCCESS} "Start" mock_gcloud_function delete_old_test_clusters "${_FAKE_BOSKOS_PROJECT_NAME}1 ${_FAKE_BOSKOS_PROJECT_NAME}2" 99
+test_function ${FAILURE} "error: missing hours" delete_old_test_clusters p1
+test_function ${SUCCESS} "Start" mock_gcloud_function delete_old_test_clusters "p1 p2" 99
 
 echo ">> All tests passed"

--- a/tools/cleanup/README.md
+++ b/tools/cleanup/README.md
@@ -3,6 +3,9 @@
 This tool is designed to clean up stale test resources. For now it deletes GCR
 images and GKE clusters created during testing.
 
+It can also be used to delete GCR images and GKE clusters from an arbitrary
+project.
+
 ## Basic Usage
 
 Directly invoke [cleanup.sh](cleanup.sh) script with certain flags, but don't
@@ -12,27 +15,44 @@ By default the current gcloud credentials are used to delete the images. If
 necessary, use the flag `--service-account _key-file.json_` to specify a service
 account that will be performing the access to the gcr.
 
-Projects to be cleaned up are expected to be defined in a `resources.yaml` file.
-To remove old images and clusters from them, call [cleanup.sh](cleanup.sh) with
-following flags:
+Project(s) to be cleaned up are expected to be either defined in a text
+file or passed (once or multiple times) using the `--project` flag.
 
-- "--project-resource-yaml" as path of `resources.yaml` file - Mandatory
-- "--re-project-name" for regex matching projects names - Optional, defaults to
-  `knative-boskos-[a-zA-Z0-9]+`
-- "--days-to-keep-images" - Optional, defaults to `365` as 1 year
-- "--hours-to-keep-clusters" - Optional, defaults to `720` as 30 days
-- "--dry-run" - Optional, performs dryrun for all gcloud functions, defaults to
+The following flags are available for the [cleanup.sh](cleanup.sh) script:
+
+- `--project-resource-yaml` Points to a resources file containing the names
+  of the projects to be cleaned up. Such file can be any form of text, as long
+  as the project names can be extracted, one per line, using a regular
+  expression.
+- `--project` Project to be cleaned up. Can be specified more than once.
+- `--re-project-name` Regular expression for filtering project names from the
+  resources file. Optional, defaults to `knative-boskos-[a-zA-Z0-9]+`.
+- `--days-to-keep-images` Optional, defaults to 365 days (aka 1 year).
+- `--hours-to-keep-clusters` Optional, defaults to 720 hours (aka 30 days).
+- `--gcr` Defines the GCR hostname to use (e.g., `us.gcr.io`). Optional, defaults
+  to `gcr.io`.
+- `--dry-run" - Optional, performs dryrun for all gcloud functions, defaults to
   false
 
-Example:
+Examples:
 
-`./cleanup.sh --project-resource-yaml "ci/prow/boskos_resources.yaml" --days-to-keep-images 90 --days-to-keep-clusters 24`
 This command deletes test images older than 90 days and test clusters created
-more than 24 hours ago.
+more than 24 hours ago in all Boskos projects.
+
+```sh
+$ ./cleanup.sh --project-resource-yaml ci/prow/boskos_resources.yaml --days-to-keep-images 90 --days-to-keep-clusters 24`
+```
+
+This command deletes test images older than 1 day and test clusters created
+more than 24 hours ago in a personal project called `my-knative-project`.
+
+```sh
+$ ./cleanup.sh --project my-knative-project --days-to-keep-images 1 --days-to-keep-clusters 24`
+```
 
 ## Prow Job
 
 There is a weekly prow job that triggers this tool runs at 11:00/12:00PM(Day
-light saving) PST every Monday. This tool scans all gcr projects defined in
+light saving) PST every Monday. This tool scans all projects defined in
 [ci/prow/boskos_resources.yaml](/ci/prow/boskos_resources.yaml) and deletes
 images older than 90 days and clusters older than 24 hours.

--- a/tools/cleanup/cleanup-functions.sh
+++ b/tools/cleanup/cleanup-functions.sh
@@ -51,13 +51,16 @@ function delete_old_images_from_gcr() {
 # Delete old images in the given GCP projects
 # Parameters: $1 - array of projects names
 #             $2 - days to keep images
+#             $3 - gcr hostname (optional, defaults to gcr.io)
 function delete_old_gcr_images() {
   [[ -z $1 ]] && abort "missing project names"
   [[ -z $2 ]] && abort "missing days to keep images"
+  local gcr=$3
+  [[ -z $3 ]] && gcr="gcr.io"
 
   for project in $1; do
     echo "Start deleting images from ${project}"
-    delete_old_images_from_gcr "gcr.io/${project}" $2
+    delete_old_images_from_gcr "${gcr}/${project}" $2
   done
 }
 

--- a/tools/cleanup/cleanup.sh
+++ b/tools/cleanup/cleanup.sh
@@ -77,6 +77,7 @@ fi
 parse_args $@
 
 [[ -z "${PROJECTS}" && -z "${PROJECT_RESOURCE_YAML}" ]] && abort "provide a project or resource file with projects"
+[[ -n "${PROJECTS}" && -n "${PROJECT_RESOURCE_YAML}" ]] && abort "provide a project or resource file with projects, not both"
 
 (( DRY_RUN )) && echo "-- Running in dry-run mode, no resource deletion --"
 


### PR DESCRIPTION
The tool can now be used to clean up personal GCP projects as well.

Bonuses: removed unnecessary variables from test.