### PR TITLE
Automatically generate the Prow plugins config

### DIFF
--- a/ci/prow/Makefile
+++ b/ci/prow/Makefile
@@ -16,7 +16,7 @@ include ../Makefile.base
 
 # Generate the Prow config file
 config:
-	go run *_config.go --prow-config-output=$(PROW_CONFIG) --testgrid-config-output=$(TESTGRID_CONFIG) --gcs-bucket=$(PROW_GCS) --testgrid-gcs-bucket=$(TESTGRID_GCS) --image-docker=gcr.io/$(PROJECT)/test-infra $(KNATIVE_CONFIG)
+	go run *_config.go --prow-config-output=$(PROW_CONFIG) --plugins-config-output=$(PROW_PLUGINS) --testgrid-config-output=$(TESTGRID_CONFIG) --gcs-bucket=$(PROW_GCS) --testgrid-gcs-bucket=$(TESTGRID_GCS) --image-docker=gcr.io/$(PROJECT)/test-infra $(KNATIVE_CONFIG)
 
 # Update all prow job configs
 update-config:
@@ -76,9 +76,11 @@ update-full: update-all-cluster-deployments update-all-boskos-deployments update
 test:
 	@echo "*** Checking config generator for prow and testgrid"
 	$(eval TMP_YAML_PROW := $(shell mktemp))
+	$(eval TMP_YAML_PLUGINS := $(shell mktemp))
 	$(eval TMP_YAML_TESTGRID := $(shell mktemp))
-	go run *_config.go --prow-config-output="$(TMP_YAML_PROW)" --testgrid-config-output="$(TMP_YAML_TESTGRID)" $(KNATIVE_CONFIG)
+	go run *_config.go --prow-config-output="$(TMP_YAML_PROW)" --plugins-config-output="$(TMP_YAML_PLUGINS)" --testgrid-config-output="$(TMP_YAML_TESTGRID)" $(KNATIVE_CONFIG)
 	diff $(PROW_CONFIG) $(TMP_YAML_PROW)
+	diff $(PROW_PLUGINS) $(TMP_YAML_PLUGINS)
 	diff $(TESTGRID_CONFIG) $(TMP_YAML_TESTGRID)
 	@echo "*** Checking configs validity"
 	bazel run @k8s//prow/cmd/checkconfig -- --plugin-config=$(PROW_PLUGINS) --config-path=$(PROW_CONFIG)

--- a/ci/prow/plugins.yaml
+++ b/ci/prow/plugins.yaml
@@ -1,4 +1,4 @@
-# Copyright 2018 The Knative Authors
+# Copyright 2019 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,19 +11,28 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 approve:
 - repos:
-  - knative
-  - google/knative-gcp
+  - "google/knative-gcp"
+  - "knative/caching"
+  - "knative/client"
+  - "knative/docs"
+  - "knative/eventing"
+  - "knative/eventing-contrib"
+  - "knative/eventing-operator"
+  - "knative/observability"
+  - "knative/pkg"
+  - "knative/sample-controller"
+  - "knative/serving"
+  - "knative/serving-operator"
+  - "knative/test-infra"
+  - "knative/website"
   require_self_approval: false
   ignore_review_state: false
-  
 heart:
   adorees:
   - knative-test-reporter-robot
   commentregexp: ".*"
-
 repo_milestone:
   # Default maintainer
   '':
@@ -32,7 +41,6 @@ repo_milestone:
     # curl -H "Authorization: token <token>" https://api.github.com/orgs/<org-name>/teams
     maintainers_id: 3012514
     maintainers_team: knative-milestone-maintainers
-
 project_config:
   project_org_configs:
     knative:
@@ -48,32 +56,7 @@ project_config:
         eventing-contrib:
           # TODO(grantr): replace with a new team eventing-contrib-project-maintainers
           repo_maintainers_team_id: 3012514 # knative-milestone-maintainers
-
 plugins:
-  knative:
-  - approve
-  - assign
-  - blunderbuss
-  - buildifier
-  - cat
-  - dog
-  - golint
-  - heart
-  - help
-  - hold
-  - label
-  - lgtm
-  - lifecycle
-  - milestone
-  - owners-label
-  - shrug
-  - size
-  - skip
-  - trigger
-  - verify-owners
-  - wip
-  - yuks
-  - project
   google/knative-gcp:
   - approve
   - assign
@@ -97,4 +80,316 @@ plugins:
   - verify-owners
   - wip
   - yuks
-
+  - project
+  knative/caching:
+  - approve
+  - assign
+  - blunderbuss
+  - buildifier
+  - cat
+  - dog
+  - golint
+  - heart
+  - help
+  - hold
+  - label
+  - lgtm
+  - lifecycle
+  - milestone
+  - owners-label
+  - shrug
+  - size
+  - skip
+  - trigger
+  - verify-owners
+  - wip
+  - yuks
+  - project
+  knative/client:
+  - approve
+  - assign
+  - blunderbuss
+  - buildifier
+  - cat
+  - dog
+  - golint
+  - heart
+  - help
+  - hold
+  - label
+  - lgtm
+  - lifecycle
+  - milestone
+  - owners-label
+  - shrug
+  - size
+  - skip
+  - trigger
+  - verify-owners
+  - wip
+  - yuks
+  - project
+  knative/docs:
+  - approve
+  - assign
+  - blunderbuss
+  - buildifier
+  - cat
+  - dog
+  - golint
+  - heart
+  - help
+  - hold
+  - label
+  - lgtm
+  - lifecycle
+  - milestone
+  - owners-label
+  - shrug
+  - size
+  - skip
+  - trigger
+  - verify-owners
+  - wip
+  - yuks
+  - project
+  knative/eventing:
+  - approve
+  - assign
+  - blunderbuss
+  - buildifier
+  - cat
+  - dog
+  - golint
+  - heart
+  - help
+  - hold
+  - label
+  - lgtm
+  - lifecycle
+  - milestone
+  - owners-label
+  - shrug
+  - size
+  - skip
+  - trigger
+  - verify-owners
+  - wip
+  - yuks
+  - project
+  knative/eventing-contrib:
+  - approve
+  - assign
+  - blunderbuss
+  - buildifier
+  - cat
+  - dog
+  - golint
+  - heart
+  - help
+  - hold
+  - label
+  - lgtm
+  - lifecycle
+  - milestone
+  - owners-label
+  - shrug
+  - size
+  - skip
+  - trigger
+  - verify-owners
+  - wip
+  - yuks
+  - project
+  knative/eventing-operator:
+  - approve
+  - assign
+  - blunderbuss
+  - buildifier
+  - cat
+  - dog
+  - golint
+  - heart
+  - help
+  - hold
+  - label
+  - lgtm
+  - lifecycle
+  - milestone
+  - owners-label
+  - shrug
+  - size
+  - skip
+  - trigger
+  - verify-owners
+  - wip
+  - yuks
+  - project
+  knative/observability:
+  - approve
+  - assign
+  - blunderbuss
+  - buildifier
+  - cat
+  - dog
+  - golint
+  - heart
+  - help
+  - hold
+  - label
+  - lgtm
+  - lifecycle
+  - milestone
+  - owners-label
+  - shrug
+  - size
+  - skip
+  - trigger
+  - verify-owners
+  - wip
+  - yuks
+  - project
+  knative/pkg:
+  - approve
+  - assign
+  - blunderbuss
+  - buildifier
+  - cat
+  - dog
+  - golint
+  - heart
+  - help
+  - hold
+  - label
+  - lgtm
+  - lifecycle
+  - milestone
+  - owners-label
+  - shrug
+  - size
+  - skip
+  - trigger
+  - verify-owners
+  - wip
+  - yuks
+  - project
+  knative/sample-controller:
+  - approve
+  - assign
+  - blunderbuss
+  - buildifier
+  - cat
+  - dog
+  - golint
+  - heart
+  - help
+  - hold
+  - label
+  - lgtm
+  - lifecycle
+  - milestone
+  - owners-label
+  - shrug
+  - size
+  - skip
+  - trigger
+  - verify-owners
+  - wip
+  - yuks
+  - project
+  knative/serving:
+  - approve
+  - assign
+  - blunderbuss
+  - buildifier
+  - cat
+  - dog
+  - golint
+  - heart
+  - help
+  - hold
+  - label
+  - lgtm
+  - lifecycle
+  - milestone
+  - owners-label
+  - shrug
+  - size
+  - skip
+  - trigger
+  - verify-owners
+  - wip
+  - yuks
+  - project
+  knative/serving-operator:
+  - approve
+  - assign
+  - blunderbuss
+  - buildifier
+  - cat
+  - dog
+  - golint
+  - heart
+  - help
+  - hold
+  - label
+  - lgtm
+  - lifecycle
+  - milestone
+  - owners-label
+  - shrug
+  - size
+  - skip
+  - trigger
+  - verify-owners
+  - wip
+  - yuks
+  - project
+  knative/test-infra:
+  - approve
+  - assign
+  - blunderbuss
+  - buildifier
+  - cat
+  - dog
+  - golint
+  - heart
+  - help
+  - hold
+  - label
+  - lgtm
+  - lifecycle
+  - milestone
+  - owners-label
+  - shrug
+  - size
+  - skip
+  - trigger
+  - verify-owners
+  - wip
+  - yuks
+  - project
+  knative/website:
+  - approve
+  - assign
+  - blunderbuss
+  - buildifier
+  - cat
+  - dog
+  - golint
+  - heart
+  - help
+  - hold
+  - label
+  - lgtm
+  - lifecycle
+  - milestone
+  - owners-label
+  - shrug
+  - size
+  - skip
+  - trigger
+  - verify-owners
+  - wip
+  - yuks
+  - project

--- a/ci/prow/templates/prow_plugins.yaml
+++ b/ci/prow/templates/prow_plugins.yaml
@@ -1,0 +1,77 @@
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+approve:
+- repos:
+  [[indent_array 2 .TideRepos]]
+  require_self_approval: false
+  ignore_review_state: false
+  
+heart:
+  adorees:
+  - knative-test-reporter-robot
+  commentregexp: ".*"
+
+repo_milestone:
+  # Default maintainer
+  '':
+    # You can curl the following endpoint in order to determine the github ID of
+    # your team responsible for maintaining the milestones:
+    # curl -H "Authorization: token <token>" https://api.github.com/orgs/<org-name>/teams
+    maintainers_id: 3012514
+    maintainers_team: knative-milestone-maintainers
+
+project_config:
+  project_org_configs:
+    knative:
+      org_maintainers_team_id: 2652083 # knative-admin
+      # TODO(Fredy-Z): Enable this plugin for other repos when needed.
+      project_repo_configs:
+        eventing:
+          # TODO(grantr): replace with a new team eventing-project-maintainers
+          repo_maintainers_team_id: 3012514 # knative-milestone-maintainers
+          repo_default_column_map:
+            perf/measurement:
+              To do
+        eventing-contrib:
+          # TODO(grantr): replace with a new team eventing-contrib-project-maintainers
+          repo_maintainers_team_id: 3012514 # knative-milestone-maintainers
+
+plugins:
+[[range .TideRepos]]
+  [[.]]:
+  - approve
+  - assign
+  - blunderbuss
+  - buildifier
+  - cat
+  - dog
+  - golint
+  - heart
+  - help
+  - hold
+  - label
+  - lgtm
+  - lifecycle
+  - milestone
+  - owners-label
+  - shrug
+  - size
+  - skip
+  - trigger
+  - verify-owners
+  - wip
+  - yuks
+  - project
+[[end]]


### PR DESCRIPTION
Repos with plugins enabled are those with tide enabled.

The autogenerated plugins config file will be longer now because each repo is specified explicitly.

Currently all repos have the same set of plugins enabled.

There are no changes in which plugins are enabled for any repos, compared to the previous static config.