### PR TITLE
Add lenses config for spyglass

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -56,7 +56,7 @@ deck:
         name: build-log
         config:
           highlight_regexes:
-          - 'panic: test timed out after'
+          - 'panic: test timed out after.*$'
           - timed out
           - 'ERROR:'
           - (\s|^)(FAIL|Failure \[)\b

--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -29,10 +29,10 @@ plank:
     grace_period: 15000000000 # 15s
     utility_images:
       # Update these versions when updating plank version in cluster.yaml
-      clonerefs: "gcr.io/k8s-prow/clonerefs:v20190925-d7e1d9b17"
-      initupload: "gcr.io/k8s-prow/initupload:v20190925-d7e1d9b17"
-      entrypoint: "gcr.io/k8s-prow/entrypoint:v20190925-d7e1d9b17"
-      sidecar: "gcr.io/k8s-prow/sidecar:v20190925-d7e1d9b17"
+      clonerefs: "gcr.io/k8s-prow/clonerefs:v20191009-0492f1d6e"
+      initupload: "gcr.io/k8s-prow/initupload:v20191009-0492f1d6e"
+      entrypoint: "gcr.io/k8s-prow/entrypoint:v20191009-0492f1d6e"
+      sidecar: "gcr.io/k8s-prow/sidecar:v20191009-0492f1d6e"
     gcs_configuration:
       bucket: "knative-prow"
       path_strategy: "explicit"

--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -43,17 +43,14 @@ deck:
     gcs_browser_prefix: https://console.cloud.google.com/storage/browser/
     testgrid_config: gs://knative-testgrid/config
     testgrid_root: https://testgrid.knative.dev/
-    viewers:
-      "started.json|finished.json":
-      - "metadata"
-      "build-log.txt":
-      - "buildlog"
-      "artifacts/junit.*\\.xml":
-      - "junit"
     announcement: "The old job viewer, Gubernator, has been deprecated in favour of this page, Spyglass.{{if .ArtifactPath}} For now, the old page is <a href='https://gubernator.knative.dev/build/{{.ArtifactPath}}'>still available</a>.{{end}} Please send feedback to Knative productivity."
     lenses:
     - lens:
-        name: build-log
+        name: metadata
+      required_files:
+      - started.json|finished.json
+    - lens:
+        name: buildlog
         config:
           highlight_regexes:
           - 'panic: test timed out after.*$'
@@ -64,6 +61,10 @@ deck:
           - ^E\d{4} \d\d:\d\d:\d\d\.\d\d\d]
       required_files:
       - build-log.txt
+    - lens:
+        name: junit
+      required_files:
+      - artifacts/junit.*\.xml
   tide_update_period: 1s
 prowjob_namespace: default
 pod_namespace: test-pods

--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -29,10 +29,10 @@ plank:
     grace_period: 15000000000 # 15s
     utility_images:
       # Update these versions when updating plank version in cluster.yaml
-      clonerefs: "gcr.io/k8s-prow/clonerefs:v20191009-0492f1d6e"
-      initupload: "gcr.io/k8s-prow/initupload:v20191009-0492f1d6e"
-      entrypoint: "gcr.io/k8s-prow/entrypoint:v20191009-0492f1d6e"
-      sidecar: "gcr.io/k8s-prow/sidecar:v20191009-0492f1d6e"
+      clonerefs: "gcr.io/k8s-prow/clonerefs:v20190925-d7e1d9b17"
+      initupload: "gcr.io/k8s-prow/initupload:v20190925-d7e1d9b17"
+      entrypoint: "gcr.io/k8s-prow/entrypoint:v20190925-d7e1d9b17"
+      sidecar: "gcr.io/k8s-prow/sidecar:v20190925-d7e1d9b17"
     gcs_configuration:
       bucket: "knative-prow"
       path_strategy: "explicit"
@@ -51,6 +51,19 @@ deck:
       "artifacts/junit.*\\.xml":
       - "junit"
     announcement: "The old job viewer, Gubernator, has been deprecated in favour of this page, Spyglass.{{if .ArtifactPath}} For now, the old page is <a href='https://gubernator.knative.dev/build/{{.ArtifactPath}}'>still available</a>.{{end}} Please send feedback to Knative productivity."
+    lenses:
+    - lens:
+        name: build-log
+        config:
+          highlight_regexes:
+          - 'panic: test timed out after'
+          - timed out
+          - 'ERROR:'
+          - (\s|^)(FAIL|Failure \[)\b
+          - (\s|^)panic\b
+          - ^E\d{4} \d\d:\d\d:\d\d\.\d\d\d]
+      required_files:
+      - build-log.txt
   tide_update_period: 1s
 prowjob_namespace: default
 pod_namespace: test-pods

--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -56,9 +56,8 @@ deck:
           - 'panic: test timed out after.*$'
           - timed out
           - 'ERROR:'
-          - (\s|^)(FAIL|Failure \[)\b
+          - 'FAIL:'
           - (\s|^)panic\b
-          - ^E\d{4} \d\d:\d\d:\d\d\.\d\d\d]
       required_files:
       - build-log.txt
     - lens:

--- a/ci/prow/templates/prow_config_header.yaml
+++ b/ci/prow/templates/prow_config_header.yaml
@@ -59,9 +59,8 @@ deck:
           - 'panic: test timed out after.*$'
           - timed out
           - 'ERROR:'
-          - (\s|^)(FAIL|Failure \[)\b
+          - 'FAIL:'
           - (\s|^)panic\b
-          - ^E\d{4} \d\d:\d\d:\d\d\.\d\d\d]
       required_files:
       - build-log.txt
     - lens:

--- a/ci/prow/templates/prow_config_header.yaml
+++ b/ci/prow/templates/prow_config_header.yaml
@@ -59,7 +59,7 @@ deck:
         name: build-log
         config:
           highlight_regexes:
-          - 'panic: test timed out after'
+          - 'panic: test timed out after.*$'
           - timed out
           - 'ERROR:'
           - (\s|^)(FAIL|Failure \[)\b

--- a/ci/prow/templates/prow_config_header.yaml
+++ b/ci/prow/templates/prow_config_header.yaml
@@ -31,10 +31,10 @@ plank:
     grace_period: 15000000000 # 15s
     utility_images:
       # Update these versions when updating plank version in cluster.yaml
-      clonerefs: "gcr.io/k8s-prow/clonerefs:v20190925-d7e1d9b17"
-      initupload: "gcr.io/k8s-prow/initupload:v20190925-d7e1d9b17"
-      entrypoint: "gcr.io/k8s-prow/entrypoint:v20190925-d7e1d9b17"
-      sidecar: "gcr.io/k8s-prow/sidecar:v20190925-d7e1d9b17"
+      clonerefs: "gcr.io/k8s-prow/clonerefs:v20191009-0492f1d6e"
+      initupload: "gcr.io/k8s-prow/initupload:v20191009-0492f1d6e"
+      entrypoint: "gcr.io/k8s-prow/entrypoint:v20191009-0492f1d6e"
+      sidecar: "gcr.io/k8s-prow/sidecar:v20191009-0492f1d6e"
     gcs_configuration:
       bucket: "[[.GcsBucket]]"
       path_strategy: "explicit"

--- a/ci/prow/templates/prow_config_header.yaml
+++ b/ci/prow/templates/prow_config_header.yaml
@@ -46,17 +46,14 @@ deck:
     gcs_browser_prefix: https://console.cloud.google.com/storage/browser/
     testgrid_config: gs://[[.TestGridGcsBucket]]/config
     testgrid_root: [[.TestGridHost]]/
-    viewers:
-      "started.json|finished.json":
-      - "metadata"
-      "build-log.txt":
-      - "buildlog"
-      "artifacts/junit.*\\.xml":
-      - "junit"
     announcement: "The old job viewer, Gubernator, has been deprecated in favour of this page, Spyglass.{{if .ArtifactPath}} For now, the old page is <a href='[[.GubernatorHost]]/build/{{.ArtifactPath}}'>still available</a>.{{end}} Please send feedback to Knative productivity."
     lenses:
     - lens:
-        name: build-log
+        name: metadata
+      required_files:
+      - started.json|finished.json
+    - lens:
+        name: buildlog
         config:
           highlight_regexes:
           - 'panic: test timed out after.*$'
@@ -67,6 +64,10 @@ deck:
           - ^E\d{4} \d\d:\d\d:\d\d\.\d\d\d]
       required_files:
       - build-log.txt
+    - lens:
+        name: junit
+      required_files:
+      - artifacts/junit.*\.xml
   tide_update_period: 1s
 
 prowjob_namespace: default

--- a/ci/prow/templates/prow_config_header.yaml
+++ b/ci/prow/templates/prow_config_header.yaml
@@ -31,10 +31,10 @@ plank:
     grace_period: 15000000000 # 15s
     utility_images:
       # Update these versions when updating plank version in cluster.yaml
-      clonerefs: "gcr.io/k8s-prow/clonerefs:v20191009-0492f1d6e"
-      initupload: "gcr.io/k8s-prow/initupload:v20191009-0492f1d6e"
-      entrypoint: "gcr.io/k8s-prow/entrypoint:v20191009-0492f1d6e"
-      sidecar: "gcr.io/k8s-prow/sidecar:v20191009-0492f1d6e"
+      clonerefs: "gcr.io/k8s-prow/clonerefs:v20190925-d7e1d9b17"
+      initupload: "gcr.io/k8s-prow/initupload:v20190925-d7e1d9b17"
+      entrypoint: "gcr.io/k8s-prow/entrypoint:v20190925-d7e1d9b17"
+      sidecar: "gcr.io/k8s-prow/sidecar:v20190925-d7e1d9b17"
     gcs_configuration:
       bucket: "[[.GcsBucket]]"
       path_strategy: "explicit"
@@ -54,6 +54,19 @@ deck:
       "artifacts/junit.*\\.xml":
       - "junit"
     announcement: "The old job viewer, Gubernator, has been deprecated in favour of this page, Spyglass.{{if .ArtifactPath}} For now, the old page is <a href='[[.GubernatorHost]]/build/{{.ArtifactPath}}'>still available</a>.{{end}} Please send feedback to Knative productivity."
+    lenses:
+    - lens:
+        name: build-log
+        config:
+          highlight_regexes:
+          - 'panic: test timed out after'
+          - timed out
+          - 'ERROR:'
+          - (\s|^)(FAIL|Failure \[)\b
+          - (\s|^)panic\b
+          - ^E\d{4} \d\d:\d\d:\d\d\.\d\d\d]
+      required_files:
+      - build-log.txt
   tide_update_period: 1s
 
 prowjob_namespace: default


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Add lenses config for spyglass, as per https://github.com/kubernetes/test-infra/tree/master/prow/spyglass.
The lenses adds all the current default regexes for highlight, and a new regex that highlights the go test timeout, to make it more noticeable. With this in place, we can highlight more contents that need our attention.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @chaodaiG 
/cc @adrcunha 

