### PR TITLE
Add regex to match boskos error to highlight on spyglass

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -53,11 +53,15 @@ deck:
         name: buildlog
         config:
           highlight_regexes:
-          - 'panic: test timed out after.*$'
           - timed out
           - 'ERROR:'
-          - 'FAIL:'
           - (\s|^)panic\b
+          # test case failure
+          - 'FAIL:'
+          # boskos error
+          - 'boskos failed to acquire project'
+          # go test timeout
+          - 'panic: test timed out after.*$'
       required_files:
       - build-log.txt
     - lens:

--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -53,15 +53,15 @@ deck:
         name: buildlog
         config:
           highlight_regexes:
+          # regexes to match generic errors
           - timed out
-          - 'ERROR:'
-          - (\s|^)panic\b
+          # regexes to match specific errors we can have
+          # go test timeout
+          - 'panic: test timed out after.*$'
           # test case failure
           - 'FAIL:'
           # boskos error
           - 'boskos failed to acquire project'
-          # go test timeout
-          - 'panic: test timed out after.*$'
       required_files:
       - build-log.txt
     - lens:

--- a/ci/prow/templates/prow_config_header.yaml
+++ b/ci/prow/templates/prow_config_header.yaml
@@ -56,15 +56,16 @@ deck:
         name: buildlog
         config:
           highlight_regexes:
+          # regexes to match generic errors
           - timed out
-          - 'ERROR:'
-          - (\s|^)panic\b
+
+          # regexes to match specific errors we can have
+          # go test timeout
+          - 'panic: test timed out after.*$'
           # test case failure
           - 'FAIL:'
           # boskos error
           - 'boskos failed to acquire project'
-          # go test timeout
-          - 'panic: test timed out after.*$'
       required_files:
       - build-log.txt
     - lens:

--- a/ci/prow/templates/prow_config_header.yaml
+++ b/ci/prow/templates/prow_config_header.yaml
@@ -56,11 +56,15 @@ deck:
         name: buildlog
         config:
           highlight_regexes:
-          - 'panic: test timed out after.*$'
           - timed out
           - 'ERROR:'
-          - 'FAIL:'
           - (\s|^)panic\b
+          # test case failure
+          - 'FAIL:'
+          # boskos error
+          - 'boskos failed to acquire project'
+          # go test timeout
+          - 'panic: test timed out after.*$'
       required_files:
       - build-log.txt
     - lens:


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
The boskos error is happening a bit frequently recently, and it's not shown clearly on the log page, e.g. https://prow.knative.dev/view/gcs/knative-prow/logs/ci-knative-eventing-continuous/1184869372296957952

Add a new regex to match it.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @chaodaiG 
/cc @adrcunha 
