### PR TITLE
Remove CI flows for Knative 0.4 and 0.5

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -125,8 +125,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-serving-build-tests),?(\\s+|$)"
     decorate: true
     branches:
-    - "release-0.4"
-    - "release-0.5"
     - "release-0.6"
     - "release-0.7"
     spec:
@@ -215,8 +213,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/serving
     skip_branches:
-    - "release-0.4"
-    - "release-0.5"
     - "release-0.6"
     - "release-0.7"
     - "release-0.8"
@@ -266,8 +262,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-serving-unit-tests),?(\\s+|$)"
     decorate: true
     branches:
-    - "release-0.4"
-    - "release-0.5"
     - "release-0.6"
     - "release-0.7"
     spec:
@@ -354,8 +348,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/serving
     skip_branches:
-    - "release-0.4"
-    - "release-0.5"
     - "release-0.6"
     - "release-0.7"
     - "release-0.8"
@@ -400,8 +392,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-serving-integration-tests),?(\\s+|$)"
     decorate: true
     branches:
-    - "release-0.4"
-    - "release-0.5"
     - "release-0.6"
     - "release-0.7"
     spec:
@@ -490,8 +480,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/serving
     skip_branches:
-    - "release-0.4"
-    - "release-0.5"
     - "release-0.6"
     - "release-0.7"
     - "release-0.8"
@@ -533,8 +521,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-serving-upgrade-tests),?(\\s+|$)"
     decorate: true
     branches:
-    - "release-0.4"
-    - "release-0.5"
     - "release-0.6"
     - "release-0.7"
     spec:
@@ -603,8 +589,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/serving
     skip_branches:
-    - "release-0.4"
-    - "release-0.5"
     - "release-0.6"
     - "release-0.7"
     - "release-0.8"
@@ -707,8 +691,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/serving
     skip_branches:
-    - "release-0.4"
-    - "release-0.5"
     - "release-0.6"
     - "release-0.7"
     - "release-0.8"
@@ -745,8 +727,6 @@ presubmits:
     optional: true
     decorate: true
     branches:
-    - "release-0.4"
-    - "release-0.5"
     - "release-0.6"
     - "release-0.7"
     spec:
@@ -809,8 +789,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/serving
     skip_branches:
-    - "release-0.4"
-    - "release-0.5"
     - "release-0.6"
     - "release-0.7"
     - "release-0.8"
@@ -843,8 +821,6 @@ presubmits:
     optional: true
     decorate: true
     skip_branches:
-    - "release-0.4"
-    - "release-0.5"
     - "release-0.6"
     - "release-0.7"
     - "release-0.8"
@@ -876,8 +852,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-serving-perf-tests),?(\\s+|$)"
     decorate: true
     branches:
-    - "release-0.4"
-    - "release-0.5"
     - "release-0.6"
     - "release-0.7"
     spec:
@@ -942,8 +916,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/serving
     skip_branches:
-    - "release-0.4"
-    - "release-0.5"
     - "release-0.6"
     - "release-0.7"
     - "release-0.8"
@@ -978,8 +950,6 @@ presubmits:
     decorate: true
     optional: true
     branches:
-    - "release-0.4"
-    - "release-0.5"
     - "release-0.6"
     - "release-0.7"
     spec:
@@ -1052,8 +1022,6 @@ presubmits:
     optional: true
     path_alias: knative.dev/serving
     skip_branches:
-    - "release-0.4"
-    - "release-0.5"
     - "release-0.6"
     - "release-0.7"
     - "release-0.8"
@@ -1091,8 +1059,6 @@ presubmits:
     decorate: true
     optional: true
     branches:
-    - "release-0.4"
-    - "release-0.5"
     - "release-0.6"
     - "release-0.7"
     spec:
@@ -1165,8 +1131,6 @@ presubmits:
     optional: true
     path_alias: knative.dev/serving
     skip_branches:
-    - "release-0.4"
-    - "release-0.5"
     - "release-0.6"
     - "release-0.7"
     - "release-0.8"
@@ -1204,8 +1168,6 @@ presubmits:
     decorate: true
     optional: true
     branches:
-    - "release-0.4"
-    - "release-0.5"
     - "release-0.6"
     - "release-0.7"
     spec:
@@ -1278,8 +1240,6 @@ presubmits:
     optional: true
     path_alias: knative.dev/serving
     skip_branches:
-    - "release-0.4"
-    - "release-0.5"
     - "release-0.6"
     - "release-0.7"
     - "release-0.8"
@@ -1317,8 +1277,6 @@ presubmits:
     decorate: true
     optional: true
     branches:
-    - "release-0.4"
-    - "release-0.5"
     - "release-0.6"
     - "release-0.7"
     spec:
@@ -1391,8 +1349,6 @@ presubmits:
     optional: true
     path_alias: knative.dev/serving
     skip_branches:
-    - "release-0.4"
-    - "release-0.5"
     - "release-0.6"
     - "release-0.7"
     - "release-0.8"
@@ -1430,8 +1386,6 @@ presubmits:
     decorate: true
     optional: true
     branches:
-    - "release-0.4"
-    - "release-0.5"
     - "release-0.6"
     - "release-0.7"
     spec:
@@ -1502,8 +1456,6 @@ presubmits:
     optional: true
     path_alias: knative.dev/serving
     skip_branches:
-    - "release-0.4"
-    - "release-0.5"
     - "release-0.6"
     - "release-0.7"
     - "release-0.8"
@@ -1714,8 +1666,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-eventing-build-tests),?(\\s+|$)"
     decorate: true
     branches:
-    - "release-0.4"
-    - "release-0.5"
     - "release-0.6"
     - "release-0.7"
     - "release-0.8"
@@ -1756,8 +1706,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/eventing
     skip_branches:
-    - "release-0.4"
-    - "release-0.5"
     - "release-0.6"
     - "release-0.7"
     - "release-0.8"
@@ -1801,8 +1749,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-eventing-unit-tests),?(\\s+|$)"
     decorate: true
     branches:
-    - "release-0.4"
-    - "release-0.5"
     - "release-0.6"
     - "release-0.7"
     - "release-0.8"
@@ -1847,8 +1793,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/eventing
     skip_branches:
-    - "release-0.4"
-    - "release-0.5"
     - "release-0.6"
     - "release-0.7"
     - "release-0.8"
@@ -1892,8 +1836,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-eventing-integration-tests),?(\\s+|$)"
     decorate: true
     branches:
-    - "release-0.4"
-    - "release-0.5"
     - "release-0.6"
     - "release-0.7"
     - "release-0.8"
@@ -1938,8 +1880,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/eventing
     skip_branches:
-    - "release-0.4"
-    - "release-0.5"
     - "release-0.6"
     - "release-0.7"
     - "release-0.8"
@@ -1980,8 +1920,6 @@ presubmits:
     optional: true
     decorate: true
     branches:
-    - "release-0.4"
-    - "release-0.5"
     - "release-0.6"
     - "release-0.7"
     - "release-0.8"
@@ -2014,8 +1952,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/eventing
     skip_branches:
-    - "release-0.4"
-    - "release-0.5"
     - "release-0.6"
     - "release-0.7"
     - "release-0.8"
@@ -2047,8 +1983,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-eventing-contrib-build-tests),?(\\s+|$)"
     decorate: true
     branches:
-    - "release-0.4"
-    - "release-0.5"
     - "release-0.6"
     - "release-0.7"
     - "release-0.8"
@@ -2089,8 +2023,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/eventing-contrib
     skip_branches:
-    - "release-0.4"
-    - "release-0.5"
     - "release-0.6"
     - "release-0.7"
     - "release-0.8"
@@ -2134,8 +2066,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-eventing-contrib-unit-tests),?(\\s+|$)"
     decorate: true
     branches:
-    - "release-0.4"
-    - "release-0.5"
     - "release-0.6"
     - "release-0.7"
     - "release-0.8"
@@ -2180,8 +2110,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/eventing-contrib
     skip_branches:
-    - "release-0.4"
-    - "release-0.5"
     - "release-0.6"
     - "release-0.7"
     - "release-0.8"
@@ -2225,8 +2153,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-eventing-contrib-integration-tests),?(\\s+|$)"
     decorate: true
     branches:
-    - "release-0.4"
-    - "release-0.5"
     - "release-0.6"
     - "release-0.7"
     - "release-0.8"
@@ -2271,8 +2197,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/eventing-contrib
     skip_branches:
-    - "release-0.4"
-    - "release-0.5"
     - "release-0.6"
     - "release-0.7"
     - "release-0.8"
@@ -2313,8 +2237,6 @@ presubmits:
     optional: true
     decorate: true
     branches:
-    - "release-0.4"
-    - "release-0.5"
     - "release-0.6"
     - "release-0.7"
     - "release-0.8"
@@ -2347,8 +2269,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/eventing-contrib
     skip_branches:
-    - "release-0.4"
-    - "release-0.5"
     - "release-0.6"
     - "release-0.7"
     - "release-0.8"
@@ -3591,96 +3511,6 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "6 8 * * *"
-  name: ci-knative-serving-0.4-continuous
-  agent: kubernetes
-  labels:
-    prow.k8s.io/pubsub.project: knative-tests
-    prow.k8s.io/pubsub.topic: knative-monitoring
-    prow.k8s.io/pubsub.runID: ci-knative-serving-0.4-continuous
-  decorate: true
-  extra_refs:
-  - org: knative
-    repo: serving
-    base_ref: release-0.4
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./hack/release.sh"
-      - "--nopublish"
-      - "--notag-release"
-      securityContext:
-        privileged: true
-      volumeMounts:
-      - name: docker-graph
-        mountPath: /docker-graph
-      - name: test-account
-        mountPath: /etc/test-account
-        readOnly: true
-      env:
-      - name: DOCKER_IN_DOCKER_ENABLED
-        value: "true"
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/test-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-      - name: PULL_BASE_REF
-        value: release-0.4
-    volumes:
-    - name: docker-graph
-      emptyDir: {}
-    - name: test-account
-      secret:
-        secretName: test-account
-- cron: "17 8 * * *"
-  name: ci-knative-serving-0.5-continuous
-  agent: kubernetes
-  labels:
-    prow.k8s.io/pubsub.project: knative-tests
-    prow.k8s.io/pubsub.topic: knative-monitoring
-    prow.k8s.io/pubsub.runID: ci-knative-serving-0.5-continuous
-  decorate: true
-  extra_refs:
-  - org: knative
-    repo: serving
-    base_ref: release-0.5
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./hack/release.sh"
-      - "--nopublish"
-      - "--notag-release"
-      securityContext:
-        privileged: true
-      volumeMounts:
-      - name: docker-graph
-        mountPath: /docker-graph
-      - name: test-account
-        mountPath: /etc/test-account
-        readOnly: true
-      env:
-      - name: DOCKER_IN_DOCKER_ENABLED
-        value: "true"
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/test-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-      - name: PULL_BASE_REF
-        value: release-0.5
-    volumes:
-    - name: docker-graph
-      emptyDir: {}
-    - name: test-account
-      secret:
-        secretName: test-account
 - cron: "28 8 * * *"
   name: ci-knative-serving-0.6-continuous
   agent: kubernetes
@@ -4615,51 +4445,6 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "36 8 * * *"
-  name: ci-knative-eventing-0.5-continuous
-  agent: kubernetes
-  labels:
-    prow.k8s.io/pubsub.project: knative-tests
-    prow.k8s.io/pubsub.topic: knative-monitoring
-    prow.k8s.io/pubsub.runID: ci-knative-eventing-0.5-continuous
-  decorate: true
-  extra_refs:
-  - org: knative
-    repo: eventing
-    base_ref: release-0.5
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./hack/release.sh"
-      - "--nopublish"
-      - "--notag-release"
-      securityContext:
-        privileged: true
-      volumeMounts:
-      - name: docker-graph
-        mountPath: /docker-graph
-      - name: test-account
-        mountPath: /etc/test-account
-        readOnly: true
-      env:
-      - name: DOCKER_IN_DOCKER_ENABLED
-        value: "true"
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/test-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-      - name: PULL_BASE_REF
-        value: release-0.5
-    volumes:
-    - name: docker-graph
-      emptyDir: {}
-    - name: test-account
-      secret:
-        secretName: test-account
 - cron: "47 8 * * *"
   name: ci-knative-eventing-0.6-continuous
   agent: kubernetes
@@ -5020,51 +4805,6 @@ periodics:
       - name: E2E_CLUSTER_REGION
         value: us-central1
     volumes:
-    - name: test-account
-      secret:
-        secretName: test-account
-- cron: "31 8 * * *"
-  name: ci-knative-eventing-contrib-0.5-continuous
-  agent: kubernetes
-  labels:
-    prow.k8s.io/pubsub.project: knative-tests
-    prow.k8s.io/pubsub.topic: knative-monitoring
-    prow.k8s.io/pubsub.runID: ci-knative-eventing-contrib-0.5-continuous
-  decorate: true
-  extra_refs:
-  - org: knative
-    repo: eventing-contrib
-    base_ref: release-0.5
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./hack/release.sh"
-      - "--nopublish"
-      - "--notag-release"
-      securityContext:
-        privileged: true
-      volumeMounts:
-      - name: docker-graph
-        mountPath: /docker-graph
-      - name: test-account
-        mountPath: /etc/test-account
-        readOnly: true
-      env:
-      - name: DOCKER_IN_DOCKER_ENABLED
-        value: "true"
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/test-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-      - name: PULL_BASE_REF
-        value: release-0.5
-    volumes:
-    - name: docker-graph
-      emptyDir: {}
     - name: test-account
       secret:
         secretName: test-account

--- a/ci/prow/config_knative.yaml
+++ b/ci/prow/config_knative.yaml
@@ -16,13 +16,9 @@ presubmits:
   knative/serving:
     - repo-settings:
       legacy-branches:
-      - release-0.4
-      - release-0.5
       - release-0.6
       - release-0.7
       go112-branches:
-      - release-0.4
-      - release-0.5
       - release-0.6
       - release-0.7
       - release-0.8
@@ -44,8 +40,6 @@ presubmits:
       - "./test/e2e-upgrade-tests.sh"
     - custom-test: smoke-tests
       skip_branches:  # Skip these branches, as test isn't available.
-      - release-0.4
-      - release-0.5
       - release-0.6
       args:
       - "--run-test"
@@ -95,8 +89,6 @@ presubmits:
   knative/eventing:
     - repo-settings:
       legacy-branches:
-      - release-0.4
-      - release-0.5
       - release-0.6
       - release-0.7
       - release-0.8
@@ -108,8 +100,6 @@ presubmits:
   knative/eventing-contrib:
     - repo-settings:
       legacy-branches:
-      - release-0.4
-      - release-0.5
       - release-0.6
       - release-0.7
       - release-0.8
@@ -209,10 +199,6 @@ periodics:
         limits:
           memory: 16Gi
     - branch-ci: true
-      release: "0.4"
-    - branch-ci: true
-      release: "0.5"
-    - branch-ci: true
       release: "0.6"
     - branch-ci: true
       release: "0.7"
@@ -301,8 +287,6 @@ periodics:
       timeout: 90
       dot-dev: true
     - branch-ci: true
-      release: "0.5"
-    - branch-ci: true
       release: "0.6"
     - branch-ci: true
       release: "0.7"
@@ -321,8 +305,6 @@ periodics:
   knative/eventing-contrib:
     - continuous: true
       dot-dev: true
-    - branch-ci: true
-      release: "0.5"
     - branch-ci: true
       release: "0.6"
     - branch-ci: true

--- a/ci/prow/testgrid.yaml
+++ b/ci/prow/testgrid.yaml
@@ -221,14 +221,6 @@ test_groups:
   gcs_prefix: knative-prow/logs/ci-knative-eventing-operator-go-coverage
   num_failures_to_alert: 9999
   short_text_metric: "coverage"
-- name: ci-knative-serving-0.4-continuous
-  gcs_prefix: knative-prow/logs/ci-knative-serving-0.4-continuous
-- name: ci-knative-serving-0.5-continuous
-  gcs_prefix: knative-prow/logs/ci-knative-serving-0.5-continuous
-- name: ci-knative-eventing-0.5-continuous
-  gcs_prefix: knative-prow/logs/ci-knative-eventing-0.5-continuous
-- name: ci-knative-eventing-contrib-0.5-continuous
-  gcs_prefix: knative-prow/logs/ci-knative-eventing-contrib-0.5-continuous
 - name: ci-knative-serving-0.6-continuous
   gcs_prefix: knative-prow/logs/ci-knative-serving-0.6-continuous
 - name: ci-knative-eventing-0.6-continuous
@@ -459,22 +451,6 @@ dashboards:
   - name: coverage
     test_group_name: pull-google-knative-gcp-test-coverage
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
-- name: knative-0.4
-  dashboard_tab:
-  - name: serving
-    test_group_name: ci-knative-serving-0.4-continuous
-    base_options: "sort-by-name="
-- name: knative-0.5
-  dashboard_tab:
-  - name: serving
-    test_group_name: ci-knative-serving-0.5-continuous
-    base_options: "sort-by-name="
-  - name: eventing
-    test_group_name: ci-knative-eventing-0.5-continuous
-    base_options: "sort-by-name="
-  - name: eventing-contrib
-    test_group_name: ci-knative-eventing-contrib-0.5-continuous
-    base_options: "sort-by-name="
 - name: knative-0.6
   dashboard_tab:
   - name: serving


### PR DESCRIPTION
Per Knative Release Principles, we keep only the last 4 branches.