### PR TITLE
Add pj-on-kind.sh script for running ProwJobs locally.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ bazel-*
 .vscode/
 .DS_Store
 *.swp
+pj.yaml
+pod.yaml

--- a/ci/prow/pj-on-kind.sh
+++ b/ci/prow/pj-on-kind.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Runs prow/pj-on-kind.sh with config arguments specific to the prow.knative.dev instance.
+# Requries go, docker, and kubectl.
+
+# Documentation: https://github.com/kubernetes/test-infra/blob/master/prow/build_test_update.md#using-pj-on-kindsh
+# Example usage:
+# ./pj-on-kind.sh pull-knative-test-infra-unit-tests
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+prowdir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+export CONFIG_PATH="${prowdir}/config.yaml"
+
+bash <(curl -sSfL https://raw.githubusercontent.com/kubernetes/test-infra/master/prow/pj-on-kind.sh) "$@"


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Allows for locally testing any ProwJob by running it in a Kind cluster.  Any volumes on the job that are not emptydir or hostpath will trigger a prompt allowing for 1) the volumesource to be used as is (assume it exists in the kind cluster), 2) a hostpath substitution, 3) an emptydir substitution.
Instead of uploading results to GCS, job logs, metadata, and artifacts are copied to a local directory.
See full docs here: https://github.com/kubernetes/test-infra/blob/master/prow/build_test_update.md#using-pj-on-kindsh

**Special notes to reviewers**:
It looks like most jobs require some low-privilege credentials to run. It would be good to provide documentation or a script explaining how devs can generate their own credentials and how to use them with pj-on-kind.sh https://github.com/knative/test-infra/blob/e9c240a0a1c460184daea05d4bf32ab1fedd52d0/ci/prow/config.yaml#L2622-L2628

/assign @chaodaiG 