### PR TITLE
Also use go 1.13 for serving perf jobs

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -6310,7 +6310,7 @@ periodics:
     path_alias: knative.dev/serving
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -6356,7 +6356,7 @@ periodics:
     path_alias: knative.dev/serving
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
       command:
       - runner.sh

--- a/ci/prow/periodic_config.go
+++ b/ci/prow/periodic_config.go
@@ -369,11 +369,17 @@ func generatePerfClusterUpdatePeriodicJobs() {
 	)
 }
 
-func perfClusterUpdatePeriodicJob(jobName, cronString, command, repo, sa string) {
+func perfClusterUpdatePeriodicJob(jobName, cronString, command, repoName, sa string) {
 	var data periodicJobTemplateData
-	data.Base = newbaseProwJobTemplateData("knative/" + repo)
+	data.Base = newbaseProwJobTemplateData("knative/" + repoName)
+	for _, repo := range repositories {
+		if "knative/"+repoName == repo.Name && repo.Go113 {
+			data.Base.Image = getGo113ImageName(data.Base.Image)
+			break
+		}
+	}
 	data.Base.ExtraRefs = append(data.Base.ExtraRefs, "  base_ref: "+data.Base.RepoBranch)
-	data.Base.ExtraRefs = append(data.Base.ExtraRefs, "  path_alias: knative.dev/"+repo)
+	data.Base.ExtraRefs = append(data.Base.ExtraRefs, "  path_alias: knative.dev/"+repoName)
 	data.Base.Command = command
 	data.PeriodicJobName = jobName
 	data.CronString = cronString


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Serving perf jobs are getting some build error, change Prow config to also use Go 1.13 image for them.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @chaodaiG 
/cc @adrcunha 