### PR TITLE
Add new test job for serving operator

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -3488,6 +3488,68 @@ presubmits:
       - name: covbot-token
         secret:
           secretName: covbot-token
+  - name: pull-knative-serving-operator-integration-tests-on-latest-serving
+    agent: kubernetes
+    context: pull-knative-serving-operator-integration-tests-on-latest-serving
+    always_run: false
+    rerun_command: "/test pull-knative-serving-operator-integration-tests-on-latest-serving"
+    trigger: "(?m)^/test (all|pull-knative-serving-operator-integration-tests-on-latest-serving),?(\\s+|$)"
+    decorate: true
+    optional: true
+    branches:
+    - "release-0.9"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/e2e-tests-latest-serving.sh"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-serving-operator-integration-tests-on-latest-serving
+    agent: kubernetes
+    context: pull-knative-serving-operator-integration-tests-on-latest-serving
+    always_run: false
+    rerun_command: "/test pull-knative-serving-operator-integration-tests-on-latest-serving"
+    trigger: "(?m)^/test (all|pull-knative-serving-operator-integration-tests-on-latest-serving),?(\\s+|$)"
+    decorate: true
+    optional: true
+    skip_branches:
+    - "release-0.9"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/e2e-tests-latest-serving.sh"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
   knative/eventing-operator:
   - name: pull-knative-eventing-operator-build-tests
     agent: kubernetes
@@ -5682,6 +5744,36 @@ periodics:
     - name: release-account
       secret:
         secretName: release-account
+- cron: "48 */2 * * *"
+  name: ci-knative-serving-operator-integration-tests-on-latest-serving
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: serving-operator
+    base_ref: master
+    path_alias: knative.dev/serving-operator
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./test/e2e-tests-latest-serving.sh"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
 - cron: "0 1 * * *"
   name: ci-knative-serving-operator-go-coverage
   labels:

--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -5764,6 +5764,8 @@ periodics:
       command:
       - runner.sh
       args:
+      - "./test/presubmit-tests.sh"
+      - "--run-test"
       - "./test/e2e-tests-latest-serving.sh"
       volumeMounts:
       - name: test-account

--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -5764,8 +5764,6 @@ periodics:
       command:
       - runner.sh
       args:
-      - ""
-      - "--run-test"
       - "./test/e2e-tests-latest-serving.sh"
       volumeMounts:
       - name: test-account

--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -5764,8 +5764,6 @@ periodics:
       command:
       - runner.sh
       args:
-      - "./test/presubmit-tests.sh"
-      - "--run-test"
       - "./test/e2e-tests-latest-serving.sh"
       volumeMounts:
       - name: test-account

--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -3505,6 +3505,8 @@ presubmits:
         command:
         - runner.sh
         args:
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
         - "./test/e2e-tests-latest-serving.sh"
         volumeMounts:
         - name: test-account
@@ -3536,6 +3538,8 @@ presubmits:
         command:
         - runner.sh
         args:
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
         - "./test/e2e-tests-latest-serving.sh"
         volumeMounts:
         - name: test-account
@@ -5760,6 +5764,8 @@ periodics:
       command:
       - runner.sh
       args:
+      - ""
+      - "--run-test"
       - "./test/e2e-tests-latest-serving.sh"
       volumeMounts:
       - name: test-account

--- a/ci/prow/config_knative.yaml
+++ b/ci/prow/config_knative.yaml
@@ -175,7 +175,8 @@ presubmits:
     - custom-test: integration-tests-on-latest-serving
       always_run: false
       optional: true
-      command:
+      args:
+      - "--run-test"
       - "./test/e2e-tests-latest-serving.sh"
 
   knative/eventing-operator:
@@ -363,7 +364,8 @@ periodics:
       dot-dev: true
       go113: true
     - custom-job: integration-tests-on-latest-serving
-      command:
+      args:
+      - "--run-test"
       - "./test/e2e-tests-latest-serving.sh"
       dot-dev: true
       go113: true

--- a/ci/prow/config_knative.yaml
+++ b/ci/prow/config_knative.yaml
@@ -364,8 +364,7 @@ periodics:
       dot-dev: true
       go113: true
     - custom-job: integration-tests-on-latest-serving
-      args:
-      - "--run-test"
+      command:
       - "./test/e2e-tests-latest-serving.sh"
       dot-dev: true
       go113: true

--- a/ci/prow/config_knative.yaml
+++ b/ci/prow/config_knative.yaml
@@ -172,6 +172,10 @@ presubmits:
       dot-dev: true
     - go-coverage: true
       dot-dev: true
+    - custom-test: integration-tests-on-latest-serving
+      always_run: false
+      optional: true
+      full-command: "./test/e2e-tests-latest-serving.sh"
 
   knative/eventing-operator:
     - build-tests: true
@@ -355,6 +359,10 @@ periodics:
       # release-0.10 is cut
       dot-dev: true
     - auto-release: true
+      dot-dev: true
+      go113: true
+    - custom-job: integration-tests-on-latest-serving
+      full-command: "./test/e2e-tests-latest-serving.sh"
       dot-dev: true
       go113: true
 

--- a/ci/prow/config_knative.yaml
+++ b/ci/prow/config_knative.yaml
@@ -365,6 +365,9 @@ periodics:
       go113: true
     - custom-job: integration-tests-on-latest-serving
       command:
+      - "./test/presubmit-tests.sh"
+      args:
+      - "--run-test"
       - "./test/e2e-tests-latest-serving.sh"
       dot-dev: true
       go113: true

--- a/ci/prow/config_knative.yaml
+++ b/ci/prow/config_knative.yaml
@@ -175,7 +175,8 @@ presubmits:
     - custom-test: integration-tests-on-latest-serving
       always_run: false
       optional: true
-      full-command: "./test/e2e-tests-latest-serving.sh"
+      command:
+      - "./test/e2e-tests-latest-serving.sh"
 
   knative/eventing-operator:
     - build-tests: true
@@ -362,7 +363,8 @@ periodics:
       dot-dev: true
       go113: true
     - custom-job: integration-tests-on-latest-serving
-      full-command: "./test/e2e-tests-latest-serving.sh"
+      command:
+      - "./test/e2e-tests-latest-serving.sh"
       dot-dev: true
       go113: true
 

--- a/ci/prow/config_knative.yaml
+++ b/ci/prow/config_knative.yaml
@@ -364,11 +364,7 @@ periodics:
       dot-dev: true
       go113: true
     - custom-job: integration-tests-on-latest-serving
-      command:
-      - "./test/presubmit-tests.sh"
-      args:
-      - "--run-test"
-      - "./test/e2e-tests-latest-serving.sh"
+      command: "./test/e2e-tests-latest-serving.sh"
       dot-dev: true
       go113: true
 

--- a/ci/prow/testgrid.yaml
+++ b/ci/prow/testgrid.yaml
@@ -201,6 +201,10 @@ test_groups:
 - name: ci-knative-serving-operator-auto-release
   gcs_prefix: knative-prow/logs/ci-knative-serving-operator-auto-release
   alert_stale_results_hours: 3
+- name: ci-knative-serving-operator-integration-tests-on-latest-serving
+  gcs_prefix: knative-prow/logs/ci-knative-serving-operator-integration-tests-on-latest-serving
+  alert_stale_results_hours: 3
+  num_failures_to_alert: 3
 - name: pull-knative-serving-operator-test-coverage
   gcs_prefix: knative-prow/logs/ci-knative-serving-operator-go-coverage
   num_failures_to_alert: 9999
@@ -413,6 +417,9 @@ dashboards:
     base_options: "sort-by-name="
   - name: auto-release
     test_group_name: ci-knative-serving-operator-auto-release
+    base_options: "sort-by-name="
+  - name: integration-tests-on-latest-serving
+    test_group_name: ci-knative-serving-operator-integration-tests-on-latest-serving
     base_options: "sort-by-name="
   - name: coverage
     test_group_name: pull-knative-serving-operator-test-coverage

--- a/ci/prow/testgrid_config.go
+++ b/ci/prow/testgrid_config.go
@@ -20,7 +20,6 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"regexp"
 	"strings"
 	"time"
@@ -173,11 +172,9 @@ func generateTestGroup(projName string, repoName string, jobNames []string) {
 			extras["short_text_metric"] = "coverage"
 			// Do not alert on coverage failures (i.e., coverage below threshold)
 			extras["num_failures_to_alert"] = "9999"
-		case "istio-1.2-mesh", "istio-1.2-no-mesh", "istio-1.3-mesh", "istio-1.3-no-mesh", "gloo-0.17.1":
+		default:
 			extras["alert_stale_results_hours"] = "3"
 			extras["num_failures_to_alert"] = "3"
-		default:
-			log.Fatalf("Unknown jobName for generateTestGroup: %s", jobName)
 		}
 		executeTestGroupTemplate(testGroupName, gcsLogDir, extras)
 	}
@@ -222,10 +219,8 @@ func generateDashboard(projName string, repoName string, jobNames []string) {
 			executeDashboardTabTemplate("nightly", testGroupName, testgridTabSortByName, noExtras)
 		case "test-coverage":
 			executeDashboardTabTemplate("coverage", testGroupName, testgridTabGroupByDir, noExtras)
-		case "istio-1.2-mesh", "istio-1.2-no-mesh", "istio-1.3-mesh", "istio-1.3-no-mesh", "gloo-0.17.1":
-			executeDashboardTabTemplate(jobName, testGroupName, testgridTabSortByName, noExtras)
 		default:
-			log.Fatalf("Unknown job name %q", jobName)
+			executeDashboardTabTemplate(jobName, testGroupName, testgridTabSortByName, noExtras)
 		}
 	}
 }
@@ -243,18 +238,13 @@ func executeDashboardTabTemplate(dashboardTabName string, testGroupName string, 
 // getTestGroupName get the testGroupName from the given repoName and jobName
 func getTestGroupName(repoName string, jobName string) string {
 	switch jobName {
-	case "continuous", "dot-release", "auto-release", "performance", "performance-mesh",
-		"latency", "webhook-apicoverage":
-		return strings.ToLower(fmt.Sprintf("ci-%s-%s", repoName, jobName))
 	case "nightly":
 		return strings.ToLower(fmt.Sprintf("ci-%s-%s-release", repoName, jobName))
 	case "test-coverage":
 		return strings.ToLower(fmt.Sprintf("pull-%s-%s", repoName, jobName))
-	case "istio-1.2-mesh", "istio-1.2-no-mesh", "istio-1.3-mesh", "istio-1.3-no-mesh", "gloo-0.17.1":
+	default:
 		return strings.ToLower(fmt.Sprintf("ci-%s-%s", repoName, jobName))
 	}
-	log.Fatalf("Unknown jobName for getTestGroupName: %s", jobName)
-	return ""
 }
 
 func generateDashboardsForReleases() {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
As requested by @houshengbo , add a new custom job for serving-operator to run test against the latest serving. 

Bonus:
Use default setting, instead of `fatal` in testgrd config generator, which makes us easier to add a custom job with any name.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @adrcunha 
/cc @chaodaiG 
/cc @houshengbo 
