### PR TITLE
Fixes to performance-tests.sh

### DIFF
--- a/scripts/performance-tests.sh
+++ b/scripts/performance-tests.sh
@@ -26,7 +26,8 @@ readonly PROJECT_NAME=${PROJECT_NAME:-knative-performance}
 readonly SERVICE_ACCOUNT_NAME=${SERVICE_ACCOUNT_NAME:-mako-job}
 
 # Setup env vars.
-readonly KO_DOCKER_REPO="gcr.io/${PROJECT_NAME}"
+export KO_DOCKER_REPO="gcr.io/${PROJECT_NAME}"
+# Constants
 readonly GOOGLE_APPLICATION_CREDENTIALS="/etc/performance-test/service-account.json"
 readonly GITHUB_TOKEN="/etc/performance-test/github-token"
 readonly SLACK_READ_TOKEN="/etc/performance-test/slack-read-token"
@@ -35,11 +36,11 @@ readonly SLACK_WRITE_TOKEN="/etc/performance-test/slack-write-token"
 # Set up the user for cluster operations.
 function setup_user() {
   echo ">> Setting up user"
-  echo "Using gcloud project ${PROJECT_NAME}"
-  gcloud config set core/project ${PROJECT_NAME}
   local user_name="${SERVICE_ACCOUNT_NAME}@${PROJECT_NAME}.iam.gserviceaccount.com"
   echo "Using gcloud user ${user_name}"
   gcloud config set core/account ${user_name}
+  echo "Using gcloud project ${PROJECT_NAME}"
+  gcloud config set core/project ${PROJECT_NAME}
 }
 
 # Update resources installed on the cluster.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Two small fixes of `performance-tests.sh`
1. `KO_DOCKER_REPO` should be exported
2. Set user before setting project, since the original sequence will get a warning `WARNING: You do not appear to have access to project [knative-performance] or it does not exist.`, it does not not any fatal error though.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @chaodaiG 
/cc @adrcunha 
