### PR TITLE
Fix custom optional presubmits for Serving

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -865,6 +865,8 @@ presubmits:
         command:
         - runner.sh
         args:
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
         - "./test/performance-tests.sh"
         volumeMounts:
         - name: test-account
@@ -897,6 +899,8 @@ presubmits:
         command:
         - runner.sh
         args:
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
         - "./test/performance-tests.sh"
         volumeMounts:
         - name: test-account
@@ -931,6 +935,8 @@ presubmits:
         command:
         - runner.sh
         args:
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
         - "./test/performance-tests.sh"
         volumeMounts:
         - name: test-account
@@ -963,10 +969,9 @@ presubmits:
         command:
         - runner.sh
         args:
-        - "./test/e2e-tests.sh"
-        - "--istio-version"
-        - "1.2-latest"
-        - "--mesh"
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-tests.sh --istio-version 1.2-latest --mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -999,10 +1004,9 @@ presubmits:
         command:
         - runner.sh
         args:
-        - "./test/e2e-tests.sh"
-        - "--istio-version"
-        - "1.2-latest"
-        - "--mesh"
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-tests.sh --istio-version 1.2-latest --mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -1037,10 +1041,9 @@ presubmits:
         command:
         - runner.sh
         args:
-        - "./test/e2e-tests.sh"
-        - "--istio-version"
-        - "1.2-latest"
-        - "--mesh"
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-tests.sh --istio-version 1.2-latest --mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -1072,10 +1075,9 @@ presubmits:
         command:
         - runner.sh
         args:
-        - "./test/e2e-tests.sh"
-        - "--istio-version"
-        - "1.2-latest"
-        - "--no-mesh"
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-tests.sh --istio-version 1.2-latest --no-mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -1108,10 +1110,9 @@ presubmits:
         command:
         - runner.sh
         args:
-        - "./test/e2e-tests.sh"
-        - "--istio-version"
-        - "1.2-latest"
-        - "--no-mesh"
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-tests.sh --istio-version 1.2-latest --no-mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -1146,10 +1147,9 @@ presubmits:
         command:
         - runner.sh
         args:
-        - "./test/e2e-tests.sh"
-        - "--istio-version"
-        - "1.2-latest"
-        - "--no-mesh"
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-tests.sh --istio-version 1.2-latest --no-mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -1181,10 +1181,9 @@ presubmits:
         command:
         - runner.sh
         args:
-        - "./test/e2e-tests.sh"
-        - "--istio-version"
-        - "1.3-latest"
-        - "--mesh"
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-tests.sh --istio-version 1.3-latest --mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -1217,10 +1216,9 @@ presubmits:
         command:
         - runner.sh
         args:
-        - "./test/e2e-tests.sh"
-        - "--istio-version"
-        - "1.3-latest"
-        - "--mesh"
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-tests.sh --istio-version 1.3-latest --mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -1255,10 +1253,9 @@ presubmits:
         command:
         - runner.sh
         args:
-        - "./test/e2e-tests.sh"
-        - "--istio-version"
-        - "1.3-latest"
-        - "--mesh"
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-tests.sh --istio-version 1.3-latest --mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -1290,10 +1287,9 @@ presubmits:
         command:
         - runner.sh
         args:
-        - "./test/e2e-tests.sh"
-        - "--istio-version"
-        - "1.3-latest"
-        - "--no-mesh"
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-tests.sh --istio-version 1.3-latest --no-mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -1326,10 +1322,9 @@ presubmits:
         command:
         - runner.sh
         args:
-        - "./test/e2e-tests.sh"
-        - "--istio-version"
-        - "1.3-latest"
-        - "--no-mesh"
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-tests.sh --istio-version 1.3-latest --no-mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -1364,10 +1359,9 @@ presubmits:
         command:
         - runner.sh
         args:
-        - "./test/e2e-tests.sh"
-        - "--istio-version"
-        - "1.3-latest"
-        - "--no-mesh"
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-tests.sh --istio-version 1.3-latest --no-mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -1399,9 +1393,9 @@ presubmits:
         command:
         - runner.sh
         args:
-        - "./test/e2e-tests.sh"
-        - "--gloo-version"
-        - "0.17.1"
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-tests.sh --gloo-version 0.17.1"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -1434,9 +1428,9 @@ presubmits:
         command:
         - runner.sh
         args:
-        - "./test/e2e-tests.sh"
-        - "--gloo-version"
-        - "0.17.1"
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-tests.sh --gloo-version 0.17.1"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -1471,9 +1465,9 @@ presubmits:
         command:
         - runner.sh
         args:
-        - "./test/e2e-tests.sh"
-        - "--gloo-version"
-        - "0.17.1"
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-tests.sh --gloo-version 0.17.1"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account

--- a/ci/prow/config_knative.yaml
+++ b/ci/prow/config_knative.yaml
@@ -48,28 +48,39 @@ presubmits:
       go-coverage-threshold: 80
     - custom-test: perf-tests
       always_run: false
-      command:
+      args:
+      - "--run-test"
       - "./test/performance-tests.sh"
     - custom-test: istio-1.2-mesh
       always_run: false
       optional: true
-      full-command: "./test/e2e-tests.sh --istio-version 1.2-latest --mesh"
+      args:
+      - "--run-test"
+      - "./test/e2e-tests.sh --istio-version 1.2-latest --mesh"
     - custom-test: istio-1.2-no-mesh
       always_run: false
       optional: true
-      full-command: "./test/e2e-tests.sh --istio-version 1.2-latest --no-mesh"
+      args:
+      - "--run-test"
+      - "./test/e2e-tests.sh --istio-version 1.2-latest --no-mesh"
     - custom-test: istio-1.3-mesh
       always_run: false
       optional: true
-      full-command: "./test/e2e-tests.sh --istio-version 1.3-latest --mesh"
+      args:
+      - "--run-test"
+      - "./test/e2e-tests.sh --istio-version 1.3-latest --mesh"
     - custom-test: istio-1.3-no-mesh
       always_run: false
       optional: true
-      full-command: "./test/e2e-tests.sh --istio-version 1.3-latest --no-mesh"
+      args:
+      - "--run-test"
+      - "./test/e2e-tests.sh --istio-version 1.3-latest --no-mesh"
     - custom-test: gloo-0.17.1
       always_run: false
       optional: true
-      full-command: "./test/e2e-tests.sh --gloo-version 0.17.1"
+      args:
+      - "--run-test"
+      - "./test/e2e-tests.sh --gloo-version 0.17.1"
 
   knative/client:
     - build-tests: true


### PR DESCRIPTION
The job setup was overriding the `presubmit-tests.sh` script, thus missing all the presubmit checks.
Since these jobs were optional, resources were not being wasted.
However, for readability/uniformity sake and future-proof, update these to the right settings.