### PR TITLE
Fixes to the perf test script

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -6542,7 +6542,7 @@ postsubmits:
         - runner.sh
         args:
         - "./test/performance/performance-tests.sh"
-        - "--reconcile-clusters"
+        - "--reconcile-benchmark-clusters"
         volumeMounts:
         - name: performance-test
           mountPath: /etc/performance-test
@@ -6626,7 +6626,7 @@ postsubmits:
         - runner.sh
         args:
         - "./test/performance/performance-tests.sh"
-        - "--reconcile-clusters"
+        - "--reconcile-benchmark-clusters"
         volumeMounts:
         - name: performance-test
           mountPath: /etc/performance-test

--- a/ci/prow/perf_config.go
+++ b/ci/prow/perf_config.go
@@ -59,7 +59,7 @@ func generatePerfClusterPostsubmitJob(repo repositoryData) {
 	perfClusterReconcilePostsubmitJob(
 		"reconcile-clusters",
 		perfTestScriptPath,
-		[]string{"--reconcile-clusters"},
+		[]string{"--reconcile-benchmark-clusters"},
 		repo.Name,
 		perfTestSecretName,
 	)

--- a/scripts/performance-tests.sh
+++ b/scripts/performance-tests.sh
@@ -23,7 +23,7 @@ source $(dirname ${BASH_SOURCE})/library.sh
 # If not provided, they will fall back to the default values.
 readonly BENCHMARK_ROOT_PATH=${BENCHMARK_ROOT_PATH:-test/performance/benchmarks}
 readonly PROJECT_NAME=${PROJECT_NAME:-knative-performance}
-readonly SERVICE_ACCOUNT_NAME=${SERVICE_ACCOUNT_NAME:-mako-job}
+readonly SERVICE_ACCOUNT_NAME=${SERVICE_ACCOUNT_NAME:-mako-job@knative-performance.iam.gserviceaccount.com}
 
 # Setup env vars.
 export KO_DOCKER_REPO="gcr.io/${PROJECT_NAME}"
@@ -36,9 +36,8 @@ readonly SLACK_WRITE_TOKEN="/etc/performance-test/slack-write-token"
 # Set up the user for cluster operations.
 function setup_user() {
   echo ">> Setting up user"
-  local user_name="${SERVICE_ACCOUNT_NAME}@${PROJECT_NAME}.iam.gserviceaccount.com"
-  echo "Using gcloud user ${user_name}"
-  gcloud config set core/account ${user_name}
+  echo "Using gcloud user ${SERVICE_ACCOUNT_NAME}"
+  gcloud config set core/account ${SERVICE_ACCOUNT_NAME}
   echo "Using gcloud project ${PROJECT_NAME}"
   gcloud config set core/project ${PROJECT_NAME}
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
In my last PR, I forgot to make changes to the service account setting in the script after I reused the `performance-test` secret. This PR changes the service account to not being binded to the same project.
Another fix is the option to reconcile clusters should be `--reconcile-benchmark-clusters` instead of `--reconcile-clusters`, I made the change in another testing branch but got it lost here..

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @adrcunha 