### PR TITLE
Configure knative/community for tide

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -92,6 +92,7 @@ tide:
     - "google/knative-gcp"
     - "knative/caching"
     - "knative/client"
+    - "knative/community"
     - "knative/docs"
     - "knative/eventing"
     - "knative/eventing-contrib"

--- a/ci/prow/config_knative.yaml
+++ b/ci/prow/config_knative.yaml
@@ -204,6 +204,13 @@ presubmits:
     - integration-tests: false
     - go-coverage: false
 
+  knative/community:
+    # This repo only uses Tide
+    - build-tests: false
+    - unit-tests: false
+    - integration-tests: false
+    - go-coverage: false
+
 periodics:
   knative/serving:
     - continuous: true

--- a/ci/prow/plugins.yaml
+++ b/ci/prow/plugins.yaml
@@ -17,6 +17,7 @@ approve:
   - "google/knative-gcp"
   - "knative/caching"
   - "knative/client"
+  - "knative/community"
   - "knative/docs"
   - "knative/eventing"
   - "knative/eventing-contrib"
@@ -110,6 +111,30 @@ plugins:
   - yuks
   - project
   knative/client:
+  - approve
+  - assign
+  - blunderbuss
+  - buildifier
+  - cat
+  - dog
+  - golint
+  - heart
+  - help
+  - hold
+  - label
+  - lgtm
+  - lifecycle
+  - milestone
+  - owners-label
+  - shrug
+  - size
+  - skip
+  - trigger
+  - verify-owners
+  - wip
+  - yuks
+  - project
+  knative/community:
   - approve
   - assign
   - blunderbuss


### PR DESCRIPTION
knative/community only uses tide, but a presubmit entry is required to generate the config. Thus, add a presubmit entry with no presubmit tests enabled.

Fixes #1492 