### PR TITLE
[monitoring] ignore build logs of success jobs

### DIFF
--- a/tools/monitoring/alert/alert.go
+++ b/tools/monitoring/alert/alert.go
@@ -58,8 +58,8 @@ func (c *Client) RunAlerting() {
 }
 
 func (c *Client) handleReportMessage(rmsg *prowapi.ReportMessage) {
-	if rmsg.Status == prowapi.SuccessState || rmsg.Status == prowapi.FailureState || rmsg.Status == prowapi.AbortedState {
-		log.Printf("Received Pubsub message %v\n", rmsg)
+	if rmsg.Status == prowapi.FailureState || rmsg.Status == prowapi.AbortedState {
+		log.Printf("Received Pubsub message in %s state: %v\n", rmsg.Status, rmsg)
 
 		config, err := config.ParseDefaultConfig()
 		if err != nil {


### PR DESCRIPTION
Processing build from success jobs costs computing power. More importantly, with all inclusive patterns ".*" now defined in monitoring's config yaml, even success runs will be included in error log. Such behavior is undesirable.

Also improved the logging a bit

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #

**Special notes to reviewers**:

**User-visible changes in this PR**:

