### PR TITLE
Add new CI jobs for 0.10

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -130,7 +130,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-serving-build-tests),?(\\s+|$)"
     decorate: true
     branches:
-    - "release-0.6"
     - "release-0.7"
     spec:
       containers:
@@ -218,7 +217,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/serving
     skip_branches:
-    - "release-0.6"
     - "release-0.7"
     - "release-0.8"
     - "release-0.9"
@@ -267,7 +265,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-serving-unit-tests),?(\\s+|$)"
     decorate: true
     branches:
-    - "release-0.6"
     - "release-0.7"
     spec:
       containers:
@@ -353,7 +350,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/serving
     skip_branches:
-    - "release-0.6"
     - "release-0.7"
     - "release-0.8"
     - "release-0.9"
@@ -397,7 +393,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-serving-integration-tests),?(\\s+|$)"
     decorate: true
     branches:
-    - "release-0.6"
     - "release-0.7"
     spec:
       containers:
@@ -485,7 +480,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/serving
     skip_branches:
-    - "release-0.6"
     - "release-0.7"
     - "release-0.8"
     - "release-0.9"
@@ -526,7 +520,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-serving-upgrade-tests),?(\\s+|$)"
     decorate: true
     branches:
-    - "release-0.6"
     - "release-0.7"
     spec:
       containers:
@@ -594,7 +587,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/serving
     skip_branches:
-    - "release-0.6"
     - "release-0.7"
     - "release-0.8"
     - "release-0.9"
@@ -696,7 +688,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/serving
     skip_branches:
-    - "release-0.6"
     - "release-0.7"
     - "release-0.8"
     - "release-0.9"
@@ -732,7 +723,6 @@ presubmits:
     optional: true
     decorate: true
     branches:
-    - "release-0.6"
     - "release-0.7"
     spec:
       containers:
@@ -794,7 +784,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/serving
     skip_branches:
-    - "release-0.6"
     - "release-0.7"
     - "release-0.8"
     - "release-0.9"
@@ -826,7 +815,6 @@ presubmits:
     optional: true
     decorate: true
     skip_branches:
-    - "release-0.6"
     - "release-0.7"
     - "release-0.8"
     - "release-0.9"
@@ -858,7 +846,6 @@ presubmits:
     decorate: true
     optional: true
     branches:
-    - "release-0.6"
     - "release-0.7"
     spec:
       containers:
@@ -928,7 +915,6 @@ presubmits:
     optional: true
     path_alias: knative.dev/serving
     skip_branches:
-    - "release-0.6"
     - "release-0.7"
     - "release-0.8"
     - "release-0.9"
@@ -964,7 +950,6 @@ presubmits:
     decorate: true
     optional: true
     branches:
-    - "release-0.6"
     - "release-0.7"
     spec:
       containers:
@@ -1034,7 +1019,6 @@ presubmits:
     optional: true
     path_alias: knative.dev/serving
     skip_branches:
-    - "release-0.6"
     - "release-0.7"
     - "release-0.8"
     - "release-0.9"
@@ -1070,7 +1054,6 @@ presubmits:
     decorate: true
     optional: true
     branches:
-    - "release-0.6"
     - "release-0.7"
     spec:
       containers:
@@ -1140,7 +1123,6 @@ presubmits:
     optional: true
     path_alias: knative.dev/serving
     skip_branches:
-    - "release-0.6"
     - "release-0.7"
     - "release-0.8"
     - "release-0.9"
@@ -1176,7 +1158,6 @@ presubmits:
     decorate: true
     optional: true
     branches:
-    - "release-0.6"
     - "release-0.7"
     spec:
       containers:
@@ -1246,7 +1227,6 @@ presubmits:
     optional: true
     path_alias: knative.dev/serving
     skip_branches:
-    - "release-0.6"
     - "release-0.7"
     - "release-0.8"
     - "release-0.9"
@@ -1282,7 +1262,6 @@ presubmits:
     decorate: true
     optional: true
     branches:
-    - "release-0.6"
     - "release-0.7"
     spec:
       containers:
@@ -1352,7 +1331,6 @@ presubmits:
     optional: true
     path_alias: knative.dev/serving
     skip_branches:
-    - "release-0.6"
     - "release-0.7"
     - "release-0.8"
     - "release-0.9"
@@ -1562,7 +1540,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-eventing-build-tests),?(\\s+|$)"
     decorate: true
     branches:
-    - "release-0.6"
     - "release-0.7"
     - "release-0.8"
     spec:
@@ -1602,7 +1579,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/eventing
     skip_branches:
-    - "release-0.6"
     - "release-0.7"
     - "release-0.8"
     spec:
@@ -1645,7 +1621,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-eventing-unit-tests),?(\\s+|$)"
     decorate: true
     branches:
-    - "release-0.6"
     - "release-0.7"
     - "release-0.8"
     spec:
@@ -1689,7 +1664,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/eventing
     skip_branches:
-    - "release-0.6"
     - "release-0.7"
     - "release-0.8"
     spec:
@@ -1732,7 +1706,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-eventing-integration-tests),?(\\s+|$)"
     decorate: true
     branches:
-    - "release-0.6"
     - "release-0.7"
     - "release-0.8"
     spec:
@@ -1776,7 +1749,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/eventing
     skip_branches:
-    - "release-0.6"
     - "release-0.7"
     - "release-0.8"
     spec:
@@ -1816,7 +1788,6 @@ presubmits:
     optional: true
     decorate: true
     branches:
-    - "release-0.6"
     - "release-0.7"
     - "release-0.8"
     spec:
@@ -1848,7 +1819,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/eventing
     skip_branches:
-    - "release-0.6"
     - "release-0.7"
     - "release-0.8"
     spec:
@@ -1879,7 +1849,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-eventing-contrib-build-tests),?(\\s+|$)"
     decorate: true
     branches:
-    - "release-0.6"
     - "release-0.7"
     - "release-0.8"
     spec:
@@ -1919,7 +1888,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/eventing-contrib
     skip_branches:
-    - "release-0.6"
     - "release-0.7"
     - "release-0.8"
     spec:
@@ -1962,7 +1930,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-eventing-contrib-unit-tests),?(\\s+|$)"
     decorate: true
     branches:
-    - "release-0.6"
     - "release-0.7"
     - "release-0.8"
     spec:
@@ -2006,7 +1973,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/eventing-contrib
     skip_branches:
-    - "release-0.6"
     - "release-0.7"
     - "release-0.8"
     spec:
@@ -2049,7 +2015,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-eventing-contrib-integration-tests),?(\\s+|$)"
     decorate: true
     branches:
-    - "release-0.6"
     - "release-0.7"
     - "release-0.8"
     spec:
@@ -2093,7 +2058,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/eventing-contrib
     skip_branches:
-    - "release-0.6"
     - "release-0.7"
     - "release-0.8"
     spec:
@@ -2133,7 +2097,6 @@ presubmits:
     optional: true
     decorate: true
     branches:
-    - "release-0.6"
     - "release-0.7"
     - "release-0.8"
     spec:
@@ -2165,7 +2128,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/eventing-contrib
     skip_branches:
-    - "release-0.6"
     - "release-0.7"
     - "release-0.8"
     spec:
@@ -3633,51 +3595,6 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "28 8 * * *"
-  name: ci-knative-serving-0.6-continuous
-  agent: kubernetes
-  labels:
-    prow.k8s.io/pubsub.project: knative-tests
-    prow.k8s.io/pubsub.topic: knative-monitoring
-    prow.k8s.io/pubsub.runID: ci-knative-serving-0.6-continuous
-  decorate: true
-  extra_refs:
-  - org: knative
-    repo: serving
-    base_ref: release-0.6
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./hack/release.sh"
-      - "--nopublish"
-      - "--notag-release"
-      securityContext:
-        privileged: true
-      volumeMounts:
-      - name: docker-graph
-        mountPath: /docker-graph
-      - name: test-account
-        mountPath: /etc/test-account
-        readOnly: true
-      env:
-      - name: DOCKER_IN_DOCKER_ENABLED
-        value: "true"
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/test-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-      - name: PULL_BASE_REF
-        value: release-0.6
-    volumes:
-    - name: docker-graph
-      emptyDir: {}
-    - name: test-account
-      secret:
-        secretName: test-account
 - cron: "39 8 * * *"
   name: ci-knative-serving-0.7-continuous
   agent: kubernetes
@@ -3809,6 +3726,52 @@ periodics:
         value: us-central1
       - name: PULL_BASE_REF
         value: release-0.9
+    volumes:
+    - name: docker-graph
+      emptyDir: {}
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "37 8 * * *"
+  name: ci-knative-serving-0.10-continuous
+  agent: kubernetes
+  labels:
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-knative-serving-0.10-continuous
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: release-0.10
+    path_alias: knative.dev/serving
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--nopublish"
+      - "--notag-release"
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - name: docker-graph
+        mountPath: /docker-graph
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.10
     volumes:
     - name: docker-graph
       emptyDir: {}
@@ -4035,7 +3998,7 @@ periodics:
     path_alias: knative.dev/serving
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -4454,51 +4417,6 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "47 8 * * *"
-  name: ci-knative-eventing-0.6-continuous
-  agent: kubernetes
-  labels:
-    prow.k8s.io/pubsub.project: knative-tests
-    prow.k8s.io/pubsub.topic: knative-monitoring
-    prow.k8s.io/pubsub.runID: ci-knative-eventing-0.6-continuous
-  decorate: true
-  extra_refs:
-  - org: knative
-    repo: eventing
-    base_ref: release-0.6
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./hack/release.sh"
-      - "--nopublish"
-      - "--notag-release"
-      securityContext:
-        privileged: true
-      volumeMounts:
-      - name: docker-graph
-        mountPath: /docker-graph
-      - name: test-account
-        mountPath: /etc/test-account
-        readOnly: true
-      env:
-      - name: DOCKER_IN_DOCKER_ENABLED
-        value: "true"
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/test-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-      - name: PULL_BASE_REF
-        value: release-0.6
-    volumes:
-    - name: docker-graph
-      emptyDir: {}
-    - name: test-account
-      secret:
-        secretName: test-account
 - cron: "58 8 * * *"
   name: ci-knative-eventing-0.7-continuous
   agent: kubernetes
@@ -4629,6 +4547,52 @@ periodics:
         value: us-central1
       - name: PULL_BASE_REF
         value: release-0.9
+    volumes:
+    - name: docker-graph
+      emptyDir: {}
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "56 8 * * *"
+  name: ci-knative-eventing-0.10-continuous
+  agent: kubernetes
+  labels:
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-knative-eventing-0.10-continuous
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: eventing
+    base_ref: release-0.10
+    path_alias: knative.dev/eventing
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--nopublish"
+      - "--notag-release"
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - name: docker-graph
+        mountPath: /docker-graph
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.10
     volumes:
     - name: docker-graph
       emptyDir: {}
@@ -4817,51 +4781,6 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "42 8 * * *"
-  name: ci-knative-eventing-contrib-0.6-continuous
-  agent: kubernetes
-  labels:
-    prow.k8s.io/pubsub.project: knative-tests
-    prow.k8s.io/pubsub.topic: knative-monitoring
-    prow.k8s.io/pubsub.runID: ci-knative-eventing-contrib-0.6-continuous
-  decorate: true
-  extra_refs:
-  - org: knative
-    repo: eventing-contrib
-    base_ref: release-0.6
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./hack/release.sh"
-      - "--nopublish"
-      - "--notag-release"
-      securityContext:
-        privileged: true
-      volumeMounts:
-      - name: docker-graph
-        mountPath: /docker-graph
-      - name: test-account
-        mountPath: /etc/test-account
-        readOnly: true
-      env:
-      - name: DOCKER_IN_DOCKER_ENABLED
-        value: "true"
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/test-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-      - name: PULL_BASE_REF
-        value: release-0.6
-    volumes:
-    - name: docker-graph
-      emptyDir: {}
-    - name: test-account
-      secret:
-        secretName: test-account
 - cron: "53 8 * * *"
   name: ci-knative-eventing-contrib-0.7-continuous
   agent: kubernetes
@@ -4992,6 +4911,52 @@ periodics:
         value: us-central1
       - name: PULL_BASE_REF
         value: release-0.9
+    volumes:
+    - name: docker-graph
+      emptyDir: {}
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "51 8 * * *"
+  name: ci-knative-eventing-contrib-0.10-continuous
+  agent: kubernetes
+  labels:
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-knative-eventing-contrib-0.10-continuous
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: eventing-contrib
+    base_ref: release-0.10
+    path_alias: knative.dev/eventing-contrib
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--nopublish"
+      - "--notag-release"
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - name: docker-graph
+        mountPath: /docker-graph
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.10
     volumes:
     - name: docker-graph
       emptyDir: {}
@@ -5454,7 +5419,7 @@ periodics:
     path_alias: knative.dev/serving-operator
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
       command:
       - runner.sh

--- a/ci/prow/config_knative.yaml
+++ b/ci/prow/config_knative.yaml
@@ -17,10 +17,8 @@ presubmits:
     - repo-settings:
       performance: true
       legacy-branches:
-      - release-0.6
       - release-0.7
       go112-branches:
-      - release-0.6
       - release-0.7
       - release-0.8
       - release-0.9
@@ -40,8 +38,6 @@ presubmits:
       - "--run-test"
       - "./test/e2e-upgrade-tests.sh --istio-version 1.2-latest --no-mesh"
     - custom-test: smoke-tests
-      skip_branches:  # Skip these branches, as test isn't available.
-      - release-0.6
       args:
       - "--run-test"
       - "./test/e2e-smoke-tests.sh"
@@ -97,7 +93,6 @@ presubmits:
     - repo-settings:
       performance: true
       legacy-branches:
-      - release-0.6
       - release-0.7
       - release-0.8
     - build-tests: true
@@ -108,7 +103,6 @@ presubmits:
   knative/eventing-contrib:
     - repo-settings:
       legacy-branches:
-      - release-0.6
       - release-0.7
       - release-0.8
     - build-tests: true
@@ -223,14 +217,15 @@ periodics:
         limits:
           memory: 16Gi
     - branch-ci: true
-      release: "0.6"
-    - branch-ci: true
       release: "0.7"
     - branch-ci: true
       release: "0.8"
       dot-dev: true
     - branch-ci: true
       release: "0.9"
+      dot-dev: true
+    - branch-ci: true
+      release: "0.10"
       dot-dev: true
     - custom-job: istio-1.2-mesh
       full-command: "./test/e2e-tests.sh --istio-version 1.2-latest --mesh"
@@ -261,9 +256,8 @@ periodics:
         limits:
           memory: 16Gi
     - dot-release: true
-      # TODO(chaodaiG): dot-release will need to use go1.13 after branch
-      # release-0.10 is cut
       dot-dev: true
+      go113: true
       resources:
         requests:
           memory: 12Gi
@@ -300,13 +294,14 @@ periodics:
       timeout: 90
       dot-dev: true
     - branch-ci: true
-      release: "0.6"
-    - branch-ci: true
       release: "0.7"
     - branch-ci: true
       release: "0.8"
     - branch-ci: true
       release: "0.9"
+      dot-dev: true
+    - branch-ci: true
+      release: "0.10"
       dot-dev: true
     - nightly: true
       dot-dev: true
@@ -319,13 +314,14 @@ periodics:
     - continuous: true
       dot-dev: true
     - branch-ci: true
-      release: "0.6"
-    - branch-ci: true
       release: "0.7"
     - branch-ci: true
       release: "0.8"
     - branch-ci: true
       release: "0.9"
+      dot-dev: true
+    - branch-ci: true
+      release: "0.10"
       dot-dev: true
     - nightly: true
       dot-dev: true
@@ -361,9 +357,8 @@ periodics:
       dot-dev: true
       go113: true
     - dot-release: true
-      # TODO(chaodaiG): dot-release will need to use go1.13 after branch
-      # release-0.10 is cut
       dot-dev: true
+      go113: true
     - auto-release: true
       dot-dev: true
       go113: true

--- a/ci/prow/testgrid.yaml
+++ b/ci/prow/testgrid.yaml
@@ -216,12 +216,6 @@ test_groups:
   gcs_prefix: knative-prow/logs/ci-knative-eventing-operator-go-coverage
   num_failures_to_alert: 9999
   short_text_metric: "coverage"
-- name: ci-knative-serving-0.6-continuous
-  gcs_prefix: knative-prow/logs/ci-knative-serving-0.6-continuous
-- name: ci-knative-eventing-0.6-continuous
-  gcs_prefix: knative-prow/logs/ci-knative-eventing-0.6-continuous
-- name: ci-knative-eventing-contrib-0.6-continuous
-  gcs_prefix: knative-prow/logs/ci-knative-eventing-contrib-0.6-continuous
 - name: ci-knative-serving-0.7-continuous
   gcs_prefix: knative-prow/logs/ci-knative-serving-0.7-continuous
 - name: ci-knative-eventing-0.7-continuous
@@ -240,6 +234,12 @@ test_groups:
   gcs_prefix: knative-prow/logs/ci-knative-eventing-0.9-continuous
 - name: ci-knative-eventing-contrib-0.9-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-contrib-0.9-continuous
+- name: ci-knative-serving-0.10-continuous
+  gcs_prefix: knative-prow/logs/ci-knative-serving-0.10-continuous
+- name: ci-knative-eventing-0.10-continuous
+  gcs_prefix: knative-prow/logs/ci-knative-eventing-0.10-continuous
+- name: ci-knative-eventing-contrib-0.10-continuous
+  gcs_prefix: knative-prow/logs/ci-knative-eventing-contrib-0.10-continuous
 - name: ci-google-knative-gcp-continuous
   gcs_prefix: knative-prow/logs/ci-google-knative-gcp-continuous
   alert_stale_results_hours: 3
@@ -439,17 +439,6 @@ dashboards:
   - name: coverage
     test_group_name: pull-google-knative-gcp-test-coverage
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
-- name: knative-0.6
-  dashboard_tab:
-  - name: serving
-    test_group_name: ci-knative-serving-0.6-continuous
-    base_options: "sort-by-name="
-  - name: eventing
-    test_group_name: ci-knative-eventing-0.6-continuous
-    base_options: "sort-by-name="
-  - name: eventing-contrib
-    test_group_name: ci-knative-eventing-contrib-0.6-continuous
-    base_options: "sort-by-name="
 - name: knative-0.7
   dashboard_tab:
   - name: serving
@@ -482,6 +471,17 @@ dashboards:
     base_options: "sort-by-name="
   - name: eventing-contrib
     test_group_name: ci-knative-eventing-contrib-0.9-continuous
+    base_options: "sort-by-name="
+- name: knative-0.10
+  dashboard_tab:
+  - name: serving
+    test_group_name: ci-knative-serving-0.10-continuous
+    base_options: "sort-by-name="
+  - name: eventing
+    test_group_name: ci-knative-eventing-0.10-continuous
+    base_options: "sort-by-name="
+  - name: eventing-contrib
+    test_group_name: ci-knative-eventing-contrib-0.10-continuous
     base_options: "sort-by-name="
 dashboard_groups:
 - name: knative


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Add new CI jobs for release 0.10, and remove jobs for release 0.6.
Also address two TODOs since the releases using Go 1.13 have already been cut.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @adrcunha 
/cc @chaodaiG 
