### PR TITLE
Fix config issue that potentially caused some alert not sent

### DIFF
--- a/tools/monitoring/config/config.yaml
+++ b/tools/monitoring/config/config.yaml
@@ -161,6 +161,7 @@ spec:
         jobs-affected: 1
         prs-affected: 0
         period: 1440
+
   - error-pattern: 'step failures'
     hint: 'Verify that these are not from dry-runs'
     alerts:
@@ -168,6 +169,7 @@ spec:
         occurrences: 2
         jobs-affected: 1
         period: 2880
+
   - error-pattern: '.*' # We need to check for all errors
     hint: 'Look at the errors in the log'
     alerts:
@@ -175,9 +177,6 @@ spec:
         occurrences: 1
         jobs-affected: 1
         period: 1440
-  - error-pattern: '.*' # Check all errors
-    hint: 'Look at the errors in build log'
-    alerts:
       - job-name-regex: 'ci-knative-.*-clusters' # Performance recycle clusters jobs
         occurrences: 3
         jobs-affected: 1


### PR DESCRIPTION
Same error pattern should not appear more than once in the config.
The monitoring tool only looks at the first matching error pattern in the config.

The mis-config likely caused the issue https://github.com/knative/test-infra/issues/1513

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #1513 

**Special notes to reviewers**:

**User-visible changes in this PR**:

