### PR TITLE
Fix two Prow jobs

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -5453,7 +5453,7 @@ periodics:
     path_alias: knative.dev/serving-operator
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
       imagePullPolicy: Always
       command:
       - runner.sh

--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -3781,7 +3781,7 @@ periodics:
     path_alias: knative.dev/serving
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
       command:
       - runner.sh

--- a/ci/prow/config_knative.yaml
+++ b/ci/prow/config_knative.yaml
@@ -235,6 +235,7 @@ periodics:
     - branch-ci: true
       release: "0.10"
       dot-dev: true
+      go113: true
     - custom-job: istio-1.2-mesh
       full-command: "./test/e2e-tests.sh --istio-version 1.2-latest --mesh"
       dot-dev: true

--- a/ci/prow/config_knative.yaml
+++ b/ci/prow/config_knative.yaml
@@ -366,8 +366,9 @@ periodics:
       dot-dev: true
       go113: true
     - dot-release: true
+      # TODO(chaodaiG): dot-release will need to use go1.13 after branch
+      # release-0.10 is cut
       dot-dev: true
-      go113: true
     - auto-release: true
       dot-dev: true
       go113: true


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
1. serving release-0.10 CI jobs should use Go 1.13
2. serving-operator dot-release job should still use Go 1.12 before 0.10 is cut.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @chaodaiG 
/cc @adrcunha 