### PR TITLE
Run the cleanup job every 6h

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -5971,7 +5971,7 @@ periodics:
       args:
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
-- cron: "0 19 * * 1"
+- cron: "0 */6 * * *"
   name: ci-knative-cleanup
   labels:
       prow.k8s.io/pubsub.project: knative-tests

--- a/ci/prow/periodic_config.go
+++ b/ci/prow/periodic_config.go
@@ -36,7 +36,7 @@ const (
 
 	// Cron strings for key jobs
 	goCoveragePeriodicJobCron           = "0 1 * * *"    // Run at 01:00 every day
-	cleanupPeriodicJobCron              = "0 19 * * 1"   // Run at 11:00PST/12:00PST every Monday (19:00 UTC)
+	cleanupPeriodicJobCron              = "0 */6 * * *"  // Run every 6 hours
 	flakesReporterPeriodicJobCron       = "0 12 * * *"   // Run at 4:00PST/5:00PST every day (12:00 UTC)
 	flakesResultRecorderPeriodicJobCron = "0 * * * *"    // Run every hour
 	prowversionbumperPeriodicJobCron    = "0 20 * * 1"   // Run at 12:00PST/13:00PST every Monday (20:00 UTC)


### PR DESCRIPTION
After the initial backlog is taken care of, this should keep the Boskos projects pretty clean, as cleaning up often reduces the backlog and thus avoids the cleanup job timing out.

Part of #1399 

/assign @chaodaiG 
/assign @chizhg 