### PR TITLE
Markdown link checker presubmit for knative/docs is optional

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -2305,6 +2305,7 @@ presubmits:
     rerun_command: "/test pull-knative-docs-markdown-link-check"
     trigger: "(?m)^/test (all|pull-knative-docs-markdown-link-check),?(\\s+|$)"
     decorate: true
+    optional: true
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable

--- a/ci/prow/config_knative.yaml
+++ b/ci/prow/config_knative.yaml
@@ -118,6 +118,7 @@ presubmits:
     - go-coverage: true
     - custom-test: markdown-link-check
       always_run: true
+      optional: true
       command:
         - "./test/presubmit-link-check.sh"
 


### PR DESCRIPTION
Otherwise tide will be blocked if the job fails (it's informational, not a merge blocker).