### PR TITLE
Enable running tests with https for presubmit

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -1357,6 +1357,110 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
+  - name: pull-knative-serving-https
+    agent: kubernetes
+    context: pull-knative-serving-https
+    always_run: false
+    rerun_command: "/test pull-knative-serving-https"
+    trigger: "(?m)^/test (all|pull-knative-serving-https),?(\\s+|$)"
+    decorate: true
+    optional: true
+    branches:
+    - "release-0.7"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-tests.sh --https"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-serving-https
+    agent: kubernetes
+    context: pull-knative-serving-https
+    always_run: false
+    rerun_command: "/test pull-knative-serving-https"
+    trigger: "(?m)^/test (all|pull-knative-serving-https),?(\\s+|$)"
+    decorate: true
+    optional: true
+    path_alias: knative.dev/serving
+    branches:
+    - "release-0.8"
+    - "release-0.9"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-tests.sh --https"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-serving-https
+    agent: kubernetes
+    context: pull-knative-serving-https
+    always_run: false
+    rerun_command: "/test pull-knative-serving-https"
+    trigger: "(?m)^/test (all|pull-knative-serving-https),?(\\s+|$)"
+    decorate: true
+    optional: true
+    path_alias: knative.dev/serving
+    skip_branches:
+    - "release-0.7"
+    - "release-0.8"
+    - "release-0.9"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-tests.sh --https"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
   knative/client:
   - name: pull-knative-client-build-tests
     agent: kubernetes

--- a/ci/prow/config_knative.yaml
+++ b/ci/prow/config_knative.yaml
@@ -73,6 +73,12 @@ presubmits:
       args:
       - "--run-test"
       - "./test/e2e-tests.sh --gloo-version 0.17.1"
+    - custom-test: https
+      always_run: false
+      optional: true
+      args:
+      - "--run-test"
+      - "./test/e2e-tests.sh --https"
 
   knative/client:
     - build-tests: true
@@ -271,10 +277,6 @@ periodics:
       go113: true
     - custom-job: gloo-0.17.1
       full-command: "./test/e2e-tests.sh --gloo-version 0.17.1"
-      dot-dev: true
-      go113: true
-    - custom-job: https
-      full-command: "./test/e2e-tests.sh --https"
       dot-dev: true
       go113: true
     - nightly: true

--- a/ci/prow/config_knative.yaml
+++ b/ci/prow/config_knative.yaml
@@ -273,6 +273,10 @@ periodics:
       full-command: "./test/e2e-tests.sh --gloo-version 0.17.1"
       dot-dev: true
       go113: true
+    - custom-job: https
+      full-command: "./test/e2e-tests.sh --https"
+      dot-dev: true
+      go113: true
     - nightly: true
       dot-dev: true
       go113: true


### PR DESCRIPTION
/lint

**What this PR does, why we need it**:
Run tests with https as a presubmit

**Which issue(s) this PR fixes**:
Part of https://github.com/knative/serving/issues/5148

**Special notes to reviewers**:

**User-visible changes in this PR**: None

