### PR TITLE
Display nodes of the test cluster before running the test

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -101,6 +101,9 @@ function setup_test_cluster() {
   set -o errexit
   set -o pipefail
 
+  header "Test cluster setup"
+  kubectl get nodes
+
   header "Setting up test cluster"
 
   # Run cluster-creator for acquiring existing test cluster, will fail if


### PR DESCRIPTION
Missed duplicating the change to e2e-tests.sh (which is test-infra specific) in 1535.

/cc @chaodaiG 