### PR TITLE
fix malformed junit result from custom build tests

### DIFF
--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -353,7 +353,7 @@ function create_junit_xml() {
     # Also escape `<` and `>` as here: https://github.com/golang/go/blob/50bd1c4d4eb4fac8ddeb5f063c099daccfb71b26/src/encoding/json/encode.go#L48, 
     # this is temporary solution for fixing https://github.com/knative/test-infra/issues/1204,
     # which should be obsolete once Test-infra 2.0 is in place
-    local msg="$(echo -n "$3" | sed 's/$/\&#xA;/g' | sed 's/</\\u003c/' | sed 's/>/\\u003e/' | tr -d '\n')"
+    local msg="$(echo -n "$3" | sed 's/$/\&#xA;/g' | sed 's/</\\u003c/' | sed 's/>/\\u003e/' | sed 's/&/\\u0026/' | tr -d '\n')"
     failure="<failure message=\"Failed\" type=\"\">${msg}</failure>"
   fi
   cat << EOF > "${xml}"


### PR DESCRIPTION
ampersand is not very friendly with junit results parsing, escape it so that it doesn't fail.

Example here: https://prow.knative.dev/view/gcs/knative-prow/logs/ci-knative-serving-continuous/1194045016050241536

This is the root cause for why flaky test results failed

/cc @chizhg 
/cc @yt3liu 