### PR TITLE
use mdl v0.5 in prow test image 

### DIFF
--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -57,7 +57,7 @@ RUN ko version > /ko_version
 
 # Extra tools through gem
 RUN gem install mixlib-config -v 2.2.4  # required because ruby is 2.1
-RUN gem install mdl
+RUN gem install mdl -v 0.5  # required because later version of mdl requires ruby >= 2.4
 
 # Temporarily add test-infra to the image to build custom tools
 ADD . /go/src/knative.dev/test-infra


### PR DESCRIPTION


<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:

use a specific mdl version because rubygem uses ruby 2.3 and starting from mdl 0.6.0, it requires ruby >= 2.4. 

Updating it to use mdl version so other components can be upgraded while we don't need new mdl features. 

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #

**Special notes to reviewers**:

**User-visible changes in this PR**:

