### PR TITLE
Modifications on Spyglass highlight regexes

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -62,6 +62,8 @@ deck:
           - 'FAIL:'
           # boskos error
           - 'boskos failed to acquire project'
+          # cluster creation error
+          - 'failed creating test cluster'
       required_files:
       - build-log.txt
     - lens:

--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -53,9 +53,8 @@ deck:
         name: buildlog
         config:
           highlight_regexes:
-          # regexes to match generic errors
-          - timed out
-          # regexes to match specific errors we can have
+          # timed out error in waiting for Kubernetes resources
+          - 'timed out waiting for the condition'
           # go test timeout
           - 'panic: test timed out after.*$'
           # test case failure

--- a/ci/prow/templates/prow_config_header.yaml
+++ b/ci/prow/templates/prow_config_header.yaml
@@ -66,6 +66,8 @@ deck:
           - 'FAIL:'
           # boskos error
           - 'boskos failed to acquire project'
+          # cluster creation error
+          - 'failed creating test cluster'
       required_files:
       - build-log.txt
     - lens:

--- a/ci/prow/templates/prow_config_header.yaml
+++ b/ci/prow/templates/prow_config_header.yaml
@@ -56,10 +56,8 @@ deck:
         name: buildlog
         config:
           highlight_regexes:
-          # regexes to match generic errors
-          - timed out
-
-          # regexes to match specific errors we can have
+          # timed out error in waiting for Kubernetes resources
+          - 'timed out waiting for the condition'
           # go test timeout
           - 'panic: test timed out after.*$'
           # test case failure


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

As we discussed in https://github.com/knative/pkg/pull/856, add a regex to match the specific cluster creation error, then we can change the log message in pkg to make it not matched with the generic `timed out` regex.

/cc @chaodaiG 
/cc @coryrc 

