### PR TITLE
githubhelper: Raise ListFiles responses PerPage to 300.

### DIFF
--- a/tools/githubhelper/githubhelper.go
+++ b/tools/githubhelper/githubhelper.go
@@ -88,7 +88,8 @@ func listChangedFiles() {
 	files := make([]*github.CommitFile, 0)
 
 	listOptions := &github.ListOptions{
-		Page: 1,
+		Page:    1,
+		PerPage: 300,
 	}
 	for {
 		commitFiles, rsp, err := client.PullRequests.ListFiles(ctx, repoOwner, repoName, pullNumber, listOptions)


### PR DESCRIPTION
**What this PR does, why we need it**:
Raise ListFiles responses PerPage to 300.

This helps reduce the number of API requests necessary to list all files
out.

We ran into an issue with Tekton where a [PR with many changed files](https://github.com/tektoncd/pipeline/pull/1607) exhausted its GitHub quota trying to fetch changed files in the PR. Even though we're currently not making authenticated requests with this tool, raising the PerPage response to 300 ([the max value](https://developer.github.com/v3/pulls/#list-pull-requests-files)), helps reduce the calls to 13 instead of 60+. 

Since the tool is trying to list all the files anyway, there's no harm in increasing this.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
n/a

**Special notes to reviewers**:

**User-visible changes in this PR**:
n/a

