### PR TITLE
Enable Istio 1.4 in pull-knative-serving-istio-1.4-* test grids and remove 1.2

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -404,7 +404,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.2-latest --no-mesh"
+        - "./test/e2e-tests.sh --istio-version 1.4-latest --no-mesh"
         volumeMounts:
         - name: repoview-token
           mountPath: /etc/repoview-token
@@ -448,7 +448,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.2-latest --no-mesh"
+        - "./test/e2e-tests.sh --istio-version 1.4-latest --no-mesh"
         volumeMounts:
         - name: repoview-token
           mountPath: /etc/repoview-token
@@ -493,7 +493,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.2-latest --no-mesh"
+        - "./test/e2e-tests.sh --istio-version 1.4-latest --no-mesh"
         volumeMounts:
         - name: repoview-token
           mountPath: /etc/repoview-token
@@ -531,7 +531,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-upgrade-tests.sh --istio-version 1.2-latest --no-mesh"
+        - "./test/e2e-upgrade-tests.sh --istio-version 1.4-latest --no-mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -565,7 +565,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-upgrade-tests.sh --istio-version 1.2-latest --no-mesh"
+        - "./test/e2e-upgrade-tests.sh --istio-version 1.4-latest --no-mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -600,7 +600,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-upgrade-tests.sh --istio-version 1.2-latest --no-mesh"
+        - "./test/e2e-upgrade-tests.sh --istio-version 1.4-latest --no-mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -838,214 +838,6 @@ presubmits:
       - name: covbot-token
         secret:
           secretName: covbot-token
-  - name: pull-knative-serving-istio-1.2-mesh
-    agent: kubernetes
-    context: pull-knative-serving-istio-1.2-mesh
-    always_run: false
-    rerun_command: "/test pull-knative-serving-istio-1.2-mesh"
-    trigger: "(?m)^/test (all|pull-knative-serving-istio-1.2-mesh),?(\\s+|$)"
-    decorate: true
-    optional: true
-    branches:
-    - "release-0.7"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.2-latest --mesh"
-        volumeMounts:
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-      volumes:
-      - name: test-account
-        secret:
-          secretName: test-account
-  - name: pull-knative-serving-istio-1.2-mesh
-    agent: kubernetes
-    context: pull-knative-serving-istio-1.2-mesh
-    always_run: false
-    rerun_command: "/test pull-knative-serving-istio-1.2-mesh"
-    trigger: "(?m)^/test (all|pull-knative-serving-istio-1.2-mesh),?(\\s+|$)"
-    decorate: true
-    optional: true
-    path_alias: knative.dev/serving
-    branches:
-    - "release-0.8"
-    - "release-0.9"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.2-latest --mesh"
-        volumeMounts:
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-      volumes:
-      - name: test-account
-        secret:
-          secretName: test-account
-  - name: pull-knative-serving-istio-1.2-mesh
-    agent: kubernetes
-    context: pull-knative-serving-istio-1.2-mesh
-    always_run: false
-    rerun_command: "/test pull-knative-serving-istio-1.2-mesh"
-    trigger: "(?m)^/test (all|pull-knative-serving-istio-1.2-mesh),?(\\s+|$)"
-    decorate: true
-    optional: true
-    path_alias: knative.dev/serving
-    skip_branches:
-    - "release-0.7"
-    - "release-0.8"
-    - "release-0.9"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.2-latest --mesh"
-        volumeMounts:
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-      volumes:
-      - name: test-account
-        secret:
-          secretName: test-account
-  - name: pull-knative-serving-istio-1.2-no-mesh
-    agent: kubernetes
-    context: pull-knative-serving-istio-1.2-no-mesh
-    always_run: false
-    rerun_command: "/test pull-knative-serving-istio-1.2-no-mesh"
-    trigger: "(?m)^/test (all|pull-knative-serving-istio-1.2-no-mesh),?(\\s+|$)"
-    decorate: true
-    optional: true
-    branches:
-    - "release-0.7"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.2-latest --no-mesh"
-        volumeMounts:
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-      volumes:
-      - name: test-account
-        secret:
-          secretName: test-account
-  - name: pull-knative-serving-istio-1.2-no-mesh
-    agent: kubernetes
-    context: pull-knative-serving-istio-1.2-no-mesh
-    always_run: false
-    rerun_command: "/test pull-knative-serving-istio-1.2-no-mesh"
-    trigger: "(?m)^/test (all|pull-knative-serving-istio-1.2-no-mesh),?(\\s+|$)"
-    decorate: true
-    optional: true
-    path_alias: knative.dev/serving
-    branches:
-    - "release-0.8"
-    - "release-0.9"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.2-latest --no-mesh"
-        volumeMounts:
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-      volumes:
-      - name: test-account
-        secret:
-          secretName: test-account
-  - name: pull-knative-serving-istio-1.2-no-mesh
-    agent: kubernetes
-    context: pull-knative-serving-istio-1.2-no-mesh
-    always_run: false
-    rerun_command: "/test pull-knative-serving-istio-1.2-no-mesh"
-    trigger: "(?m)^/test (all|pull-knative-serving-istio-1.2-no-mesh),?(\\s+|$)"
-    decorate: true
-    optional: true
-    path_alias: knative.dev/serving
-    skip_branches:
-    - "release-0.7"
-    - "release-0.8"
-    - "release-0.9"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.2-latest --no-mesh"
-        volumeMounts:
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-      volumes:
-      - name: test-account
-        secret:
-          secretName: test-account
   - name: pull-knative-serving-istio-1.3-mesh
     agent: kubernetes
     context: pull-knative-serving-istio-1.3-mesh
@@ -1241,6 +1033,214 @@ presubmits:
         - "./test/presubmit-tests.sh"
         - "--run-test"
         - "./test/e2e-tests.sh --istio-version 1.3-latest --no-mesh"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-serving-istio-1.4-mesh
+    agent: kubernetes
+    context: pull-knative-serving-istio-1.4-mesh
+    always_run: false
+    rerun_command: "/test pull-knative-serving-istio-1.4-mesh"
+    trigger: "(?m)^/test (all|pull-knative-serving-istio-1.4-mesh),?(\\s+|$)"
+    decorate: true
+    optional: true
+    branches:
+    - "release-0.7"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-tests.sh --istio-version 1.4-latest --mesh"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-serving-istio-1.4-mesh
+    agent: kubernetes
+    context: pull-knative-serving-istio-1.4-mesh
+    always_run: false
+    rerun_command: "/test pull-knative-serving-istio-1.4-mesh"
+    trigger: "(?m)^/test (all|pull-knative-serving-istio-1.4-mesh),?(\\s+|$)"
+    decorate: true
+    optional: true
+    path_alias: knative.dev/serving
+    branches:
+    - "release-0.8"
+    - "release-0.9"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-tests.sh --istio-version 1.4-latest --mesh"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-serving-istio-1.4-mesh
+    agent: kubernetes
+    context: pull-knative-serving-istio-1.4-mesh
+    always_run: false
+    rerun_command: "/test pull-knative-serving-istio-1.4-mesh"
+    trigger: "(?m)^/test (all|pull-knative-serving-istio-1.4-mesh),?(\\s+|$)"
+    decorate: true
+    optional: true
+    path_alias: knative.dev/serving
+    skip_branches:
+    - "release-0.7"
+    - "release-0.8"
+    - "release-0.9"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-tests.sh --istio-version 1.4-latest --mesh"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-serving-istio-1.4-no-mesh
+    agent: kubernetes
+    context: pull-knative-serving-istio-1.4-no-mesh
+    always_run: false
+    rerun_command: "/test pull-knative-serving-istio-1.4-no-mesh"
+    trigger: "(?m)^/test (all|pull-knative-serving-istio-1.4-no-mesh),?(\\s+|$)"
+    decorate: true
+    optional: true
+    branches:
+    - "release-0.7"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-tests.sh --istio-version 1.4-latest --no-mesh"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-serving-istio-1.4-no-mesh
+    agent: kubernetes
+    context: pull-knative-serving-istio-1.4-no-mesh
+    always_run: false
+    rerun_command: "/test pull-knative-serving-istio-1.4-no-mesh"
+    trigger: "(?m)^/test (all|pull-knative-serving-istio-1.4-no-mesh),?(\\s+|$)"
+    decorate: true
+    optional: true
+    path_alias: knative.dev/serving
+    branches:
+    - "release-0.8"
+    - "release-0.9"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-tests.sh --istio-version 1.4-latest --no-mesh"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-serving-istio-1.4-no-mesh
+    agent: kubernetes
+    context: pull-knative-serving-istio-1.4-no-mesh
+    always_run: false
+    rerun_command: "/test pull-knative-serving-istio-1.4-no-mesh"
+    trigger: "(?m)^/test (all|pull-knative-serving-istio-1.4-no-mesh),?(\\s+|$)"
+    decorate: true
+    optional: true
+    path_alias: knative.dev/serving
+    skip_branches:
+    - "release-0.7"
+    - "release-0.8"
+    - "release-0.9"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-tests.sh --istio-version 1.4-latest --no-mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -3967,72 +3967,6 @@ periodics:
       secret:
         secretName: test-account
 - cron: "40 */2 * * *"
-  name: ci-knative-serving-istio-1.2-mesh
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: knative
-    repo: serving
-    base_ref: master
-    path_alias: knative.dev/serving
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./test/e2e-tests.sh"
-      - "--istio-version"
-      - "1.2-latest"
-      - "--mesh"
-      volumeMounts:
-      - name: test-account
-        mountPath: /etc/test-account
-        readOnly: true
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/test-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-    volumes:
-    - name: test-account
-      secret:
-        secretName: test-account
-- cron: "1 */2 * * *"
-  name: ci-knative-serving-istio-1.2-no-mesh
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: knative
-    repo: serving
-    base_ref: master
-    path_alias: knative.dev/serving
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./test/e2e-tests.sh"
-      - "--istio-version"
-      - "1.2-latest"
-      - "--no-mesh"
-      volumeMounts:
-      - name: test-account
-        mountPath: /etc/test-account
-        readOnly: true
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/test-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-    volumes:
-    - name: test-account
-      secret:
-        secretName: test-account
-- cron: "50 */2 * * *"
   name: ci-knative-serving-istio-1.3-mesh
   agent: kubernetes
   decorate: true
@@ -4065,7 +3999,7 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "12 */2 * * *"
+- cron: "1 */2 * * *"
   name: ci-knative-serving-istio-1.3-no-mesh
   agent: kubernetes
   decorate: true
@@ -4084,6 +4018,72 @@ periodics:
       - "./test/e2e-tests.sh"
       - "--istio-version"
       - "1.3-latest"
+      - "--no-mesh"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "50 */2 * * *"
+  name: ci-knative-serving-istio-1.4-mesh
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: master
+    path_alias: knative.dev/serving
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./test/e2e-tests.sh"
+      - "--istio-version"
+      - "1.4-latest"
+      - "--mesh"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "12 */2 * * *"
+  name: ci-knative-serving-istio-1.4-no-mesh
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: master
+    path_alias: knative.dev/serving
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./test/e2e-tests.sh"
+      - "--istio-version"
+      - "1.4-latest"
       - "--no-mesh"
       volumeMounts:
       - name: test-account

--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -3966,7 +3966,7 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "40 */2 * * *"
+- cron: "50 */2 * * *"
   name: ci-knative-serving-istio-1.3-mesh
   agent: kubernetes
   decorate: true
@@ -3999,7 +3999,7 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "1 */2 * * *"
+- cron: "12 */2 * * *"
   name: ci-knative-serving-istio-1.3-no-mesh
   agent: kubernetes
   decorate: true
@@ -4032,7 +4032,7 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "50 */2 * * *"
+- cron: "1 */2 * * *"
   name: ci-knative-serving-istio-1.4-mesh
   agent: kubernetes
   decorate: true
@@ -4065,7 +4065,7 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "12 */2 * * *"
+- cron: "23 */2 * * *"
   name: ci-knative-serving-istio-1.4-no-mesh
   agent: kubernetes
   decorate: true

--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -404,7 +404,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.4-latest --no-mesh"
+        - "./test/e2e-tests.sh --istio-version 1.3-latest --no-mesh"
         volumeMounts:
         - name: repoview-token
           mountPath: /etc/repoview-token
@@ -448,7 +448,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.4-latest --no-mesh"
+        - "./test/e2e-tests.sh --istio-version 1.3-latest --no-mesh"
         volumeMounts:
         - name: repoview-token
           mountPath: /etc/repoview-token
@@ -493,7 +493,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.4-latest --no-mesh"
+        - "./test/e2e-tests.sh --istio-version 1.3-latest --no-mesh"
         volumeMounts:
         - name: repoview-token
           mountPath: /etc/repoview-token
@@ -531,7 +531,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-upgrade-tests.sh --istio-version 1.4-latest --no-mesh"
+        - "./test/e2e-upgrade-tests.sh --istio-version 1.3-latest --no-mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -565,7 +565,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-upgrade-tests.sh --istio-version 1.4-latest --no-mesh"
+        - "./test/e2e-upgrade-tests.sh --istio-version 1.3-latest --no-mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -600,7 +600,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-upgrade-tests.sh --istio-version 1.4-latest --no-mesh"
+        - "./test/e2e-upgrade-tests.sh --istio-version 1.3-latest --no-mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account

--- a/ci/prow/config_knative.yaml
+++ b/ci/prow/config_knative.yaml
@@ -32,29 +32,17 @@ presubmits:
     - integration-tests: true
       args:
       - "--run-test"
-      - "./test/e2e-tests.sh --istio-version 1.2-latest --no-mesh"
+      - "./test/e2e-tests.sh --istio-version 1.4-latest --no-mesh"
     - custom-test: upgrade-tests
       args:
       - "--run-test"
-      - "./test/e2e-upgrade-tests.sh --istio-version 1.2-latest --no-mesh"
+      - "./test/e2e-upgrade-tests.sh --istio-version 1.4-latest --no-mesh"
     - custom-test: smoke-tests
       args:
       - "--run-test"
       - "./test/e2e-smoke-tests.sh"
     - go-coverage: true
       go-coverage-threshold: 80
-    - custom-test: istio-1.2-mesh
-      always_run: false
-      optional: true
-      args:
-      - "--run-test"
-      - "./test/e2e-tests.sh --istio-version 1.2-latest --mesh"
-    - custom-test: istio-1.2-no-mesh
-      always_run: false
-      optional: true
-      args:
-      - "--run-test"
-      - "./test/e2e-tests.sh --istio-version 1.2-latest --no-mesh"
     - custom-test: istio-1.3-mesh
       always_run: false
       optional: true
@@ -66,7 +54,19 @@ presubmits:
       optional: true
       args:
       - "--run-test"
-      - "./test/e2e-tests.sh --istio-version 1.3-latest --no-mesh"
+      - "./test/e2e-tests.sh --istio-version 1.4-latest --no-mesh"
+    - custom-test: istio-1.4-mesh
+      always_run: false
+      optional: true
+      args:
+      - "--run-test"
+      - "./test/e2e-tests.sh --istio-version 1.4-latest --mesh"
+    - custom-test: istio-1.4-no-mesh
+      always_run: false
+      optional: true
+      args:
+      - "--run-test"
+      - "./test/e2e-tests.sh --istio-version 1.4-latest --no-mesh"
     - custom-test: gloo-0.17.1
       always_run: false
       optional: true
@@ -259,20 +259,20 @@ periodics:
       release: "0.10"
       dot-dev: true
       go113: true
-    - custom-job: istio-1.2-mesh
-      full-command: "./test/e2e-tests.sh --istio-version 1.2-latest --mesh"
-      dot-dev: true
-      go113: true
-    - custom-job: istio-1.2-no-mesh
-      full-command: "./test/e2e-tests.sh --istio-version 1.2-latest --no-mesh"
-      dot-dev: true
-      go113: true
     - custom-job: istio-1.3-mesh
       full-command: "./test/e2e-tests.sh --istio-version 1.3-latest --mesh"
       dot-dev: true
       go113: true
     - custom-job: istio-1.3-no-mesh
       full-command: "./test/e2e-tests.sh --istio-version 1.3-latest --no-mesh"
+      dot-dev: true
+      go113: true
+    - custom-job: istio-1.4-mesh
+      full-command: "./test/e2e-tests.sh --istio-version 1.4-latest --mesh"
+      dot-dev: true
+      go113: true
+    - custom-job: istio-1.4-no-mesh
+      full-command: "./test/e2e-tests.sh --istio-version 1.4-latest --no-mesh"
       dot-dev: true
       go113: true
     - custom-job: gloo-0.17.1

--- a/ci/prow/config_knative.yaml
+++ b/ci/prow/config_knative.yaml
@@ -32,11 +32,11 @@ presubmits:
     - integration-tests: true
       args:
       - "--run-test"
-      - "./test/e2e-tests.sh --istio-version 1.4-latest --no-mesh"
+      - "./test/e2e-tests.sh --istio-version 1.3-latest --no-mesh"
     - custom-test: upgrade-tests
       args:
       - "--run-test"
-      - "./test/e2e-upgrade-tests.sh --istio-version 1.4-latest --no-mesh"
+      - "./test/e2e-upgrade-tests.sh --istio-version 1.3-latest --no-mesh"
     - custom-test: smoke-tests
       args:
       - "--run-test"
@@ -54,7 +54,7 @@ presubmits:
       optional: true
       args:
       - "--run-test"
-      - "./test/e2e-tests.sh --istio-version 1.4-latest --no-mesh"
+      - "./test/e2e-tests.sh --istio-version 1.3-latest --no-mesh"
     - custom-test: istio-1.4-mesh
       always_run: false
       optional: true

--- a/ci/prow/testgrid.yaml
+++ b/ci/prow/testgrid.yaml
@@ -60,20 +60,20 @@ test_groups:
   gcs_prefix: knative-prow/logs/ci-knative-serving-continuous
   alert_stale_results_hours: 3
   num_failures_to_alert: 3
-- name: ci-knative-serving-istio-1.2-mesh
-  gcs_prefix: knative-prow/logs/ci-knative-serving-istio-1.2-mesh
-  alert_stale_results_hours: 3
-  num_failures_to_alert: 3
-- name: ci-knative-serving-istio-1.2-no-mesh
-  gcs_prefix: knative-prow/logs/ci-knative-serving-istio-1.2-no-mesh
-  alert_stale_results_hours: 3
-  num_failures_to_alert: 3
 - name: ci-knative-serving-istio-1.3-mesh
   gcs_prefix: knative-prow/logs/ci-knative-serving-istio-1.3-mesh
   alert_stale_results_hours: 3
   num_failures_to_alert: 3
 - name: ci-knative-serving-istio-1.3-no-mesh
   gcs_prefix: knative-prow/logs/ci-knative-serving-istio-1.3-no-mesh
+  alert_stale_results_hours: 3
+  num_failures_to_alert: 3
+- name: ci-knative-serving-istio-1.4-mesh
+  gcs_prefix: knative-prow/logs/ci-knative-serving-istio-1.4-mesh
+  alert_stale_results_hours: 3
+  num_failures_to_alert: 3
+- name: ci-knative-serving-istio-1.4-no-mesh
+  gcs_prefix: knative-prow/logs/ci-knative-serving-istio-1.4-no-mesh
   alert_stale_results_hours: 3
   num_failures_to_alert: 3
 - name: ci-knative-serving-gloo-0.17.1
@@ -269,17 +269,17 @@ dashboards:
   - name: conformance
     test_group_name: ci-knative-serving-continuous
     base_options: "include-filter-by-regex=test/conformance/&sort-by-name="
-  - name: istio-1.2-mesh
-    test_group_name: ci-knative-serving-istio-1.2-mesh
-    base_options: "sort-by-name="
-  - name: istio-1.2-no-mesh
-    test_group_name: ci-knative-serving-istio-1.2-no-mesh
-    base_options: "sort-by-name="
   - name: istio-1.3-mesh
     test_group_name: ci-knative-serving-istio-1.3-mesh
     base_options: "sort-by-name="
   - name: istio-1.3-no-mesh
     test_group_name: ci-knative-serving-istio-1.3-no-mesh
+    base_options: "sort-by-name="
+  - name: istio-1.4-mesh
+    test_group_name: ci-knative-serving-istio-1.4-mesh
+    base_options: "sort-by-name="
+  - name: istio-1.4-no-mesh
+    test_group_name: ci-knative-serving-istio-1.4-no-mesh
     base_options: "sort-by-name="
   - name: gloo-0.17.1
     test_group_name: ci-knative-serving-gloo-0.17.1

--- a/shared/testgrid/testgrid.go
+++ b/shared/testgrid/testgrid.go
@@ -39,10 +39,10 @@ const (
 // jobNameTestgridURLMap contains harded coded mapping of job name: Testgrid tab URL relative to base URL
 var jobNameTestgridURLMap = map[string]string{
 	"ci-knative-serving-continuous":        "serving#continuous",
-	"ci-knative-serving-istio-1.2-mesh":    "serving#istio-1.2-mesh",
-	"ci-knative-serving-istio-1.2-no-mesh": "serving#istio-1.2-no-mesh",
 	"ci-knative-serving-istio-1.3-mesh":    "serving#istio-1.3-mesh",
 	"ci-knative-serving-istio-1.3-no-mesh": "serving#istio-1.3-no-mesh",
+	"ci-knative-serving-istio-1.4-mesh":    "serving#istio-1.4-mesh",
+	"ci-knative-serving-istio-1.4-no-mesh": "serving#istio-1.4-no-mesh",
 	"ci-knative-serving-gloo-0.17.1":       "serving#gloo-0.17.1",
 }
 

--- a/tools/flaky-test-reporter/config/config.yaml
+++ b/tools/flaky-test-reporter/config/config.yaml
@@ -20,18 +20,6 @@ jobConfigs:
     slackChannels:
       - name: serving-api
         identity: CA4DNJ9A4
-  - name: ci-knative-serving-istio-1.2-mesh
-    repo: serving
-    type: postsubmit
-    slackChannels:
-      - name: networking
-        identity: CA9RHBGJX
-  - name: ci-knative-serving-istio-1.2-no-mesh
-    repo: serving
-    type: postsubmit
-    slackChannels:
-      - name: networking
-        identity: CA9RHBGJX
   - name: ci-knative-serving-istio-1.3-mesh
     repo: serving
     type: postsubmit
@@ -39,6 +27,18 @@ jobConfigs:
       - name: networking
         identity: CA9RHBGJX
   - name: ci-knative-serving-istio-1.3-no-mesh
+    repo: serving
+    type: postsubmit
+    slackChannels:
+      - name: networking
+        identity: CA9RHBGJX
+  - name: ci-knative-serving-istio-1.4-mesh
+    repo: serving
+    type: postsubmit
+    slackChannels:
+      - name: networking
+        identity: CA9RHBGJX
+  - name: ci-knative-serving-istio-1.4-no-mesh
     repo: serving
     type: postsubmit
     slackChannels:


### PR DESCRIPTION
This is similar request with https://github.com/knative/serving/issues/5656 and https://github.com/knative/test-infra/pull/1394.

**What this PR does, why we need it**:

This PR has following two changes:

[x] Enable Istio 1.4.0 as it is already included by https://github.com/knative/serving/pull/6097
[x] Remove Istio 1.2.x as it will be EOL on December 13th/2019
[x] Use Istio ~~1.4~~ 1.3 for pull-knative-serving-integration-tests
/lint

