### PR TITLE
Add job for running knative-serving e2e against kourier stable

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -1359,6 +1359,110 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
+  - name: pull-knative-serving-kourier-stable
+    agent: kubernetes
+    context: pull-knative-serving-kourier-stable
+    always_run: false
+    rerun_command: "/test pull-knative-serving-kourier-stable"
+    trigger: "(?m)^/test (all|pull-knative-serving-kourier-stable),?(\\s+|$)"
+    decorate: true
+    optional: true
+    branches:
+    - "release-0.7"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-tests.sh --kourier-version stable"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-serving-kourier-stable
+    agent: kubernetes
+    context: pull-knative-serving-kourier-stable
+    always_run: false
+    rerun_command: "/test pull-knative-serving-kourier-stable"
+    trigger: "(?m)^/test (all|pull-knative-serving-kourier-stable),?(\\s+|$)"
+    decorate: true
+    optional: true
+    path_alias: knative.dev/serving
+    branches:
+    - "release-0.8"
+    - "release-0.9"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-tests.sh --kourier-version stable"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-serving-kourier-stable
+    agent: kubernetes
+    context: pull-knative-serving-kourier-stable
+    always_run: false
+    rerun_command: "/test pull-knative-serving-kourier-stable"
+    trigger: "(?m)^/test (all|pull-knative-serving-kourier-stable),?(\\s+|$)"
+    decorate: true
+    optional: true
+    path_alias: knative.dev/serving
+    skip_branches:
+    - "release-0.7"
+    - "release-0.8"
+    - "release-0.9"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-tests.sh --kourier-version stable"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
   - name: pull-knative-serving-https
     agent: kubernetes
     context: pull-knative-serving-https
@@ -4195,6 +4299,38 @@ periodics:
       - "./test/e2e-tests.sh"
       - "--gloo-version"
       - "0.17.1"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "31 */2 * * *"
+  name: ci-knative-serving-kourier-stable
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: master
+    path_alias: knative.dev/serving
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./test/e2e-tests.sh"
+      - "--kourier-version"
+      - "stable"
       volumeMounts:
       - name: test-account
         mountPath: /etc/test-account

--- a/ci/prow/config_knative.yaml
+++ b/ci/prow/config_knative.yaml
@@ -73,6 +73,12 @@ presubmits:
       args:
       - "--run-test"
       - "./test/e2e-tests.sh --gloo-version 0.17.1"
+    - custom-test: kourier-stable
+      always_run: false
+      optional: true
+      args:
+        - "--run-test"
+        - "./test/e2e-tests.sh --kourier-version stable"
     - custom-test: https
       always_run: false
       optional: true
@@ -283,6 +289,10 @@ periodics:
       go113: true
     - custom-job: gloo-0.17.1
       full-command: "./test/e2e-tests.sh --gloo-version 0.17.1"
+      dot-dev: true
+      go113: true
+    - custom-job: kourier-stable
+      full-command: "./test/e2e-tests.sh --kourier-version stable"
       dot-dev: true
       go113: true
     - nightly: true

--- a/ci/prow/testgrid.yaml
+++ b/ci/prow/testgrid.yaml
@@ -80,6 +80,10 @@ test_groups:
   gcs_prefix: knative-prow/logs/ci-knative-serving-gloo-0.17.1
   alert_stale_results_hours: 3
   num_failures_to_alert: 3
+- name: ci-knative-serving-kourier-stable
+  gcs_prefix: knative-prow/logs/ci-knative-serving-kourier-stable
+  alert_stale_results_hours: 3
+  num_failures_to_alert: 3
 - name: ci-knative-serving-nightly-release
   gcs_prefix: knative-prow/logs/ci-knative-serving-nightly-release
 - name: ci-knative-serving-dot-release
@@ -287,6 +291,9 @@ dashboards:
     base_options: "sort-by-name="
   - name: gloo-0.17.1
     test_group_name: ci-knative-serving-gloo-0.17.1
+    base_options: "sort-by-name="
+  - name: kourier-stable
+    test_group_name: ci-knative-serving-kourier-stable
     base_options: "sort-by-name="
   - name: nightly
     test_group_name: ci-knative-serving-nightly-release

--- a/shared/testgrid/testgrid.go
+++ b/shared/testgrid/testgrid.go
@@ -44,6 +44,7 @@ var jobNameTestgridURLMap = map[string]string{
 	"ci-knative-serving-istio-1.4-mesh":    "serving#istio-1.4-mesh",
 	"ci-knative-serving-istio-1.4-no-mesh": "serving#istio-1.4-no-mesh",
 	"ci-knative-serving-gloo-0.17.1":       "serving#gloo-0.17.1",
+	"ci-knative-serving-kourier-stable":    "serving#kourier-stable",
 }
 
 // GetTestgridTabURL gets Testgrid URL for giving job and filters for Testgrid


### PR DESCRIPTION
/lint

**What this PR does, why we need it**:

* This PR adds support for running the knative-serving e2e tests against Kourier stable.

**Special notes to reviewers**:

related to https://github.com/knative/serving/pull/6136

**User-visible changes in this PR**:

NONE

