### PR TITLE
Add start_knative_eventing to library

### DIFF
--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -443,6 +443,29 @@ function start_latest_knative_serving() {
   start_knative_serving "${KNATIVE_SERVING_RELEASE}"
 }
 
+# Install Knative Eventing in the current cluster.
+# Parameters: $1 - Knative Eventing manifest.
+function start_knative_eventing() {
+  header "Starting Knative Eventing"
+  subheader "Installing Knative Eventing"
+  echo "Installing Eventing CRDs from $1"
+  kubectl apply --selector knative.dev/crd-install=true -f "$1"
+  echo "Installing the rest of eventing components from $1"
+  kubectl apply -f "$1"
+  wait_until_pods_running knative-eventing || return 1
+}
+
+# Install the stable release Knative/eventing in the current cluster.
+# Parameters: $1 - Knative Eventing version number, e.g. 0.6.0.
+function start_release_knative_eventing() {
+  start_knative_eventing "https://storage.googleapis.com/knative-releases/eventing/previous/v$1/release.yaml"
+}
+
+# Install the latest stable Knative Eventing in the current cluster.
+function start_latest_knative_eventing() {
+  start_knative_eventing "${KNATIVE_EVENTING_RELEASE}"
+}
+
 # Run a go tool, installing it first if necessary.
 # Parameters: $1 - tool package/dir for go get/install.
 #             $2 - tool to run.


### PR DESCRIPTION
**What this PR does, why we need it**:

Add `start_knative_eventing` to library, for reuse the function in Knative client, eventing and eventing-contrib.

**Which issue(s) this PR fixes**:
Fixes #1566 
