### PR TITLE
Increase cpu request so that we don't overscheduling

### DIFF
--- a/ci/prow/deployments/cpu_limitrange.yaml
+++ b/ci/prow/deployments/cpu_limitrange.yaml
@@ -22,5 +22,5 @@ spec:
     - default:
         cpu: 4000m
       defaultRequest:
-        cpu: 1000m
+        cpu: 2000m
       type: Container


### PR DESCRIPTION
CPU request was 1 and limit was 4, which results in overscheduling of pods competing for resources, and when a node is busy containers are competing for cpus, this makes some of serving unit test fail due to timeout, this has been repro'ed with KIND on my devbox. Double requested cpu to avoid overscheduling and preventing test from being flaky

Related: https://github.com/knative/serving/issues/6127

/cc @adrcunha 
/cc @chizhg 
