### PR TITLE
Prow job to run serving e2e against ambassador

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -968,6 +968,110 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
+  - name: pull-knative-serving-ambassador-latest
+    agent: kubernetes
+    context: pull-knative-serving-ambassador-latest
+    always_run: false
+    rerun_command: "/test pull-knative-serving-ambassador-latest"
+    trigger: "(?m)^/test (all|pull-knative-serving-ambassador-latest),?(\\s+|$)"
+    decorate: true
+    optional: true
+    branches:
+      - "release-0.7"
+    spec:
+      containers:
+        - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
+          imagePullPolicy: Always
+          command:
+            - runner.sh
+          args:
+            - "./test/presubmit-tests.sh"
+            - "--run-test"
+            - "./test/e2e-tests.sh --ambassador-version 0.86.1"
+          volumeMounts:
+            - name: test-account
+              mountPath: /etc/test-account
+              readOnly: true
+          env:
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /etc/test-account/service-account.json
+            - name: E2E_CLUSTER_REGION
+              value: us-central1
+      volumes:
+        - name: test-account
+          secret:
+            secretName: test-account
+  - name: pull-knative-serving-ambassador-latest
+    agent: kubernetes
+    context: pull-knative-serving-ambassador-latest
+    always_run: false
+    rerun_command: "/test pull-knative-serving-ambassador-latest"
+    trigger: "(?m)^/test (all|pull-knative-serving-ambassador-latest),?(\\s+|$)"
+    decorate: true
+    optional: true
+    path_alias: knative.dev/serving
+    branches:
+      - "release-0.8"
+      - "release-0.9"
+    spec:
+      containers:
+        - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
+          imagePullPolicy: Always
+          command:
+            - runner.sh
+          args:
+            - "./test/presubmit-tests.sh"
+            - "--run-test"
+            - "./test/e2e-tests.sh --ambassador-version 0.86.1"
+          volumeMounts:
+            - name: test-account
+              mountPath: /etc/test-account
+              readOnly: true
+          env:
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /etc/test-account/service-account.json
+            - name: E2E_CLUSTER_REGION
+              value: us-central1
+      volumes:
+        - name: test-account
+          secret:
+            secretName: test-account
+  - name: pull-knative-serving-ambassador-latest
+    agent: kubernetes
+    context: pull-knative-serving-ambassador-latest
+    always_run: false
+    rerun_command: "/test pull-knative-serving-ambassador-latest"
+    trigger: "(?m)^/test (all|pull-knative-serving-ambassador-latest),?(\\s+|$)"
+    decorate: true
+    optional: true
+    path_alias: knative.dev/serving
+    skip_branches:
+      - "release-0.7"
+      - "release-0.8"
+      - "release-0.9"
+    spec:
+      containers:
+        - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+          imagePullPolicy: Always
+          command:
+            - runner.sh
+          args:
+            - "./test/presubmit-tests.sh"
+            - "--run-test"
+            - "./test/e2e-tests.sh --ambassador-version 0.86.1"
+          volumeMounts:
+            - name: test-account
+              mountPath: /etc/test-account
+              readOnly: true
+          env:
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /etc/test-account/service-account.json
+            - name: E2E_CLUSTER_REGION
+              value: us-central1
+      volumes:
+        - name: test-account
+          secret:
+            secretName: test-account
   - name: pull-knative-serving-kourier-stable
     agent: kubernetes
     context: pull-knative-serving-kourier-stable
@@ -5854,6 +5958,38 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
+- cron: "31 */2 * * *"
+  name: ci-knative-serving-ambassador-latest
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+    - org: knative
+      repo: serving
+      base_ref: master
+      path_alias: knative.dev/serving
+  spec:
+    containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+          - runner.sh
+        args:
+          - "./test/e2e-tests.sh"
+          - "--ambassador-version"
+          - "0.86.1"
+        volumeMounts:
+          - name: test-account
+            mountPath: /etc/test-account
+            readOnly: true
+        env:
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /etc/test-account/service-account.json
+          - name: E2E_CLUSTER_REGION
+            value: us-central1
+    volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
 - cron: "56 9 * * *"
   name: ci-knative-serving-nightly-release
   agent: kubernetes

--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -968,110 +968,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-serving-ambassador-latest
-    agent: kubernetes
-    context: pull-knative-serving-ambassador-latest
-    always_run: false
-    rerun_command: "/test pull-knative-serving-ambassador-latest"
-    trigger: "(?m)^/test (all|pull-knative-serving-ambassador-latest),?(\\s+|$)"
-    decorate: true
-    optional: true
-    branches:
-      - "release-0.7"
-    spec:
-      containers:
-        - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
-          imagePullPolicy: Always
-          command:
-            - runner.sh
-          args:
-            - "./test/presubmit-tests.sh"
-            - "--run-test"
-            - "./test/e2e-tests.sh --ambassador-version latest"
-          volumeMounts:
-            - name: test-account
-              mountPath: /etc/test-account
-              readOnly: true
-          env:
-            - name: GOOGLE_APPLICATION_CREDENTIALS
-              value: /etc/test-account/service-account.json
-            - name: E2E_CLUSTER_REGION
-              value: us-central1
-      volumes:
-        - name: test-account
-          secret:
-            secretName: test-account
-  - name: pull-knative-serving-ambassador-latest
-    agent: kubernetes
-    context: pull-knative-serving-ambassador-latest
-    always_run: false
-    rerun_command: "/test pull-knative-serving-ambassador-latest"
-    trigger: "(?m)^/test (all|pull-knative-serving-ambassador-latest),?(\\s+|$)"
-    decorate: true
-    optional: true
-    path_alias: knative.dev/serving
-    branches:
-      - "release-0.8"
-      - "release-0.9"
-    spec:
-      containers:
-        - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
-          imagePullPolicy: Always
-          command:
-            - runner.sh
-          args:
-            - "./test/presubmit-tests.sh"
-            - "--run-test"
-            - "./test/e2e-tests.sh --ambassador-version latest"
-          volumeMounts:
-            - name: test-account
-              mountPath: /etc/test-account
-              readOnly: true
-          env:
-            - name: GOOGLE_APPLICATION_CREDENTIALS
-              value: /etc/test-account/service-account.json
-            - name: E2E_CLUSTER_REGION
-              value: us-central1
-      volumes:
-        - name: test-account
-          secret:
-            secretName: test-account
-  - name: pull-knative-serving-ambassador-latest
-    agent: kubernetes
-    context: pull-knative-serving-ambassador-latest
-    always_run: false
-    rerun_command: "/test pull-knative-serving-ambassador-latest"
-    trigger: "(?m)^/test (all|pull-knative-serving-ambassador-latest),?(\\s+|$)"
-    decorate: true
-    optional: true
-    path_alias: knative.dev/serving
-    skip_branches:
-      - "release-0.7"
-      - "release-0.8"
-      - "release-0.9"
-    spec:
-      containers:
-        - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-          imagePullPolicy: Always
-          command:
-            - runner.sh
-          args:
-            - "./test/presubmit-tests.sh"
-            - "--run-test"
-            - "./test/e2e-tests.sh --ambassador-version latest"
-          volumeMounts:
-            - name: test-account
-              mountPath: /etc/test-account
-              readOnly: true
-          env:
-            - name: GOOGLE_APPLICATION_CREDENTIALS
-              value: /etc/test-account/service-account.json
-            - name: E2E_CLUSTER_REGION
-              value: us-central1
-      volumes:
-        - name: test-account
-          secret:
-            secretName: test-account
   - name: pull-knative-serving-kourier-stable
     agent: kubernetes
     context: pull-knative-serving-kourier-stable
@@ -1199,6 +1095,76 @@ presubmits:
         - "./test/presubmit-tests.sh"
         - "--run-test"
         - "./test/e2e-tests.sh --contour-version latest"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-serving-ambassador-latest
+    agent: kubernetes
+    context: pull-knative-serving-ambassador-latest
+    always_run: false
+    rerun_command: "/test pull-knative-serving-ambassador-latest"
+    trigger: "(?m)^/test (all|pull-knative-serving-ambassador-latest),?(\\s+|$)"
+    decorate: true
+    optional: true
+    path_alias: knative.dev/serving
+    branches:
+    - "release-0.8"
+    - "release-0.9"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-tests.sh --ambassador-version latest"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-serving-ambassador-latest
+    agent: kubernetes
+    context: pull-knative-serving-ambassador-latest
+    always_run: false
+    rerun_command: "/test pull-knative-serving-ambassador-latest"
+    trigger: "(?m)^/test (all|pull-knative-serving-ambassador-latest),?(\\s+|$)"
+    decorate: true
+    optional: true
+    path_alias: knative.dev/serving
+    skip_branches:
+    - "release-0.8"
+    - "release-0.9"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-tests.sh --ambassador-version latest"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -5958,38 +5924,38 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "31 */2 * * *"
+- cron: "56 */2 * * *"
   name: ci-knative-serving-ambassador-latest
   agent: kubernetes
   decorate: true
   extra_refs:
-    - org: knative
-      repo: serving
-      base_ref: master
-      path_alias: knative.dev/serving
+  - org: knative
+    repo: serving
+    base_ref: master
+    path_alias: knative.dev/serving
   spec:
     containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-          - runner.sh
-        args:
-          - "./test/e2e-tests.sh"
-          - "--ambassador-version"
-          - "latest"
-        volumeMounts:
-          - name: test-account
-            mountPath: /etc/test-account
-            readOnly: true
-        env:
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/test-account/service-account.json
-          - name: E2E_CLUSTER_REGION
-            value: us-central1
-    volumes:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./test/e2e-tests.sh"
+      - "--ambassador-version"
+      - "latest"
+      volumeMounts:
       - name: test-account
-        secret:
-          secretName: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
 - cron: "56 9 * * *"
   name: ci-knative-serving-nightly-release
   agent: kubernetes

--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -987,7 +987,7 @@ presubmits:
           args:
             - "./test/presubmit-tests.sh"
             - "--run-test"
-            - "./test/e2e-tests.sh --ambassador-version 0.86.1"
+            - "./test/e2e-tests.sh --ambassador-version latest"
           volumeMounts:
             - name: test-account
               mountPath: /etc/test-account
@@ -1022,7 +1022,7 @@ presubmits:
           args:
             - "./test/presubmit-tests.sh"
             - "--run-test"
-            - "./test/e2e-tests.sh --ambassador-version 0.86.1"
+            - "./test/e2e-tests.sh --ambassador-version latest"
           volumeMounts:
             - name: test-account
               mountPath: /etc/test-account
@@ -1058,7 +1058,7 @@ presubmits:
           args:
             - "./test/presubmit-tests.sh"
             - "--run-test"
-            - "./test/e2e-tests.sh --ambassador-version 0.86.1"
+            - "./test/e2e-tests.sh --ambassador-version latest"
           volumeMounts:
             - name: test-account
               mountPath: /etc/test-account
@@ -5976,7 +5976,7 @@ periodics:
         args:
           - "./test/e2e-tests.sh"
           - "--ambassador-version"
-          - "0.86.1"
+          - "latest"
         volumeMounts:
           - name: test-account
             mountPath: /etc/test-account

--- a/ci/prow/config_knative.yaml
+++ b/ci/prow/config_knative.yaml
@@ -95,6 +95,13 @@ presubmits:
       args:
         - "--run-test"
         - "./test/e2e-tests.sh --contour-version latest"
+    - custom-test: ambassador-latest
+      dot-dev: true
+      always_run: false
+      optional: true
+      args:
+        - "--run-test"
+        - "./test/e2e-tests.sh --ambassador-version 0.86.1"
     - custom-test: https
       dot-dev: true
       always_run: false
@@ -358,6 +365,10 @@ periodics:
       go113: true
     - custom-job: contour-latest
       full-command: "./test/e2e-tests.sh --contour-version latest"
+      dot-dev: true
+      go113: true
+    - custom-job: ambassador-latest
+      full-command: "./test/e2e-tests.sh --ambassador-version 0.86.1"
       dot-dev: true
       go113: true
     - nightly: true

--- a/ci/prow/config_knative.yaml
+++ b/ci/prow/config_knative.yaml
@@ -101,7 +101,7 @@ presubmits:
       optional: true
       args:
         - "--run-test"
-        - "./test/e2e-tests.sh --ambassador-version 0.86.1"
+        - "./test/e2e-tests.sh --ambassador-version latest"
     - custom-test: https
       dot-dev: true
       always_run: false
@@ -368,7 +368,7 @@ periodics:
       dot-dev: true
       go113: true
     - custom-job: ambassador-latest
-      full-command: "./test/e2e-tests.sh --ambassador-version 0.86.1"
+      full-command: "./test/e2e-tests.sh --ambassador-version latest"
       dot-dev: true
       go113: true
     - nightly: true

--- a/ci/prow/testgrid.yaml
+++ b/ci/prow/testgrid.yaml
@@ -88,6 +88,10 @@ test_groups:
   gcs_prefix: knative-prow/logs/ci-knative-serving-contour-latest
   alert_stale_results_hours: 3
   num_failures_to_alert: 3
+- name: ci-knative-serving-ambassador-latest
+  gcs_prefix: knative-prow/logs/ci-knative-serving-ambassador-latest
+  alert_stale_results_hours: 3
+  num_failures_to_alert: 3
 - name: ci-knative-serving-nightly-release
   gcs_prefix: knative-prow/logs/ci-knative-serving-nightly-release
 - name: ci-knative-serving-dot-release
@@ -311,6 +315,9 @@ dashboards:
     base_options: "sort-by-name="
   - name: contour-latest
     test_group_name: ci-knative-serving-contour-latest
+    base_options: "sort-by-name="
+  - name: ambassador-latest
+    test_group_name: ci-knative-serving-ambassador-latest
     base_options: "sort-by-name="
   - name: nightly
     test_group_name: ci-knative-serving-nightly-release

--- a/shared/testgrid/testgrid.go
+++ b/shared/testgrid/testgrid.go
@@ -46,6 +46,7 @@ var jobNameTestgridURLMap = map[string]string{
 	"ci-knative-serving-gloo-0.17.1":       "serving#gloo-0.17.1",
 	"ci-knative-serving-kourier-stable":    "serving#kourier-stable",
 	"ci-knative-serving-contour-latest":    "serving#contour-latest",
+	"ci-knative-serving-ambassador-latest": "serving#ambassador-latest",
 }
 
 // GetTestgridTabURL gets Testgrid URL for giving job and filters for Testgrid

--- a/tools/flaky-test-reporter/config/config.yaml
+++ b/tools/flaky-test-reporter/config/config.yaml
@@ -62,6 +62,12 @@ jobConfigs:
     slackChannels:
       - name: networking
         identity: CA9RHBGJX
+  - name: ci-knative-serving-ambassador-latest
+    repo: serving
+    type: postsubmit
+    slackChannels:
+      - name: networking
+        identity: CA9RHBGJX
   - name: ci-knative-test-infra-continuous
     repo: test-infra
     type: postsubmit


### PR DESCRIPTION
/lint


**What this PR does, why we need it**:

This PR adds support to run Knative Serving's e2e tests with Ambassador latest (currently 0.86.1)

**Special notes to reviewers**:

This PR needs to be merged to run tests at https://github.com/knative/serving/pull/6268

**User-visible changes in this PR**:

None