### PR TITLE
Highlight Knative setup errors in Spyglass logs

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -63,6 +63,9 @@ deck:
           - 'boskos failed to acquire project'
           # cluster creation error
           - 'failed creating test cluster'
+          # Knative setup errors
+          - 'Knative setup failed'
+          - 'timeout waiting for pods to come up'
       required_files:
       - build-log.txt
     - lens:

--- a/ci/prow/templates/prow_config_header.yaml
+++ b/ci/prow/templates/prow_config_header.yaml
@@ -66,6 +66,9 @@ deck:
           - 'boskos failed to acquire project'
           # cluster creation error
           - 'failed creating test cluster'
+          # Knative setup errors
+          - 'Knative setup failed'
+          - 'timeout waiting for pods to come up'
       required_files:
       - build-log.txt
     - lens:


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Highlight Knative setup errors in Spyglass logs by adding two regexes:
- 'Knative setup failed'
- 'timeout waiting for pods to come up'

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @mattmoor 
/cc @adrcunha 
