### PR TITLE
Updated prow and testgrid config licenses for 2020

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2019 The Knative Authors
+# Copyright 2020 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ci/prow/testgrid.yaml
+++ b/ci/prow/testgrid.yaml
@@ -1,4 +1,4 @@
-# Copyright 2019 The Knative Authors
+# Copyright 2020 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:

Build tests fails in 2020 because license header doesn't match. Re-ran `make config` for the new year :D 

Failed message: (from https://prow.knative.dev/view/gcs/knative-prow/pr-logs/pull/knative_test-infra/1605/pull-knative-test-infra-build-tests/1213143733772488704)
```
-------------------------------
---- Checking config files ----
-------------------------------
---- Fri Jan  3 09:03:32 PST 2020
-------------------------------
make: Entering directory '/home/prow/go/src/knative.dev/test-infra/ci/prow'
*** Checking config generator for prow and testgrid
cd /home/prow/go/src/knative.dev/test-infra/ci/prow && go run *_config.go \
	--gcs-bucket=knative-prow \
	--generate-maintenance-jobs=true \
	--image-docker=gcr.io/knative-tests/test-infra \
	--plugins-config-output=/tmp/tmp.cn5x7w7VIt \
	--prow-config-output=/tmp/tmp.nGzeidudBx \
	--prow-host=https://prow.knative.dev \
	--testgrid-config-output=/tmp/tmp.4lmbaJQBOH \
	--testgrid-gcs-bucket=knative-testgrid \
	/home/prow/go/src/knative.dev/test-infra/ci/prow/config_knative.yaml
diff /home/prow/go/src/knative.dev/test-infra/ci/prow/config.yaml /tmp/tmp.nGzeidudBx
1c1
< # Copyright 2019 The Knative Authors
---
> # Copyright 2020 The Knative Authors
Makefile:127: recipe for target 'test' failed
make: *** [test] Error 1
make: Leaving directory '/home/prow/go/src/knative.dev/test-infra/ci/prow'
```

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #

**Special notes to reviewers**:

**User-visible changes in this PR**:

