### PR TITLE
Add CI jobs for new Knative releases

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -135,49 +135,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-serving-build-tests),?(\\s+|$)"
     decorate: true
     branches:
-    - "release-0.7"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--build-tests"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        resources:
-          requests:
-            memory: 12Gi
-          limits:
-            memory: 16Gi
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: test-account
-        secret:
-          secretName: test-account
-  - name: pull-knative-serving-build-tests
-    agent: kubernetes
-    context: pull-knative-serving-build-tests
-    always_run: true
-    rerun_command: "/test pull-knative-serving-build-tests"
-    trigger: "(?m)^/test (all|pull-knative-serving-build-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/serving
-    branches:
     - "release-0.8"
     - "release-0.9"
     spec:
@@ -220,9 +177,7 @@ presubmits:
     rerun_command: "/test pull-knative-serving-build-tests"
     trigger: "(?m)^/test (all|pull-knative-serving-build-tests),?(\\s+|$)"
     decorate: true
-    path_alias: knative.dev/serving
     skip_branches:
-    - "release-0.7"
     - "release-0.8"
     - "release-0.9"
     spec:
@@ -270,48 +225,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-serving-unit-tests),?(\\s+|$)"
     decorate: true
     branches:
-    - "release-0.7"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--unit-tests"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: test-account
-        secret:
-          secretName: test-account
-  - name: pull-knative-serving-unit-tests
-    agent: kubernetes
-    labels:
-      prow.k8s.io/pubsub.project: knative-tests
-      prow.k8s.io/pubsub.topic: knative-monitoring
-      prow.k8s.io/pubsub.runID: pull-knative-serving-unit-tests
-    context: pull-knative-serving-unit-tests
-    always_run: true
-    rerun_command: "/test pull-knative-serving-unit-tests"
-    trigger: "(?m)^/test (all|pull-knative-serving-unit-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/serving
-    branches:
     - "release-0.8"
     - "release-0.9"
     spec:
@@ -353,9 +266,7 @@ presubmits:
     rerun_command: "/test pull-knative-serving-unit-tests"
     trigger: "(?m)^/test (all|pull-knative-serving-unit-tests),?(\\s+|$)"
     decorate: true
-    path_alias: knative.dev/serving
     skip_branches:
-    - "release-0.7"
     - "release-0.8"
     - "release-0.9"
     spec:
@@ -398,49 +309,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-serving-integration-tests),?(\\s+|$)"
     decorate: true
     branches:
-    - "release-0.7"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.3-latest --no-mesh"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: test-account
-        secret:
-          secretName: test-account
-  - name: pull-knative-serving-integration-tests
-    agent: kubernetes
-    labels:
-      prow.k8s.io/pubsub.project: knative-tests
-      prow.k8s.io/pubsub.topic: knative-monitoring
-      prow.k8s.io/pubsub.runID: pull-knative-serving-integration-tests
-    context: pull-knative-serving-integration-tests
-    always_run: true
-    rerun_command: "/test pull-knative-serving-integration-tests"
-    trigger: "(?m)^/test (all|pull-knative-serving-integration-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/serving
-    branches:
     - "release-0.8"
     - "release-0.9"
     spec:
@@ -483,9 +351,7 @@ presubmits:
     rerun_command: "/test pull-knative-serving-integration-tests"
     trigger: "(?m)^/test (all|pull-knative-serving-integration-tests),?(\\s+|$)"
     decorate: true
-    path_alias: knative.dev/serving
     skip_branches:
-    - "release-0.7"
     - "release-0.8"
     - "release-0.9"
     spec:
@@ -525,39 +391,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-serving-upgrade-tests),?(\\s+|$)"
     decorate: true
     branches:
-    - "release-0.7"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--run-test"
-        - "./test/e2e-upgrade-tests.sh --istio-version 1.3-latest --no-mesh"
-        volumeMounts:
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-      volumes:
-      - name: test-account
-        secret:
-          secretName: test-account
-  - name: pull-knative-serving-upgrade-tests
-    agent: kubernetes
-    context: pull-knative-serving-upgrade-tests
-    always_run: true
-    rerun_command: "/test pull-knative-serving-upgrade-tests"
-    trigger: "(?m)^/test (all|pull-knative-serving-upgrade-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/serving
-    branches:
     - "release-0.8"
     - "release-0.9"
     spec:
@@ -590,9 +423,7 @@ presubmits:
     rerun_command: "/test pull-knative-serving-upgrade-tests"
     trigger: "(?m)^/test (all|pull-knative-serving-upgrade-tests),?(\\s+|$)"
     decorate: true
-    path_alias: knative.dev/serving
     skip_branches:
-    - "release-0.7"
     - "release-0.8"
     - "release-0.9"
     spec:
@@ -626,39 +457,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-serving-smoke-tests),?(\\s+|$)"
     decorate: true
     branches:
-    - "release-0.7"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--run-test"
-        - "./test/e2e-smoke-tests.sh"
-        volumeMounts:
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-      volumes:
-      - name: test-account
-        secret:
-          secretName: test-account
-  - name: pull-knative-serving-smoke-tests
-    agent: kubernetes
-    context: pull-knative-serving-smoke-tests
-    always_run: true
-    rerun_command: "/test pull-knative-serving-smoke-tests"
-    trigger: "(?m)^/test (all|pull-knative-serving-smoke-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/serving
-    branches:
     - "release-0.8"
     - "release-0.9"
     spec:
@@ -691,9 +489,7 @@ presubmits:
     rerun_command: "/test pull-knative-serving-smoke-tests"
     trigger: "(?m)^/test (all|pull-knative-serving-smoke-tests),?(\\s+|$)"
     decorate: true
-    path_alias: knative.dev/serving
     skip_branches:
-    - "release-0.7"
     - "release-0.8"
     - "release-0.9"
     spec:
@@ -728,36 +524,6 @@ presubmits:
     optional: true
     decorate: true
     branches:
-    - "release-0.7"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/coverage-go112:latest
-        imagePullPolicy: Always
-        command:
-        - "/coverage"
-        args:
-        - "--postsubmit-job-name=post-knative-serving-go-coverage"
-        - "--artifacts=$(ARTIFACTS)"
-        - "--cov-threshold-percentage=80"
-        - "--github-token=/etc/covbot-token/token"
-        volumeMounts:
-        - name: covbot-token
-          mountPath: /etc/covbot-token
-          readOnly: true
-      volumes:
-      - name: covbot-token
-        secret:
-          secretName: covbot-token
-  - name: pull-knative-serving-go-coverage
-    agent: kubernetes
-    context: pull-knative-serving-go-coverage
-    always_run: true
-    rerun_command: "/test pull-knative-serving-go-coverage"
-    trigger: "(?m)^/test (all|pull-knative-serving-go-coverage),?(\\s+|$)"
-    optional: true
-    decorate: true
-    path_alias: knative.dev/serving
-    branches:
     - "release-0.8"
     - "release-0.9"
     spec:
@@ -787,9 +553,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-serving-go-coverage),?(\\s+|$)"
     optional: true
     decorate: true
-    path_alias: knative.dev/serving
     skip_branches:
-    - "release-0.7"
     - "release-0.8"
     - "release-0.9"
     spec:
@@ -820,7 +584,6 @@ presubmits:
     optional: true
     decorate: true
     skip_branches:
-    - "release-0.7"
     - "release-0.8"
     - "release-0.9"
     spec:
@@ -851,40 +614,6 @@ presubmits:
     decorate: true
     optional: true
     branches:
-    - "release-0.7"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.3-latest --mesh"
-        volumeMounts:
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-      volumes:
-      - name: test-account
-        secret:
-          secretName: test-account
-  - name: pull-knative-serving-istio-1.3-mesh
-    agent: kubernetes
-    context: pull-knative-serving-istio-1.3-mesh
-    always_run: false
-    rerun_command: "/test pull-knative-serving-istio-1.3-mesh"
-    trigger: "(?m)^/test (all|pull-knative-serving-istio-1.3-mesh),?(\\s+|$)"
-    decorate: true
-    optional: true
-    path_alias: knative.dev/serving
-    branches:
     - "release-0.8"
     - "release-0.9"
     spec:
@@ -918,9 +647,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-serving-istio-1.3-mesh),?(\\s+|$)"
     decorate: true
     optional: true
-    path_alias: knative.dev/serving
     skip_branches:
-    - "release-0.7"
     - "release-0.8"
     - "release-0.9"
     spec:
@@ -955,40 +682,6 @@ presubmits:
     decorate: true
     optional: true
     branches:
-    - "release-0.7"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.3-latest --no-mesh"
-        volumeMounts:
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-      volumes:
-      - name: test-account
-        secret:
-          secretName: test-account
-  - name: pull-knative-serving-istio-1.3-no-mesh
-    agent: kubernetes
-    context: pull-knative-serving-istio-1.3-no-mesh
-    always_run: false
-    rerun_command: "/test pull-knative-serving-istio-1.3-no-mesh"
-    trigger: "(?m)^/test (all|pull-knative-serving-istio-1.3-no-mesh),?(\\s+|$)"
-    decorate: true
-    optional: true
-    path_alias: knative.dev/serving
-    branches:
     - "release-0.8"
     - "release-0.9"
     spec:
@@ -1022,9 +715,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-serving-istio-1.3-no-mesh),?(\\s+|$)"
     decorate: true
     optional: true
-    path_alias: knative.dev/serving
     skip_branches:
-    - "release-0.7"
     - "release-0.8"
     - "release-0.9"
     spec:
@@ -1059,40 +750,6 @@ presubmits:
     decorate: true
     optional: true
     branches:
-    - "release-0.7"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.4-latest --mesh"
-        volumeMounts:
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-      volumes:
-      - name: test-account
-        secret:
-          secretName: test-account
-  - name: pull-knative-serving-istio-1.4-mesh
-    agent: kubernetes
-    context: pull-knative-serving-istio-1.4-mesh
-    always_run: false
-    rerun_command: "/test pull-knative-serving-istio-1.4-mesh"
-    trigger: "(?m)^/test (all|pull-knative-serving-istio-1.4-mesh),?(\\s+|$)"
-    decorate: true
-    optional: true
-    path_alias: knative.dev/serving
-    branches:
     - "release-0.8"
     - "release-0.9"
     spec:
@@ -1126,9 +783,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-serving-istio-1.4-mesh),?(\\s+|$)"
     decorate: true
     optional: true
-    path_alias: knative.dev/serving
     skip_branches:
-    - "release-0.7"
     - "release-0.8"
     - "release-0.9"
     spec:
@@ -1163,40 +818,6 @@ presubmits:
     decorate: true
     optional: true
     branches:
-    - "release-0.7"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.4-latest --no-mesh"
-        volumeMounts:
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-      volumes:
-      - name: test-account
-        secret:
-          secretName: test-account
-  - name: pull-knative-serving-istio-1.4-no-mesh
-    agent: kubernetes
-    context: pull-knative-serving-istio-1.4-no-mesh
-    always_run: false
-    rerun_command: "/test pull-knative-serving-istio-1.4-no-mesh"
-    trigger: "(?m)^/test (all|pull-knative-serving-istio-1.4-no-mesh),?(\\s+|$)"
-    decorate: true
-    optional: true
-    path_alias: knative.dev/serving
-    branches:
     - "release-0.8"
     - "release-0.9"
     spec:
@@ -1230,9 +851,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-serving-istio-1.4-no-mesh),?(\\s+|$)"
     decorate: true
     optional: true
-    path_alias: knative.dev/serving
     skip_branches:
-    - "release-0.7"
     - "release-0.8"
     - "release-0.9"
     spec:
@@ -1267,40 +886,6 @@ presubmits:
     decorate: true
     optional: true
     branches:
-    - "release-0.7"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--run-test"
-        - "./test/e2e-tests.sh --gloo-version 0.17.1"
-        volumeMounts:
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-      volumes:
-      - name: test-account
-        secret:
-          secretName: test-account
-  - name: pull-knative-serving-gloo-0.17.1
-    agent: kubernetes
-    context: pull-knative-serving-gloo-0.17.1
-    always_run: false
-    rerun_command: "/test pull-knative-serving-gloo-0.17.1"
-    trigger: "(?m)^/test (all|pull-knative-serving-gloo-0.17.1),?(\\s+|$)"
-    decorate: true
-    optional: true
-    path_alias: knative.dev/serving
-    branches:
     - "release-0.8"
     - "release-0.9"
     spec:
@@ -1334,9 +919,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-serving-gloo-0.17.1),?(\\s+|$)"
     decorate: true
     optional: true
-    path_alias: knative.dev/serving
     skip_branches:
-    - "release-0.7"
     - "release-0.8"
     - "release-0.9"
     spec:
@@ -1371,40 +954,6 @@ presubmits:
     decorate: true
     optional: true
     branches:
-    - "release-0.7"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--run-test"
-        - "./test/e2e-tests.sh --kourier-version stable"
-        volumeMounts:
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-      volumes:
-      - name: test-account
-        secret:
-          secretName: test-account
-  - name: pull-knative-serving-kourier-stable
-    agent: kubernetes
-    context: pull-knative-serving-kourier-stable
-    always_run: false
-    rerun_command: "/test pull-knative-serving-kourier-stable"
-    trigger: "(?m)^/test (all|pull-knative-serving-kourier-stable),?(\\s+|$)"
-    decorate: true
-    optional: true
-    path_alias: knative.dev/serving
-    branches:
     - "release-0.8"
     - "release-0.9"
     spec:
@@ -1438,9 +987,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-serving-kourier-stable),?(\\s+|$)"
     decorate: true
     optional: true
-    path_alias: knative.dev/serving
     skip_branches:
-    - "release-0.7"
     - "release-0.8"
     - "release-0.9"
     spec:
@@ -1474,40 +1021,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-serving-https),?(\\s+|$)"
     decorate: true
     optional: true
-    branches:
-    - "release-0.7"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--run-test"
-        - "./test/e2e-tests.sh --https"
-        volumeMounts:
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-      volumes:
-      - name: test-account
-        secret:
-          secretName: test-account
-  - name: pull-knative-serving-https
-    agent: kubernetes
-    context: pull-knative-serving-https
-    always_run: false
-    rerun_command: "/test pull-knative-serving-https"
-    trigger: "(?m)^/test (all|pull-knative-serving-https),?(\\s+|$)"
-    decorate: true
-    optional: true
-    path_alias: knative.dev/serving
     branches:
     - "release-0.8"
     - "release-0.9"
@@ -1542,9 +1055,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-serving-https),?(\\s+|$)"
     decorate: true
     optional: true
-    path_alias: knative.dev/serving
     skip_branches:
-    - "release-0.7"
     - "release-0.8"
     - "release-0.9"
     spec:
@@ -1956,7 +1467,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-eventing-build-tests),?(\\s+|$)"
     decorate: true
     branches:
-    - "release-0.7"
     - "release-0.8"
     spec:
       containers:
@@ -2044,7 +1554,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/eventing
     skip_branches:
-    - "release-0.7"
     - "release-0.8"
     - "release-0.9"
     - "release-0.10"
@@ -2093,7 +1602,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-eventing-unit-tests),?(\\s+|$)"
     decorate: true
     branches:
-    - "release-0.7"
     - "release-0.8"
     spec:
       containers:
@@ -2179,7 +1687,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/eventing
     skip_branches:
-    - "release-0.7"
     - "release-0.8"
     - "release-0.9"
     - "release-0.10"
@@ -2223,7 +1730,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-eventing-integration-tests),?(\\s+|$)"
     decorate: true
     branches:
-    - "release-0.7"
     - "release-0.8"
     spec:
       containers:
@@ -2309,7 +1815,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/eventing
     skip_branches:
-    - "release-0.7"
     - "release-0.8"
     - "release-0.9"
     - "release-0.10"
@@ -2350,7 +1855,6 @@ presubmits:
     optional: true
     decorate: true
     branches:
-    - "release-0.7"
     - "release-0.8"
     spec:
       containers:
@@ -2412,7 +1916,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/eventing
     skip_branches:
-    - "release-0.7"
     - "release-0.8"
     - "release-0.9"
     - "release-0.10"
@@ -2444,7 +1947,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-eventing-contrib-build-tests),?(\\s+|$)"
     decorate: true
     branches:
-    - "release-0.7"
     - "release-0.8"
     spec:
       containers:
@@ -2532,7 +2034,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/eventing-contrib
     skip_branches:
-    - "release-0.7"
     - "release-0.8"
     - "release-0.9"
     - "release-0.10"
@@ -2581,7 +2082,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-eventing-contrib-unit-tests),?(\\s+|$)"
     decorate: true
     branches:
-    - "release-0.7"
     - "release-0.8"
     spec:
       containers:
@@ -2667,7 +2167,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/eventing-contrib
     skip_branches:
-    - "release-0.7"
     - "release-0.8"
     - "release-0.9"
     - "release-0.10"
@@ -2711,7 +2210,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-eventing-contrib-integration-tests),?(\\s+|$)"
     decorate: true
     branches:
-    - "release-0.7"
     - "release-0.8"
     spec:
       containers:
@@ -2797,7 +2295,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/eventing-contrib
     skip_branches:
-    - "release-0.7"
     - "release-0.8"
     - "release-0.9"
     - "release-0.10"
@@ -2838,7 +2335,6 @@ presubmits:
     optional: true
     decorate: true
     branches:
-    - "release-0.7"
     - "release-0.8"
     spec:
       containers:
@@ -2900,7 +2396,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/eventing-contrib
     skip_branches:
-    - "release-0.7"
     - "release-0.8"
     - "release-0.9"
     - "release-0.10"
@@ -2932,7 +2427,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-docs-build-tests),?(\\s+|$)"
     decorate: true
     branches:
-    - "release-0.7"
     - "release-0.8"
     - "release-0.9"
     - "release-0.10"
@@ -2972,7 +2466,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-docs-build-tests),?(\\s+|$)"
     decorate: true
     skip_branches:
-    - "release-0.7"
     - "release-0.8"
     - "release-0.9"
     - "release-0.10"
@@ -3016,7 +2509,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-docs-unit-tests),?(\\s+|$)"
     decorate: true
     branches:
-    - "release-0.7"
     - "release-0.8"
     - "release-0.9"
     - "release-0.10"
@@ -3060,7 +2552,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-docs-unit-tests),?(\\s+|$)"
     decorate: true
     skip_branches:
-    - "release-0.7"
     - "release-0.8"
     - "release-0.9"
     - "release-0.10"
@@ -3104,7 +2595,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-docs-integration-tests),?(\\s+|$)"
     decorate: true
     branches:
-    - "release-0.7"
     - "release-0.8"
     - "release-0.9"
     - "release-0.10"
@@ -3156,7 +2646,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-docs-integration-tests),?(\\s+|$)"
     decorate: true
     skip_branches:
-    - "release-0.7"
     - "release-0.8"
     - "release-0.9"
     - "release-0.10"
@@ -3205,7 +2694,6 @@ presubmits:
     optional: true
     decorate: true
     branches:
-    - "release-0.7"
     - "release-0.8"
     - "release-0.9"
     - "release-0.10"
@@ -3237,7 +2725,6 @@ presubmits:
     optional: true
     decorate: true
     skip_branches:
-    - "release-0.7"
     - "release-0.8"
     - "release-0.9"
     - "release-0.10"
@@ -3269,7 +2756,6 @@ presubmits:
     decorate: true
     optional: true
     branches:
-    - "release-0.7"
     - "release-0.8"
     - "release-0.9"
     - "release-0.10"
@@ -3303,7 +2789,6 @@ presubmits:
     decorate: true
     optional: true
     skip_branches:
-    - "release-0.7"
     - "release-0.8"
     - "release-0.9"
     - "release-0.10"
@@ -3338,7 +2823,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/pkg
     branches:
-    - "release-0.7"
     - "release-0.8"
     - "release-0.9"
     - "release-0.10"
@@ -3379,7 +2863,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/pkg
     skip_branches:
-    - "release-0.7"
     - "release-0.8"
     - "release-0.9"
     - "release-0.10"
@@ -3424,7 +2907,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/pkg
     branches:
-    - "release-0.7"
     - "release-0.8"
     - "release-0.9"
     - "release-0.10"
@@ -3469,7 +2951,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/pkg
     skip_branches:
-    - "release-0.7"
     - "release-0.8"
     - "release-0.9"
     - "release-0.10"
@@ -3514,7 +2995,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/pkg
     branches:
-    - "release-0.7"
     - "release-0.8"
     - "release-0.9"
     - "release-0.10"
@@ -3559,7 +3039,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/pkg
     skip_branches:
-    - "release-0.7"
     - "release-0.8"
     - "release-0.9"
     - "release-0.10"
@@ -3601,7 +3080,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/pkg
     branches:
-    - "release-0.7"
     - "release-0.8"
     - "release-0.9"
     - "release-0.10"
@@ -3634,7 +3112,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/pkg
     skip_branches:
-    - "release-0.7"
     - "release-0.8"
     - "release-0.9"
     - "release-0.10"
@@ -5868,51 +5345,6 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "39 8 * * *"
-  name: ci-knative-serving-0.7-continuous
-  agent: kubernetes
-  labels:
-    prow.k8s.io/pubsub.project: knative-tests
-    prow.k8s.io/pubsub.topic: knative-monitoring
-    prow.k8s.io/pubsub.runID: ci-knative-serving-0.7-continuous
-  decorate: true
-  extra_refs:
-  - org: knative
-    repo: serving
-    base_ref: release-0.7
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./hack/release.sh"
-      - "--nopublish"
-      - "--notag-release"
-      securityContext:
-        privileged: true
-      volumeMounts:
-      - name: docker-graph
-        mountPath: /docker-graph
-      - name: test-account
-        mountPath: /etc/test-account
-        readOnly: true
-      env:
-      - name: DOCKER_IN_DOCKER_ENABLED
-        value: "true"
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/test-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-      - name: PULL_BASE_REF
-        value: release-0.7
-    volumes:
-    - name: docker-graph
-      emptyDir: {}
-    - name: test-account
-      secret:
-        secretName: test-account
 - cron: "40 8 * * *"
   name: ci-knative-serving-0.8-continuous
   agent: kubernetes
@@ -6045,6 +5477,52 @@ periodics:
         value: us-central1
       - name: PULL_BASE_REF
         value: release-0.10
+    volumes:
+    - name: docker-graph
+      emptyDir: {}
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "48 8 * * *"
+  name: ci-knative-serving-0.11-continuous
+  agent: kubernetes
+  labels:
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-knative-serving-0.11-continuous
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: release-0.11
+    path_alias: knative.dev/serving
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--nopublish"
+      - "--notag-release"
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - name: docker-graph
+        mountPath: /docker-graph
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.11
     volumes:
     - name: docker-graph
       emptyDir: {}
@@ -6475,6 +5953,52 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
+- cron: "32 8 * * *"
+  name: ci-knative-client-0.11-continuous
+  agent: kubernetes
+  labels:
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-knative-client-0.11-continuous
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: client
+    base_ref: release-0.11
+    path_alias: knative.dev/client
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--nopublish"
+      - "--notag-release"
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - name: docker-graph
+        mountPath: /docker-graph
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.11
+    volumes:
+    - name: docker-graph
+      emptyDir: {}
+    - name: test-account
+      secret:
+        secretName: test-account
 - cron: "40 9 * * *"
   name: ci-knative-client-nightly-release
   agent: kubernetes
@@ -6754,51 +6278,6 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "58 8 * * *"
-  name: ci-knative-eventing-0.7-continuous
-  agent: kubernetes
-  labels:
-    prow.k8s.io/pubsub.project: knative-tests
-    prow.k8s.io/pubsub.topic: knative-monitoring
-    prow.k8s.io/pubsub.runID: ci-knative-eventing-0.7-continuous
-  decorate: true
-  extra_refs:
-  - org: knative
-    repo: eventing
-    base_ref: release-0.7
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./hack/release.sh"
-      - "--nopublish"
-      - "--notag-release"
-      securityContext:
-        privileged: true
-      volumeMounts:
-      - name: docker-graph
-        mountPath: /docker-graph
-      - name: test-account
-        mountPath: /etc/test-account
-        readOnly: true
-      env:
-      - name: DOCKER_IN_DOCKER_ENABLED
-        value: "true"
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/test-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-      - name: PULL_BASE_REF
-        value: release-0.7
-    volumes:
-    - name: docker-graph
-      emptyDir: {}
-    - name: test-account
-      secret:
-        secretName: test-account
 - cron: "9 8 * * *"
   name: ci-knative-eventing-0.8-continuous
   agent: kubernetes
@@ -6930,6 +6409,52 @@ periodics:
         value: us-central1
       - name: PULL_BASE_REF
         value: release-0.10
+    volumes:
+    - name: docker-graph
+      emptyDir: {}
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "7 8 * * *"
+  name: ci-knative-eventing-0.11-continuous
+  agent: kubernetes
+  labels:
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-knative-eventing-0.11-continuous
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: eventing
+    base_ref: release-0.11
+    path_alias: knative.dev/eventing
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--nopublish"
+      - "--notag-release"
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - name: docker-graph
+        mountPath: /docker-graph
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.11
     volumes:
     - name: docker-graph
       emptyDir: {}
@@ -7137,51 +6662,6 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "53 8 * * *"
-  name: ci-knative-eventing-contrib-0.7-continuous
-  agent: kubernetes
-  labels:
-    prow.k8s.io/pubsub.project: knative-tests
-    prow.k8s.io/pubsub.topic: knative-monitoring
-    prow.k8s.io/pubsub.runID: ci-knative-eventing-contrib-0.7-continuous
-  decorate: true
-  extra_refs:
-  - org: knative
-    repo: eventing-contrib
-    base_ref: release-0.7
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./hack/release.sh"
-      - "--nopublish"
-      - "--notag-release"
-      securityContext:
-        privileged: true
-      volumeMounts:
-      - name: docker-graph
-        mountPath: /docker-graph
-      - name: test-account
-        mountPath: /etc/test-account
-        readOnly: true
-      env:
-      - name: DOCKER_IN_DOCKER_ENABLED
-        value: "true"
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/test-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-      - name: PULL_BASE_REF
-        value: release-0.7
-    volumes:
-    - name: docker-graph
-      emptyDir: {}
-    - name: test-account
-      secret:
-        secretName: test-account
 - cron: "4 8 * * *"
   name: ci-knative-eventing-contrib-0.8-continuous
   agent: kubernetes
@@ -7313,6 +6793,52 @@ periodics:
         value: us-central1
       - name: PULL_BASE_REF
         value: release-0.10
+    volumes:
+    - name: docker-graph
+      emptyDir: {}
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "2 8 * * *"
+  name: ci-knative-eventing-contrib-0.11-continuous
+  agent: kubernetes
+  labels:
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-knative-eventing-contrib-0.11-continuous
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: eventing-contrib
+    base_ref: release-0.11
+    path_alias: knative.dev/eventing-contrib
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--nopublish"
+      - "--notag-release"
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - name: docker-graph
+        mountPath: /docker-graph
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.11
     volumes:
     - name: docker-graph
       emptyDir: {}
@@ -7768,6 +7294,52 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
+- cron: "15 8 * * *"
+  name: ci-knative-serving-operator-0.11-continuous
+  agent: kubernetes
+  labels:
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-knative-serving-operator-0.11-continuous
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: serving-operator
+    base_ref: release-0.11
+    path_alias: knative.dev/serving-operator
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--nopublish"
+      - "--notag-release"
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - name: docker-graph
+        mountPath: /docker-graph
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.11
+    volumes:
+    - name: docker-graph
+      emptyDir: {}
+    - name: test-account
+      secret:
+        secretName: test-account
 - cron: "23 9 * * *"
   name: ci-knative-serving-operator-nightly-release
   agent: kubernetes
@@ -7976,6 +7548,52 @@ periodics:
       - name: E2E_CLUSTER_REGION
         value: us-central1
     volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "34 8 * * *"
+  name: ci-knative-eventing-operator-0.11-continuous
+  agent: kubernetes
+  labels:
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-knative-eventing-operator-0.11-continuous
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: eventing-operator
+    base_ref: release-0.11
+    path_alias: knative.dev/eventing-operator
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--nopublish"
+      - "--notag-release"
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - name: docker-graph
+        mountPath: /docker-graph
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.11
+    volumes:
+    - name: docker-graph
+      emptyDir: {}
     - name: test-account
       secret:
         secretName: test-account

--- a/ci/prow/config_knative.yaml
+++ b/ci/prow/config_knative.yaml
@@ -16,10 +16,7 @@ presubmits:
   knative/serving:
     - repo-settings:
       performance: true
-      legacy-branches:
-      - release-0.7
       go112-branches:
-      - release-0.7
       - release-0.8
       - release-0.9
     - build-tests: true
@@ -109,10 +106,8 @@ presubmits:
     - repo-settings:
       performance: true
       legacy-branches:
-      - release-0.7
       - release-0.8
       go112-branches:
-      - release-0.7
       - release-0.8
       - release-0.9
       - release-0.10
@@ -129,10 +124,8 @@ presubmits:
   knative/eventing-contrib:
     - repo-settings:
       legacy-branches:
-      - release-0.7
       - release-0.8
       go112-branches:
-      - release-0.7
       - release-0.8
       - release-0.9
       - release-0.10
@@ -149,7 +142,6 @@ presubmits:
   knative/docs:
     - repo-settings:
       go112-branches:
-      - release-0.7
       - release-0.8
       - release-0.9
       - release-0.10
@@ -167,7 +159,6 @@ presubmits:
   knative/pkg:
     - repo-settings:
       go112-branches:
-      - release-0.7
       - release-0.8
       - release-0.9
       - release-0.10
@@ -308,8 +299,6 @@ periodics:
         limits:
           memory: 16Gi
     - branch-ci: true
-      release: "0.7"
-    - branch-ci: true
       release: "0.8"
       dot-dev: true
     - branch-ci: true
@@ -317,6 +306,10 @@ periodics:
       dot-dev: true
     - branch-ci: true
       release: "0.10"
+      dot-dev: true
+      go113: true
+    - branch-ci: true
+      release: "0.11"
       dot-dev: true
       go113: true
     - custom-job: istio-1.3-mesh
@@ -375,6 +368,10 @@ periodics:
     - continuous: true
       dot-dev: true
       go113: true
+    - branch-ci: true
+      release: "0.11"
+      dot-dev: true
+      go113: true
     - nightly: true
       dot-dev: true
       go113: true
@@ -408,8 +405,6 @@ periodics:
         limits:
           memory: 16Gi
     - branch-ci: true
-      release: "0.7"
-    - branch-ci: true
       release: "0.8"
     - branch-ci: true
       release: "0.9"
@@ -417,6 +412,10 @@ periodics:
     - branch-ci: true
       release: "0.10"
       dot-dev: true
+    - branch-ci: true
+      release: "0.11"
+      dot-dev: true
+      go113: true
     - nightly: true
       dot-dev: true
       go113: true
@@ -452,8 +451,6 @@ periodics:
         limits:
           memory: 16Gi
     - branch-ci: true
-      release: "0.7"
-    - branch-ci: true
       release: "0.8"
     - branch-ci: true
       release: "0.9"
@@ -461,6 +458,10 @@ periodics:
     - branch-ci: true
       release: "0.10"
       dot-dev: true
+    - branch-ci: true
+      release: "0.11"
+      dot-dev: true
+      go113: true
     - nightly: true
       dot-dev: true
       go113: true
@@ -519,6 +520,10 @@ periodics:
     - continuous: true
       dot-dev: true
       go113: true
+    - branch-ci: true
+      release: "0.11"
+      dot-dev: true
+      go113: true
     - nightly: true
       dot-dev: true
       go113: true
@@ -535,6 +540,10 @@ periodics:
 
   knative/eventing-operator:
     - continuous: true
+      dot-dev: true
+      go113: true
+    - branch-ci: true
+      release: "0.11"
       dot-dev: true
       go113: true
     - nightly: true

--- a/ci/prow/testgrid.yaml
+++ b/ci/prow/testgrid.yaml
@@ -232,12 +232,6 @@ test_groups:
   gcs_prefix: knative-prow/logs/ci-knative-eventing-operator-go-coverage
   num_failures_to_alert: 9999
   short_text_metric: "coverage"
-- name: ci-knative-serving-0.7-continuous
-  gcs_prefix: knative-prow/logs/ci-knative-serving-0.7-continuous
-- name: ci-knative-eventing-0.7-continuous
-  gcs_prefix: knative-prow/logs/ci-knative-eventing-0.7-continuous
-- name: ci-knative-eventing-contrib-0.7-continuous
-  gcs_prefix: knative-prow/logs/ci-knative-eventing-contrib-0.7-continuous
 - name: ci-knative-serving-0.8-continuous
   gcs_prefix: knative-prow/logs/ci-knative-serving-0.8-continuous
 - name: ci-knative-eventing-0.8-continuous
@@ -256,6 +250,18 @@ test_groups:
   gcs_prefix: knative-prow/logs/ci-knative-eventing-0.10-continuous
 - name: ci-knative-eventing-contrib-0.10-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-contrib-0.10-continuous
+- name: ci-knative-serving-0.11-continuous
+  gcs_prefix: knative-prow/logs/ci-knative-serving-0.11-continuous
+- name: ci-knative-client-0.11-continuous
+  gcs_prefix: knative-prow/logs/ci-knative-client-0.11-continuous
+- name: ci-knative-eventing-0.11-continuous
+  gcs_prefix: knative-prow/logs/ci-knative-eventing-0.11-continuous
+- name: ci-knative-eventing-contrib-0.11-continuous
+  gcs_prefix: knative-prow/logs/ci-knative-eventing-contrib-0.11-continuous
+- name: ci-knative-serving-operator-0.11-continuous
+  gcs_prefix: knative-prow/logs/ci-knative-serving-operator-0.11-continuous
+- name: ci-knative-eventing-operator-0.11-continuous
+  gcs_prefix: knative-prow/logs/ci-knative-eventing-operator-0.11-continuous
 - name: ci-google-knative-gcp-continuous
   gcs_prefix: knative-prow/logs/ci-google-knative-gcp-continuous
   alert_stale_results_hours: 3
@@ -469,17 +475,6 @@ dashboards:
   - name: coverage
     test_group_name: pull-google-knative-gcp-test-coverage
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
-- name: knative-0.7
-  dashboard_tab:
-  - name: serving
-    test_group_name: ci-knative-serving-0.7-continuous
-    base_options: "sort-by-name="
-  - name: eventing
-    test_group_name: ci-knative-eventing-0.7-continuous
-    base_options: "sort-by-name="
-  - name: eventing-contrib
-    test_group_name: ci-knative-eventing-contrib-0.7-continuous
-    base_options: "sort-by-name="
 - name: knative-0.8
   dashboard_tab:
   - name: serving
@@ -512,6 +507,26 @@ dashboards:
     base_options: "sort-by-name="
   - name: eventing-contrib
     test_group_name: ci-knative-eventing-contrib-0.10-continuous
+    base_options: "sort-by-name="
+- name: knative-0.11
+  dashboard_tab:
+  - name: serving
+    test_group_name: ci-knative-serving-0.11-continuous
+    base_options: "sort-by-name="
+  - name: client
+    test_group_name: ci-knative-client-0.11-continuous
+    base_options: "sort-by-name="
+  - name: eventing
+    test_group_name: ci-knative-eventing-0.11-continuous
+    base_options: "sort-by-name="
+  - name: eventing-contrib
+    test_group_name: ci-knative-eventing-contrib-0.11-continuous
+    base_options: "sort-by-name="
+  - name: serving-operator
+    test_group_name: ci-knative-serving-operator-0.11-continuous
+    base_options: "sort-by-name="
+  - name: eventing-operator
+    test_group_name: ci-knative-eventing-operator-0.11-continuous
     base_options: "sort-by-name="
 dashboard_groups:
 - name: knative


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
1. Add CI jobs for Knative release-0.11, and remove for release-0.7
2. Also add CI jobs for `client`, `serving-operator` and `eventing-operator`, as they also started cutting releases in each Knative release cycle.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @adrcunha 
