### PR TITLE
Add dot-dev for all Serving jobs

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -134,6 +134,7 @@ presubmits:
     rerun_command: "/test pull-knative-serving-build-tests"
     trigger: "(?m)^/test (all|pull-knative-serving-build-tests),?(\\s+|$)"
     decorate: true
+    path_alias: knative.dev/serving
     branches:
     - "release-0.8"
     - "release-0.9"
@@ -177,6 +178,7 @@ presubmits:
     rerun_command: "/test pull-knative-serving-build-tests"
     trigger: "(?m)^/test (all|pull-knative-serving-build-tests),?(\\s+|$)"
     decorate: true
+    path_alias: knative.dev/serving
     skip_branches:
     - "release-0.8"
     - "release-0.9"
@@ -224,6 +226,7 @@ presubmits:
     rerun_command: "/test pull-knative-serving-unit-tests"
     trigger: "(?m)^/test (all|pull-knative-serving-unit-tests),?(\\s+|$)"
     decorate: true
+    path_alias: knative.dev/serving
     branches:
     - "release-0.8"
     - "release-0.9"
@@ -266,6 +269,7 @@ presubmits:
     rerun_command: "/test pull-knative-serving-unit-tests"
     trigger: "(?m)^/test (all|pull-knative-serving-unit-tests),?(\\s+|$)"
     decorate: true
+    path_alias: knative.dev/serving
     skip_branches:
     - "release-0.8"
     - "release-0.9"
@@ -308,6 +312,7 @@ presubmits:
     rerun_command: "/test pull-knative-serving-integration-tests"
     trigger: "(?m)^/test (all|pull-knative-serving-integration-tests),?(\\s+|$)"
     decorate: true
+    path_alias: knative.dev/serving
     branches:
     - "release-0.8"
     - "release-0.9"
@@ -351,6 +356,7 @@ presubmits:
     rerun_command: "/test pull-knative-serving-integration-tests"
     trigger: "(?m)^/test (all|pull-knative-serving-integration-tests),?(\\s+|$)"
     decorate: true
+    path_alias: knative.dev/serving
     skip_branches:
     - "release-0.8"
     - "release-0.9"
@@ -390,6 +396,7 @@ presubmits:
     rerun_command: "/test pull-knative-serving-upgrade-tests"
     trigger: "(?m)^/test (all|pull-knative-serving-upgrade-tests),?(\\s+|$)"
     decorate: true
+    path_alias: knative.dev/serving
     branches:
     - "release-0.8"
     - "release-0.9"
@@ -423,6 +430,7 @@ presubmits:
     rerun_command: "/test pull-knative-serving-upgrade-tests"
     trigger: "(?m)^/test (all|pull-knative-serving-upgrade-tests),?(\\s+|$)"
     decorate: true
+    path_alias: knative.dev/serving
     skip_branches:
     - "release-0.8"
     - "release-0.9"
@@ -456,6 +464,7 @@ presubmits:
     rerun_command: "/test pull-knative-serving-smoke-tests"
     trigger: "(?m)^/test (all|pull-knative-serving-smoke-tests),?(\\s+|$)"
     decorate: true
+    path_alias: knative.dev/serving
     branches:
     - "release-0.8"
     - "release-0.9"
@@ -489,6 +498,7 @@ presubmits:
     rerun_command: "/test pull-knative-serving-smoke-tests"
     trigger: "(?m)^/test (all|pull-knative-serving-smoke-tests),?(\\s+|$)"
     decorate: true
+    path_alias: knative.dev/serving
     skip_branches:
     - "release-0.8"
     - "release-0.9"
@@ -523,6 +533,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-serving-go-coverage),?(\\s+|$)"
     optional: true
     decorate: true
+    path_alias: knative.dev/serving
     branches:
     - "release-0.8"
     - "release-0.9"
@@ -553,6 +564,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-serving-go-coverage),?(\\s+|$)"
     optional: true
     decorate: true
+    path_alias: knative.dev/serving
     skip_branches:
     - "release-0.8"
     - "release-0.9"
@@ -583,6 +595,7 @@ presubmits:
     trigger: "(?m)^/test (pull-knative-serving-go-coverage-dev),?(\\s+|$)"
     optional: true
     decorate: true
+    path_alias: knative.dev/serving
     skip_branches:
     - "release-0.8"
     - "release-0.9"
@@ -613,6 +626,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-serving-istio-1.3-mesh),?(\\s+|$)"
     decorate: true
     optional: true
+    path_alias: knative.dev/serving
     branches:
     - "release-0.8"
     - "release-0.9"
@@ -647,6 +661,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-serving-istio-1.3-mesh),?(\\s+|$)"
     decorate: true
     optional: true
+    path_alias: knative.dev/serving
     skip_branches:
     - "release-0.8"
     - "release-0.9"
@@ -681,6 +696,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-serving-istio-1.3-no-mesh),?(\\s+|$)"
     decorate: true
     optional: true
+    path_alias: knative.dev/serving
     branches:
     - "release-0.8"
     - "release-0.9"
@@ -715,6 +731,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-serving-istio-1.3-no-mesh),?(\\s+|$)"
     decorate: true
     optional: true
+    path_alias: knative.dev/serving
     skip_branches:
     - "release-0.8"
     - "release-0.9"
@@ -749,6 +766,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-serving-istio-1.4-mesh),?(\\s+|$)"
     decorate: true
     optional: true
+    path_alias: knative.dev/serving
     branches:
     - "release-0.8"
     - "release-0.9"
@@ -783,6 +801,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-serving-istio-1.4-mesh),?(\\s+|$)"
     decorate: true
     optional: true
+    path_alias: knative.dev/serving
     skip_branches:
     - "release-0.8"
     - "release-0.9"
@@ -817,6 +836,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-serving-istio-1.4-no-mesh),?(\\s+|$)"
     decorate: true
     optional: true
+    path_alias: knative.dev/serving
     branches:
     - "release-0.8"
     - "release-0.9"
@@ -851,6 +871,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-serving-istio-1.4-no-mesh),?(\\s+|$)"
     decorate: true
     optional: true
+    path_alias: knative.dev/serving
     skip_branches:
     - "release-0.8"
     - "release-0.9"
@@ -885,6 +906,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-serving-gloo-0.17.1),?(\\s+|$)"
     decorate: true
     optional: true
+    path_alias: knative.dev/serving
     branches:
     - "release-0.8"
     - "release-0.9"
@@ -919,6 +941,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-serving-gloo-0.17.1),?(\\s+|$)"
     decorate: true
     optional: true
+    path_alias: knative.dev/serving
     skip_branches:
     - "release-0.8"
     - "release-0.9"
@@ -953,6 +976,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-serving-kourier-stable),?(\\s+|$)"
     decorate: true
     optional: true
+    path_alias: knative.dev/serving
     branches:
     - "release-0.8"
     - "release-0.9"
@@ -987,6 +1011,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-serving-kourier-stable),?(\\s+|$)"
     decorate: true
     optional: true
+    path_alias: knative.dev/serving
     skip_branches:
     - "release-0.8"
     - "release-0.9"
@@ -1021,6 +1046,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-serving-https),?(\\s+|$)"
     decorate: true
     optional: true
+    path_alias: knative.dev/serving
     branches:
     - "release-0.8"
     - "release-0.9"
@@ -1055,6 +1081,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-serving-https),?(\\s+|$)"
     decorate: true
     optional: true
+    path_alias: knative.dev/serving
     skip_branches:
     - "release-0.8"
     - "release-0.9"

--- a/ci/prow/config_knative.yaml
+++ b/ci/prow/config_knative.yaml
@@ -20,63 +20,76 @@ presubmits:
       - release-0.8
       - release-0.9
     - build-tests: true
+      dot-dev: true
       resources:
         requests:
           memory: 12Gi # Real request for this pod is 16 as sidecar requests 4
         limits:
           memory: 16Gi
     - unit-tests: true
+      dot-dev: true
     - integration-tests: true
+      dot-dev: true
       args:
       - "--run-test"
       - "./test/e2e-tests.sh --istio-version 1.3-latest --no-mesh"
     - custom-test: upgrade-tests
+      dot-dev: true
       args:
       - "--run-test"
       - "./test/e2e-upgrade-tests.sh --istio-version 1.3-latest --no-mesh"
     - custom-test: smoke-tests
+      dot-dev: true
       args:
       - "--run-test"
       - "./test/e2e-smoke-tests.sh"
     - go-coverage: true
       go-coverage-threshold: 80
+      dot-dev: true
     - custom-test: istio-1.3-mesh
+      dot-dev: true
       always_run: false
       optional: true
       args:
       - "--run-test"
       - "./test/e2e-tests.sh --istio-version 1.3-latest --mesh"
     - custom-test: istio-1.3-no-mesh
+      dot-dev: true
       always_run: false
       optional: true
       args:
       - "--run-test"
       - "./test/e2e-tests.sh --istio-version 1.3-latest --no-mesh"
     - custom-test: istio-1.4-mesh
+      dot-dev: true
       always_run: false
       optional: true
       args:
       - "--run-test"
       - "./test/e2e-tests.sh --istio-version 1.4-latest --mesh"
     - custom-test: istio-1.4-no-mesh
+      dot-dev: true
       always_run: false
       optional: true
       args:
       - "--run-test"
       - "./test/e2e-tests.sh --istio-version 1.4-latest --no-mesh"
     - custom-test: gloo-0.17.1
+      dot-dev: true
       always_run: false
       optional: true
       args:
       - "--run-test"
       - "./test/e2e-tests.sh --gloo-version 0.17.1"
     - custom-test: kourier-stable
+      dot-dev: true
       always_run: false
       optional: true
       args:
         - "--run-test"
         - "./test/e2e-tests.sh --kourier-version stable"
     - custom-test: https
+      dot-dev: true
       always_run: false
       optional: true
       args:


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Fix the broken Prow config caused by https://github.com/knative/test-infra/pull/1608.

If there is no `legacy-branches` for a Knative project, every meta job config must have `dot-dev` to be true to add `path_alias` for the Prow job config.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @adrcunha 
