### PR TITLE
Increase unit test run count to 5 to reduce flakiness

### DIFF
--- a/scripts/presubmit-tests.sh
+++ b/scripts/presubmit-tests.sh
@@ -231,7 +231,7 @@ function run_unit_tests() {
 
 # Default unit test runner that runs all go tests in the repo.
 function default_unit_test_runner() {
-  report_go_test -race ./...
+  report_go_test -race -count=5 ./...
 }
 
 # Run integration tests. If there's no `integration_tests` function, run the


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:
/assign @mattmoor 
/lint
-->

**What this PR does, why we need it**:
`-count=1` is not enough to catch data races and other sources of flakiness in the unit tests.
This increases the test run count to 5 to increase the likelihood to catch those issues early on.

Ideally, it should be higher than 5, but we don't want to make the execution of the unit tests leg too long.
