### PR TITLE
Enable cloudscheduler API for boskos projects

### DIFF
--- a/ci/prow/set_boskos_permissions.sh
+++ b/ci/prow/set_boskos_permissions.sh
@@ -65,6 +65,7 @@ readonly RESOURCES=(
     "cloudresourcemanager.googleapis.com"
     "compute.googleapis.com"
     "container.googleapis.com"
+    "cloudscheduler.googleapis.com"
 )
 
 # Loop through the list of resources and add them.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
We are adding an e2e test for `SchedulerSource` in knative-gcp project, and it requires `cloudscheduler` API to be enabled, see https://github.com/google/knative-gcp/tree/master/docs/scheduler. 
This PR will enable the API for our boskos projects.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @adrcunha 
/cc @chaodaiG 
FYI @petereberlein 
