### PR TITLE
Add Scheduler admin role to Prow test service account

### DIFF
--- a/ci/prow/set_boskos_permissions.sh
+++ b/ci/prow/set_boskos_permissions.sh
@@ -58,6 +58,9 @@ readonly RESOURCES=(
     "roles/logging.configWriter"
     "prow-job@knative-tests.iam.gserviceaccount.com"
 
+    "roles/cloudscheduler.admin"
+    "prow-job@knative-tests.iam.gserviceaccount.com"
+
     "roles/viewer"
     "knative-dev@googlegroups.com"
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
We also need Scheduler admin role running e2e test for `SchedulerSource` in knative-gcp project, which I missed in https://github.com/knative/test-infra/pull/1618

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @adrcunha 
/cc @chaodaiG 
FYI @petereberlein 
