### PR TITLE
Create App Engine app for boskos projects

### DIFF
--- a/ci/prow/README.md
+++ b/ci/prow/README.md
@@ -17,7 +17,6 @@ This directory contains the config for our
   `plugins.yaml` and `testgrid.yaml` from `config_knative.yaml`.
 - `plugins.yaml` Generated configuration of the Prow plugins.
 - `run_job.sh` Convenience script to start a Prow job from command-line.
-- `set_boskos_permissions.sh` Script to set up permissions for a Boskos project.
+- `set_up_boskos_project.sh` Script to set up a Boskos project.
 - `testgrid.yaml` Generated Testgrid configuration.
-- `update_all_boskos_permissions.sh` Script to reset permissions in Boskos
-  projects.
+- `update_all_boskos_projects.sh` Script to set up all Boskos projects.

--- a/ci/prow/set_boskos_permissions.sh
+++ b/ci/prow/set_boskos_permissions.sh
@@ -99,3 +99,8 @@ curl -s -X GET -H "Authorization: Bearer ${ACCESS_TOKEN}" "https://www.googleapi
 gcloud projects add-iam-policy-binding ${PROJECT} \
   --member="serviceAccount:service-${PROJECT_NUMBER}@gs-project-accounts.iam.gserviceaccount.com" \
   --role roles/pubsub.publisher
+
+# As required by step 1 in https://github.com/google/knative-gcp/tree/master/docs/scheduler,
+# create an App Engine app.
+# We use us-central here, but it indeed does not matter which region this app is created in.
+gcloud app create --region=us-central

--- a/ci/prow/set_up_boskos_project.sh
+++ b/ci/prow/set_up_boskos_project.sh
@@ -106,4 +106,4 @@ gcloud projects add-iam-policy-binding ${PROJECT} \
 #
 # This command will throw an error if the app is already created, but since we expect to run
 # this script idempotently, we always mark this command as succeeded.
-gcloud app create --region=us-central || true
+gcloud app create --region=us-central || echo "AppEngine app probably already exists, ignoring..."

--- a/ci/prow/set_up_boskos_project.sh
+++ b/ci/prow/set_up_boskos_project.sh
@@ -19,7 +19,7 @@ set -e
 readonly PROJECT=${1:?"First argument must be the boskos project name."}
 # Remaining arguments are resources to be added, just like the RESOURCES array below.
 # For example, this command add an extra editor to the project:
-# $ set_boskos_permissions.sh my-boskos roles/editor my@service-account.com
+# $ set_up_boskos_project.sh my-boskos roles/editor my@service-account.com
 shift
 
 if [[ ! -f $HOME/.config/gcloud/application_default_credentials.json ]]; then
@@ -103,4 +103,7 @@ gcloud projects add-iam-policy-binding ${PROJECT} \
 # As required by step 1 in https://github.com/google/knative-gcp/tree/master/docs/scheduler,
 # create an App Engine app.
 # We use us-central here, but it indeed does not matter which region this app is created in.
-gcloud app create --region=us-central
+#
+# This command will throw an error if the app is already created, but since we expect to run
+# this script idempotently, we always mark this command as succeeded.
+gcloud app create --region=us-central || true

--- a/ci/prow/update_all_boskos_projects.sh
+++ b/ci/prow/update_all_boskos_projects.sh
@@ -39,5 +39,5 @@ fi
 
 for boskos_project in ${BOSKOS_PROJECTS}; do
   # Set up this project
-  "./set_up_boskos_project.sh" ${boskos_project} $@
+  ./set_up_boskos_project.sh ${boskos_project} $@
 done

--- a/ci/prow/update_all_boskos_projects.sh
+++ b/ci/prow/update_all_boskos_projects.sh
@@ -17,8 +17,8 @@
 set -e
 
 # This scripts takes no command line parameters. It reads from BOSKOS_RESOURCE_FILE
-# and run set_boskos_permissions.sh on projects that matches BOSKOS_PROJECT_PREFIX.
-# All additional arguments will be passed verbatim to set_boskos_permissions.sh
+# and run set_up_boskos_project.sh on projects that matches BOSKOS_PROJECT_PREFIX.
+# All additional arguments will be passed verbatim to set_up_boskos_project.sh
 
 cd "$(dirname $0)"
 
@@ -38,6 +38,6 @@ if [[ -z "${BOSKOS_PROJECTS}" ]]; then
 fi
 
 for boskos_project in ${BOSKOS_PROJECTS}; do
-  # Set permissions for this project
-  "./set_boskos_permissions.sh" ${boskos_project} $@
+  # Set up this project
+  "./set_up_boskos_project.sh" ${boskos_project} $@
 done


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
As required by step 1 in https://github.com/google/knative-gcp/tree/master/docs/scheduler, in order to use `SchedulerSource`, an App Engine app needs to be created.

I think it's better to do it here instead of in the tests of knative-gcp, because:
1. Once an App Engine app is created, it cannot be deleted
2. Each project can only has one App Engine app

So it's basically a one-time work similar as the other things we are doing in this script.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @adrcunha 
