### PR TITLE
ProwAutoBumper also updates images for boskos

### DIFF
--- a/tools/prow-auto-bumper/config.go
+++ b/tools/prow-auto-bumper/config.go
@@ -48,8 +48,9 @@ const (
 	PRBase = "master"
 
 	// Index for regex matching groups
-	imageImagePart = 1 // first group is image part
-	imageTagPart   = 2 // second group is tag part
+	imageRootPart = 1 // first group is image root folder part
+	imageSubPart  = 2 // second group is the optional subfolder in the image path
+	imageTagPart  = 3 // third group is tag part
 	// Max delta away from target date
 	maxDelta = 2 * 24 // 2 days
 	// K8s updates Prow versions everyday, which should be ~24 hours,
@@ -63,8 +64,8 @@ const (
 var (
 	// Whitelist of files to be scanned by this tool
 	fileFilters = []*regexp.Regexp{regexp.MustCompile(`\.yaml$`)}
-	// Matching            gcr.io /k8s-(prow|testimage)/(tide|kubekin-e2e|.*)    :vYYYYMMDD-HASH-VARIANT
-	imagePattern     = `\b(gcr\.io/k8s[a-z0-9-]{5,29}/[a-zA-Z0-9][a-zA-Z0-9_.-]+):(v[a-zA-Z0-9_.-]+)\b`
+	// Matching            gcr.io /k8s-(prow|testimage)/(kubekin-e2e|boskos|.*) (/janitor|/reaper|/.*)?        :vYYYYMMDD-HASH-VARIANT
+	imagePattern     = `\b(gcr\.io/k8s[a-z0-9-]{5,29}/[a-zA-Z0-9][a-zA-Z0-9_.-]+(/[a-zA-Z0-9][a-zA-Z0-9_.-]+)?):(v[a-zA-Z0-9_.-]+)\b`
 	imageRegexp      = regexp.MustCompile(imagePattern)
 	imageLinePattern = fmt.Sprintf(`\s+[a-z]+:\s+"?'?%s"?'?`, imagePattern)
 	// Matching   "-    image: gcr.io /k8s-(prow|testimage)/(tide|kubekin-e2e|.*)    :vYYYYMMDD-HASH-VARIANT"

--- a/tools/prow-auto-bumper/file.go
+++ b/tools/prow-auto-bumper/file.go
@@ -43,9 +43,9 @@ func (pv *PRVersions) updateAllTags(content []byte, imageFilter *regexp.Regexp) 
 	lastIndex := 0
 	for _, m := range indexes {
 		// Append from end of last match to end of image part, including ":"
-		res += string(content[lastIndex : m[imageImagePart*2+1]+1])
+		res += string(content[lastIndex : m[imageRootPart*2+1]+1])
 		// Image part of a version, i.e. the portion before ":"
-		image := string(content[m[imageImagePart*2]:m[imageImagePart*2+1]])
+		image := string(content[m[imageRootPart*2]:m[imageRootPart*2+1]])
 		// Tag part of a version, i.e. the portion after ":"
 		tag := string(content[m[imageTagPart*2]:m[imageTagPart*2+1]])
 		// m[1] is the end index of current match

--- a/tools/prow-auto-bumper/parser.go
+++ b/tools/prow-auto-bumper/parser.go
@@ -92,14 +92,14 @@ func (pv *PRVersions) parseChangelist(gcw *GHClientWrapper, gi gitInfo) error {
 		}
 		minuses := imageMinusRegexp.FindAllStringSubmatch(*f.Patch, -1)
 		for _, minus := range minuses {
-			iv := pv.getIndex(minus[imageImagePart], minus[imageTagPart])
-			pv.images[minus[imageImagePart]][iv].oldVersion = minus[imageTagPart]
+			iv := pv.getIndex(minus[imageRootPart], minus[imageTagPart])
+			pv.images[minus[imageRootPart]][iv].oldVersion = minus[imageTagPart]
 		}
 
 		pluses := imagePlusRegexp.FindAllStringSubmatch(*f.Patch, -1)
 		for _, plus := range pluses {
-			iv := pv.getIndex(plus[imageImagePart], plus[imageTagPart])
-			pv.images[plus[imageImagePart]][iv].newVersion = plus[imageTagPart]
+			iv := pv.getIndex(plus[imageRootPart], plus[imageTagPart])
+			pv.images[plus[imageRootPart]][iv].newVersion = plus[imageTagPart]
 		}
 	}
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
The images for boskos are in a subfolder, this PR changes the regex to also match images in the subfolders (in our case only for boskos)

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fix #1583 

/cc @chaodaiG 
/cc @adrcunha 
/cc @yt3liu 

