### PR TITLE
Prow jobs for net-contour repo use go1.13

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -4366,9 +4366,49 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-net-contour-build-tests),?(\\s+|$)"
     decorate: true
     path_alias: knative.dev/net-contour
+    branches:
+    - "release-0.9"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--build-tests"
+        volumeMounts:
+        - name: repoview-token
+          mountPath: /etc/repoview-token
+          readOnly: true
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: repoview-token
+        secret:
+          secretName: repoview-token
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-net-contour-build-tests
+    agent: kubernetes
+    context: pull-knative-net-contour-build-tests
+    always_run: true
+    rerun_command: "/test pull-knative-net-contour-build-tests"
+    trigger: "(?m)^/test (all|pull-knative-net-contour-build-tests),?(\\s+|$)"
+    decorate: true
+    path_alias: knative.dev/net-contour
+    skip_branches:
+    - "release-0.9"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -4406,9 +4446,53 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-net-contour-unit-tests),?(\\s+|$)"
     decorate: true
     path_alias: knative.dev/net-contour
+    branches:
+    - "release-0.9"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--unit-tests"
+        volumeMounts:
+        - name: repoview-token
+          mountPath: /etc/repoview-token
+          readOnly: true
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: repoview-token
+        secret:
+          secretName: repoview-token
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-net-contour-unit-tests
+    agent: kubernetes
+    labels:
+      prow.k8s.io/pubsub.project: knative-tests
+      prow.k8s.io/pubsub.topic: knative-monitoring
+      prow.k8s.io/pubsub.runID: pull-knative-net-contour-unit-tests
+    context: pull-knative-net-contour-unit-tests
+    always_run: true
+    rerun_command: "/test pull-knative-net-contour-unit-tests"
+    trigger: "(?m)^/test (all|pull-knative-net-contour-unit-tests),?(\\s+|$)"
+    decorate: true
+    path_alias: knative.dev/net-contour
+    skip_branches:
+    - "release-0.9"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -4443,9 +4527,41 @@ presubmits:
     optional: true
     decorate: true
     path_alias: knative.dev/net-contour
+    branches:
+    - "release-0.9"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/coverage-go112:latest
+        imagePullPolicy: Always
+        command:
+        - "/coverage"
+        args:
+        - "--postsubmit-job-name=post-knative-net-contour-go-coverage"
+        - "--artifacts=$(ARTIFACTS)"
+        - "--cov-threshold-percentage=50"
+        - "--github-token=/etc/covbot-token/token"
+        volumeMounts:
+        - name: covbot-token
+          mountPath: /etc/covbot-token
+          readOnly: true
+      volumes:
+      - name: covbot-token
+        secret:
+          secretName: covbot-token
+  - name: pull-knative-net-contour-go-coverage
+    agent: kubernetes
+    context: pull-knative-net-contour-go-coverage
+    always_run: true
+    rerun_command: "/test pull-knative-net-contour-go-coverage"
+    trigger: "(?m)^/test (all|pull-knative-net-contour-go-coverage),?(\\s+|$)"
+    optional: true
+    decorate: true
+    path_alias: knative.dev/net-contour
+    skip_branches:
+    - "release-0.9"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/coverage:latest
         imagePullPolicy: Always
         command:
         - "/coverage"
@@ -8106,6 +8222,161 @@ periodics:
       args:
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
+- cron: "10 * * * *"
+  name: ci-knative-net-contour-continuous
+  agent: kubernetes
+  labels:
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-knative-net-contour-continuous
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: net-contour
+    base_ref: master
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./test/presubmit-tests.sh"
+      - "--all-tests"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "55 9 * * *"
+  name: ci-knative-net-contour-nightly-release
+  agent: kubernetes
+  labels:
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-knative-net-contour-nightly-release
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: net-contour
+    base_ref: master
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--publish"
+      - "--tag-release"
+      volumeMounts:
+      - name: nightly-account
+        mountPath: /etc/nightly-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/nightly-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: nightly-account
+      secret:
+        secretName: nightly-account
+- cron: "36 9 * * 2"
+  name: ci-knative-net-contour-dot-release
+  agent: kubernetes
+  labels:
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-knative-net-contour-dot-release
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: net-contour
+    base_ref: master
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--dot-release"
+      - "--release-gcs knative-releases/net-contour"
+      - "--release-gcr gcr.io/knative-releases"
+      - "--github-token /etc/hub-token/token"
+      volumeMounts:
+      - name: hub-token
+        mountPath: /etc/hub-token
+        readOnly: true
+      - name: release-account
+        mountPath: /etc/release-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: hub-token
+      secret:
+        secretName: hub-token
+    - name: release-account
+      secret:
+        secretName: release-account
+- cron: "33 */2 * * *"
+  name: ci-knative-net-contour-auto-release
+  agent: kubernetes
+  labels:
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-knative-net-contour-auto-release
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: net-contour
+    base_ref: master
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--auto-release"
+      - "--release-gcs knative-releases/net-contour"
+      - "--release-gcr gcr.io/knative-releases"
+      - "--github-token /etc/hub-token/token"
+      volumeMounts:
+      - name: hub-token
+        mountPath: /etc/hub-token
+        readOnly: true
+      - name: release-account
+        mountPath: /etc/release-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: hub-token
+      secret:
+        secretName: hub-token
+    - name: release-account
+      secret:
+        secretName: release-account
 - cron: "0 1 * * *"
   name: ci-knative-net-contour-go-coverage
   labels:
@@ -8121,7 +8392,7 @@ periodics:
     path_alias: knative.dev/net-contour
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/coverage-go112:latest
+    - image: gcr.io/knative-tests/test-infra/coverage:latest
       imagePullPolicy: Always
       command:
       - "/coverage"
@@ -9114,7 +9385,7 @@ postsubmits:
     path_alias: knative.dev/net-contour
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/coverage-go112:latest
+      - image: gcr.io/knative-tests/test-infra/coverage:latest
         imagePullPolicy: Always
         command:
         - "/coverage"

--- a/ci/prow/config_knative.yaml
+++ b/ci/prow/config_knative.yaml
@@ -259,6 +259,10 @@ presubmits:
     - go-coverage: true
 
   knative/net-contour:
+    - repo-settings:
+      go112-branches:
+      - release-0.9 # This branch doesn't actually exist, create here to make
+      # config generator work
     - build-tests: true
       dot-dev: true
     - unit-tests: true
@@ -636,3 +640,13 @@ periodics:
       go113: true
       env-vars:
       - ORG_NAME=google
+
+  knative/net-contour:
+    - continuous: true
+      go113: true
+    - nightly: true
+      go113: true
+    - dot-release: true
+      go113: true
+    - auto-release: true
+      go113: true

--- a/ci/prow/testgrid.yaml
+++ b/ci/prow/testgrid.yaml
@@ -240,6 +240,18 @@ test_groups:
   gcs_prefix: knative-prow/logs/ci-knative-eventing-operator-go-coverage
   num_failures_to_alert: 9999
   short_text_metric: "coverage"
+- name: ci-knative-net-contour-continuous
+  gcs_prefix: knative-prow/logs/ci-knative-net-contour-continuous
+  alert_stale_results_hours: 3
+  num_failures_to_alert: 3
+- name: ci-knative-net-contour-nightly-release
+  gcs_prefix: knative-prow/logs/ci-knative-net-contour-nightly-release
+- name: ci-knative-net-contour-dot-release
+  gcs_prefix: knative-prow/logs/ci-knative-net-contour-dot-release
+  alert_stale_results_hours: 170
+- name: ci-knative-net-contour-auto-release
+  gcs_prefix: knative-prow/logs/ci-knative-net-contour-auto-release
+  alert_stale_results_hours: 3
 - name: pull-knative-net-contour-test-coverage
   gcs_prefix: knative-prow/logs/ci-knative-net-contour-go-coverage
   num_failures_to_alert: 9999
@@ -486,6 +498,18 @@ dashboards:
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
 - name: net-contour
   dashboard_tab:
+  - name: continuous
+    test_group_name: ci-knative-net-contour-continuous
+    base_options: "sort-by-name="
+  - name: nightly
+    test_group_name: ci-knative-net-contour-nightly-release
+    base_options: "sort-by-name="
+  - name: dot-release
+    test_group_name: ci-knative-net-contour-dot-release
+    base_options: "sort-by-name="
+  - name: auto-release
+    test_group_name: ci-knative-net-contour-auto-release
+    base_options: "sort-by-name="
   - name: coverage
     test_group_name: pull-knative-net-contour-test-coverage
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="


### PR DESCRIPTION
Unfortunately, to make config generator work for this new repo, we need to imagine an old release branch using go1.12, so that it knows that new branches should use go1.13

/cc @mattmoor 