### PR TITLE
Fix flag values when running cleanup tool

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -8426,10 +8426,10 @@ periodics:
       args:
       - "run"
       - "./tools/cleanup/cleanup.go"
-      - "--project-resource-yaml ci/prow/boskos_resources.yaml"
-      - "--days-to-keep-images 30"
-      - "--hours-to-keep-clusters 24"
-      - "--service-account /etc/test-account/service-account.json"
+      - "--project-resource-yaml=ci/prow/boskos_resources.yaml"
+      - "--days-to-keep-images=30"
+      - "--hours-to-keep-clusters=24"
+      - "--service-account=/etc/test-account/service-account.json"
       volumeMounts:
       - name: test-account
         mountPath: /etc/test-account

--- a/ci/prow/periodic_config.go
+++ b/ci/prow/periodic_config.go
@@ -236,10 +236,10 @@ func generateCleanupPeriodicJob() {
 	data.Base.Args = []string{
 		"run",
 		"./tools/cleanup/cleanup.go",
-		"--project-resource-yaml ci/prow/boskos_resources.yaml",
-		"--days-to-keep-images 30",
-		"--hours-to-keep-clusters 24",
-		"--service-account " + data.Base.ServiceAccount}
+		"--project-resource-yaml=ci/prow/boskos_resources.yaml",
+		"--days-to-keep-images=30",
+		"--hours-to-keep-clusters=24",
+		"--service-account=" + data.Base.ServiceAccount}
 	data.Base.ExtraRefs = append(data.Base.ExtraRefs, "  base_ref: "+data.Base.RepoBranch)
 	addExtraEnvVarsToJob(extraEnvVars, &data.Base)
 	configureServiceAccountForJob(&data.Base)


### PR DESCRIPTION
Each line is passed as a single parameter to the command, so the flag name becomes the whole key+value (including the space) and is not recognized.

Tested: https://prow.knative.dev/log?job=ci-knative-cleanup&id=1223453059300986880

Fixes #1654.