### PR TITLE
Prow auto bumper /assigns oncall instead of /cc

### DIFF
--- a/tools/prow-auto-bumper/pullrequest.go
+++ b/tools/prow-auto-bumper/pullrequest.go
@@ -58,7 +58,7 @@ func generatePRBody(extraMsgs []string) string {
 	var assignment string
 	if err == nil {
 		if oncaller != "" {
-			assignment = "/cc @" + oncaller
+			assignment = "/assign @" + oncaller
 		} else {
 			assignment = "Nobody is currently oncall."
 		}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
The way Prow works is, if you /cc someone in a PR, it will only cc that person but assign to nobody. But if you /assign someone, it will automatically cc someone that has approve power. And for this kind of job, it makes sense to assign instead of cc.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #1638 

