### PR TITLE
Fixes to prow-auto-bumper

### DIFF
--- a/images/prow-auto-bumper/Dockerfile
+++ b/images/prow-auto-bumper/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.10.2
+FROM golang:1.13
 LABEL maintainer "Chao Dai <chaodai@google.com>"
 RUN apt-get update
 

--- a/tools/prow-auto-bumper/config.go
+++ b/tools/prow-auto-bumper/config.go
@@ -39,6 +39,9 @@ const (
 	// srcPRUserID is the user from which PR was created
 	srcPRUserID = "k8s-ci-robot"
 
+	// configPath is the path where the configuration files are saved
+	configPath = "ci"
+
 	// Git info for target repo that Prow version bump PR targets
 	org  = "knative"
 	repo = "test-infra"

--- a/tools/prow-auto-bumper/file.go
+++ b/tools/prow-auto-bumper/file.go
@@ -96,13 +96,13 @@ func (pv *PRVersions) updateAllFiles(fileFilters []*regexp.Regexp, imageFilter *
 		return msgs, fmt.Errorf("failed to change to root dir")
 	}
 
-	err := filepath.Walk(".", func(filename string, info os.FileInfo, err error) error {
+	err := filepath.Walk(configPath, func(filename string, info os.FileInfo, err error) error {
 		for _, ff := range fileFilters {
 			if ff.Match([]byte(filename)) {
 				tmp, err := pv.updateFile(filename, imageFilter, dryrun)
 				msgs = append(msgs, tmp...)
 				if err != nil {
-					return fmt.Errorf("Failed to update path %s '%v'", filename, err)
+					return fmt.Errorf("failed to update path %s '%v'", filename, err)
 				}
 			}
 		}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
1. prow-auto-bumper job failed in https://prow.knative.dev/view/gcs/knative-prow/logs/ci-knative-prow-auto-bumper/1224422502353080320, which is because it failed to find some yaml files under vendor/k8s.io/...., we should only scan the folder where we save the config files for Knative
2. `make push` fails because it's using a rather old Go version, bump it to Go 1.13

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

