### PR TITLE
added prow-test go114 image

### DIFF
--- a/images/prow-tests-go114/Dockerfile
+++ b/images/prow-tests-go114/Dockerfile
@@ -1,0 +1,24 @@
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/knative-tests/test-infra/prow-tests:stable
+LABEL maintainer "Chao Dai <chaodai@google.com>"
+
+# Install go at 1.14 same as how it's installed in kubekins-e2e image, reference code here:
+# https://github.com/kubernetes/test-infra/blob/1e9b5dc3de4b268aab57c9c48120aa3dcf096bc6/images/kubekins-e2e/Dockerfile#L64
+ENV GO_TARBALL "go1.14.linux-amd64.tar.gz"
+RUN rm -rf /usr/local/go && \
+    wget -q "https://storage.googleapis.com/golang/${GO_TARBALL}" && \
+    tar xzf "${GO_TARBALL}" -C /usr/local && \
+    rm "${GO_TARBALL}"

--- a/images/prow-tests-go114/Dockerfile
+++ b/images/prow-tests-go114/Dockerfile
@@ -15,10 +15,25 @@
 FROM gcr.io/knative-tests/test-infra/prow-tests:stable
 LABEL maintainer "Chao Dai <chaodai@google.com>"
 
-# Install go at 1.14 same as how it's installed in kubekins-e2e image, reference code here:
-# https://github.com/kubernetes/test-infra/blob/1e9b5dc3de4b268aab57c9c48120aa3dcf096bc6/images/kubekins-e2e/Dockerfile#L64
-ENV GO_TARBALL "go1.14.linux-amd64.tar.gz"
-RUN rm -rf /usr/local/go && \
-    wget -q "https://storage.googleapis.com/golang/${GO_TARBALL}" && \
+ENV GO_TARBALL "go1.14beta1.tar.gz"
+
+# Required variables to install go from source
+ENV GOROOT_BOOTSTRAP "/usr/local/go-old"
+ENV GOROOT "/usr/local/go"
+ENV CGO_ENABLED 0
+ENV GOOS "linux"
+ENV GOARCH "amd64"
+
+# install netbase as it's required for Go linux amd64 install (OS specific)
+RUN apt-get update && \
+    apt-get install netbase
+
+# go1.14 is not released yet. Downloading the beta version directly from github and building from source
+# Reference: https://golang.org/doc/install/source
+RUN mv /usr/local/go /usr/local/go-old && \
+    wget -q "https://github.com/golang/go/archive/${GO_TARBALL}" && \
     tar xzf "${GO_TARBALL}" -C /usr/local && \
-    rm "${GO_TARBALL}"
+    mv /usr/local/go-go1.14beta1 /usr/local/go && \
+    cd ${GOROOT}/src && \
+    echo go1.14beta1 > ${GOROOT}/VERSION && \
+    ./all.bash

--- a/images/prow-tests-go114/Dockerfile
+++ b/images/prow-tests-go114/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2019 The Knative Authors
+# Copyright 2020 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ LABEL maintainer "Chao Dai <chaodai@google.com>"
 ENV GO_TARBALL "go1.14beta1.tar.gz"
 
 # Required variables to install go from source
+# Reference: https://golang.org/doc/install/source#environment
 ENV GOROOT_BOOTSTRAP "/usr/local/go-old"
 ENV GOROOT "/usr/local/go"
 ENV CGO_ENABLED 0
@@ -25,8 +26,7 @@ ENV GOOS "linux"
 ENV GOARCH "amd64"
 
 # install netbase as it's required for Go linux amd64 install (OS specific)
-RUN apt-get update && \
-    apt-get install netbase
+RUN apt-get install netbase
 
 # go1.14 is not released yet. Downloading the beta version directly from github and building from source
 # Reference: https://golang.org/doc/install/source
@@ -36,4 +36,5 @@ RUN mv /usr/local/go /usr/local/go-old && \
     mv /usr/local/go-go1.14beta1 /usr/local/go && \
     cd ${GOROOT}/src && \
     echo go1.14beta1 > ${GOROOT}/VERSION && \
-    ./all.bash
+    ./all.bash && \
+    rm -rf ${GOROOT_BOOTSTRAP}

--- a/images/prow-tests-go114/Makefile
+++ b/images/prow-tests-go114/Makefile
@@ -1,0 +1,16 @@
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+IMAGE_NAME = prow-tests-go114
+include ../../shared/Makefile.simple-image

--- a/images/prow-tests-go114/README.md
+++ b/images/prow-tests-go114/README.md
@@ -1,0 +1,2 @@
+This is a legacy image, see [prow-test](../prow-tests/README.md) for more
+details

--- a/images/prow-tests-go114/README.md
+++ b/images/prow-tests-go114/README.md
@@ -1,2 +1,2 @@
-This is a legacy image, see [prow-test](../prow-tests/README.md) for more
+This is a new beta image, see [prow-test](../prow-tests/README.md) for more
 details


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Part of https://github.com/knative/test-infra/issues/1658
**Special notes to reviewers**:

**User-visible changes in this PR**:

**TESTING** 

Confirmed in docker run that the go version is modified 
```
joyceyu@joyceyu-macbookpro:prow-tests-go114(k8s: boskos)$ docker run --entrypoint="" gcr.io/knative-tests/test-infra/prow-tests-go114:v20200204-1856973d-dirty go version 
go version go1.14beta1 linux/amd64
```

Output of make build 
<details><summary>show</summary>
<p>

```
joyceyu@joyceyu-macbookpro:prow-tests-go114(k8s: boskos)$ make build 
docker build  -t gcr.io/knative-tests/test-infra/prow-tests-go114:v20200204-1856973d-dirty -f Dockerfile ../..
Sending build context to Docker daemon  522.3MB
Step 1/10 : FROM gcr.io/knative-tests/test-infra/prow-tests:stable
 ---> 3b07768068d6
Step 2/10 : LABEL maintainer "Chao Dai <chaodai@google.com>"
 ---> Using cache
 ---> 28e32a7ae970
Step 3/10 : ENV GO_TARBALL "go1.14beta1.tar.gz"
 ---> Using cache
 ---> 280ba2f2416b
Step 4/10 : ENV GOROOT_BOOTSTRAP "/usr/local/go-old"
 ---> Using cache
 ---> aceee062b26a
Step 5/10 : ENV GOROOT "/usr/local/go"
 ---> Using cache
 ---> 3f5754152724
Step 6/10 : ENV CGO_ENABLED 0
 ---> Using cache
 ---> 3c5a7529a4d3
Step 7/10 : ENV GOOS "linux"
 ---> Using cache
 ---> eddf70e7765e
Step 8/10 : ENV GOARCH "amd64"
 ---> Using cache
 ---> b90390dfa195
Step 9/10 : RUN apt-get update &&     apt-get install netbase
 ---> Running in d2565bf7526f
Ign:1 http://deb.debian.org/debian stretch InRelease
Get:3 http://deb.debian.org/debian stretch-updates InRelease [91.0 kB]
Get:2 http://security-cdn.debian.org/debian-security stretch/updates InRelease [94.3 kB]
Hit:4 http://deb.debian.org/debian stretch Release
Get:5 https://download.docker.com/linux/debian stretch InRelease [44.8 kB]
Get:7 http://security-cdn.debian.org/debian-security stretch/updates/main amd64 Packages [516 kB]
Fetched 747 kB in 1s (649 kB/s)
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
The following NEW packages will be installed:
  netbase
0 upgraded, 1 newly installed, 0 to remove and 40 not upgraded.
Need to get 19.1 kB of archives.
After this operation, 45.1 kB of additional disk space will be used.
Get:1 http://deb.debian.org/debian stretch/main amd64 netbase all 5.4 [19.1 kB]
debconf: delaying package configuration, since apt-utils is not installed
Fetched 19.1 kB in 0s (48.4 kB/s)
Selecting previously unselected package netbase.
(Reading database ... 20897 files and directories currently installed.)
Preparing to unpack .../archives/netbase_5.4_all.deb ...
Unpacking netbase (5.4) ...
Setting up netbase (5.4) ...
Removing intermediate container d2565bf7526f
 ---> 7c1537b897dd
Step 10/10 : RUN mv /usr/local/go /usr/local/go-old &&     wget -q "https://github.com/golang/go/archive/${GO_TARBALL}" &&     tar xzf "${GO_TARBALL}" -C /usr/local &&     mv /usr/local/go-go1.14beta1 /usr/local/go &&     cd ${GOROOT}/src &&     echo go1.14beta1 > ${GOROOT}/VERSION &&     ./all.bash
 ---> Running in a5c1eca9136f
Building Go cmd/dist using /usr/local/go-old. (go1.13 linux/amd64)
Building Go toolchain1 using /usr/local/go-old.
Building Go bootstrap cmd/go (go_bootstrap) using Go toolchain1.
Building Go toolchain2 using go_bootstrap and Go toolchain1.
Building Go toolchain3 using go_bootstrap and Go toolchain2.
Building packages and commands for linux/amd64.

##### Testing packages.
ok      archive/tar     0.129s
ok      archive/zip     0.069s
ok      bufio   0.088s
ok      bytes   0.213s
ok      compress/bzip2  0.083s
ok      compress/flate  0.747s
ok      compress/gzip   0.041s
ok      compress/lzw    0.055s
ok      compress/zlib   0.043s
ok      container/heap  0.037s
ok      container/list  0.027s
ok      container/ring  0.013s
ok      context 1.000s
ok      crypto  0.055s
ok      crypto/aes      0.093s
ok      crypto/cipher   0.019s
ok      crypto/des      0.041s
ok      crypto/dsa      0.004s
ok      crypto/ecdsa    0.176s
ok      crypto/ed25519  0.076s
ok      crypto/elliptic 0.035s
ok      crypto/hmac     0.007s
ok      crypto/internal/subtle  0.013s
ok      crypto/md5      0.008s
ok      crypto/rand     0.042s
ok      crypto/rc4      0.034s
ok      crypto/rsa      0.116s
ok      crypto/sha1     0.030s
ok      crypto/sha256   0.006s
ok      crypto/sha512   0.011s
ok      crypto/subtle   0.007s
ok      crypto/tls      1.261s
ok      crypto/x509     0.758s
ok      database/sql    0.590s
ok      database/sql/driver     0.046s
ok      debug/dwarf     0.044s
ok      debug/elf       0.094s
ok      debug/gosym     0.073s
ok      debug/macho     0.023s
ok      debug/pe        0.020s
ok      debug/plan9obj  0.051s
ok      encoding/ascii85        0.013s
ok      encoding/asn1   0.020s
ok      encoding/base32 0.036s
ok      encoding/base64 0.024s
ok      encoding/binary 0.022s
ok      encoding/csv    0.011s
ok      encoding/gob    0.062s
ok      encoding/hex    0.024s
ok      encoding/json   0.100s
ok      encoding/pem    0.021s
ok      encoding/xml    0.076s
ok      errors  0.024s
ok      expvar  0.003s
ok      flag    0.006s
ok      fmt     0.095s
ok      go/ast  0.004s
ok      go/build        0.218s
ok      go/constant     0.017s
ok      go/doc  0.055s
ok      go/format       0.017s
ok      go/importer     0.226s
ok      go/internal/gccgoimporter       0.021s
ok      go/internal/gcimporter  0.552s
ok      go/internal/srcimporter 1.163s
ok      go/parser       0.098s
ok      go/printer      0.387s
ok      go/scanner      0.012s
ok      go/token        0.047s
ok      go/types        0.843s
ok      hash    0.010s
ok      hash/adler32    0.048s
ok      hash/crc32      0.009s
ok      hash/crc64      0.018s
ok      hash/fnv        0.023s
ok      hash/maphash    0.171s
ok      html    0.006s
ok      html/template   0.092s
ok      image   0.100s
ok      image/color     0.033s
ok      image/draw      0.083s
ok      image/gif       0.455s
ok      image/jpeg      0.186s
ok      image/png       0.044s
ok      index/suffixarray       0.273s
ok      internal/cpu    0.066s
ok      internal/fmtsort        0.025s
ok      internal/poll   0.143s
ok      internal/reflectlite    0.118s
ok      internal/singleflight   0.014s
ok      internal/trace  0.143s
ok      internal/xcoff  0.019s
ok      io      0.104s
ok      io/ioutil       0.006s
ok      log     0.028s
ok      log/syslog      1.257s
ok      math    0.011s
ok      math/big        1.609s
ok      math/bits       0.043s
ok      math/cmplx      0.030s
ok      math/rand       0.190s
ok      mime    0.026s
ok      mime/multipart  0.219s
ok      mime/quotedprintable    0.010s
ok      net     5.055s
ok      net/http        10.271s
ok      net/http/cgi    1.156s
ok      net/http/cookiejar      0.039s
ok      net/http/fcgi   0.032s
ok      net/http/httptest       0.082s
ok      net/http/httptrace      0.054s
ok      net/http/httputil       0.125s
ok      net/http/internal       0.023s
ok      net/http/pprof  2.056s
ok      net/internal/socktest   0.029s
ok      net/mail        0.013s
ok      net/rpc 0.048s
ok      net/rpc/jsonrpc 0.029s
ok      net/smtp        0.025s
ok      net/textproto   0.073s
ok      net/url 0.018s
ok      os      0.805s
ok      os/exec 0.700s
ok      os/signal       5.226s
ok      os/user 0.027s
ok      path    0.005s
ok      path/filepath   0.105s
ok      plugin  0.019s
ok      reflect 0.484s
ok      regexp  0.198s
ok      regexp/syntax   0.646s
ok      runtime 21.354s
ok      runtime/debug   0.163s
ok      runtime/internal/atomic 0.049s
ok      runtime/internal/math   0.020s
ok      runtime/internal/sys    0.031s
ok      runtime/pprof   4.283s
ok      runtime/pprof/internal/profile  0.013s
ok      runtime/trace   0.757s
ok      sort    0.097s
ok      strconv 0.598s
ok      strings 0.185s
ok      sync    0.459s
ok      sync/atomic     0.121s
ok      syscall 0.104s
ok      testing 0.306s
ok      testing/iotest  0.037s
ok      testing/quick   0.046s
ok      text/scanner    0.068s
ok      text/tabwriter  0.012s
ok      text/template   0.082s
ok      text/template/parse     0.019s
ok      time    1.854s
ok      unicode 0.042s
ok      unicode/utf16   0.043s
ok      unicode/utf8    0.019s
ok      cmd/addr2line   2.033s
ok      cmd/api 0.047s
ok      cmd/asm/internal/asm    0.969s
ok      cmd/asm/internal/lex    0.003s
ok      cmd/compile     0.055s
ok      cmd/compile/internal/gc 15.242s
ok      cmd/compile/internal/logopt     0.122s
ok      cmd/compile/internal/ssa        0.993s
ok      cmd/compile/internal/syntax     0.050s
ok      cmd/compile/internal/test       0.015s [no tests to run]
ok      cmd/compile/internal/types      0.020s
ok      cmd/cover       4.844s
ok      cmd/doc 0.110s
ok      cmd/fix 3.241s
ok      cmd/go  50.020s
ok      cmd/go/internal/auth    0.017s
ok      cmd/go/internal/cache   0.344s
ok      cmd/go/internal/generate        0.007s
ok      cmd/go/internal/get     0.095s
ok      cmd/go/internal/imports 0.039s
ok      cmd/go/internal/load    0.059s
ok      cmd/go/internal/lockedfile      0.149s
ok      cmd/go/internal/lockedfile/internal/filelock    0.055s
ok      cmd/go/internal/modconv 0.039s
ok      cmd/go/internal/modfetch        0.043s
ok      cmd/go/internal/modfetch/codehost       0.029s
ok      cmd/go/internal/modfetch/zip_sum_test   0.197s
ok      cmd/go/internal/modload 0.049s
ok      cmd/go/internal/mvs     0.025s
ok      cmd/go/internal/par     0.061s
ok      cmd/go/internal/renameio        0.148s
ok      cmd/go/internal/search  0.014s
ok      cmd/go/internal/txtar   0.014s
ok      cmd/go/internal/web     0.018s
ok      cmd/go/internal/work    0.050s
ok      cmd/gofmt       0.165s
ok      cmd/internal/buildid    0.288s
ok      cmd/internal/dwarf      0.022s
ok      cmd/internal/edit       0.018s
ok      cmd/internal/goobj      0.199s
ok      cmd/internal/obj        0.022s
ok      cmd/internal/obj/arm64  0.022s
ok      cmd/internal/obj/x86    0.452s
ok      cmd/internal/objabi     0.029s
ok      cmd/internal/src        0.018s
ok      cmd/internal/test2json  0.149s
ok      cmd/link        20.597s
ok      cmd/link/internal/ld    2.568s
ok      cmd/link/internal/sym   0.004s
ok      cmd/nm  2.386s
ok      cmd/objdump     2.542s
ok      cmd/pack        1.766s
ok      cmd/trace       0.034s
ok      cmd/vet 8.421s

##### os/user with tag osusergo
ok      os/user 0.004s

##### GOMAXPROCS=2 runtime -cpu=1,2,4 -quick
ok      runtime 16.922s

##### cmd/go terminal test
skipping terminal test; stdout/stderr not terminals

##### Testing without libgcc.
ok      crypto/x509     0.408s
ok      net     0.012s
ok      os/user 0.009s

##### internal linking of -buildmode=pie
ok      reflect 2.100s

##### sync -cpu=10
ok      sync    0.366s

##### ../test/bench/go1

##### ../test

##### API check
Go version is "go1.14beta1", ignoring -next /usr/local/go/api/next.txt

ALL TESTS PASSED
---
Installed Go for linux/amd64 in /usr/local/go
Installed commands in /usr/local/go/bin
Removing intermediate container a5c1eca9136f
 ---> 025e02274a29
Successfully built 025e02274a29
Successfully tagged gcr.io/knative-tests/test-infra/prow-tests-go114:v20200204-1856973d-dirty
```

</p>
</details>