### PR TITLE
Code coverage prow tool uses ARTIFACTS env var

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,5 +2,5 @@
 
 So you want to hack on Knative Test Infrastructure? Yay! Please refer to
 Knative's overall
-[contribution guidelines](https://github.com/knative/docs/blob/master/contributing/CONTRIBUTING.md)
+[contribution guidelines](https://knative.dev/contributing/)
 to find out how you can help.

--- a/tools/coverage/main.go
+++ b/tools/coverage/main.go
@@ -43,9 +43,14 @@ const (
 func main() {
 	fmt.Println("entering code coverage main")
 
+	envOverriddenDefaultArtifactsDir := os.Getenv("ARTIFACTS")
+	if envOverriddenDefaultArtifactsDir == "" {
+		envOverriddenDefaultArtifactsDir = defaultArtifactsDir
+	}
+
 	gcsBucketName := flag.String("postsubmit-gcs-bucket", defaultGcsBucket, "gcs bucket name")
 	postSubmitJobName := flag.String("postsubmit-job-name", defaultPostSubmitJobName, "name of the prow job")
-	artifactsDir := flag.String("artifacts", defaultArtifactsDir, "directory for artifacts")
+	artifactsDir := flag.String("artifacts", envOverriddenDefaultArtifactsDir, "directory for artifacts")
 	coverageTargetDir := flag.String("cov-target", defaultCoverageTargetDir, "target directory for test coverage")
 	coverageProfileName := flag.String("profile-name", defaultCoverageProfileName, "file name for coverage profile")
 	githubTokenPath := flag.String("github-token", "", "path to token to access github repo")


### PR DESCRIPTION
If the ARTIFACTS environment variable is available,
then the artifacts flag will use it as the default

Corrected contribution guidelines link

**Which issue(s) this PR fixes**:
Fixes #1644

/test pull-knative-serving-go-coverage-dev
/test post-knative-serving-go-coverage-dev

/assign @coryrc @chaodaiG @chizhg @yt3liu  
