### PR TITLE
enable cgo in prow-test-go114 image

### DIFF
--- a/images/prow-tests-go114/Dockerfile
+++ b/images/prow-tests-go114/Dockerfile
@@ -21,7 +21,7 @@ ENV GO_TARBALL "go1.14beta1.tar.gz"
 # Reference: https://golang.org/doc/install/source#environment
 ENV GOROOT_BOOTSTRAP "/usr/local/go-old"
 ENV GOROOT "/usr/local/go"
-ENV CGO_ENABLED 0
+ENV CGO_ENABLED 1
 ENV GOOS "linux"
 ENV GOARCH "amd64"
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:

CGO is required for running serving integration test. Enabling this when building the the go binary from source. 

Failed log: https://prow.knative.dev/view/gcs/knative-prow/pr-logs/pull/knative_serving/6745/pull-knative-serving-integration-tests-go114/1225223825331851264 

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Part of https://github.com/knative/test-infra/issues/1658

**Special notes to reviewers**:

**User-visible changes in this PR**:

