### PR TITLE
Testgroup Failure Alert Modification (PR#1609):

### DIFF
--- a/ci/prow/templates/testgrid_config_header.yaml
+++ b/ci/prow/templates/testgrid_config_header.yaml
@@ -31,7 +31,6 @@ default_test_group:
   use_kubernetes_client: true    # ** This field is deprecated and should always be true **
   is_external: true              # ** This field is deprecated and should always be true **
   alert_stale_results_hours: 26  # Alert if tests haven't run for a day (1 day + 2h)
-  num_failures_to_alert: 1       # Alert for every failure
   num_passes_to_disable_alert: 1 # Consider a failing test passing if it has 1 or more consecutive passes
 
 default_dashboard_tab:

--- a/ci/prow/testgrid.yaml
+++ b/ci/prow/testgrid.yaml
@@ -29,7 +29,6 @@ default_test_group:
   use_kubernetes_client: true    # ** This field is deprecated and should always be true **
   is_external: true              # ** This field is deprecated and should always be true **
   alert_stale_results_hours: 26  # Alert if tests haven't run for a day (1 day + 2h)
-  num_failures_to_alert: 1       # Alert for every failure
   num_passes_to_disable_alert: 1 # Consider a failing test passing if it has 1 or more consecutive passes
 default_dashboard_tab:
   open_test_template:            # The URL template to visit after clicking on a cell
@@ -59,261 +58,257 @@ test_groups:
 - name: ci-knative-serving-continuous
   gcs_prefix: knative-prow/logs/ci-knative-serving-continuous
   alert_stale_results_hours: 3
-  num_failures_to_alert: 3
 - name: ci-knative-serving-istio-1.3-mesh
   gcs_prefix: knative-prow/logs/ci-knative-serving-istio-1.3-mesh
   alert_stale_results_hours: 3
-  num_failures_to_alert: 3
 - name: ci-knative-serving-istio-1.3-no-mesh
   gcs_prefix: knative-prow/logs/ci-knative-serving-istio-1.3-no-mesh
   alert_stale_results_hours: 3
-  num_failures_to_alert: 3
 - name: ci-knative-serving-istio-1.4-mesh
   gcs_prefix: knative-prow/logs/ci-knative-serving-istio-1.4-mesh
   alert_stale_results_hours: 3
-  num_failures_to_alert: 3
 - name: ci-knative-serving-istio-1.4-no-mesh
   gcs_prefix: knative-prow/logs/ci-knative-serving-istio-1.4-no-mesh
   alert_stale_results_hours: 3
-  num_failures_to_alert: 3
 - name: ci-knative-serving-gloo-0.17.1
   gcs_prefix: knative-prow/logs/ci-knative-serving-gloo-0.17.1
   alert_stale_results_hours: 3
-  num_failures_to_alert: 3
 - name: ci-knative-serving-kourier-stable
   gcs_prefix: knative-prow/logs/ci-knative-serving-kourier-stable
   alert_stale_results_hours: 3
-  num_failures_to_alert: 3
 - name: ci-knative-serving-contour-latest
   gcs_prefix: knative-prow/logs/ci-knative-serving-contour-latest
   alert_stale_results_hours: 3
-  num_failures_to_alert: 3
 - name: ci-knative-serving-ambassador-latest
   gcs_prefix: knative-prow/logs/ci-knative-serving-ambassador-latest
   alert_stale_results_hours: 3
-  num_failures_to_alert: 3
 - name: ci-knative-serving-nightly-release
   gcs_prefix: knative-prow/logs/ci-knative-serving-nightly-release
+  num_failures_to_alert: 1
 - name: ci-knative-serving-dot-release
   gcs_prefix: knative-prow/logs/ci-knative-serving-dot-release
   alert_stale_results_hours: 170
+  num_failures_to_alert: 1
 - name: ci-knative-serving-auto-release
   gcs_prefix: knative-prow/logs/ci-knative-serving-auto-release
-  alert_stale_results_hours: 3
+  num_failures_to_alert: 1
 - name: ci-knative-serving-webhook-apicoverage
   gcs_prefix: knative-prow/logs/ci-knative-serving-webhook-apicoverage
   alert_stale_results_hours: 48
-  num_failures_to_alert: 3
 - name: ci-knative-serving-continuous-go114
   gcs_prefix: knative-prow/logs/ci-knative-serving-continuous-go114
   alert_stale_results_hours: 3
-  num_failures_to_alert: 3
 - name: pull-knative-serving-test-coverage
   gcs_prefix: knative-prow/logs/ci-knative-serving-go-coverage
-  num_failures_to_alert: 9999
   short_text_metric: "coverage"
 - name: ci-knative-client-continuous
   gcs_prefix: knative-prow/logs/ci-knative-client-continuous
   alert_stale_results_hours: 3
-  num_failures_to_alert: 3
 - name: ci-knative-client-nightly-release
   gcs_prefix: knative-prow/logs/ci-knative-client-nightly-release
+  num_failures_to_alert: 1
 - name: ci-knative-client-tekton
   gcs_prefix: knative-prow/logs/ci-knative-client-tekton
   alert_stale_results_hours: 3
-  num_failures_to_alert: 3
 - name: ci-knative-client-dot-release
   gcs_prefix: knative-prow/logs/ci-knative-client-dot-release
   alert_stale_results_hours: 170
+  num_failures_to_alert: 1
 - name: ci-knative-client-auto-release
   gcs_prefix: knative-prow/logs/ci-knative-client-auto-release
-  alert_stale_results_hours: 3
+  num_failures_to_alert: 1
 - name: pull-knative-client-test-coverage
   gcs_prefix: knative-prow/logs/ci-knative-client-go-coverage
-  num_failures_to_alert: 9999
   short_text_metric: "coverage"
 - name: ci-knative-docs-continuous
   gcs_prefix: knative-prow/logs/ci-knative-docs-continuous
   alert_stale_results_hours: 3
-  num_failures_to_alert: 3
 - name: pull-knative-docs-test-coverage
   gcs_prefix: knative-prow/logs/ci-knative-docs-go-coverage
-  num_failures_to_alert: 9999
   short_text_metric: "coverage"
 - name: ci-knative-eventing-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-continuous
   alert_stale_results_hours: 3
-  num_failures_to_alert: 3
 - name: ci-knative-eventing-nightly-release
   gcs_prefix: knative-prow/logs/ci-knative-eventing-nightly-release
+  num_failures_to_alert: 1
 - name: ci-knative-eventing-dot-release
   gcs_prefix: knative-prow/logs/ci-knative-eventing-dot-release
   alert_stale_results_hours: 170
+  num_failures_to_alert: 1
 - name: ci-knative-eventing-auto-release
   gcs_prefix: knative-prow/logs/ci-knative-eventing-auto-release
-  alert_stale_results_hours: 3
+  num_failures_to_alert: 1
 - name: pull-knative-eventing-test-coverage
   gcs_prefix: knative-prow/logs/ci-knative-eventing-go-coverage
-  num_failures_to_alert: 9999
   short_text_metric: "coverage"
 - name: ci-knative-eventing-contrib-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-contrib-continuous
   alert_stale_results_hours: 3
-  num_failures_to_alert: 3
 - name: ci-knative-eventing-contrib-nightly-release
   gcs_prefix: knative-prow/logs/ci-knative-eventing-contrib-nightly-release
+  num_failures_to_alert: 1
 - name: ci-knative-eventing-contrib-dot-release
   gcs_prefix: knative-prow/logs/ci-knative-eventing-contrib-dot-release
   alert_stale_results_hours: 170
+  num_failures_to_alert: 1
 - name: ci-knative-eventing-contrib-auto-release
   gcs_prefix: knative-prow/logs/ci-knative-eventing-contrib-auto-release
-  alert_stale_results_hours: 3
+  num_failures_to_alert: 1
 - name: pull-knative-eventing-contrib-test-coverage
   gcs_prefix: knative-prow/logs/ci-knative-eventing-contrib-go-coverage
-  num_failures_to_alert: 9999
   short_text_metric: "coverage"
 - name: ci-knative-pkg-continuous
   gcs_prefix: knative-prow/logs/ci-knative-pkg-continuous
   alert_stale_results_hours: 3
-  num_failures_to_alert: 3
 - name: pull-knative-pkg-test-coverage
   gcs_prefix: knative-prow/logs/ci-knative-pkg-go-coverage
-  num_failures_to_alert: 9999
   short_text_metric: "coverage"
 - name: ci-knative-caching-continuous
   gcs_prefix: knative-prow/logs/ci-knative-caching-continuous
   alert_stale_results_hours: 3
-  num_failures_to_alert: 3
 - name: pull-knative-caching-test-coverage
   gcs_prefix: knative-prow/logs/ci-knative-caching-go-coverage
-  num_failures_to_alert: 9999
   short_text_metric: "coverage"
 - name: ci-knative-observability-continuous
   gcs_prefix: knative-prow/logs/ci-knative-observability-continuous
   alert_stale_results_hours: 3
-  num_failures_to_alert: 3
 - name: ci-knative-sample-controller-continuous
   gcs_prefix: knative-prow/logs/ci-knative-sample-controller-continuous
   alert_stale_results_hours: 3
-  num_failures_to_alert: 3
 - name: ci-knative-sample-source-continuous
   gcs_prefix: knative-prow/logs/ci-knative-sample-source-continuous
   alert_stale_results_hours: 3
-  num_failures_to_alert: 3
 - name: ci-knative-test-infra-continuous
   gcs_prefix: knative-prow/logs/ci-knative-test-infra-continuous
   alert_stale_results_hours: 3
-  num_failures_to_alert: 3
 - name: ci-knative-serving-operator-continuous
   gcs_prefix: knative-prow/logs/ci-knative-serving-operator-continuous
   alert_stale_results_hours: 3
-  num_failures_to_alert: 3
 - name: ci-knative-serving-operator-nightly-release
   gcs_prefix: knative-prow/logs/ci-knative-serving-operator-nightly-release
+  num_failures_to_alert: 1
 - name: ci-knative-serving-operator-dot-release
   gcs_prefix: knative-prow/logs/ci-knative-serving-operator-dot-release
   alert_stale_results_hours: 170
+  num_failures_to_alert: 1
 - name: ci-knative-serving-operator-auto-release
   gcs_prefix: knative-prow/logs/ci-knative-serving-operator-auto-release
-  alert_stale_results_hours: 3
+  num_failures_to_alert: 1
 - name: ci-knative-serving-operator-integration-tests-on-latest-serving
   gcs_prefix: knative-prow/logs/ci-knative-serving-operator-integration-tests-on-latest-serving
   alert_stale_results_hours: 3
-  num_failures_to_alert: 3
 - name: pull-knative-serving-operator-test-coverage
   gcs_prefix: knative-prow/logs/ci-knative-serving-operator-go-coverage
-  num_failures_to_alert: 9999
   short_text_metric: "coverage"
 - name: ci-knative-eventing-operator-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-operator-continuous
   alert_stale_results_hours: 3
-  num_failures_to_alert: 3
 - name: ci-knative-eventing-operator-nightly-release
   gcs_prefix: knative-prow/logs/ci-knative-eventing-operator-nightly-release
+  num_failures_to_alert: 1
 - name: ci-knative-eventing-operator-dot-release
   gcs_prefix: knative-prow/logs/ci-knative-eventing-operator-dot-release
   alert_stale_results_hours: 170
+  num_failures_to_alert: 1
 - name: ci-knative-eventing-operator-auto-release
   gcs_prefix: knative-prow/logs/ci-knative-eventing-operator-auto-release
-  alert_stale_results_hours: 3
+  num_failures_to_alert: 1
 - name: ci-knative-eventing-operator-integration-tests-on-latest-eventing
   gcs_prefix: knative-prow/logs/ci-knative-eventing-operator-integration-tests-on-latest-eventing
   alert_stale_results_hours: 3
-  num_failures_to_alert: 3
 - name: pull-knative-eventing-operator-test-coverage
   gcs_prefix: knative-prow/logs/ci-knative-eventing-operator-go-coverage
-  num_failures_to_alert: 9999
   short_text_metric: "coverage"
 - name: ci-knative-net-contour-continuous
   gcs_prefix: knative-prow/logs/ci-knative-net-contour-continuous
   alert_stale_results_hours: 3
-  num_failures_to_alert: 3
 - name: ci-knative-net-contour-nightly-release
   gcs_prefix: knative-prow/logs/ci-knative-net-contour-nightly-release
+  num_failures_to_alert: 1
 - name: ci-knative-net-contour-dot-release
   gcs_prefix: knative-prow/logs/ci-knative-net-contour-dot-release
   alert_stale_results_hours: 170
+  num_failures_to_alert: 1
 - name: ci-knative-net-contour-auto-release
   gcs_prefix: knative-prow/logs/ci-knative-net-contour-auto-release
-  alert_stale_results_hours: 3
+  num_failures_to_alert: 1
 - name: pull-knative-net-contour-test-coverage
   gcs_prefix: knative-prow/logs/ci-knative-net-contour-go-coverage
-  num_failures_to_alert: 9999
   short_text_metric: "coverage"
 - name: ci-knative-serving-0.9-continuous
   gcs_prefix: knative-prow/logs/ci-knative-serving-0.9-continuous
+  num_failures_to_alert: 3
 - name: ci-knative-eventing-0.9-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-0.9-continuous
+  num_failures_to_alert: 3
 - name: ci-knative-eventing-contrib-0.9-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-contrib-0.9-continuous
+  num_failures_to_alert: 3
 - name: ci-knative-serving-0.10-continuous
   gcs_prefix: knative-prow/logs/ci-knative-serving-0.10-continuous
+  num_failures_to_alert: 3
 - name: ci-knative-eventing-0.10-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-0.10-continuous
+  num_failures_to_alert: 3
 - name: ci-knative-eventing-contrib-0.10-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-contrib-0.10-continuous
+  num_failures_to_alert: 3
 - name: ci-knative-serving-0.11-continuous
   gcs_prefix: knative-prow/logs/ci-knative-serving-0.11-continuous
+  num_failures_to_alert: 3
 - name: ci-knative-client-0.11-continuous
   gcs_prefix: knative-prow/logs/ci-knative-client-0.11-continuous
+  num_failures_to_alert: 3
 - name: ci-knative-eventing-0.11-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-0.11-continuous
+  num_failures_to_alert: 3
 - name: ci-knative-eventing-contrib-0.11-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-contrib-0.11-continuous
+  num_failures_to_alert: 3
 - name: ci-knative-serving-operator-0.11-continuous
   gcs_prefix: knative-prow/logs/ci-knative-serving-operator-0.11-continuous
+  num_failures_to_alert: 3
 - name: ci-knative-eventing-operator-0.11-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-operator-0.11-continuous
+  num_failures_to_alert: 3
 - name: ci-knative-serving-0.12-continuous
   gcs_prefix: knative-prow/logs/ci-knative-serving-0.12-continuous
+  num_failures_to_alert: 3
 - name: ci-knative-client-0.12-continuous
   gcs_prefix: knative-prow/logs/ci-knative-client-0.12-continuous
+  num_failures_to_alert: 3
 - name: ci-knative-eventing-0.12-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-0.12-continuous
+  num_failures_to_alert: 3
 - name: ci-knative-eventing-contrib-0.12-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-contrib-0.12-continuous
+  num_failures_to_alert: 3
 - name: ci-knative-serving-operator-0.12-continuous
   gcs_prefix: knative-prow/logs/ci-knative-serving-operator-0.12-continuous
+  num_failures_to_alert: 3
 - name: ci-knative-eventing-operator-0.12-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-operator-0.12-continuous
+  num_failures_to_alert: 3
 - name: ci-google-knative-gcp-continuous
   gcs_prefix: knative-prow/logs/ci-google-knative-gcp-continuous
   alert_stale_results_hours: 3
-  num_failures_to_alert: 3
 - name: ci-google-knative-gcp-nightly-release
   gcs_prefix: knative-prow/logs/ci-google-knative-gcp-nightly-release
+  num_failures_to_alert: 1
 - name: ci-google-knative-gcp-dot-release
   gcs_prefix: knative-prow/logs/ci-google-knative-gcp-dot-release
   alert_stale_results_hours: 170
+  num_failures_to_alert: 1
 - name: ci-google-knative-gcp-auto-release
   gcs_prefix: knative-prow/logs/ci-google-knative-gcp-auto-release
-  alert_stale_results_hours: 3
+  num_failures_to_alert: 1
 - name: pull-google-knative-gcp-test-coverage
   gcs_prefix: knative-prow/logs/ci-google-knative-gcp-go-coverage
-  num_failures_to_alert: 9999
   short_text_metric: "coverage"
 - name: ci-google-knative-gcp-0.12-continuous
   gcs_prefix: knative-prow/logs/ci-google-knative-gcp-0.12-continuous
+  num_failures_to_alert: 3
 dashboards:
 - name: serving
   dashboard_tab:


### PR DESCRIPTION
**What this PR does, why we need it**:

Previously, alerts were generated on every test fail with the exception
of continuous jobs on master of a repo. We are changing this to 3
consecutive failures on tagged continuous jobs of a repo and on any failures
for auto-release, dot-release and nightly-release.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #1609 

**Special notes to reviewers**:

**User-visible changes in this PR**:
/cc @chizhg @yt3liu @efiturri 
