### PR TITLE
Make smoke tests in serving optional

### DIFF
--- a/ci/prow/config.yaml
+++ b/ci/prow/config.yaml
@@ -455,10 +455,11 @@ presubmits:
   - name: pull-knative-serving-smoke-tests
     agent: kubernetes
     context: pull-knative-serving-smoke-tests
-    always_run: true
+    always_run: false
     rerun_command: "/test pull-knative-serving-smoke-tests"
     trigger: "(?m)^/test (all|pull-knative-serving-smoke-tests),?(\\s+|$)"
     decorate: true
+    optional: true
     path_alias: knative.dev/serving
     branches:
     - "release-0.9"
@@ -488,10 +489,11 @@ presubmits:
   - name: pull-knative-serving-smoke-tests
     agent: kubernetes
     context: pull-knative-serving-smoke-tests
-    always_run: true
+    always_run: false
     rerun_command: "/test pull-knative-serving-smoke-tests"
     trigger: "(?m)^/test (all|pull-knative-serving-smoke-tests),?(\\s+|$)"
     decorate: true
+    optional: true
     path_alias: knative.dev/serving
     skip_branches:
     - "release-0.9"

--- a/ci/prow/config_knative.yaml
+++ b/ci/prow/config_knative.yaml
@@ -39,6 +39,9 @@ presubmits:
       - "./test/e2e-upgrade-tests.sh --istio-version 1.3-latest --no-mesh"
     - custom-test: smoke-tests
       dot-dev: true
+      #
+      always_run: false
+      optional: true
       args:
       - "--run-test"
       - "./test/e2e-smoke-tests.sh"


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
As the smoke tests sometimes can be very flaky, see https://prow.knative.dev/view/gcs/knative-prow/pr-logs/pull/knative_serving/6771/pull-knative-serving-smoke-tests/1225867524990570497, setting it as a required job will be consistently blocking PRs. For now setting it to be optional to stop bothering developers..
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @chaodaiG 

