### PR TITLE
Document how/what files are excluded from coverage

### DIFF
--- a/tools/coverage/README.md
+++ b/tools/coverage/README.md
@@ -20,7 +20,7 @@ This tool allows users to specify which files to skip, from reporting and aggreg
 User can add the git attribute `coverage-excluded=true` to any directory or file to exclude files.
 [Here](https://github.com/knative/serving/blob/master/.gitattributes) is an example.
 
-### Other automatically excluded files
+### Other Automatically Excluded Files
 - Source file (say `abc.go`) without corresponding `_test.go` file (abc_test.go)
 - Any file that has the gitattribute of `linguist-generated=true`
 

--- a/tools/coverage/README.md
+++ b/tools/coverage/README.md
@@ -14,6 +14,16 @@ The code coverage tool has two major features:
 
 See the [design document](design.md).
 
+## Skipped Files
+
+This tool allows users to specify which files to skip, from reporting and aggregation.
+User can add the git attribute `coverage-excluded=true` to any directory or file to exclude files.
+[Here](https://github.com/knative/serving/blob/master/.gitattributes) is an example.
+
+### Other automatically excluded files
+- Source file (say `abc.go`) without corresponding `_test.go` file (abc_test.go)
+- Any file that has the gitattribute of `linguist-generated=true`
+
 ## Build and Release
 
 In the `/images/coverage` directory, run `make IMAGE_NAME=coverage-dev push` to


### PR DESCRIPTION
Adds documentation on how and what files are excluded by the coverage tool

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #

**Special notes to reviewers**:

**User-visible changes in this PR**:

