### PR TITLE
e2e-tests.sh supports --skip-teardowns

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -175,6 +175,9 @@ This is a helper script for Knative E2E test scripts. To use it:
 1. Calling your script with `--run-tests` and the variable `KO_DOCKER_REPO` set
    will immediately start the tests against the cluster currently configured for
    `kubectl`.
+   
+1. By default `knative_teardown()` and `test_teardown()` will be called after
+   the tests finish, use `--skip-teardowns` if you don't want them to be called.
 
 1. By default Istio is installed on the cluster via Addon, use
    `--skip-istio-addon` if you choose not to have it preinstalled.

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -455,8 +455,8 @@ function initialize() {
     case ${parameter} in
       --run-tests) RUN_TESTS=1 ;;
       --skip-knative-setup) SKIP_KNATIVE_SETUP=1 ;;
+      --skip-teardowns) SKIP_TEARDOWNS=1 ;;
       --skip-istio-addon) SKIP_ISTIO_ADDON=1 ;;
-      --skip-tear-downs) SKIP_TEARDOWNS=1 ;;
       *)
         [[ $# -ge 2 ]] || abort "missing parameter after $1"
         shift

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -365,7 +365,8 @@ function setup_test_cluster() {
 
   export KO_DATA_PATH="${REPO_ROOT_DIR}/.git"
 
-  trap teardown_test_resources EXIT
+  # Do not run teardowns if we explicitly want to skip them.
+  (( ! SKIP_TEARDOWNS )) && trap teardown_test_resources EXIT
 
   # Handle failures ourselves, so we can dump useful info.
   set +o errexit
@@ -419,6 +420,7 @@ function fail_test() {
 RUN_TESTS=0
 SKIP_KNATIVE_SETUP=0
 SKIP_ISTIO_ADDON=0
+SKIP_TEARDOWNS=0
 GCP_PROJECT=""
 E2E_SCRIPT=""
 E2E_CLUSTER_VERSION=""
@@ -454,6 +456,7 @@ function initialize() {
       --run-tests) RUN_TESTS=1 ;;
       --skip-knative-setup) SKIP_KNATIVE_SETUP=1 ;;
       --skip-istio-addon) SKIP_ISTIO_ADDON=1 ;;
+      --skip-tear-downs) SKIP_TEARDOWNS=1 ;;
       *)
         [[ $# -ge 2 ]] || abort "missing parameter after $1"
         shift
@@ -487,6 +490,7 @@ function initialize() {
   readonly EXTRA_CLUSTER_CREATION_FLAGS
   readonly EXTRA_KUBETEST_FLAGS
   readonly SKIP_KNATIVE_SETUP
+  readonly SKIP_TEARDOWNS
   readonly GKE_ADDONS
 
   if (( ! RUN_TESTS )); then


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
When developers run the e2e tests on their own cluster, sometimes they will want to install Knative and test resources, and keep them on the cluster, so they can continue running `go test xxx` without having to run the setups again.

This PR adds a simple flag to allow developers to skip the teardowns when they run e2e-tests.sh.

<!--

