### PR TITLE
additional labels for eventing-contrib

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -74,6 +74,15 @@ label:
   - proposal/0.17
   - proposal/0.18
   - proposal/0.19
+  - channel/kafka
+  - channel/natss
+  - source/awssqs
+  - source/camel
+  - source/ceph
+  - source/couchdb
+  - source/github
+  - source/kafka
+  - source/prometheus
 # Plugins enabled for each repo.
 plugins:
   google/knative-gcp:

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -74,6 +74,7 @@ label:
   - proposal/0.17
   - proposal/0.18
   - proposal/0.19
+  # eventing-contrib labels
   - channel/kafka
   - channel/natss
   - source/awssqs

--- a/config/prow/templates/prow_plugins.yaml
+++ b/config/prow/templates/prow_plugins.yaml
@@ -63,6 +63,8 @@ label:
   - proposal/0.17
   - proposal/0.18
   - proposal/0.19
+
+  # eventing-contrib labels
   - channel/kafka
   - channel/natss
   - source/awssqs

--- a/config/prow/templates/prow_plugins.yaml
+++ b/config/prow/templates/prow_plugins.yaml
@@ -63,7 +63,15 @@ label:
   - proposal/0.17
   - proposal/0.18
   - proposal/0.19
-
+  - channel/kafka
+  - channel/natss
+  - source/awssqs
+  - source/camel
+  - source/ceph
+  - source/couchdb
+  - source/github
+  - source/kafka
+  - source/prometheus
 # Plugins enabled for each repo.
 
 plugins:


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
it has additional labels for categorizing eventing-contrib issues by channel and source type.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:



**Special notes to reviewers**:

**User-visible changes in this PR**: 