### PR TITLE
Update prow images and deployments

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -29,10 +29,10 @@ plank:
     grace_period: 15000000000 # 15s
     utility_images:
       # Update these versions when updating plank version in cluster.yaml
-      clonerefs: "gcr.io/k8s-prow/clonerefs:v20200130-51abc4f96"
-      initupload: "gcr.io/k8s-prow/initupload:v20200130-51abc4f96"
-      entrypoint: "gcr.io/k8s-prow/entrypoint:v20200130-51abc4f96"
-      sidecar: "gcr.io/k8s-prow/sidecar:v20200130-51abc4f96"
+      clonerefs: "gcr.io/k8s-prow/clonerefs:v20200204-7e8cd997a"
+      initupload: "gcr.io/k8s-prow/initupload:v20200204-7e8cd997a"
+      entrypoint: "gcr.io/k8s-prow/entrypoint:v20200204-7e8cd997a"
+      sidecar: "gcr.io/k8s-prow/sidecar:v20200204-7e8cd997a"
     gcs_configuration:
       bucket: "knative-prow"
       path_strategy: "explicit"

--- a/config/prow/deployments/boskos_deployment.yaml
+++ b/config/prow/deployments/boskos_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: boskos
-        image: gcr.io/k8s-prow/boskos/boskos:v20200121-9a9eed662
+        image: gcr.io/k8s-prow/boskos/boskos:v20200203-a909b961a
         args:
         - --config=/etc/config/config
         - --namespace=test-pods

--- a/config/prow/deployments/boskos_janitor.yaml
+++ b/config/prow/deployments/boskos_janitor.yaml
@@ -31,7 +31,7 @@ spec:
       terminationGracePeriodSeconds: 300
       containers:
       - name: boskos-janitor
-        image: gcr.io/k8s-prow/boskos/janitor:v20200121-9a9eed662
+        image: gcr.io/k8s-prow/boskos/janitor:v20200203-a909b961a
         args:
         - --resource-type=gke-project
         - --

--- a/config/prow/deployments/boskos_reaper.yaml
+++ b/config/prow/deployments/boskos_reaper.yaml
@@ -31,6 +31,6 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: boskos-reaper
-        image: gcr.io/k8s-prow/boskos/reaper:v20200121-9a9eed662
+        image: gcr.io/k8s-prow/boskos/reaper:v20200203-a909b961a
         args:
         - --resource-type=gke-project

--- a/config/prow/deployments/crier.yaml
+++ b/config/prow/deployments/crier.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20200130-51abc4f96
+        image: gcr.io/k8s-prow/crier:v20200204-7e8cd997a
         args:
         - --pubsub-workers=5 # Arbitrary number of multiplier
         - --report-agent=knative-build

--- a/config/prow/deployments/deck.yaml
+++ b/config/prow/deployments/deck.yaml
@@ -25,6 +25,9 @@ spec:
     rollingUpdate:
       maxSurge: 1
       maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: deck
   template:
     metadata:
       labels:
@@ -34,7 +37,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20200130-51abc4f96
+        image: gcr.io/k8s-prow/deck:v20200204-7e8cd997a
         args:
         - --hook-url=http://hook:8888/plugin-help
         - --tide-url=http://tide/
@@ -58,6 +61,19 @@ spec:
         - name: cookie-secret
           mountPath: /etc/cookie
           readOnly: true
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 3
+          periodSeconds: 3
+        readinessProbe:
+          httpGet:
+            path: /healthz/ready
+            port: 8081
+          initialDelaySeconds: 10
+          periodSeconds: 3
+          timeoutSeconds: 600
       volumes:
       - name: config
         configMap:

--- a/config/prow/deployments/hook.yaml
+++ b/config/prow/deployments/hook.yaml
@@ -26,6 +26,9 @@ spec:
     rollingUpdate:
       maxSurge: 1
       maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: hook
   template:
     metadata:
       labels:
@@ -35,7 +38,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20200130-51abc4f96
+        image: gcr.io/k8s-prow/hook:v20200204-7e8cd997a
         imagePullPolicy: Always
         args:
         - --dry-run=false
@@ -60,6 +63,19 @@ spec:
         - name: plugins
           mountPath: /etc/plugins
           readOnly: true
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 3
+          periodSeconds: 3
+        readinessProbe:
+          httpGet:
+            path: /healthz/ready
+            port: 8081
+          initialDelaySeconds: 10
+          periodSeconds: 3
+          timeoutSeconds: 600
       volumes:
       - name: hmac
         secret:

--- a/config/prow/deployments/horologium.yaml
+++ b/config/prow/deployments/horologium.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20200130-51abc4f96
+        image: gcr.io/k8s-prow/horologium:v20200204-7e8cd997a
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/config/prow/deployments/plank.yaml
+++ b/config/prow/deployments/plank.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
       - name: plank
         # Update plank utility_images versions in config.yaml when updating this version
-        image: gcr.io/k8s-prow/plank:v20200130-51abc4f96
+        image: gcr.io/k8s-prow/plank:v20200204-7e8cd997a
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/config/prow/deployments/sinker.yaml
+++ b/config/prow/deployments/sinker.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: "sinker"
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:v20200130-51abc4f96
+        image: gcr.io/k8s-prow/sinker:v20200204-7e8cd997a
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/config/prow/deployments/tide.yaml
+++ b/config/prow/deployments/tide.yaml
@@ -41,7 +41,7 @@ spec:
       serviceAccountName: "tide"
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20200130-51abc4f96
+        image: gcr.io/k8s-prow/tide:v20200204-7e8cd997a
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/config/prow/staging/config.yaml
+++ b/config/prow/staging/config.yaml
@@ -28,10 +28,10 @@ plank:
     grace_period: 15000000000 # 15s
     utility_images:
       # Update these versions when updating plank version in cluster.yaml
-      clonerefs: "gcr.io/k8s-prow/clonerefs:v20200130-51abc4f96"
-      initupload: "gcr.io/k8s-prow/initupload:v20200130-51abc4f96"
-      entrypoint: "gcr.io/k8s-prow/entrypoint:v20200130-51abc4f96"
-      sidecar: "gcr.io/k8s-prow/sidecar:v20200130-51abc4f96"
+      clonerefs: "gcr.io/k8s-prow/clonerefs:v20200204-7e8cd997a"
+      initupload: "gcr.io/k8s-prow/initupload:v20200204-7e8cd997a"
+      entrypoint: "gcr.io/k8s-prow/entrypoint:v20200204-7e8cd997a"
+      sidecar: "gcr.io/k8s-prow/sidecar:v20200204-7e8cd997a"
     gcs_configuration:
       bucket: "knative-prow-staging"
       path_strategy: "explicit"

--- a/config/prow/templates/prow_config.yaml
+++ b/config/prow/templates/prow_config.yaml
@@ -9,10 +9,10 @@ plank:
     grace_period: 15000000000 # 15s
     utility_images:
       # Update these versions when updating plank version in cluster.yaml
-      clonerefs: "gcr.io/k8s-prow/clonerefs:v20200130-51abc4f96"
-      initupload: "gcr.io/k8s-prow/initupload:v20200130-51abc4f96"
-      entrypoint: "gcr.io/k8s-prow/entrypoint:v20200130-51abc4f96"
-      sidecar: "gcr.io/k8s-prow/sidecar:v20200130-51abc4f96"
+      clonerefs: "gcr.io/k8s-prow/clonerefs:v20200204-7e8cd997a"
+      initupload: "gcr.io/k8s-prow/initupload:v20200204-7e8cd997a"
+      entrypoint: "gcr.io/k8s-prow/entrypoint:v20200204-7e8cd997a"
+      sidecar: "gcr.io/k8s-prow/sidecar:v20200204-7e8cd997a"
     gcs_configuration:
       bucket: "[[.GcsBucket]]"
       path_strategy: "explicit"


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
1. Update Prow images to the same version that was committed in https://github.com/knative/test-infra/pull/1682
2. Fix #1693 
To be more clear, the images update actually did not break Prow. When that issue happened, prow.knative.dev was not accessible because we were doing rolling update for deck but didn't set readinessProbe for it, so the deployment will possibly route the request to unreachable pod. Adding readinessProbe and livenessProbe will solve this problem.

/cc @chaodaiG 
