### PR TITLE
Fix the issue tracker jobs and improve doc

### DIFF
--- a/config/prow/issue_tracker_config.go
+++ b/config/prow/issue_tracker_config.go
@@ -130,7 +130,6 @@ func (r repoIssue) generateJob(jobName, labelFilter, updatedTime, comment string
 	data.Base.Command = jobCmd
 	data.Base.Args = []string{
 		fmt.Sprintf(`--query=repo:%s
-        is:issue
         is:open
         %s`, r.name, labelFilter),
 		"--updated=" + updatedTime,

--- a/config/prow/jobs/config.yaml
+++ b/config/prow/jobs/config.yaml
@@ -8605,7 +8605,6 @@ periodics:
       - "/app/robots/commenter/app.binary"
       args:
       - "--query=repo:knative/test-infra
-        is:issue
         is:open
         -label:lifecycle/frozen
         -label:lifecycle/stale
@@ -8640,7 +8639,6 @@ periodics:
       - "/app/robots/commenter/app.binary"
       args:
       - "--query=repo:knative/test-infra
-        is:issue
         is:open
         -label:lifecycle/frozen
         label:lifecycle/stale
@@ -8675,7 +8673,6 @@ periodics:
       - "/app/robots/commenter/app.binary"
       args:
       - "--query=repo:knative/test-infra
-        is:issue
         is:open
         -label:lifecycle/frozen
         -label:lifecycle/stale
@@ -8710,7 +8707,6 @@ periodics:
       - "/app/robots/commenter/app.binary"
       args:
       - "--query=repo:knative/docs
-        is:issue
         is:open
         -label:lifecycle/frozen
         -label:lifecycle/stale
@@ -8745,7 +8741,6 @@ periodics:
       - "/app/robots/commenter/app.binary"
       args:
       - "--query=repo:knative/docs
-        is:issue
         is:open
         -label:lifecycle/frozen
         label:lifecycle/stale
@@ -8780,7 +8775,6 @@ periodics:
       - "/app/robots/commenter/app.binary"
       args:
       - "--query=repo:knative/docs
-        is:issue
         is:open
         -label:lifecycle/frozen
         -label:lifecycle/stale
@@ -8815,7 +8809,6 @@ periodics:
       - "/app/robots/commenter/app.binary"
       args:
       - "--query=repo:knative/serving
-        is:issue
         is:open
         -label:lifecycle/frozen
         -label:lifecycle/stale
@@ -8850,7 +8843,6 @@ periodics:
       - "/app/robots/commenter/app.binary"
       args:
       - "--query=repo:knative/serving
-        is:issue
         is:open
         -label:lifecycle/frozen
         label:lifecycle/stale
@@ -8885,7 +8877,6 @@ periodics:
       - "/app/robots/commenter/app.binary"
       args:
       - "--query=repo:knative/serving
-        is:issue
         is:open
         -label:lifecycle/frozen
         -label:lifecycle/stale

--- a/config/prow_setup.md
+++ b/config/prow_setup.md
@@ -104,10 +104,14 @@
 
    ![Branch Checks](branch_checks.png)
 
-## Setting up the issue tracker for a new repo
+## Setting up the issue tracker for a repo
+
+If you want Prow to manage the freshness level for Issues and Pull Requests for
+a repo (see the [proposal](https://docs.google.com/document/d/15sqqVxOGAXLNEDFp777NWIpevwrSMYbGQABFLNqiq5Q/edit#heading=h.n8a530nnrb)),
+you can set it up by following steps below:
 
 1. Create the labels `lifecycle/stale`, `lifecycle/rotten` and
-   `lifecycle/frozen` in the new repo.
+   `lifecycle/frozen` in the repo.
 
 1. Update
    [`generateIssueTrackerPeriodicJobs()`](https://github.com/knative/test-infra/blob/51c37921d4a7722855fcbb020db3c3865db1cb8f/ci/prow/issue_tracker_config.go#L48)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
1. The doc confused developer in https://github.com/knative/test-infra/pull/1698#discussion_r378588352, as it's actually not a required setting for all new repos. Fix the doc to be more clear.
2. The proposal actually states that the job should be run on all both issue and PRs, so remove the `is:issue` filter in the jobs.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

