### PR TITLE
We have to use kubectl replace for job-config configmap

### DIFF
--- a/config/prow/Makefile
+++ b/config/prow/Makefile
@@ -89,7 +89,9 @@ ifndef SKIP_CONFIG_BACKUP
 else
 	$(eval NEW_YAML_CONFIG := $(PROW_JOB_CONFIG))
 endif
-	kubectl create configmap job-config --from-file=config.yaml=$(NEW_YAML_CONFIG) --dry-run --save-config -o yaml | kubectl apply -f -
+	# We'll have to use `kubectl replace` here because `kubectl apply` will add the whole original configmap to the
+	# `last-applied-configuration` annotation, but k8s has a maxmium 256kb limit for it, see https://github.com/kubernetes/kubectl/issues/712
+	kubectl create configmap job-config --from-file=config.yaml=$(NEW_YAML_CONFIG) --dry-run -o yaml | kubectl replace configmap job-config -f -
 	$(UNSET_CONTEXT)
 ifndef SKIP_CONFIG_BACKUP
 	diff "${OLD_YAML_CONFIG}" "${NEW_YAML_CONFIG}" --color=auto || true


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
For `job-config` configmap, we'll have to use `kubectl replace`, see the comment added in the PR.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @chaodaiG 
