### PR TITLE
golang format tools

### DIFF
--- a/tools/config-generator/issue_tracker_config.go
+++ b/tools/config-generator/issue_tracker_config.go
@@ -19,7 +19,7 @@ limitations under the License.
 package main
 
 import (
-    "fmt"
+	"fmt"
 	"strings"
 )
 

--- a/tools/config-generator/perf_config.go
+++ b/tools/config-generator/perf_config.go
@@ -20,7 +20,7 @@ limitations under the License.
 package main
 
 import (
-    "fmt"
+	"fmt"
 )
 
 const (
@@ -35,7 +35,7 @@ func generatePerfClusterUpdatePeriodicJobs() {
 		if repo.EnablePerformanceTests {
 			perfClusterPeriodicJob(
 				"recreate-clusters",
-                recreatePerfClusterPeriodicJobCron,
+				recreatePerfClusterPeriodicJobCron,
 				perfTestScriptPath,
 				[]string{"--recreate-clusters"},
 				repo,
@@ -43,7 +43,7 @@ func generatePerfClusterUpdatePeriodicJobs() {
 			)
 			perfClusterPeriodicJob(
 				"update-clusters",
-                updatePerfClusterPeriodicJobCron,
+				updatePerfClusterPeriodicJobCron,
 				perfTestScriptPath,
 				[]string{"--update-clusters"},
 				repo,

--- a/tools/config-generator/periodic_config.go
+++ b/tools/config-generator/periodic_config.go
@@ -19,7 +19,7 @@ limitations under the License.
 package main
 
 import (
-    "fmt"
+	"fmt"
 	"log"
 	"math"
 	"path"

--- a/tools/config-generator/postsubmit_config.go
+++ b/tools/config-generator/postsubmit_config.go
@@ -17,7 +17,7 @@ limitations under the License.
 package main
 
 import (
-    "fmt"
+	"fmt"
 	"path"
 	"strings"
 

--- a/tools/config-generator/presubmit_config.go
+++ b/tools/config-generator/presubmit_config.go
@@ -17,7 +17,7 @@ limitations under the License.
 package main
 
 import (
-    "strings"
+	"strings"
 
 	"gopkg.in/yaml.v2"
 )

--- a/tools/config-generator/testgrid_config.go
+++ b/tools/config-generator/testgrid_config.go
@@ -19,7 +19,7 @@ limitations under the License.
 package main
 
 import (
-    "fmt"
+	"fmt"
 	"regexp"
 	"strings"
 	"time"


### PR DESCRIPTION
<!--golang format tools-->
<!---->
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -path './third_party' -prune -o -type f -name '*.go' -print)`
  `goimports -w $(find -name '*.go' | grep -v vendor | grep -v third_party)`
/assign chaodaig
/cc chaodaig
