### PR TITLE
prow-auto-bumper also scans templates folder

### DIFF
--- a/config/prow/pj-on-kind.sh
+++ b/config/prow/pj-on-kind.sh
@@ -25,7 +25,7 @@ set -o nounset
 set -o pipefail
 
 prowdir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
-export CONFIG_PATH="${prowdir}/config.yaml"
+export CONFIG_PATH="${prowdir}/core/config.yaml"
 export JOB_CONFIG_PATH="${prowdir}/jobs/config.yaml"
 
 bash <(curl -sSfL https://raw.githubusercontent.com/kubernetes/test-infra/master/prow/pj-on-kind.sh) "$@"

--- a/config/prow/run_job.sh
+++ b/config/prow/run_job.sh
@@ -30,7 +30,7 @@ run_mkpj="mkpj"
 [[ -z "$(which mkpj)" ]] && run_mkpj="bazel run @k8s//prow/cmd/mkpj --"
 
 JOB_YAML=$(mktemp)
-CONFIG_YAML=${REPO_ROOT_DIR}/config/prow/config.yaml
+CONFIG_YAML=${REPO_ROOT_DIR}/config/prow/core/config.yaml
 JOB_CONFIG_YAML=${REPO_ROOT_DIR}/config/prow/jobs/config.yaml
 ${run_mkpj} --job=$1 --config-path=${CONFIG_YAML} --job-config-path=${JOB_CONFIG_YAML} > ${JOB_YAML}
 echo "Job YAML file saved to ${JOB_YAML}"

--- a/tools/prow-auto-bumper/config.go
+++ b/tools/prow-auto-bumper/config.go
@@ -39,9 +39,6 @@ const (
 	// srcPRUserID is the user from which PR was created
 	srcPRUserID = "k8s-ci-robot"
 
-	// configPath is the path where the configuration files are saved
-	configPath = "config"
-
 	// Git info for target repo that Prow version bump PR targets
 	org  = "knative"
 	repo = "test-infra"
@@ -65,6 +62,8 @@ const (
 )
 
 var (
+	// configPaths are the list of paths where the configuration files are saved
+	configPaths = []string{"config", "tools/config-generator"}
 	// Whitelist of files to be scanned by this tool
 	fileFilters = []*regexp.Regexp{regexp.MustCompile(`\.yaml$`)}
 	// Matching            gcr.io /k8s-(prow|testimage)/(kubekin-e2e|boskos|.*) (/janitor|/reaper|/.*)?        :vYYYYMMDD-HASH-VARIANT


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
`prow-auto-bumper` also scans templates folder as there are Prow images paths in the yaml files as well, after we moved the config-generator tool.

Also fix some other errors that are due to the path change.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @chaodaiG 
