### PR TITLE
Revert "Update prow to v20200212-1f7b8ac1d"

### DIFF
--- a/config/prow/cluster/400-boskos-deployment.yaml
+++ b/config/prow/cluster/400-boskos-deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: boskos
-        image: gcr.io/k8s-prow/boskos/boskos:v20200212-1f7b8ac1d
+        image: gcr.io/k8s-prow/boskos/boskos:v20200203-a909b961a
         args:
         - --config=/etc/config/config
         - --namespace=test-pods

--- a/config/prow/cluster/400-boskos-janitor.yaml
+++ b/config/prow/cluster/400-boskos-janitor.yaml
@@ -31,7 +31,7 @@ spec:
       terminationGracePeriodSeconds: 300
       containers:
       - name: boskos-janitor
-        image: gcr.io/k8s-prow/boskos/janitor:v20200212-1f7b8ac1d
+        image: gcr.io/k8s-prow/boskos/janitor:v20200203-a909b961a
         args:
         - --resource-type=gke-project
         - --

--- a/config/prow/cluster/400-boskos-metrics.yaml
+++ b/config/prow/cluster/400-boskos-metrics.yaml
@@ -32,7 +32,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: metrics
-        image: gcr.io/k8s-prow/boskos/metrics:v20200212-1f7b8ac1d
+        image: gcr.io/k8s-prow/boskos/metrics:v20200121-9a9eed662
         args:
         - --resource-type=gke-project
         ports:

--- a/config/prow/cluster/400-boskos-reaper.yaml
+++ b/config/prow/cluster/400-boskos-reaper.yaml
@@ -31,6 +31,6 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: boskos-reaper
-        image: gcr.io/k8s-prow/boskos/reaper:v20200212-1f7b8ac1d
+        image: gcr.io/k8s-prow/boskos/reaper:v20200203-a909b961a
         args:
         - --resource-type=gke-project

--- a/config/prow/cluster/400-crier.yaml
+++ b/config/prow/cluster/400-crier.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20200212-1f7b8ac1d
+        image: gcr.io/k8s-prow/crier:v20200204-7e8cd997a
         args:
         - --pubsub-workers=5 # Arbitrary number of multiplier
         - --report-agent=knative-build

--- a/config/prow/cluster/400-deck.yaml
+++ b/config/prow/cluster/400-deck.yaml
@@ -37,7 +37,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20200212-1f7b8ac1d
+        image: gcr.io/k8s-prow/deck:v20200204-7e8cd997a
         args:
         - --hook-url=http://hook:8888/plugin-help
         - --tide-url=http://tide/

--- a/config/prow/cluster/400-hook.yaml
+++ b/config/prow/cluster/400-hook.yaml
@@ -38,7 +38,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20200212-1f7b8ac1d
+        image: gcr.io/k8s-prow/hook:v20200204-7e8cd997a
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/config/prow/cluster/400-horologium.yaml
+++ b/config/prow/cluster/400-horologium.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20200212-1f7b8ac1d
+        image: gcr.io/k8s-prow/horologium:v20200204-7e8cd997a
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/config/prow/cluster/400-plank.yaml
+++ b/config/prow/cluster/400-plank.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
       - name: plank
         # Update plank utility_images versions in config.yaml when updating this version
-        image: gcr.io/k8s-prow/plank:v20200212-1f7b8ac1d
+        image: gcr.io/k8s-prow/plank:v20200204-7e8cd997a
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/config/prow/cluster/400-sinker.yaml
+++ b/config/prow/cluster/400-sinker.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: "sinker"
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:v20200212-1f7b8ac1d
+        image: gcr.io/k8s-prow/sinker:v20200204-7e8cd997a
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/config/prow/cluster/400-tide.yaml
+++ b/config/prow/cluster/400-tide.yaml
@@ -41,7 +41,7 @@ spec:
       serviceAccountName: "tide"
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20200212-1f7b8ac1d
+        image: gcr.io/k8s-prow/tide:v20200204-7e8cd997a
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/config/prow/core/config.yaml
+++ b/config/prow/core/config.yaml
@@ -29,10 +29,10 @@ plank:
     grace_period: 15000000000 # 15s
     utility_images:
       # Update these versions when updating plank version in cluster.yaml
-      clonerefs: "gcr.io/k8s-prow/clonerefs:v20200212-1f7b8ac1d"
-      initupload: "gcr.io/k8s-prow/initupload:v20200212-1f7b8ac1d"
-      entrypoint: "gcr.io/k8s-prow/entrypoint:v20200212-1f7b8ac1d"
-      sidecar: "gcr.io/k8s-prow/sidecar:v20200212-1f7b8ac1d"
+      clonerefs: "gcr.io/k8s-prow/clonerefs:v20200204-7e8cd997a"
+      initupload: "gcr.io/k8s-prow/initupload:v20200204-7e8cd997a"
+      entrypoint: "gcr.io/k8s-prow/entrypoint:v20200204-7e8cd997a"
+      sidecar: "gcr.io/k8s-prow/sidecar:v20200204-7e8cd997a"
     gcs_configuration:
       bucket: "knative-prow"
       path_strategy: "explicit"

--- a/config/prow/staging/config.yaml
+++ b/config/prow/staging/config.yaml
@@ -29,10 +29,10 @@ plank:
     grace_period: 15000000000 # 15s
     utility_images:
       # Update these versions when updating plank version in cluster.yaml
-      clonerefs: "gcr.io/k8s-prow/clonerefs:v20200212-1f7b8ac1d"
-      initupload: "gcr.io/k8s-prow/initupload:v20200212-1f7b8ac1d"
-      entrypoint: "gcr.io/k8s-prow/entrypoint:v20200212-1f7b8ac1d"
-      sidecar: "gcr.io/k8s-prow/sidecar:v20200212-1f7b8ac1d"
+      clonerefs: "gcr.io/k8s-prow/clonerefs:v20200204-7e8cd997a"
+      initupload: "gcr.io/k8s-prow/initupload:v20200204-7e8cd997a"
+      entrypoint: "gcr.io/k8s-prow/entrypoint:v20200204-7e8cd997a"
+      sidecar: "gcr.io/k8s-prow/sidecar:v20200204-7e8cd997a"
     gcs_configuration:
       bucket: "knative-prow-staging"
       path_strategy: "explicit"

--- a/tools/config-generator/templates/prow_config.yaml
+++ b/tools/config-generator/templates/prow_config.yaml
@@ -9,10 +9,10 @@ plank:
     grace_period: 15000000000 # 15s
     utility_images:
       # Update these versions when updating plank version in cluster.yaml
-      clonerefs: "gcr.io/k8s-prow/clonerefs:v20200212-1f7b8ac1d"
-      initupload: "gcr.io/k8s-prow/initupload:v20200212-1f7b8ac1d"
-      entrypoint: "gcr.io/k8s-prow/entrypoint:v20200212-1f7b8ac1d"
-      sidecar: "gcr.io/k8s-prow/sidecar:v20200212-1f7b8ac1d"
+      clonerefs: "gcr.io/k8s-prow/clonerefs:v20200204-7e8cd997a"
+      initupload: "gcr.io/k8s-prow/initupload:v20200204-7e8cd997a"
+      entrypoint: "gcr.io/k8s-prow/entrypoint:v20200204-7e8cd997a"
+      sidecar: "gcr.io/k8s-prow/sidecar:v20200204-7e8cd997a"
     gcs_configuration:
       bucket: "[[.GcsBucket]]"
       path_strategy: "explicit"


### PR DESCRIPTION
Boskos is broken after this update:

```
chizhg@chizhg-macbookpro:~/go/src/github.com/knative-prow-robot$ ku logs boskos-85f49fd654-9dxjb -n test-pods
E0217 23:44:28.890959       1 reflector.go:125] external/io_k8s_client_go/tools/cache/reflector.go:98: Failed to list *crds.DRLCObject: no kind "DRLCCollection" is registered for version "boskos.k8s.io/v1" in scheme "pkg/runtime/scheme.go:101"
E0217 23:44:28.896037       1 reflector.go:125] external/io_k8s_client_go/tools/cache/reflector.go:98: Failed to list *crds.ResourceObject: no kind "ResourceCollection" is registered for version "boskos.k8s.io/v1" in scheme "pkg/runtime/scheme.go:101"
```

/cc @chaodaiG 