### PR TITLE
Disable default failure alert

### DIFF
--- a/config/prow/testgrid/testgrid.yaml
+++ b/config/prow/testgrid/testgrid.yaml
@@ -52,6 +52,8 @@ default_dashboard_tab:
   num_columns_recent: 10
   code_search_url_template:      # The URL template to visit when searching for changelists
     url: https://github.com/knative/serving/compare/<start-custom-0>...<end-custom-0>
+  num_failures_to_alert: 0
+  num_passes_to_disable_alert: 1
 test_groups:
 - name: ci-knative-serving-continuous
   gcs_prefix: knative-prow/logs/ci-knative-serving-continuous

--- a/config/prow/testgrid/testgrid.yaml
+++ b/config/prow/testgrid/testgrid.yaml
@@ -426,9 +426,15 @@ dashboards:
   - name: continuous
     test_group_name: ci-knative-serving-continuous
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 3
   - name: conformance
     test_group_name: ci-knative-serving-continuous
     base_options: "include-filter-by-regex=test/conformance/&sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 3
   - name: istio-1.5-mesh
     test_group_name: ci-knative-serving-istio-1.5-mesh
     base_options: "sort-by-name="
@@ -459,12 +465,21 @@ dashboards:
   - name: nightly
     test_group_name: ci-knative-serving-nightly-release
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 1
   - name: dot-release
     test_group_name: ci-knative-serving-dot-release
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 1
   - name: auto-release
     test_group_name: ci-knative-serving-auto-release
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 1
   - name: webhook-apicoverage
     test_group_name: ci-knative-serving-webhook-apicoverage
     base_options: "sort-by-name="
@@ -479,18 +494,30 @@ dashboards:
   - name: continuous
     test_group_name: ci-knative-client-continuous
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 3
   - name: nightly
     test_group_name: ci-knative-client-nightly-release
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 1
   - name: tekton
     test_group_name: ci-knative-client-tekton
     base_options: "sort-by-name="
   - name: dot-release
     test_group_name: ci-knative-client-dot-release
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 1
   - name: auto-release
     test_group_name: ci-knative-client-auto-release
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 1
   - name: coverage
     test_group_name: ci-knative-client-test-coverage
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
@@ -499,6 +526,9 @@ dashboards:
   - name: continuous
     test_group_name: ci-knative-client-contrib-continuous
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 3
   - name: coverage
     test_group_name: ci-knative-client-contrib-test-coverage
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
@@ -507,6 +537,9 @@ dashboards:
   - name: continuous
     test_group_name: ci-knative-docs-continuous
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 3
   - name: coverage
     test_group_name: ci-knative-docs-test-coverage
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
@@ -515,15 +548,27 @@ dashboards:
   - name: continuous
     test_group_name: ci-knative-eventing-continuous
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 3
   - name: nightly
     test_group_name: ci-knative-eventing-nightly-release
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 1
   - name: dot-release
     test_group_name: ci-knative-eventing-dot-release
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 1
   - name: auto-release
     test_group_name: ci-knative-eventing-auto-release
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 1
   - name: coverage
     test_group_name: ci-knative-eventing-test-coverage
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
@@ -532,15 +577,27 @@ dashboards:
   - name: continuous
     test_group_name: ci-knative-eventing-contrib-continuous
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 3
   - name: nightly
     test_group_name: ci-knative-eventing-contrib-nightly-release
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 1
   - name: dot-release
     test_group_name: ci-knative-eventing-contrib-dot-release
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 1
   - name: auto-release
     test_group_name: ci-knative-eventing-contrib-auto-release
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 1
   - name: coverage
     test_group_name: ci-knative-eventing-contrib-test-coverage
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
@@ -549,6 +606,9 @@ dashboards:
   - name: continuous
     test_group_name: ci-knative-pkg-continuous
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 3
   - name: coverage
     test_group_name: ci-knative-pkg-test-coverage
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
@@ -557,6 +617,9 @@ dashboards:
   - name: continuous
     test_group_name: ci-knative-caching-continuous
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 3
   - name: coverage
     test_group_name: ci-knative-caching-test-coverage
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
@@ -565,35 +628,59 @@ dashboards:
   - name: continuous
     test_group_name: ci-knative-observability-continuous
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 3
 - name: sample-controller
   dashboard_tab:
   - name: continuous
     test_group_name: ci-knative-sample-controller-continuous
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 3
 - name: sample-source
   dashboard_tab:
   - name: continuous
     test_group_name: ci-knative-sample-source-continuous
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 3
 - name: test-infra
   dashboard_tab:
   - name: continuous
     test_group_name: ci-knative-test-infra-continuous
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 3
 - name: serving-operator
   dashboard_tab:
   - name: continuous
     test_group_name: ci-knative-serving-operator-continuous
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 3
   - name: nightly
     test_group_name: ci-knative-serving-operator-nightly-release
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 1
   - name: dot-release
     test_group_name: ci-knative-serving-operator-dot-release
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 1
   - name: auto-release
     test_group_name: ci-knative-serving-operator-auto-release
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 1
   - name: coverage
     test_group_name: ci-knative-serving-operator-test-coverage
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
@@ -602,15 +689,27 @@ dashboards:
   - name: continuous
     test_group_name: ci-knative-eventing-operator-continuous
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 3
   - name: nightly
     test_group_name: ci-knative-eventing-operator-nightly-release
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 1
   - name: dot-release
     test_group_name: ci-knative-eventing-operator-dot-release
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 1
   - name: auto-release
     test_group_name: ci-knative-eventing-operator-auto-release
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 1
   - name: coverage
     test_group_name: ci-knative-eventing-operator-test-coverage
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
@@ -619,15 +718,27 @@ dashboards:
   - name: continuous
     test_group_name: ci-knative-net-contour-continuous
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 3
   - name: nightly
     test_group_name: ci-knative-net-contour-nightly-release
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 1
   - name: dot-release
     test_group_name: ci-knative-net-contour-dot-release
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 1
   - name: auto-release
     test_group_name: ci-knative-net-contour-auto-release
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 1
   - name: coverage
     test_group_name: ci-knative-net-contour-test-coverage
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
@@ -636,15 +747,27 @@ dashboards:
   - name: continuous
     test_group_name: ci-knative-net-istio-continuous
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 3
   - name: nightly
     test_group_name: ci-knative-net-istio-nightly-release
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 1
   - name: dot-release
     test_group_name: ci-knative-net-istio-dot-release
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 1
   - name: auto-release
     test_group_name: ci-knative-net-istio-auto-release
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 1
   - name: coverage
     test_group_name: ci-knative-net-istio-test-coverage
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
@@ -653,15 +776,27 @@ dashboards:
   - name: continuous
     test_group_name: ci-google-knative-gcp-continuous
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 3
   - name: nightly
     test_group_name: ci-google-knative-gcp-nightly-release
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 1
   - name: dot-release
     test_group_name: ci-google-knative-gcp-dot-release
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 1
   - name: auto-release
     test_group_name: ci-google-knative-gcp-auto-release
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 1
   - name: coverage
     test_group_name: ci-google-knative-gcp-test-coverage
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
@@ -670,68 +805,125 @@ dashboards:
   - name: serving
     test_group_name: ci-knative-serving-0.9-continuous
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 3
   - name: eventing
     test_group_name: ci-knative-eventing-0.9-continuous
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 3
   - name: eventing-contrib
     test_group_name: ci-knative-eventing-contrib-0.9-continuous
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 3
 - name: knative-0.10
   dashboard_tab:
   - name: serving
     test_group_name: ci-knative-serving-0.10-continuous
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 3
   - name: eventing
     test_group_name: ci-knative-eventing-0.10-continuous
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 3
   - name: eventing-contrib
     test_group_name: ci-knative-eventing-contrib-0.10-continuous
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 3
 - name: knative-0.11
   dashboard_tab:
   - name: serving
     test_group_name: ci-knative-serving-0.11-continuous
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 3
   - name: client
     test_group_name: ci-knative-client-0.11-continuous
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 3
   - name: eventing
     test_group_name: ci-knative-eventing-0.11-continuous
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 3
   - name: eventing-contrib
     test_group_name: ci-knative-eventing-contrib-0.11-continuous
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 3
   - name: serving-operator
     test_group_name: ci-knative-serving-operator-0.11-continuous
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 3
   - name: eventing-operator
     test_group_name: ci-knative-eventing-operator-0.11-continuous
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 3
 - name: knative-0.12
   dashboard_tab:
   - name: serving
     test_group_name: ci-knative-serving-0.12-continuous
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 3
   - name: client
     test_group_name: ci-knative-client-0.12-continuous
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 3
   - name: eventing
     test_group_name: ci-knative-eventing-0.12-continuous
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 3
   - name: eventing-contrib
     test_group_name: ci-knative-eventing-contrib-0.12-continuous
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 3
   - name: serving-operator
     test_group_name: ci-knative-serving-operator-0.12-continuous
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 3
   - name: eventing-operator
     test_group_name: ci-knative-eventing-operator-0.12-continuous
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 3
 - name: google-0.12
   dashboard_tab:
   - name: knative-gcp
     test_group_name: ci-google-knative-gcp-0.12-continuous
     base_options: "sort-by-name="
+    alert_options: 
+      alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+    num_failures_to_alert: 3
 dashboard_groups:
 - name: knative
   dashboard_names:

--- a/config/prow/testgrid/testgrid.yaml
+++ b/config/prow/testgrid/testgrid.yaml
@@ -31,6 +31,8 @@ default_test_group:
   alert_stale_results_hours: 26  # Alert if tests haven't run for a day (1 day + 2h)
   num_passes_to_disable_alert: 1 # Consider a failing test passing if it has 1 or more consecutive passes
   num_failures_to_alert: 0 #Disable failure alerts by default
+  alert_options:
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
 default_dashboard_tab:
   open_test_template:            # The URL template to visit after clicking on a cell
     url: https://prow.knative.dev/view/gcs/<gcs_prefix>/<changelist>
@@ -53,8 +55,6 @@ default_dashboard_tab:
   num_columns_recent: 10
   code_search_url_template:      # The URL template to visit when searching for changelists
     url: https://github.com/knative/serving/compare/<start-custom-0>...<end-custom-0>
-  alert_options:
-    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
 test_groups:
 - name: ci-knative-serving-continuous
   gcs_prefix: knative-prow/logs/ci-knative-serving-continuous

--- a/config/prow/testgrid/testgrid.yaml
+++ b/config/prow/testgrid/testgrid.yaml
@@ -30,6 +30,7 @@ default_test_group:
   is_external: true              # ** This field is deprecated and should always be true **
   alert_stale_results_hours: 26  # Alert if tests haven't run for a day (1 day + 2h)
   num_passes_to_disable_alert: 1 # Consider a failing test passing if it has 1 or more consecutive passes
+  num_failures_to_alert: 0 #Disable failure alerts by default
 default_dashboard_tab:
   open_test_template:            # The URL template to visit after clicking on a cell
     url: https://prow.knative.dev/view/gcs/<gcs_prefix>/<changelist>

--- a/config/prow/testgrid/testgrid.yaml
+++ b/config/prow/testgrid/testgrid.yaml
@@ -30,9 +30,6 @@ default_test_group:
   is_external: true              # ** This field is deprecated and should always be true **
   alert_stale_results_hours: 26  # Alert if tests haven't run for a day (1 day + 2h)
   num_passes_to_disable_alert: 1 # Consider a failing test passing if it has 1 or more consecutive passes
-  num_failures_to_alert: 0 #Disable failure alerts by default
-  alert_options:
-    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
 default_dashboard_tab:
   open_test_template:            # The URL template to visit after clicking on a cell
     url: https://prow.knative.dev/view/gcs/<gcs_prefix>/<changelist>
@@ -88,13 +85,19 @@ test_groups:
   alert_stale_results_hours: 3
 - name: ci-knative-serving-nightly-release
   gcs_prefix: knative-prow/logs/ci-knative-serving-nightly-release
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 1
 - name: ci-knative-serving-dot-release
   gcs_prefix: knative-prow/logs/ci-knative-serving-dot-release
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   alert_stale_results_hours: 170
   num_failures_to_alert: 1
 - name: ci-knative-serving-auto-release
   gcs_prefix: knative-prow/logs/ci-knative-serving-auto-release
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 1
 - name: ci-knative-serving-webhook-apicoverage
   gcs_prefix: knative-prow/logs/ci-knative-serving-webhook-apicoverage
@@ -110,16 +113,22 @@ test_groups:
   alert_stale_results_hours: 3
 - name: ci-knative-client-nightly-release
   gcs_prefix: knative-prow/logs/ci-knative-client-nightly-release
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 1
 - name: ci-knative-client-tekton
   gcs_prefix: knative-prow/logs/ci-knative-client-tekton
   alert_stale_results_hours: 3
 - name: ci-knative-client-dot-release
   gcs_prefix: knative-prow/logs/ci-knative-client-dot-release
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   alert_stale_results_hours: 170
   num_failures_to_alert: 1
 - name: ci-knative-client-auto-release
   gcs_prefix: knative-prow/logs/ci-knative-client-auto-release
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 1
 - name: ci-knative-client-test-coverage
   gcs_prefix: knative-prow/logs/ci-knative-client-go-coverage
@@ -141,13 +150,19 @@ test_groups:
   alert_stale_results_hours: 3
 - name: ci-knative-eventing-nightly-release
   gcs_prefix: knative-prow/logs/ci-knative-eventing-nightly-release
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 1
 - name: ci-knative-eventing-dot-release
   gcs_prefix: knative-prow/logs/ci-knative-eventing-dot-release
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   alert_stale_results_hours: 170
   num_failures_to_alert: 1
 - name: ci-knative-eventing-auto-release
   gcs_prefix: knative-prow/logs/ci-knative-eventing-auto-release
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 1
 - name: ci-knative-eventing-test-coverage
   gcs_prefix: knative-prow/logs/ci-knative-eventing-go-coverage
@@ -157,13 +172,19 @@ test_groups:
   alert_stale_results_hours: 3
 - name: ci-knative-eventing-contrib-nightly-release
   gcs_prefix: knative-prow/logs/ci-knative-eventing-contrib-nightly-release
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 1
 - name: ci-knative-eventing-contrib-dot-release
   gcs_prefix: knative-prow/logs/ci-knative-eventing-contrib-dot-release
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   alert_stale_results_hours: 170
   num_failures_to_alert: 1
 - name: ci-knative-eventing-contrib-auto-release
   gcs_prefix: knative-prow/logs/ci-knative-eventing-contrib-auto-release
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 1
 - name: ci-knative-eventing-contrib-test-coverage
   gcs_prefix: knative-prow/logs/ci-knative-eventing-contrib-go-coverage
@@ -197,13 +218,19 @@ test_groups:
   alert_stale_results_hours: 3
 - name: ci-knative-serving-operator-nightly-release
   gcs_prefix: knative-prow/logs/ci-knative-serving-operator-nightly-release
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 1
 - name: ci-knative-serving-operator-dot-release
   gcs_prefix: knative-prow/logs/ci-knative-serving-operator-dot-release
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   alert_stale_results_hours: 170
   num_failures_to_alert: 1
 - name: ci-knative-serving-operator-auto-release
   gcs_prefix: knative-prow/logs/ci-knative-serving-operator-auto-release
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 1
 - name: ci-knative-serving-operator-test-coverage
   gcs_prefix: knative-prow/logs/ci-knative-serving-operator-go-coverage
@@ -213,13 +240,19 @@ test_groups:
   alert_stale_results_hours: 3
 - name: ci-knative-eventing-operator-nightly-release
   gcs_prefix: knative-prow/logs/ci-knative-eventing-operator-nightly-release
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 1
 - name: ci-knative-eventing-operator-dot-release
   gcs_prefix: knative-prow/logs/ci-knative-eventing-operator-dot-release
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   alert_stale_results_hours: 170
   num_failures_to_alert: 1
 - name: ci-knative-eventing-operator-auto-release
   gcs_prefix: knative-prow/logs/ci-knative-eventing-operator-auto-release
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 1
 - name: ci-knative-eventing-operator-test-coverage
   gcs_prefix: knative-prow/logs/ci-knative-eventing-operator-go-coverage
@@ -229,13 +262,19 @@ test_groups:
   alert_stale_results_hours: 3
 - name: ci-knative-net-contour-nightly-release
   gcs_prefix: knative-prow/logs/ci-knative-net-contour-nightly-release
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 1
 - name: ci-knative-net-contour-dot-release
   gcs_prefix: knative-prow/logs/ci-knative-net-contour-dot-release
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   alert_stale_results_hours: 170
   num_failures_to_alert: 1
 - name: ci-knative-net-contour-auto-release
   gcs_prefix: knative-prow/logs/ci-knative-net-contour-auto-release
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 1
 - name: ci-knative-net-contour-test-coverage
   gcs_prefix: knative-prow/logs/ci-knative-net-contour-go-coverage
@@ -245,89 +284,139 @@ test_groups:
   alert_stale_results_hours: 3
 - name: ci-knative-net-istio-nightly-release
   gcs_prefix: knative-prow/logs/ci-knative-net-istio-nightly-release
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 1
 - name: ci-knative-net-istio-dot-release
   gcs_prefix: knative-prow/logs/ci-knative-net-istio-dot-release
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   alert_stale_results_hours: 170
   num_failures_to_alert: 1
 - name: ci-knative-net-istio-auto-release
   gcs_prefix: knative-prow/logs/ci-knative-net-istio-auto-release
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 1
 - name: ci-knative-net-istio-test-coverage
   gcs_prefix: knative-prow/logs/ci-knative-net-istio-go-coverage
   short_text_metric: "coverage"
 - name: ci-knative-serving-0.9-continuous
   gcs_prefix: knative-prow/logs/ci-knative-serving-0.9-continuous
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 3
 - name: ci-knative-eventing-0.9-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-0.9-continuous
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 3
 - name: ci-knative-eventing-contrib-0.9-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-contrib-0.9-continuous
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 3
 - name: ci-knative-serving-0.10-continuous
   gcs_prefix: knative-prow/logs/ci-knative-serving-0.10-continuous
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 3
 - name: ci-knative-eventing-0.10-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-0.10-continuous
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 3
 - name: ci-knative-eventing-contrib-0.10-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-contrib-0.10-continuous
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 3
 - name: ci-knative-serving-0.11-continuous
   gcs_prefix: knative-prow/logs/ci-knative-serving-0.11-continuous
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 3
 - name: ci-knative-client-0.11-continuous
   gcs_prefix: knative-prow/logs/ci-knative-client-0.11-continuous
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 3
 - name: ci-knative-eventing-0.11-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-0.11-continuous
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 3
 - name: ci-knative-eventing-contrib-0.11-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-contrib-0.11-continuous
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 3
 - name: ci-knative-serving-operator-0.11-continuous
   gcs_prefix: knative-prow/logs/ci-knative-serving-operator-0.11-continuous
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 3
 - name: ci-knative-eventing-operator-0.11-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-operator-0.11-continuous
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 3
 - name: ci-knative-serving-0.12-continuous
   gcs_prefix: knative-prow/logs/ci-knative-serving-0.12-continuous
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 3
 - name: ci-knative-client-0.12-continuous
   gcs_prefix: knative-prow/logs/ci-knative-client-0.12-continuous
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 3
 - name: ci-knative-eventing-0.12-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-0.12-continuous
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 3
 - name: ci-knative-eventing-contrib-0.12-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-contrib-0.12-continuous
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 3
 - name: ci-knative-serving-operator-0.12-continuous
   gcs_prefix: knative-prow/logs/ci-knative-serving-operator-0.12-continuous
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 3
 - name: ci-knative-eventing-operator-0.12-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-operator-0.12-continuous
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 3
 - name: ci-google-knative-gcp-continuous
   gcs_prefix: knative-prow/logs/ci-google-knative-gcp-continuous
   alert_stale_results_hours: 3
 - name: ci-google-knative-gcp-nightly-release
   gcs_prefix: knative-prow/logs/ci-google-knative-gcp-nightly-release
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 1
 - name: ci-google-knative-gcp-dot-release
   gcs_prefix: knative-prow/logs/ci-google-knative-gcp-dot-release
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   alert_stale_results_hours: 170
   num_failures_to_alert: 1
 - name: ci-google-knative-gcp-auto-release
   gcs_prefix: knative-prow/logs/ci-google-knative-gcp-auto-release
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 1
 - name: ci-google-knative-gcp-test-coverage
   gcs_prefix: knative-prow/logs/ci-google-knative-gcp-go-coverage
   short_text_metric: "coverage"
 - name: ci-google-knative-gcp-0.12-continuous
   gcs_prefix: knative-prow/logs/ci-google-knative-gcp-0.12-continuous
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 3
 dashboards:
 - name: serving

--- a/tools/config-generator/templates/testgrid_config_header.yaml
+++ b/tools/config-generator/templates/testgrid_config_header.yaml
@@ -11,9 +11,6 @@ default_test_group:
   is_external: true              # ** This field is deprecated and should always be true **
   alert_stale_results_hours: 26  # Alert if tests haven't run for a day (1 day + 2h)
   num_passes_to_disable_alert: 1 # Consider a failing test passing if it has 1 or more consecutive passes
-  num_failures_to_alert: 0 #Disable failure alerts by default
-  alert_options:
-    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
 
 default_dashboard_tab:
   open_test_template:            # The URL template to visit after clicking on a cell

--- a/tools/config-generator/templates/testgrid_config_header.yaml
+++ b/tools/config-generator/templates/testgrid_config_header.yaml
@@ -11,6 +11,7 @@ default_test_group:
   is_external: true              # ** This field is deprecated and should always be true **
   alert_stale_results_hours: 26  # Alert if tests haven't run for a day (1 day + 2h)
   num_passes_to_disable_alert: 1 # Consider a failing test passing if it has 1 or more consecutive passes
+  num_failures_to_alert: 0 #Disable failure alerts by default
 
 default_dashboard_tab:
   open_test_template:            # The URL template to visit after clicking on a cell

--- a/tools/config-generator/templates/testgrid_config_header.yaml
+++ b/tools/config-generator/templates/testgrid_config_header.yaml
@@ -12,6 +12,8 @@ default_test_group:
   alert_stale_results_hours: 26  # Alert if tests haven't run for a day (1 day + 2h)
   num_passes_to_disable_alert: 1 # Consider a failing test passing if it has 1 or more consecutive passes
   num_failures_to_alert: 0 #Disable failure alerts by default
+  alert_options:
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
 
 default_dashboard_tab:
   open_test_template:            # The URL template to visit after clicking on a cell
@@ -35,5 +37,3 @@ default_dashboard_tab:
   num_columns_recent: 10
   code_search_url_template:      # The URL template to visit when searching for changelists
     url: https://github.com/knative/serving/compare/<start-custom-0>...<end-custom-0>
-  alert_options:
-    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"

--- a/tools/config-generator/templates/testgrid_config_header.yaml
+++ b/tools/config-generator/templates/testgrid_config_header.yaml
@@ -34,3 +34,5 @@ default_dashboard_tab:
   num_columns_recent: 10
   code_search_url_template:      # The URL template to visit when searching for changelists
     url: https://github.com/knative/serving/compare/<start-custom-0>...<end-custom-0>
+  num_failures_to_alert: 0
+  num_passes_to_disable_alert: 1

--- a/tools/config-generator/templates/testgrid_dashboardtab.yaml
+++ b/tools/config-generator/templates/testgrid_dashboardtab.yaml
@@ -1,4 +1,4 @@
   - name: [[.Name]]
     test_group_name: [[.Base.TestGroupName]]
     base_options: "[[.BaseOptions]]"
-    [[indent_map 2 .Extras]]
+    [[indent_map 4 .Extras]]

--- a/tools/config-generator/testgrid_config.go
+++ b/tools/config-generator/testgrid_config.go
@@ -185,17 +185,28 @@ func generateDashboard(projName string, repoName string, jobNames []string) {
 		testGroupName := getTestGroupName(projRepoStr, jobName)
 		switch jobName {
 		case "continuous":
-			executeDashboardTabTemplate("continuous", testGroupName, testgridTabSortByName, noExtras)
+			extras := make(map[string]string)
+			extras["num_failures_to_alert"] = "3"
+			extras["alert_options"] = "\n      alert_mail_to_addresses: \"knative-productivity-dev@googlegroups.com\""
+			executeDashboardTabTemplate("continuous", testGroupName, testgridTabSortByName, extras)
 			// This is a special case for knative/serving, as conformance tab is just a filtered view of the continuous tab.
 			if projRepoStr == "knative-serving" {
-				executeDashboardTabTemplate("conformance", testGroupName, "include-filter-by-regex=test/conformance/&sort-by-name=", noExtras)
+				executeDashboardTabTemplate("conformance", testGroupName, "include-filter-by-regex=test/conformance/&sort-by-name=", extras)
 			}
-		case "dot-release", "auto-release", "webhook-apicoverage":
+		case "dot-release", "auto-release":
 			extras := make(map[string]string)
+			extras["num_failures_to_alert"] = "1"
+			extras["alert_options"] = "\n      alert_mail_to_addresses: \"knative-productivity-dev@googlegroups.com\""
 			baseOptions := testgridTabSortByName
 			executeDashboardTabTemplate(jobName, testGroupName, baseOptions, extras)
+		case "webhook-apicoverage":
+			baseOptions := testgridTabSortByName
+			executeDashboardTabTemplate(jobName, testGroupName, baseOptions, noExtras)
 		case "nightly":
-			executeDashboardTabTemplate("nightly", testGroupName, testgridTabSortByName, noExtras)
+			extras := make(map[string]string)
+			extras["num_failures_to_alert"] = "1"
+			extras["alert_options"] = "\n      alert_mail_to_addresses: \"knative-productivity-dev@googlegroups.com\""
+			executeDashboardTabTemplate("nightly", testGroupName, testgridTabSortByName, extras)
 		case "test-coverage":
 			executeDashboardTabTemplate("coverage", testGroupName, testgridTabGroupByDir, noExtras)
 		default:
@@ -232,11 +243,13 @@ func generateDashboardsForReleases() {
 		}
 		repos := metaData[projName]
 		outputConfig("- name: " + projName + "\n" + baseIndent + "dashboard_tab:")
-		noExtras := make(map[string]string)
 		for _, repoName := range repoNames {
 			if _, exists := repos[repoName]; exists {
+				extras := make(map[string]string)
+				extras["num_failures_to_alert"] = "3"
+				extras["alert_options"] = "\n      alert_mail_to_addresses: \"knative-productivity-dev@googlegroups.com\""
 				testGroupName := getTestGroupName(buildProjRepoStr(projName, repoName), "continuous")
-				executeDashboardTabTemplate(repoName, testGroupName, testgridTabSortByName, noExtras)
+				executeDashboardTabTemplate(repoName, testGroupName, testgridTabSortByName, extras)
 			}
 		}
 	}

--- a/tools/config-generator/testgrid_config.go
+++ b/tools/config-generator/testgrid_config.go
@@ -145,11 +145,13 @@ func generateTestGroup(projName string, repoName string, jobNames []string) {
 		case "continuous":
 			if contRegex.FindString(testGroupName) != "" {
 				extras["num_failures_to_alert"] = "3"
+				extras["alert_options"] = "\n    alert_mail_to_addresses: \"knative-productivity-dev@googlegroups.com\""
 			} else {
 				extras["alert_stale_results_hours"] = "3"
 			}
 		case "dot-release", "auto-release", "nightly":
 			extras["num_failures_to_alert"] = "1"
+			extras["alert_options"] = "\n    alert_mail_to_addresses: \"knative-productivity-dev@googlegroups.com\""
 			if jobName == "dot-release" {
 				extras["alert_stale_results_hours"] = "170" // 1 week + 2h
 			}


### PR DESCRIPTION
**What this PR does, why we need it**:

Disable alerts by default on failures for all test groups. If a test group wants failure alerts, it sets it individually in its test group config instead.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes to reviewers**:

**User-visible changes in this PR**:
/cc @chizhg 
