### PR TITLE
Ignore github templates when linting markdown

### DIFF
--- a/scripts/presubmit-tests.sh
+++ b/scripts/presubmit-tests.sh
@@ -127,9 +127,9 @@ function report_build_test() {
 # Perform markdown build tests if necessary, unless disabled.
 function markdown_build_tests() {
   (( DISABLE_MD_LINTING && DISABLE_MD_LINK_CHECK )) && return 0
-  # Get changed markdown files (ignore /vendor and deleted files)
+  # Get changed markdown files (ignore /vendor, github templates, and deleted files)
   local mdfiles=""
-  for file in $(echo "${CHANGED_FILES}" | grep \.md$ | grep -v ^vendor/); do
+  for file in $(echo "${CHANGED_FILES}" | grep \.md$ | grep -v ^vendor/ | grep -v ^.github/); do
     [[ -f "${file}" ]] && mdfiles="${mdfiles} ${file}"
   done
   [[ -z "${mdfiles}" ]] && return 0


### PR DESCRIPTION
**What this PR does, why we need it**:

GitHub issue and PR templates are not intended to be complete documents. Since there doesn't seem to be a way to apply different rules to different directories, this PR ignores the github template directory when doing the markdown lint in the presubmit build test.

This is intended to unblock https://github.com/knative/eventing-contrib/pull/941.