### PR TITLE
Update ko in prow-tests image

### DIFF
--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -42,7 +42,7 @@ RUN rm -rf /usr/local/go && \
     rm "${GO_TARBALL}"
 
 # Extra tools through go get
-RUN GO111MODULE=on go get github.com/google/ko/cmd/ko
+RUN GO111MODULE=on go get github.com/google/ko/cmd/ko@v0.3.0
 RUN GO111MODULE=on go get github.com/boz/kail/cmd/kail
 RUN go get -u github.com/golang/dep/cmd/dep
 RUN go get -u github.com/jstemmer/go-junit-report


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Since ko is a critical tool we use in the CI/CD flow, I believe it makes sense to pin a version that we have verified, so we don't accidentally introduce breaking changes in doing update. v0.3.0 was released 8 days ago and includes the fix we need. 

Also I run some tests with the new image and it works (the tests fail because they are flaky):
https://prow.knative.dev/view/gcs/knative-prow/logs/ci-knative-serving-continuous/1230632067109228544
https://prow.knative.dev/view/gcs/knative-prow/logs/ci-knative-serving-istio-1.3-no-mesh/1230655850540961792
https://prow.knative.dev/view/gcs/knative-prow/logs/ci-knative-serving-istio-1.3-mesh/1230655724787339264

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #1557 

/cc @chaodaiG 
/cc @yt3liu 

