### PR TITLE
Add autotls test as a separate presubmit test for serving

### DIFF
--- a/config/prow/config_knative.yaml
+++ b/config/prow/config_knative.yaml
@@ -41,6 +41,13 @@ presubmits:
       args:
       - "--run-test"
       - "./test/e2e-upgrade-tests.sh"
+    - custom-test: autotls-tests
+      dot-dev: true
+      always_run: false # TODO(chaodaiG): Lets make sure it works before turn on
+      optional: true
+      args:
+      - "--run-test"
+      - "./test/e2e-auto-tls.sh"
     - custom-test: smoke-tests
       dot-dev: true
       #

--- a/config/prow/jobs/config.yaml
+++ b/config/prow/jobs/config.yaml
@@ -342,6 +342,74 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
+  - name: pull-knative-serving-autotls-tests
+    agent: kubernetes
+    context: pull-knative-serving-autotls-tests
+    always_run: false
+    rerun_command: "/test pull-knative-serving-autotls-tests"
+    trigger: "(?m)^/test (all|pull-knative-serving-autotls-tests),?(\\s+|$)"
+    decorate: true
+    optional: true
+    path_alias: knative.dev/serving
+    branches:
+    - "release-0.9"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-auto-tls.sh"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-serving-autotls-tests
+    agent: kubernetes
+    context: pull-knative-serving-autotls-tests
+    always_run: false
+    rerun_command: "/test pull-knative-serving-autotls-tests"
+    trigger: "(?m)^/test (all|pull-knative-serving-autotls-tests),?(\\s+|$)"
+    decorate: true
+    optional: true
+    path_alias: knative.dev/serving
+    skip_branches:
+    - "release-0.9"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-auto-tls.sh"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
   - name: pull-knative-serving-smoke-tests
     agent: kubernetes
     context: pull-knative-serving-smoke-tests


### PR DESCRIPTION
Part of: https://github.com/knative/serving/issues/6862

/assign @chizhg 
/assign @ZhiminXiang 

This PR can't be merged until `auto-tls-tests.sh` is self sufficient
/hold
