### PR TITLE
Add needs-rebase to missingLabels

### DIFF
--- a/config/prow/core/config.yaml
+++ b/config/prow/core/config.yaml
@@ -120,6 +120,7 @@ tide:
     - do-not-merge/hold
     - do-not-merge/work-in-progress
     - do-not-merge/invalid-owners-file
+    - needs-rebase
   merge_method:
     knative: squash
     google/knative-gcp: squash

--- a/config/prow/staging/config.yaml
+++ b/config/prow/staging/config.yaml
@@ -104,6 +104,7 @@ tide:
     - do-not-merge/hold
     - do-not-merge/work-in-progress
     - do-not-merge/invalid-owners-file
+    - needs-rebase
   merge_method:
     knative: squash
     google/knative-gcp: squash

--- a/tools/config-generator/templates/prow_config.yaml
+++ b/tools/config-generator/templates/prow_config.yaml
@@ -87,6 +87,7 @@ tide:
     - do-not-merge/hold
     - do-not-merge/work-in-progress
     - do-not-merge/invalid-owners-file
+    - needs-rebase
   merge_method:
     knative: squash
     google/knative-gcp: squash


### PR DESCRIPTION
**What this PR does, why we need it**:

Follow up https://github.com/knative/test-infra/pull/1732

This patch adds needs-rebase to missingLabels, to stop merging by
mistake when PR has the needs-rebase label.

/lint

/cc @chizhg @chaodaiG
