### PR TITLE
Update to janitor with cleanup fix

### DIFF
--- a/config/prow/cluster/400-boskos-deployment.yaml
+++ b/config/prow/cluster/400-boskos-deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: boskos
-        image: gcr.io/k8s-prow/boskos/boskos:v20200218-a445c54db
+        image: gcr.io/k8s-prow/boskos/boskos:v20200220-47050c474
         args:
         - --config=/etc/config/config
         - --namespace=test-pods

--- a/config/prow/cluster/400-boskos-janitor.yaml
+++ b/config/prow/cluster/400-boskos-janitor.yaml
@@ -31,7 +31,7 @@ spec:
       terminationGracePeriodSeconds: 300
       containers:
       - name: boskos-janitor
-        image: gcr.io/k8s-prow/boskos/janitor:v20200218-a445c54db
+        image: gcr.io/k8s-prow/boskos/janitor:v20200220-47050c474
         args:
         - --resource-type=gke-project
         - --

--- a/config/prow/cluster/400-boskos-metrics.yaml
+++ b/config/prow/cluster/400-boskos-metrics.yaml
@@ -32,7 +32,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: metrics
-        image: gcr.io/k8s-prow/boskos/metrics:v20200212-1f7b8ac1d
+        image: gcr.io/k8s-prow/boskos/metrics:v20200220-47050c474
         args:
         - --resource-type=gke-project
         ports:

--- a/config/prow/cluster/400-boskos-reaper.yaml
+++ b/config/prow/cluster/400-boskos-reaper.yaml
@@ -31,6 +31,6 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: boskos-reaper
-        image: gcr.io/k8s-prow/boskos/reaper:v20200218-a445c54db
+        image: gcr.io/k8s-prow/boskos/reaper:v20200220-47050c474
         args:
         - --resource-type=gke-project


### PR DESCRIPTION
This fix: https://github.com/kubernetes/test-infra/pull/16353

Deployed in this commit:
https://github.com/kubernetes/test-infra/tree/5bf81d2ead6a6bda6bf001b78cf54a4c731d3d98/prow/cluster

I'm told it's working fine for Kubernetes team for the last few days.

/cc @chizhg
/assign @chizhg
