### PR TITLE
All network tests run both e2e and auto tls tests

### DIFF
--- a/config/prow/config_knative.yaml
+++ b/config/prow/config_knative.yaml
@@ -64,73 +64,55 @@ presubmits:
       dot-dev: true
       always_run: false
       optional: true
-      args:
-      - "--run-test"
-      - "./test/e2e-tests.sh --istio-version 1.3-latest --mesh &&
+      full-command: "./test/e2e-tests.sh --istio-version 1.3-latest --mesh &&
       ./test/e2e-tests.sh --run-tests --skip-knative-setup --istio-version 1.3-latest --mesh"
     - custom-test: istio-1.3-no-mesh
       dot-dev: true
       always_run: false
       optional: true
-      args:
-      - "--run-test"
-      - "./test/e2e-tests.sh --istio-version 1.3-latest --no-mesh &&
+      full-command: "./test/e2e-tests.sh --istio-version 1.3-latest --no-mesh &&
       ./test/e2e-tests.sh --run-tests --skip-knative-setup --istio-version 1.3-latest --no-mesh"
     - custom-test: istio-1.4-mesh
       dot-dev: true
       always_run: false
       optional: true
-      args:
-      - "--run-test"
-      - "./test/e2e-tests.sh --istio-version 1.4-latest --mesh &&
+      full-command: "./test/e2e-tests.sh --istio-version 1.4-latest --mesh &&
       ./test/e2e-tests.sh --run-tests --skip-knative-setup --istio-version 1.4-latest --mesh"
     - custom-test: istio-1.4-no-mesh
       dot-dev: true
       always_run: false
       optional: true
-      args:
-      - "--run-test"
-      - "./test/e2e-tests.sh --istio-version 1.4-latest --no-mesh &&
+      full-command: "./test/e2e-tests.sh --istio-version 1.4-latest --no-mesh &&
       ./test/e2e-tests.sh --run-tests --skip-knative-setup --istio-version 1.4-latest --no-mesh"
     - custom-test: gloo-0.17.1
       dot-dev: true
       always_run: false
       optional: true
-      args:
-      - "--run-test"
-      - "./test/e2e-tests.sh --gloo-version 0.17.1 &&
+      full-command: "./test/e2e-tests.sh --gloo-version 0.17.1 &&
       ./test/e2e-tests.sh --run-tests --skip-knative-setup --gloo-version 0.17.1"
     - custom-test: kourier-stable
       dot-dev: true
       always_run: false
       optional: true
-      args:
-        - "--run-test"
-        - "./test/e2e-tests.sh --kourier-version stable &&
+      full-command: "./test/e2e-tests.sh --kourier-version stable &&
       ./test/e2e-tests.sh --run-tests --skip-knative-setup --kourier-version stable"
     - custom-test: contour-latest
       dot-dev: true
       always_run: false
       optional: true
-      args:
-        - "--run-test"
-        - "./test/e2e-tests.sh --contour-version latest &&
+      full-command: "./test/e2e-tests.sh --contour-version latest &&
       ./test/e2e-tests.sh --run-tests --skip-knative-setup --contour-version latest"
     - custom-test: ambassador-latest
       dot-dev: true
       always_run: false
       optional: true
-      args:
-        - "--run-test"
-        - "./test/e2e-tests.sh --ambassador-version latest &&
+      full-command: "./test/e2e-tests.sh --ambassador-version latest &&
       ./test/e2e-tests.sh --run-tests --skip-knative-setup --ambassador-version latest"
     - custom-test: https
       dot-dev: true
       always_run: false
       optional: true
-      args:
-      - "--run-test"
-      - "./test/e2e-tests.sh --https &&
+      full-command: "./test/e2e-tests.sh --https &&
       ./test/e2e-tests.sh --run-tests --skip-knative-setup --https"
     - custom-test: build-tests-go114
       dot-dev: true

--- a/config/prow/config_knative.yaml
+++ b/config/prow/config_knative.yaml
@@ -66,63 +66,72 @@ presubmits:
       optional: true
       args:
       - "--run-test"
-      - "./test/e2e-tests.sh --istio-version 1.3-latest --mesh"
+      - "./test/e2e-tests.sh --istio-version 1.3-latest --mesh &&
+      ./test/e2e-tests.sh --run-tests --skip-knative-setup --istio-version 1.3-latest --mesh"
     - custom-test: istio-1.3-no-mesh
       dot-dev: true
       always_run: false
       optional: true
       args:
       - "--run-test"
-      - "./test/e2e-tests.sh --istio-version 1.3-latest --no-mesh"
+      - "./test/e2e-tests.sh --istio-version 1.3-latest --no-mesh &&
+      ./test/e2e-tests.sh --run-tests --skip-knative-setup --istio-version 1.3-latest --no-mesh"
     - custom-test: istio-1.4-mesh
       dot-dev: true
       always_run: false
       optional: true
       args:
       - "--run-test"
-      - "./test/e2e-tests.sh --istio-version 1.4-latest --mesh"
+      - "./test/e2e-tests.sh --istio-version 1.4-latest --mesh &&
+      ./test/e2e-tests.sh --run-tests --skip-knative-setup --istio-version 1.4-latest --mesh"
     - custom-test: istio-1.4-no-mesh
       dot-dev: true
       always_run: false
       optional: true
       args:
       - "--run-test"
-      - "./test/e2e-tests.sh --istio-version 1.4-latest --no-mesh"
+      - "./test/e2e-tests.sh --istio-version 1.4-latest --no-mesh &&
+      ./test/e2e-tests.sh --run-tests --skip-knative-setup --istio-version 1.4-latest --no-mesh"
     - custom-test: gloo-0.17.1
       dot-dev: true
       always_run: false
       optional: true
       args:
       - "--run-test"
-      - "./test/e2e-tests.sh --gloo-version 0.17.1"
+      - "./test/e2e-tests.sh --gloo-version 0.17.1 &&
+      ./test/e2e-tests.sh --run-tests --skip-knative-setup --gloo-version 0.17.1"
     - custom-test: kourier-stable
       dot-dev: true
       always_run: false
       optional: true
       args:
         - "--run-test"
-        - "./test/e2e-tests.sh --kourier-version stable"
+        - "./test/e2e-tests.sh --kourier-version stable &&
+      ./test/e2e-tests.sh --run-tests --skip-knative-setup --kourier-version stable"
     - custom-test: contour-latest
       dot-dev: true
       always_run: false
       optional: true
       args:
         - "--run-test"
-        - "./test/e2e-tests.sh --contour-version latest"
+        - "./test/e2e-tests.sh --contour-version latest &&
+      ./test/e2e-tests.sh --run-tests --skip-knative-setup --contour-version latest"
     - custom-test: ambassador-latest
       dot-dev: true
       always_run: false
       optional: true
       args:
         - "--run-test"
-        - "./test/e2e-tests.sh --ambassador-version latest"
+        - "./test/e2e-tests.sh --ambassador-version latest &&
+      ./test/e2e-tests.sh --run-tests --skip-knative-setup --ambassador-version latest"
     - custom-test: https
       dot-dev: true
       always_run: false
       optional: true
       args:
       - "--run-test"
-      - "./test/e2e-tests.sh --https"
+      - "./test/e2e-tests.sh --https &&
+      ./test/e2e-tests.sh --run-tests --skip-knative-setup --https"
     - custom-test: build-tests-go114
       dot-dev: true
       always_run: false
@@ -398,39 +407,48 @@ periodics:
       dot-dev: true
       go113: true
     - custom-job: istio-1.3-mesh
-      full-command: "./test/e2e-tests.sh --istio-version 1.3-latest --mesh"
+      full-command: "./test/e2e-tests.sh --istio-version 1.3-latest --mesh &&
+      ./test/e2e-tests.sh --run-tests --skip-knative-setup --istio-version 1.3-latest --mesh"
       dot-dev: true
       go113: true
     - custom-job: istio-1.3-no-mesh
-      full-command: "./test/e2e-tests.sh --istio-version 1.3-latest --no-mesh"
+      full-command: "./test/e2e-tests.sh --istio-version 1.3-latest --no-mesh &&
+      ./test/e2e-tests.sh --run-tests --skip-knative-setup --istio-version 1.3-latest --no-mesh"
       dot-dev: true
       go113: true
     - custom-job: istio-1.4-mesh
-      full-command: "./test/e2e-tests.sh --istio-version 1.4-latest --mesh"
+      full-command: "./test/e2e-tests.sh --istio-version 1.4-latest --mesh &&
+      ./test/e2e-tests.sh --run-tests --skip-knative-setup --istio-version 1.4-latest --mesh"
       dot-dev: true
       go113: true
     - custom-job: istio-1.4-no-mesh
-      full-command: "./test/e2e-tests.sh --istio-version 1.4-latest --no-mesh"
+      full-command: "./test/e2e-tests.sh --istio-version 1.4-latest --no-mesh &&
+      ./test/e2e-tests.sh --run-tests --skip-knative-setup --istio-version 1.4-latest --no-mesh"
       dot-dev: true
       go113: true
     - custom-job: gloo-0.17.1
-      full-command: "./test/e2e-tests.sh --gloo-version 0.17.1"
+      full-command: "./test/e2e-tests.sh --gloo-version 0.17.1 &&
+      ./test/e2e-tests.sh --run-tests --skip-knative-setup --gloo-version 0.17.1"
       dot-dev: true
       go113: true
     - custom-job: kourier-stable
-      full-command: "./test/e2e-tests.sh --kourier-version stable"
+      full-command: "./test/e2e-tests.sh --kourier-version stable &&
+      ./test/e2e-tests.sh --run-tests --skip-knative-setup --kourier-version stable"
       dot-dev: true
       go113: true
     - custom-job: contour-latest
-      full-command: "./test/e2e-tests.sh --contour-version latest"
+      full-command: "./test/e2e-tests.sh --contour-version latest &&
+      ./test/e2e-tests.sh --run-tests --skip-knative-setup --contour-version latest"
       dot-dev: true
       go113: true
     - custom-job: ambassador-latest
-      full-command: "./test/e2e-tests.sh --ambassador-version latest"
+      full-command: "./test/e2e-tests.sh --ambassador-version latest &&
+      ./test/e2e-tests.sh --run-tests --skip-knative-setup --ambassador-version latest"
       dot-dev: true
       go113: true
     - custom-job: https
-      full-command: "./test/e2e-tests.sh --https"
+      full-command: "./test/e2e-tests.sh --https &&
+      ./test/e2e-tests.sh --run-tests --skip-knative-setup --https"
       dot-dev: true
       go113: true
     - nightly: true

--- a/config/prow/jobs/config.yaml
+++ b/config/prow/jobs/config.yaml
@@ -602,7 +602,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.3-latest --mesh"
+        - "./test/e2e-tests.sh --istio-version 1.3-latest --mesh && ./test/e2e-tests.sh --run-tests --skip-knative-setup --istio-version 1.3-latest --mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -636,7 +636,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.3-latest --mesh"
+        - "./test/e2e-tests.sh --istio-version 1.3-latest --mesh && ./test/e2e-tests.sh --run-tests --skip-knative-setup --istio-version 1.3-latest --mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -670,7 +670,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.3-latest --no-mesh"
+        - "./test/e2e-tests.sh --istio-version 1.3-latest --no-mesh && ./test/e2e-tests.sh --run-tests --skip-knative-setup --istio-version 1.3-latest --no-mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -704,7 +704,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.3-latest --no-mesh"
+        - "./test/e2e-tests.sh --istio-version 1.3-latest --no-mesh && ./test/e2e-tests.sh --run-tests --skip-knative-setup --istio-version 1.3-latest --no-mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -738,7 +738,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.4-latest --mesh"
+        - "./test/e2e-tests.sh --istio-version 1.4-latest --mesh && ./test/e2e-tests.sh --run-tests --skip-knative-setup --istio-version 1.4-latest --mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -772,7 +772,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.4-latest --mesh"
+        - "./test/e2e-tests.sh --istio-version 1.4-latest --mesh && ./test/e2e-tests.sh --run-tests --skip-knative-setup --istio-version 1.4-latest --mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -806,7 +806,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.4-latest --no-mesh"
+        - "./test/e2e-tests.sh --istio-version 1.4-latest --no-mesh && ./test/e2e-tests.sh --run-tests --skip-knative-setup --istio-version 1.4-latest --no-mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -840,7 +840,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.4-latest --no-mesh"
+        - "./test/e2e-tests.sh --istio-version 1.4-latest --no-mesh && ./test/e2e-tests.sh --run-tests --skip-knative-setup --istio-version 1.4-latest --no-mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -874,7 +874,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-tests.sh --gloo-version 0.17.1"
+        - "./test/e2e-tests.sh --gloo-version 0.17.1 && ./test/e2e-tests.sh --run-tests --skip-knative-setup --gloo-version 0.17.1"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -908,7 +908,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-tests.sh --gloo-version 0.17.1"
+        - "./test/e2e-tests.sh --gloo-version 0.17.1 && ./test/e2e-tests.sh --run-tests --skip-knative-setup --gloo-version 0.17.1"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -942,7 +942,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-tests.sh --kourier-version stable"
+        - "./test/e2e-tests.sh --kourier-version stable && ./test/e2e-tests.sh --run-tests --skip-knative-setup --kourier-version stable"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -976,7 +976,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-tests.sh --kourier-version stable"
+        - "./test/e2e-tests.sh --kourier-version stable && ./test/e2e-tests.sh --run-tests --skip-knative-setup --kourier-version stable"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -1010,7 +1010,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-tests.sh --contour-version latest"
+        - "./test/e2e-tests.sh --contour-version latest && ./test/e2e-tests.sh --run-tests --skip-knative-setup --contour-version latest"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -1044,7 +1044,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-tests.sh --contour-version latest"
+        - "./test/e2e-tests.sh --contour-version latest && ./test/e2e-tests.sh --run-tests --skip-knative-setup --contour-version latest"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -1078,7 +1078,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-tests.sh --ambassador-version latest"
+        - "./test/e2e-tests.sh --ambassador-version latest && ./test/e2e-tests.sh --run-tests --skip-knative-setup --ambassador-version latest"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -1112,7 +1112,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-tests.sh --ambassador-version latest"
+        - "./test/e2e-tests.sh --ambassador-version latest && ./test/e2e-tests.sh --run-tests --skip-knative-setup --ambassador-version latest"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -1146,7 +1146,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-tests.sh --https"
+        - "./test/e2e-tests.sh --https && ./test/e2e-tests.sh --run-tests --skip-knative-setup --https"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -1180,7 +1180,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-tests.sh --https"
+        - "./test/e2e-tests.sh --https && ./test/e2e-tests.sh --run-tests --skip-knative-setup --https"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -5772,6 +5772,13 @@ periodics:
       - "--istio-version"
       - "1.3-latest"
       - "--mesh"
+      - "&&"
+      - "./test/e2e-tests.sh"
+      - "--run-tests"
+      - "--skip-knative-setup"
+      - "--istio-version"
+      - "1.3-latest"
+      - "--mesh"
       volumeMounts:
       - name: test-account
         mountPath: /etc/test-account
@@ -5802,6 +5809,13 @@ periodics:
       - runner.sh
       args:
       - "./test/e2e-tests.sh"
+      - "--istio-version"
+      - "1.3-latest"
+      - "--no-mesh"
+      - "&&"
+      - "./test/e2e-tests.sh"
+      - "--run-tests"
+      - "--skip-knative-setup"
       - "--istio-version"
       - "1.3-latest"
       - "--no-mesh"
@@ -5838,6 +5852,13 @@ periodics:
       - "--istio-version"
       - "1.4-latest"
       - "--mesh"
+      - "&&"
+      - "./test/e2e-tests.sh"
+      - "--run-tests"
+      - "--skip-knative-setup"
+      - "--istio-version"
+      - "1.4-latest"
+      - "--mesh"
       volumeMounts:
       - name: test-account
         mountPath: /etc/test-account
@@ -5868,6 +5889,13 @@ periodics:
       - runner.sh
       args:
       - "./test/e2e-tests.sh"
+      - "--istio-version"
+      - "1.4-latest"
+      - "--no-mesh"
+      - "&&"
+      - "./test/e2e-tests.sh"
+      - "--run-tests"
+      - "--skip-knative-setup"
       - "--istio-version"
       - "1.4-latest"
       - "--no-mesh"
@@ -5903,6 +5931,12 @@ periodics:
       - "./test/e2e-tests.sh"
       - "--gloo-version"
       - "0.17.1"
+      - "&&"
+      - "./test/e2e-tests.sh"
+      - "--run-tests"
+      - "--skip-knative-setup"
+      - "--gloo-version"
+      - "0.17.1"
       volumeMounts:
       - name: test-account
         mountPath: /etc/test-account
@@ -5933,6 +5967,12 @@ periodics:
       - runner.sh
       args:
       - "./test/e2e-tests.sh"
+      - "--kourier-version"
+      - "stable"
+      - "&&"
+      - "./test/e2e-tests.sh"
+      - "--run-tests"
+      - "--skip-knative-setup"
       - "--kourier-version"
       - "stable"
       volumeMounts:
@@ -5967,6 +6007,12 @@ periodics:
       - "./test/e2e-tests.sh"
       - "--contour-version"
       - "latest"
+      - "&&"
+      - "./test/e2e-tests.sh"
+      - "--run-tests"
+      - "--skip-knative-setup"
+      - "--contour-version"
+      - "latest"
       volumeMounts:
       - name: test-account
         mountPath: /etc/test-account
@@ -5999,6 +6045,12 @@ periodics:
       - "./test/e2e-tests.sh"
       - "--ambassador-version"
       - "latest"
+      - "&&"
+      - "./test/e2e-tests.sh"
+      - "--run-tests"
+      - "--skip-knative-setup"
+      - "--ambassador-version"
+      - "latest"
       volumeMounts:
       - name: test-account
         mountPath: /etc/test-account
@@ -6029,6 +6081,11 @@ periodics:
       - runner.sh
       args:
       - "./test/e2e-tests.sh"
+      - "--https"
+      - "&&"
+      - "./test/e2e-tests.sh"
+      - "--run-tests"
+      - "--skip-knative-setup"
       - "--https"
       volumeMounts:
       - name: test-account

--- a/config/prow/jobs/config.yaml
+++ b/config/prow/jobs/config.yaml
@@ -600,9 +600,17 @@ presubmits:
         command:
         - runner.sh
         args:
-        - "./test/presubmit-tests.sh"
-        - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.3-latest --mesh && ./test/e2e-tests.sh --run-tests --skip-knative-setup --istio-version 1.3-latest --mesh"
+        - "./test/e2e-tests.sh"
+        - "--istio-version"
+        - "1.3-latest"
+        - "--mesh"
+        - "&&"
+        - "./test/e2e-tests.sh"
+        - "--run-tests"
+        - "--skip-knative-setup"
+        - "--istio-version"
+        - "1.3-latest"
+        - "--mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -634,9 +642,17 @@ presubmits:
         command:
         - runner.sh
         args:
-        - "./test/presubmit-tests.sh"
-        - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.3-latest --mesh && ./test/e2e-tests.sh --run-tests --skip-knative-setup --istio-version 1.3-latest --mesh"
+        - "./test/e2e-tests.sh"
+        - "--istio-version"
+        - "1.3-latest"
+        - "--mesh"
+        - "&&"
+        - "./test/e2e-tests.sh"
+        - "--run-tests"
+        - "--skip-knative-setup"
+        - "--istio-version"
+        - "1.3-latest"
+        - "--mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -668,9 +684,17 @@ presubmits:
         command:
         - runner.sh
         args:
-        - "./test/presubmit-tests.sh"
-        - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.3-latest --no-mesh && ./test/e2e-tests.sh --run-tests --skip-knative-setup --istio-version 1.3-latest --no-mesh"
+        - "./test/e2e-tests.sh"
+        - "--istio-version"
+        - "1.3-latest"
+        - "--no-mesh"
+        - "&&"
+        - "./test/e2e-tests.sh"
+        - "--run-tests"
+        - "--skip-knative-setup"
+        - "--istio-version"
+        - "1.3-latest"
+        - "--no-mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -702,9 +726,17 @@ presubmits:
         command:
         - runner.sh
         args:
-        - "./test/presubmit-tests.sh"
-        - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.3-latest --no-mesh && ./test/e2e-tests.sh --run-tests --skip-knative-setup --istio-version 1.3-latest --no-mesh"
+        - "./test/e2e-tests.sh"
+        - "--istio-version"
+        - "1.3-latest"
+        - "--no-mesh"
+        - "&&"
+        - "./test/e2e-tests.sh"
+        - "--run-tests"
+        - "--skip-knative-setup"
+        - "--istio-version"
+        - "1.3-latest"
+        - "--no-mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -736,9 +768,17 @@ presubmits:
         command:
         - runner.sh
         args:
-        - "./test/presubmit-tests.sh"
-        - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.4-latest --mesh && ./test/e2e-tests.sh --run-tests --skip-knative-setup --istio-version 1.4-latest --mesh"
+        - "./test/e2e-tests.sh"
+        - "--istio-version"
+        - "1.4-latest"
+        - "--mesh"
+        - "&&"
+        - "./test/e2e-tests.sh"
+        - "--run-tests"
+        - "--skip-knative-setup"
+        - "--istio-version"
+        - "1.4-latest"
+        - "--mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -770,9 +810,17 @@ presubmits:
         command:
         - runner.sh
         args:
-        - "./test/presubmit-tests.sh"
-        - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.4-latest --mesh && ./test/e2e-tests.sh --run-tests --skip-knative-setup --istio-version 1.4-latest --mesh"
+        - "./test/e2e-tests.sh"
+        - "--istio-version"
+        - "1.4-latest"
+        - "--mesh"
+        - "&&"
+        - "./test/e2e-tests.sh"
+        - "--run-tests"
+        - "--skip-knative-setup"
+        - "--istio-version"
+        - "1.4-latest"
+        - "--mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -804,9 +852,17 @@ presubmits:
         command:
         - runner.sh
         args:
-        - "./test/presubmit-tests.sh"
-        - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.4-latest --no-mesh && ./test/e2e-tests.sh --run-tests --skip-knative-setup --istio-version 1.4-latest --no-mesh"
+        - "./test/e2e-tests.sh"
+        - "--istio-version"
+        - "1.4-latest"
+        - "--no-mesh"
+        - "&&"
+        - "./test/e2e-tests.sh"
+        - "--run-tests"
+        - "--skip-knative-setup"
+        - "--istio-version"
+        - "1.4-latest"
+        - "--no-mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -838,9 +894,17 @@ presubmits:
         command:
         - runner.sh
         args:
-        - "./test/presubmit-tests.sh"
-        - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.4-latest --no-mesh && ./test/e2e-tests.sh --run-tests --skip-knative-setup --istio-version 1.4-latest --no-mesh"
+        - "./test/e2e-tests.sh"
+        - "--istio-version"
+        - "1.4-latest"
+        - "--no-mesh"
+        - "&&"
+        - "./test/e2e-tests.sh"
+        - "--run-tests"
+        - "--skip-knative-setup"
+        - "--istio-version"
+        - "1.4-latest"
+        - "--no-mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -872,9 +936,15 @@ presubmits:
         command:
         - runner.sh
         args:
-        - "./test/presubmit-tests.sh"
-        - "--run-test"
-        - "./test/e2e-tests.sh --gloo-version 0.17.1 && ./test/e2e-tests.sh --run-tests --skip-knative-setup --gloo-version 0.17.1"
+        - "./test/e2e-tests.sh"
+        - "--gloo-version"
+        - "0.17.1"
+        - "&&"
+        - "./test/e2e-tests.sh"
+        - "--run-tests"
+        - "--skip-knative-setup"
+        - "--gloo-version"
+        - "0.17.1"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -906,9 +976,15 @@ presubmits:
         command:
         - runner.sh
         args:
-        - "./test/presubmit-tests.sh"
-        - "--run-test"
-        - "./test/e2e-tests.sh --gloo-version 0.17.1 && ./test/e2e-tests.sh --run-tests --skip-knative-setup --gloo-version 0.17.1"
+        - "./test/e2e-tests.sh"
+        - "--gloo-version"
+        - "0.17.1"
+        - "&&"
+        - "./test/e2e-tests.sh"
+        - "--run-tests"
+        - "--skip-knative-setup"
+        - "--gloo-version"
+        - "0.17.1"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -940,9 +1016,15 @@ presubmits:
         command:
         - runner.sh
         args:
-        - "./test/presubmit-tests.sh"
-        - "--run-test"
-        - "./test/e2e-tests.sh --kourier-version stable && ./test/e2e-tests.sh --run-tests --skip-knative-setup --kourier-version stable"
+        - "./test/e2e-tests.sh"
+        - "--kourier-version"
+        - "stable"
+        - "&&"
+        - "./test/e2e-tests.sh"
+        - "--run-tests"
+        - "--skip-knative-setup"
+        - "--kourier-version"
+        - "stable"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -974,9 +1056,15 @@ presubmits:
         command:
         - runner.sh
         args:
-        - "./test/presubmit-tests.sh"
-        - "--run-test"
-        - "./test/e2e-tests.sh --kourier-version stable && ./test/e2e-tests.sh --run-tests --skip-knative-setup --kourier-version stable"
+        - "./test/e2e-tests.sh"
+        - "--kourier-version"
+        - "stable"
+        - "&&"
+        - "./test/e2e-tests.sh"
+        - "--run-tests"
+        - "--skip-knative-setup"
+        - "--kourier-version"
+        - "stable"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -1008,9 +1096,15 @@ presubmits:
         command:
         - runner.sh
         args:
-        - "./test/presubmit-tests.sh"
-        - "--run-test"
-        - "./test/e2e-tests.sh --contour-version latest && ./test/e2e-tests.sh --run-tests --skip-knative-setup --contour-version latest"
+        - "./test/e2e-tests.sh"
+        - "--contour-version"
+        - "latest"
+        - "&&"
+        - "./test/e2e-tests.sh"
+        - "--run-tests"
+        - "--skip-knative-setup"
+        - "--contour-version"
+        - "latest"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -1042,9 +1136,15 @@ presubmits:
         command:
         - runner.sh
         args:
-        - "./test/presubmit-tests.sh"
-        - "--run-test"
-        - "./test/e2e-tests.sh --contour-version latest && ./test/e2e-tests.sh --run-tests --skip-knative-setup --contour-version latest"
+        - "./test/e2e-tests.sh"
+        - "--contour-version"
+        - "latest"
+        - "&&"
+        - "./test/e2e-tests.sh"
+        - "--run-tests"
+        - "--skip-knative-setup"
+        - "--contour-version"
+        - "latest"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -1076,9 +1176,15 @@ presubmits:
         command:
         - runner.sh
         args:
-        - "./test/presubmit-tests.sh"
-        - "--run-test"
-        - "./test/e2e-tests.sh --ambassador-version latest && ./test/e2e-tests.sh --run-tests --skip-knative-setup --ambassador-version latest"
+        - "./test/e2e-tests.sh"
+        - "--ambassador-version"
+        - "latest"
+        - "&&"
+        - "./test/e2e-tests.sh"
+        - "--run-tests"
+        - "--skip-knative-setup"
+        - "--ambassador-version"
+        - "latest"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -1110,9 +1216,15 @@ presubmits:
         command:
         - runner.sh
         args:
-        - "./test/presubmit-tests.sh"
-        - "--run-test"
-        - "./test/e2e-tests.sh --ambassador-version latest && ./test/e2e-tests.sh --run-tests --skip-knative-setup --ambassador-version latest"
+        - "./test/e2e-tests.sh"
+        - "--ambassador-version"
+        - "latest"
+        - "&&"
+        - "./test/e2e-tests.sh"
+        - "--run-tests"
+        - "--skip-knative-setup"
+        - "--ambassador-version"
+        - "latest"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -1144,9 +1256,13 @@ presubmits:
         command:
         - runner.sh
         args:
-        - "./test/presubmit-tests.sh"
-        - "--run-test"
-        - "./test/e2e-tests.sh --https && ./test/e2e-tests.sh --run-tests --skip-knative-setup --https"
+        - "./test/e2e-tests.sh"
+        - "--https"
+        - "&&"
+        - "./test/e2e-tests.sh"
+        - "--run-tests"
+        - "--skip-knative-setup"
+        - "--https"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -1178,9 +1294,13 @@ presubmits:
         command:
         - runner.sh
         args:
-        - "./test/presubmit-tests.sh"
-        - "--run-test"
-        - "./test/e2e-tests.sh --https && ./test/e2e-tests.sh --run-tests --skip-knative-setup --https"
+        - "./test/e2e-tests.sh"
+        - "--https"
+        - "&&"
+        - "./test/e2e-tests.sh"
+        - "--run-tests"
+        - "--skip-knative-setup"
+        - "--https"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account


### PR DESCRIPTION
Update all Prow jobs for running network tests, so that they still run auto tls tests

/assign @chizhg 
/assign @ZhiminXiang 

/hold
Let's make sure it's not merged before testing