### PR TITLE
Rename auto tls test script

### DIFF
--- a/config/prow/config_knative.yaml
+++ b/config/prow/config_knative.yaml
@@ -49,7 +49,7 @@ presubmits:
       needs-monitor: true
       args:
       - "--run-test"
-      - "./test/e2e-auto-tls.sh"
+      - "./test/e2e-auto-tls-tests.sh"
     - custom-test: smoke-tests
       dot-dev: true
       always_run: false

--- a/config/prow/jobs/config.yaml
+++ b/config/prow/jobs/config.yaml
@@ -373,7 +373,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-auto-tls.sh"
+        - "./test/e2e-auto-tls-tests.sh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -410,7 +410,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-auto-tls.sh"
+        - "./test/e2e-auto-tls-tests.sh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account


### PR DESCRIPTION
The current name of script doesn't follow `e2e-*tests.sh` naming convention and not discoverable by presubmit tests, rename it
/assign @chizhg 

/hold
Will need to have the script before merging
