### PR TITLE
Highlight "code is outdated" error

### DIFF
--- a/config/prow/core/config.yaml
+++ b/config/prow/core/config.yaml
@@ -68,6 +68,9 @@ deck:
           - 'timeout waiting for pods to come up'
           # Prow job killed
           - 'Entrypoint received interrupt: terminated'
+          # Code is outdated
+          # TODO(chizhg): this error message should be defined by the common test infrastructure
+          - 'Please run .*hack/update-codegen.sh'
       required_files:
       - build-log.txt
     - lens:

--- a/config/prow/staging/config.yaml
+++ b/config/prow/staging/config.yaml
@@ -68,6 +68,9 @@ deck:
           - 'timeout waiting for pods to come up'
           # Prow job killed
           - 'Entrypoint received interrupt: terminated'
+          # Code is outdated
+          # TODO(chizhg): this error message should be defined by the common test infrastructure
+          - 'Please run .*hack/update-codegen.sh'
       required_files:
       - build-log.txt
     - lens:

--- a/config/prow/staging/jobs/config.yaml
+++ b/config/prow/staging/jobs/config.yaml
@@ -98,10 +98,6 @@ presubmits:
           secretName: test-account
   - name: pull-knative-prow-robot-serving-unit-tests
     agent: kubernetes
-    labels:
-      prow.k8s.io/pubsub.project: knative-tests
-      prow.k8s.io/pubsub.topic: knative-monitoring
-      prow.k8s.io/pubsub.runID: pull-knative-prow-robot-serving-unit-tests
     context: pull-knative-prow-robot-serving-unit-tests
     always_run: true
     rerun_command: "/test pull-knative-prow-robot-serving-unit-tests"
@@ -140,10 +136,6 @@ presubmits:
           secretName: test-account
   - name: pull-knative-prow-robot-serving-unit-tests
     agent: kubernetes
-    labels:
-      prow.k8s.io/pubsub.project: knative-tests
-      prow.k8s.io/pubsub.topic: knative-monitoring
-      prow.k8s.io/pubsub.runID: pull-knative-prow-robot-serving-unit-tests
     context: pull-knative-prow-robot-serving-unit-tests
     always_run: true
     rerun_command: "/test pull-knative-prow-robot-serving-unit-tests"
@@ -182,10 +174,6 @@ presubmits:
           secretName: test-account
   - name: pull-knative-prow-robot-serving-integration-tests
     agent: kubernetes
-    labels:
-      prow.k8s.io/pubsub.project: knative-tests
-      prow.k8s.io/pubsub.topic: knative-monitoring
-      prow.k8s.io/pubsub.runID: pull-knative-prow-robot-serving-integration-tests
     context: pull-knative-prow-robot-serving-integration-tests
     always_run: true
     rerun_command: "/test pull-knative-prow-robot-serving-integration-tests"
@@ -224,10 +212,6 @@ presubmits:
           secretName: test-account
   - name: pull-knative-prow-robot-serving-integration-tests
     agent: kubernetes
-    labels:
-      prow.k8s.io/pubsub.project: knative-tests
-      prow.k8s.io/pubsub.topic: knative-monitoring
-      prow.k8s.io/pubsub.runID: pull-knative-prow-robot-serving-integration-tests
     context: pull-knative-prow-robot-serving-integration-tests
     always_run: true
     rerun_command: "/test pull-knative-prow-robot-serving-integration-tests"
@@ -303,10 +287,6 @@ presubmits:
           secretName: test-account
   - name: pull-knative-prow-robot-test-infra-unit-tests
     agent: kubernetes
-    labels:
-      prow.k8s.io/pubsub.project: knative-tests
-      prow.k8s.io/pubsub.topic: knative-monitoring
-      prow.k8s.io/pubsub.runID: pull-knative-prow-robot-test-infra-unit-tests
     context: pull-knative-prow-robot-test-infra-unit-tests
     always_run: true
     rerun_command: "/test pull-knative-prow-robot-test-infra-unit-tests"
@@ -343,10 +323,6 @@ presubmits:
           secretName: test-account
   - name: pull-knative-prow-robot-test-infra-integration-tests
     agent: kubernetes
-    labels:
-      prow.k8s.io/pubsub.project: knative-tests
-      prow.k8s.io/pubsub.topic: knative-monitoring
-      prow.k8s.io/pubsub.runID: pull-knative-prow-robot-test-infra-integration-tests
     context: pull-knative-prow-robot-test-infra-integration-tests
     always_run: true
     rerun_command: "/test pull-knative-prow-robot-test-infra-integration-tests"

--- a/tools/config-generator/templates/prow_config.yaml
+++ b/tools/config-generator/templates/prow_config.yaml
@@ -49,6 +49,9 @@ deck:
           - 'timeout waiting for pods to come up'
           # Prow job killed
           - 'Entrypoint received interrupt: terminated'
+          # Code is outdated
+          # TODO(chizhg): this error message should be defined by the common test infrastructure
+          - 'Please run .*hack/update-codegen.sh'
       required_files:
       - build-log.txt
     - lens:


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
As reported on Slack https://knative.slack.com/archives/CQBKVH4QY/p1582704778000800, highlight the "code is outdated" error on Spyglass.

Note:
We don't have a central point that defines this error message, but it's the same pattern that every repository follows. I added a TODO to move it to the common test infrastructure.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @chaodaiG 

