### PR TITLE
Update flaky test reporter Dockerfile to use go1.13

### DIFF
--- a/images/flaky-test-reporter/Dockerfile
+++ b/images/flaky-test-reporter/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.12
+FROM golang:1.13
 LABEL maintainer "Chao Dai <chaodai@google.com>"
 RUN apt-get update
 


### PR DESCRIPTION
it failed to build with go1.12 due to a dependency error

/assign @chizhg 