### PR TITLE
Revoke flakes retry for eventing and enable alerting

### DIFF
--- a/config/prow/config_knative.yaml
+++ b/config/prow/config_knative.yaml
@@ -192,10 +192,8 @@ presubmits:
           memory: 16Gi
     - unit-tests: true
       dot-dev: true
-      needs-monitor: true
     - integration-tests: true
       dot-dev: true
-      needs-monitor: true
     - go-coverage: true
       dot-dev: true
 

--- a/config/prow/jobs/config.yaml
+++ b/config/prow/jobs/config.yaml
@@ -2079,10 +2079,6 @@ presubmits:
           secretName: test-account
   - name: pull-knative-eventing-unit-tests
     agent: kubernetes
-    labels:
-      prow.k8s.io/pubsub.project: knative-tests
-      prow.k8s.io/pubsub.topic: knative-monitoring
-      prow.k8s.io/pubsub.runID: pull-knative-eventing-unit-tests
     context: pull-knative-eventing-unit-tests
     always_run: true
     rerun_command: "/test pull-knative-eventing-unit-tests"
@@ -2122,10 +2118,6 @@ presubmits:
           secretName: test-account
   - name: pull-knative-eventing-unit-tests
     agent: kubernetes
-    labels:
-      prow.k8s.io/pubsub.project: knative-tests
-      prow.k8s.io/pubsub.topic: knative-monitoring
-      prow.k8s.io/pubsub.runID: pull-knative-eventing-unit-tests
     context: pull-knative-eventing-unit-tests
     always_run: true
     rerun_command: "/test pull-knative-eventing-unit-tests"
@@ -2165,10 +2157,6 @@ presubmits:
           secretName: test-account
   - name: pull-knative-eventing-integration-tests
     agent: kubernetes
-    labels:
-      prow.k8s.io/pubsub.project: knative-tests
-      prow.k8s.io/pubsub.topic: knative-monitoring
-      prow.k8s.io/pubsub.runID: pull-knative-eventing-integration-tests
     context: pull-knative-eventing-integration-tests
     always_run: true
     rerun_command: "/test pull-knative-eventing-integration-tests"
@@ -2208,10 +2196,6 @@ presubmits:
           secretName: test-account
   - name: pull-knative-eventing-integration-tests
     agent: kubernetes
-    labels:
-      prow.k8s.io/pubsub.project: knative-tests
-      prow.k8s.io/pubsub.topic: knative-monitoring
-      prow.k8s.io/pubsub.runID: pull-knative-eventing-integration-tests
     context: pull-knative-eventing-integration-tests
     always_run: true
     rerun_command: "/test pull-knative-eventing-integration-tests"

--- a/tools/flaky-test-reporter/config/config.yaml
+++ b/tools/flaky-test-reporter/config/config.yaml
@@ -71,12 +71,10 @@ jobConfigs:
   - name: ci-knative-eventing-continuous
     repo: eventing
     type: postsubmit
-    # Uncomment line below to enable auto bugs
-    # issueRepo: eventing
-    # Uncomment section below to enable slack notifications
-    # slackChannels:
-    #   - name: eventing
-    #     identity: C9JP909F0
+    issueRepo: eventing
+    slackChannels:
+      - name: eventing
+        identity: C9JP909F0
   - name: ci-knative-test-infra-continuous
     repo: test-infra
     type: postsubmit


### PR DESCRIPTION
As discussed in eventing channel, it's preferred to not auto retry but want to have auto bugs and slack notification

/assign @chizhg 
/cc @vaikas 
/cc @grantr 
/cc @lionelvillard 