### PR TITLE
Report flakes for eventing-contrib in Github and Slack

### DIFF
--- a/tools/flaky-test-reporter/config/config.yaml
+++ b/tools/flaky-test-reporter/config/config.yaml
@@ -75,6 +75,15 @@ jobConfigs:
     slackChannels:
       - name: eventing
         identity: C9JP909F0
+  - name: ci-knative-eventing-contrib-continuous
+    repo: eventing-contrib
+    type: postsubmit
+    issueRepo: eventing-contrib
+    slackChannels:
+      - name: eventing-sources
+        identity: CQBKVH4QY
+      - name: eventing-channels
+        identity: CR2141CGY
   - name: ci-knative-test-infra-continuous
     repo: test-infra
     type: postsubmit


### PR DESCRIPTION
As discussed in eventing channel on Slack, it's expected to also report flakes status for eventing-contrib, which will be reported to both `eventing-sources` and `eventing-channels`

/assign @chizhg 
/cc @vaikas 
/cc @grantr 
/cc @lionelvillard 