### PR TITLE
Enable showing pod info on spyglass

### DIFF
--- a/config/prow/cluster/400-crier.yaml
+++ b/config/prow/cluster/400-crier.yaml
@@ -32,6 +32,9 @@ spec:
         image: gcr.io/k8s-prow/crier:v20200219-5ea024fc8
         args:
         - --pubsub-workers=5 # Arbitrary number of multiplier
+        - --gcs-workers=1
+        - --gcs-credentials-file=/etc/service-account/service-account.json # TODO(chizhg): use workload identity
+        - --kubernetes-gcs-workers=1
         - --report-agent=knative-build
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
@@ -45,6 +48,9 @@ spec:
         - name: oauth
           mountPath: /etc/github
           readOnly: true
+        - name: service-account
+          mountPath: /etc/service-account
+          readOnly: true
       volumes:
       - name: config
         configMap:
@@ -55,3 +61,6 @@ spec:
       - name: oauth
         secret:
           secretName: oauth-token
+      - name: service-account
+        secret:
+          secretName: service-account

--- a/config/prow/core/config.yaml
+++ b/config/prow/core/config.yaml
@@ -49,6 +49,8 @@ deck:
         name: metadata
       required_files:
       - started.json|finished.json
+      optional_files:
+      - podinfo.json
     - lens:
         name: buildlog
         config:
@@ -77,6 +79,10 @@ deck:
         name: junit
       required_files:
       - artifacts/junit.*\.xml
+    - lens:
+        name: podinfo
+      required_files:
+      - podinfo.json
   tide_update_period: 1s
 prowjob_namespace: default
 pod_namespace: test-pods

--- a/config/prow/staging/config.yaml
+++ b/config/prow/staging/config.yaml
@@ -49,6 +49,8 @@ deck:
         name: metadata
       required_files:
       - started.json|finished.json
+      optional_files:
+      - podinfo.json
     - lens:
         name: buildlog
         config:
@@ -77,6 +79,10 @@ deck:
         name: junit
       required_files:
       - artifacts/junit.*\.xml
+    - lens:
+        name: podinfo
+      required_files:
+      - podinfo.json
   tide_update_period: 1s
 prowjob_namespace: default
 pod_namespace: test-pods

--- a/tools/config-generator/templates/prow_config.yaml
+++ b/tools/config-generator/templates/prow_config.yaml
@@ -30,6 +30,8 @@ deck:
         name: metadata
       required_files:
       - started.json|finished.json
+      optional_files:
+      - podinfo.json
     - lens:
         name: buildlog
         config:
@@ -58,6 +60,10 @@ deck:
         name: junit
       required_files:
       - artifacts/junit.*\.xml
+    - lens:
+        name: podinfo
+      required_files:
+      - podinfo.json
   tide_update_period: 1s
 
 prowjob_namespace: default


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Enable showing pod info on spyglass, example on staging-prow cluster: https://prow-staging.knative.dev/view/gcs/knative-prow-staging/pr-logs/pull/knative-prow-robot_test-infra/16/pull-knative-prow-robot-test-infra-unit-tests/1233488108905828353

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #1735

/cc @chaodaiG 

