### PR TITLE
Update liche in prow-tests image to pick up the fix

### DIFF
--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -46,7 +46,7 @@ RUN GO111MODULE=on go get github.com/google/ko/cmd/ko@v0.3.0
 RUN GO111MODULE=on go get github.com/boz/kail/cmd/kail
 RUN go get -u github.com/golang/dep/cmd/dep
 RUN go get -u github.com/jstemmer/go-junit-report
-RUN GO111MODULE=on go get -u github.com/raviqqe/liche
+RUN GO111MODULE=on go get -u github.com/raviqqe/liche@v0.0.0-20200229003944-f57a5d1c5be4  # stable liche version for checking md links
 
 # Extract bazel version
 RUN bazel version > /bazel_version


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
There was a bug in liche, the tool we use to check links in markdown files, see https://github.com/raviqqe/liche/issues/33.

It's now fixed, update its version in the prow-tests image to pick up the fix.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @chaodaiG 
/cc @coryrc 

