### PR TITLE
Fix the check-config presubmit job

### DIFF
--- a/config/prow/config_knative.yaml
+++ b/config/prow/config_knative.yaml
@@ -251,7 +251,7 @@ presubmits:
       dot-dev: true
     - custom-test: check-config
       dot-dev: true
-      args:
+      command:
         - "./test/presubmit-config-check.sh"
 
   knative/caching:

--- a/config/prow/jobs/config.yaml
+++ b/config/prow/jobs/config.yaml
@@ -3445,7 +3445,6 @@ presubmits:
         command:
         - runner.sh
         args:
-        - "./test/presubmit-tests.sh"
         - "./test/presubmit-config-check.sh"
         volumeMounts:
         - name: test-account
@@ -3477,7 +3476,6 @@ presubmits:
         command:
         - runner.sh
         args:
-        - "./test/presubmit-tests.sh"
         - "./test/presubmit-config-check.sh"
         volumeMounts:
         - name: test-account

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -53,7 +53,6 @@ function post_unit_tests() {
   return ${failed}
 }
 
-
 # We use the default integration test runner.
 
 main "$@"

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -53,6 +53,7 @@ function post_unit_tests() {
   return ${failed}
 }
 
+
 # We use the default integration test runner.
 
 main "$@"


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
I made it wrong in the config generator, should use `command` instead of `args`... This PR fixes it.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->