### PR TITLE
Reduce Boskos Janitor count

### DIFF
--- a/config/prow/cluster/400-boskos-janitor.yaml
+++ b/config/prow/cluster/400-boskos-janitor.yaml
@@ -21,7 +21,7 @@ metadata:
     app: boskos-janitor
   namespace: test-pods
 spec:
-  replicas: 35  # Number of distributed janitor instances
+  replicas: 8  # Number of distributed janitor instances; k8s has ~1/16 as many projects
   template:
     metadata:
       labels:


### PR DESCRIPTION
Now that janitor properly cleans images, we don't need so many (k8s
has 16 for 256 projects...).

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

/cc @nbarthwal 
/assign @chizhg 
