### PR TITLE
Update the prow-tests image

### DIFF
--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -16,7 +16,8 @@
 # do `make push` in `../prow-tests-go112` directory to make sure these 2 images are in
 # sync
 
-FROM gcr.io/k8s-testimages/kubekins-e2e:v20190716-41e2a9e-master
+# TODO(chizhg): probably build the image from scratch?
+FROM gcr.io/k8s-testimages/kubekins-e2e:v20200302-c921a88-master
 LABEL maintainer "Adriano Cunha <adrcunha@google.com>"
 
 # Install extras on top of base image


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
The Git version we use in prow-tests image is pretty old, see https://github.com/knative/test-infra/pull/1766#discussion_r386185336. So update the image to use the latest kubekins-e2e image.
