### PR TITLE
Make all serving network tests test auto tls

### DIFF
--- a/config/prow/config_knative.yaml
+++ b/config/prow/config_knative.yaml
@@ -59,63 +59,63 @@ presubmits:
       optional: true
       args:
       - "--run-test"
-      - "./test/e2e-tests.sh --istio-version 1.3-latest --mesh"
+      - "./test/e2e-basic-entrypoint.sh --istio-version 1.3-latest --mesh"
     - custom-test: istio-1.3-no-mesh
       dot-dev: true
       always_run: false
       optional: true
       args:
       - "--run-test"
-      - "./test/e2e-tests.sh --istio-version 1.3-latest --no-mesh"
+      - "./test/e2e-basic-entrypoint.sh --istio-version 1.3-latest --no-mesh"
     - custom-test: istio-1.4-mesh
       dot-dev: true
       always_run: false
       optional: true
       args:
       - "--run-test"
-      - "./test/e2e-tests.sh --istio-version 1.4-latest --mesh"
+      - "./test/e2e-basic-entrypoint.sh --istio-version 1.4-latest --mesh"
     - custom-test: istio-1.4-no-mesh
       dot-dev: true
       always_run: false
       optional: true
       args:
       - "--run-test"
-      - "./test/e2e-tests.sh --istio-version 1.4-latest --no-mesh"
+      - "./test/e2e-basic-entrypoint.sh --istio-version 1.4-latest --no-mesh"
     - custom-test: gloo-0.17.1
       dot-dev: true
       always_run: false
       optional: true
       args:
       - "--run-test"
-      - "./test/e2e-tests.sh --gloo-version 0.17.1"
+      - "./test/e2e-basic-entrypoint.sh --gloo-version 0.17.1"
     - custom-test: kourier-stable
       dot-dev: true
       always_run: false
       optional: true
       args:
         - "--run-test"
-        - "./test/e2e-tests.sh --kourier-version stable"
+        - "./test/e2e-basic-entrypoint.sh --kourier-version stable"
     - custom-test: contour-latest
       dot-dev: true
       always_run: false
       optional: true
       args:
         - "--run-test"
-        - "./test/e2e-tests.sh --contour-version latest"
+        - "./test/e2e-basic-entrypoint.sh --contour-version latest"
     - custom-test: ambassador-latest
       dot-dev: true
       always_run: false
       optional: true
       args:
         - "--run-test"
-        - "./test/e2e-tests.sh --ambassador-version latest"
+        - "./test/e2e-basic-entrypoint.sh --ambassador-version latest"
     - custom-test: https
       dot-dev: true
       always_run: false
       optional: true
       args:
       - "--run-test"
-      - "./test/e2e-tests.sh --https"
+      - "./test/e2e-basic-entrypoint.sh --https"
     - custom-test: build-tests-go114
       dot-dev: true
       always_run: false
@@ -409,39 +409,39 @@ periodics:
       dot-dev: true
       go113: true
     - custom-job: istio-1.3-mesh
-      full-command: "./test/e2e-tests.sh --istio-version 1.3-latest --mesh"
+      full-command: "./test/e2e-basic-entrypoint.sh --istio-version 1.3-latest --mesh"
       dot-dev: true
       go113: true
     - custom-job: istio-1.3-no-mesh
-      full-command: "./test/e2e-tests.sh --istio-version 1.3-latest --no-mesh"
+      full-command: "./test/e2e-basic-entrypoint.sh --istio-version 1.3-latest --no-mesh"
       dot-dev: true
       go113: true
     - custom-job: istio-1.4-mesh
-      full-command: "./test/e2e-tests.sh --istio-version 1.4-latest --mesh"
+      full-command: "./test/e2e-basic-entrypoint.sh --istio-version 1.4-latest --mesh"
       dot-dev: true
       go113: true
     - custom-job: istio-1.4-no-mesh
-      full-command: "./test/e2e-tests.sh --istio-version 1.4-latest --no-mesh"
+      full-command: "./test/e2e-basic-entrypoint.sh --istio-version 1.4-latest --no-mesh"
       dot-dev: true
       go113: true
     - custom-job: gloo-0.17.1
-      full-command: "./test/e2e-tests.sh --gloo-version 0.17.1"
+      full-command: "./test/e2e-basic-entrypoint.sh --gloo-version 0.17.1"
       dot-dev: true
       go113: true
     - custom-job: kourier-stable
-      full-command: "./test/e2e-tests.sh --kourier-version stable"
+      full-command: "./test/e2e-basic-entrypoint.sh --kourier-version stable"
       dot-dev: true
       go113: true
     - custom-job: contour-latest
-      full-command: "./test/e2e-tests.sh --contour-version latest"
+      full-command: "./test/e2e-basic-entrypoint.sh --contour-version latest"
       dot-dev: true
       go113: true
     - custom-job: ambassador-latest
-      full-command: "./test/e2e-tests.sh --ambassador-version latest"
+      full-command: "./test/e2e-basic-entrypoint.sh --ambassador-version latest"
       dot-dev: true
       go113: true
     - custom-job: https
-      full-command: "./test/e2e-tests.sh --https"
+      full-command: "./test/e2e-basic-entrypoint.sh --https"
       dot-dev: true
       go113: true
     - nightly: true

--- a/config/prow/jobs/config.yaml
+++ b/config/prow/jobs/config.yaml
@@ -533,7 +533,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.3-latest --mesh"
+        - "./test/e2e-basic-entrypoint.sh --istio-version 1.3-latest --mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -567,7 +567,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.3-latest --mesh"
+        - "./test/e2e-basic-entrypoint.sh --istio-version 1.3-latest --mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -601,7 +601,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.3-latest --no-mesh"
+        - "./test/e2e-basic-entrypoint.sh --istio-version 1.3-latest --no-mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -635,7 +635,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.3-latest --no-mesh"
+        - "./test/e2e-basic-entrypoint.sh --istio-version 1.3-latest --no-mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -669,7 +669,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.4-latest --mesh"
+        - "./test/e2e-basic-entrypoint.sh --istio-version 1.4-latest --mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -703,7 +703,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.4-latest --mesh"
+        - "./test/e2e-basic-entrypoint.sh --istio-version 1.4-latest --mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -737,7 +737,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.4-latest --no-mesh"
+        - "./test/e2e-basic-entrypoint.sh --istio-version 1.4-latest --no-mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -771,7 +771,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.4-latest --no-mesh"
+        - "./test/e2e-basic-entrypoint.sh --istio-version 1.4-latest --no-mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -805,7 +805,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-tests.sh --gloo-version 0.17.1"
+        - "./test/e2e-basic-entrypoint.sh --gloo-version 0.17.1"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -839,7 +839,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-tests.sh --gloo-version 0.17.1"
+        - "./test/e2e-basic-entrypoint.sh --gloo-version 0.17.1"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -873,7 +873,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-tests.sh --kourier-version stable"
+        - "./test/e2e-basic-entrypoint.sh --kourier-version stable"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -907,7 +907,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-tests.sh --kourier-version stable"
+        - "./test/e2e-basic-entrypoint.sh --kourier-version stable"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -941,7 +941,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-tests.sh --contour-version latest"
+        - "./test/e2e-basic-entrypoint.sh --contour-version latest"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -975,7 +975,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-tests.sh --contour-version latest"
+        - "./test/e2e-basic-entrypoint.sh --contour-version latest"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -1009,7 +1009,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-tests.sh --ambassador-version latest"
+        - "./test/e2e-basic-entrypoint.sh --ambassador-version latest"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -1043,7 +1043,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-tests.sh --ambassador-version latest"
+        - "./test/e2e-basic-entrypoint.sh --ambassador-version latest"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -1077,7 +1077,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-tests.sh --https"
+        - "./test/e2e-basic-entrypoint.sh --https"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -1111,7 +1111,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-tests.sh --https"
+        - "./test/e2e-basic-entrypoint.sh --https"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -5974,7 +5974,7 @@ periodics:
       command:
       - runner.sh
       args:
-      - "./test/e2e-tests.sh"
+      - "./test/e2e-basic-entrypoint.sh"
       - "--istio-version"
       - "1.3-latest"
       - "--mesh"
@@ -6007,7 +6007,7 @@ periodics:
       command:
       - runner.sh
       args:
-      - "./test/e2e-tests.sh"
+      - "./test/e2e-basic-entrypoint.sh"
       - "--istio-version"
       - "1.3-latest"
       - "--no-mesh"
@@ -6040,7 +6040,7 @@ periodics:
       command:
       - runner.sh
       args:
-      - "./test/e2e-tests.sh"
+      - "./test/e2e-basic-entrypoint.sh"
       - "--istio-version"
       - "1.4-latest"
       - "--mesh"
@@ -6073,7 +6073,7 @@ periodics:
       command:
       - runner.sh
       args:
-      - "./test/e2e-tests.sh"
+      - "./test/e2e-basic-entrypoint.sh"
       - "--istio-version"
       - "1.4-latest"
       - "--no-mesh"
@@ -6106,7 +6106,7 @@ periodics:
       command:
       - runner.sh
       args:
-      - "./test/e2e-tests.sh"
+      - "./test/e2e-basic-entrypoint.sh"
       - "--gloo-version"
       - "0.17.1"
       volumeMounts:
@@ -6138,7 +6138,7 @@ periodics:
       command:
       - runner.sh
       args:
-      - "./test/e2e-tests.sh"
+      - "./test/e2e-basic-entrypoint.sh"
       - "--kourier-version"
       - "stable"
       volumeMounts:
@@ -6170,7 +6170,7 @@ periodics:
       command:
       - runner.sh
       args:
-      - "./test/e2e-tests.sh"
+      - "./test/e2e-basic-entrypoint.sh"
       - "--contour-version"
       - "latest"
       volumeMounts:
@@ -6202,7 +6202,7 @@ periodics:
       command:
       - runner.sh
       args:
-      - "./test/e2e-tests.sh"
+      - "./test/e2e-basic-entrypoint.sh"
       - "--ambassador-version"
       - "latest"
       volumeMounts:
@@ -6234,7 +6234,7 @@ periodics:
       command:
       - runner.sh
       args:
-      - "./test/e2e-tests.sh"
+      - "./test/e2e-basic-entrypoint.sh"
       - "--https"
       volumeMounts:
       - name: test-account


### PR DESCRIPTION
The networking tests haven't been running these tests since separation, let's have them running first.

/assign @chizhg @ZhiminXiang 
/cc @chizhg  @ZhiminXiang 

/hold
Let's wait until this merged: https://github.com/knative/serving/pull/7124