### PR TITLE
Add permissions for release service accounts

### DIFF
--- a/config/prow/boskos/set_up_boskos_project.sh
+++ b/config/prow/boskos/set_up_boskos_project.sh
@@ -51,15 +51,23 @@ readonly RESOURCES=(
 
     "roles/storage.admin"
     "prow-job@knative-tests.iam.gserviceaccount.com"
+    "prow-job@knative-nightly.iam.gserviceaccount.com"
+    "prow-job@knative-releases.iam.gserviceaccount.com"
 
     "roles/pubsub.admin"
     "prow-job@knative-tests.iam.gserviceaccount.com"
+    "prow-job@knative-nightly.iam.gserviceaccount.com"
+    "prow-job@knative-releases.iam.gserviceaccount.com"
 
     "roles/logging.configWriter"
     "prow-job@knative-tests.iam.gserviceaccount.com"
+    "prow-job@knative-nightly.iam.gserviceaccount.com"
+    "prow-job@knative-releases.iam.gserviceaccount.com"
 
     "roles/cloudscheduler.admin"
     "prow-job@knative-tests.iam.gserviceaccount.com"
+    "prow-job@knative-nightly.iam.gserviceaccount.com"
+    "prow-job@knative-releases.iam.gserviceaccount.com"
 
     "roles/viewer"
     "knative-dev@googlegroups.com"


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
As release related jobs are running the same set of tests as the integration tests, the service account used in these jobs should be granted the same permissions. Currently we are missing some permissions for the two service accounts on the boskos projects, and it's causing the knative-gcp auto-release and nightly-release jobs to fail, see https://testgrid.knative.dev/knative-gcp#auto-release.

This PR adds the permissions for these service accounts.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @nachocano 
/cc @chaodaiG 

BTW I'm not sure why we chose to use different service accounts for tests and release jobs, @adrcunha could you please provide some background? Thanks.
