### PR TITLE
All networking jobs run both e2e and auto tls

### DIFF
--- a/config/prow/config_knative.yaml
+++ b/config/prow/config_knative.yaml
@@ -407,7 +407,11 @@ periodics:
       release: "0.12"
       dot-dev: true
       go113: true
-    - custom-job: istio-1.3-mesh
+    - branch-ci: true
+      release: "0.13"
+      dot-dev: true
+      go113: true
+    - custom-job: istio-1.5-mesh
       command:
       - "./test/presubmit-tests.sh"
       args:
@@ -417,7 +421,7 @@ periodics:
       - "./test/e2e-auto-tls-tests.sh --istio-version 1.5-latest --mesh"
       dot-dev: true
       go113: true
-    - custom-job: istio-1.3-no-mesh
+    - custom-job: istio-1.5-no-mesh
       command:
       - "./test/presubmit-tests.sh"
       args:

--- a/config/prow/config_knative.yaml
+++ b/config/prow/config_knative.yaml
@@ -58,6 +58,8 @@ presubmits:
       args:
       - "--run-test"
       - "./test/e2e-tests.sh --istio-version 1.5-latest --mesh"
+      - "--run-test"
+      - "./test/e2e-auto-tls-tests.sh --istio-version 1.5-latest --mesh"
     - custom-test: istio-1.5-no-mesh
       dot-dev: true
       always_run: false
@@ -65,6 +67,8 @@ presubmits:
       args:
       - "--run-test"
       - "./test/e2e-tests.sh --istio-version 1.5-latest --no-mesh"
+      - "--run-test"
+      - "./test/e2e-auto-tls-tests.sh --istio-version 1.5-latest --no-mesh"
     - custom-test: istio-1.4-mesh
       dot-dev: true
       always_run: false
@@ -72,6 +76,8 @@ presubmits:
       args:
       - "--run-test"
       - "./test/e2e-tests.sh --istio-version 1.4-latest --mesh"
+      - "--run-test"
+      - "./test/e2e-auto-tls-tests.sh --istio-version 1.4-latest --mesh"
     - custom-test: istio-1.4-no-mesh
       dot-dev: true
       always_run: false
@@ -79,6 +85,8 @@ presubmits:
       args:
       - "--run-test"
       - "./test/e2e-tests.sh --istio-version 1.4-latest --no-mesh"
+      - "--run-test"
+      - "./test/e2e-auto-tls-tests.sh --istio-version 1.4-latest --no-mesh"
     - custom-test: gloo-0.17.1
       dot-dev: true
       always_run: false
@@ -86,27 +94,35 @@ presubmits:
       args:
       - "--run-test"
       - "./test/e2e-tests.sh --gloo-version 0.17.1"
+      - "--run-test"
+      - "./test/e2e-auto-tls-tests.sh --gloo-version 0.17.1"
     - custom-test: kourier-stable
       dot-dev: true
       always_run: false
       optional: true
       args:
-        - "--run-test"
-        - "./test/e2e-tests.sh --kourier-version stable"
+      - "--run-test"
+      - "./test/e2e-tests.sh --kourier-version stable"
+      - "--run-test"
+      - "./test/e2e-auto-tls-tests.sh --kourier-version stable"
     - custom-test: contour-latest
       dot-dev: true
       always_run: false
       optional: true
       args:
-        - "--run-test"
-        - "./test/e2e-tests.sh --contour-version latest"
+      - "--run-test"
+      - "./test/e2e-tests.sh --contour-version latest"
+      - "--run-test"
+      - "./test/e2e-auto-tls-tests.sh --contour-version latest"
     - custom-test: ambassador-latest
       dot-dev: true
       always_run: false
       optional: true
       args:
-        - "--run-test"
-        - "./test/e2e-tests.sh --ambassador-version latest"
+      - "--run-test"
+      - "./test/e2e-tests.sh --ambassador-version latest"
+      - "--run-test"
+      - "./test/e2e-auto-tls-tests.sh --ambassador-version latest"
     - custom-test: https
       dot-dev: true
       always_run: false
@@ -114,6 +130,8 @@ presubmits:
       args:
       - "--run-test"
       - "./test/e2e-tests.sh --https"
+      - "--run-test"
+      - "./test/e2e-auto-tls-tests.sh --https"
     - custom-test: build-tests-go114
       dot-dev: true
       always_run: false
@@ -389,44 +407,94 @@ periodics:
       release: "0.12"
       dot-dev: true
       go113: true
-    - branch-ci: true
-      release: "0.13"
+    - custom-job: istio-1.3-mesh
+      command:
+      - "./test/presubmit-tests.sh"
+      args:
+      - "--run-test"
+      - "./test/e2e-tests.sh --istio-version 1.5-latest --mesh"
+      - "--run-test"
+      - "./test/e2e-auto-tls-tests.sh --istio-version 1.5-latest --mesh"
       dot-dev: true
       go113: true
-    - custom-job: istio-1.5-mesh
-      full-command: "./test/e2e-tests.sh --istio-version 1.5-latest --mesh"
-      dot-dev: true
-      go113: true
-    - custom-job: istio-1.5-no-mesh
-      full-command: "./test/e2e-tests.sh --istio-version 1.5-latest --no-mesh"
+    - custom-job: istio-1.3-no-mesh
+      command:
+      - "./test/presubmit-tests.sh"
+      args:
+      - "--run-test"
+      - "./test/e2e-tests.sh --istio-version 1.5-latest --no-mesh"
+      - "--run-test"
+      - "./test/e2e-auto-tls-tests.sh --istio-version 1.5-latest --no-mesh"
       dot-dev: true
       go113: true
     - custom-job: istio-1.4-mesh
-      full-command: "./test/e2e-tests.sh --istio-version 1.4-latest --mesh"
+      command:
+      - "./test/presubmit-tests.sh"
+      args:
+      - "--run-test"
+      - "./test/e2e-tests.sh --istio-version 1.4-latest --mesh"
+      - "--run-test"
+      - "./test/e2e-auto-tls-tests.sh --istio-version 1.4-latest --mesh"
       dot-dev: true
       go113: true
     - custom-job: istio-1.4-no-mesh
-      full-command: "./test/e2e-tests.sh --istio-version 1.4-latest --no-mesh"
+      command:
+      - "./test/presubmit-tests.sh"
+      args:
+      - "--run-test"
+      - "./test/e2e-tests.sh --istio-version 1.4-latest --no-mesh"
+      - "--run-test"
+      - "./test/e2e-auto-tls-tests.sh --istio-version 1.4-latest --no-mesh"
       dot-dev: true
       go113: true
     - custom-job: gloo-0.17.1
-      full-command: "./test/e2e-tests.sh --gloo-version 0.17.1"
+      command:
+      - "./test/presubmit-tests.sh"
+      args:
+      - "--run-test"
+      - "./test/e2e-tests.sh --gloo-version 0.17.1"
+      - "--run-test"
+      - "./test/e2e-auto-tls-tests.sh --gloo-version 0.17.1"
       dot-dev: true
       go113: true
     - custom-job: kourier-stable
-      full-command: "./test/e2e-tests.sh --kourier-version stable"
+      command:
+      - "./test/presubmit-tests.sh"
+      args:
+      - "--run-test"
+      - "./test/e2e-tests.sh --kourier-version stable"
+      - "--run-test"
+      - "./test/e2e-auto-tls-tests.sh --kourier-version stable"
       dot-dev: true
       go113: true
     - custom-job: contour-latest
-      full-command: "./test/e2e-tests.sh --contour-version latest"
+      command:
+      - "./test/presubmit-tests.sh"
+      args:
+      - "--run-test"
+      - "./test/e2e-tests.sh --contour-version latest"
+      - "--run-test"
+      - "./test/e2e-auto-tls-tests.sh --contour-version latest"
       dot-dev: true
       go113: true
     - custom-job: ambassador-latest
-      full-command: "./test/e2e-tests.sh --ambassador-version latest"
+      command:
+      - "./test/presubmit-tests.sh"
+      args:
+      - "--run-test"
+      - "./test/e2e-tests.sh --ambassador-version latest"
+      - "--run-test"
+      - "./test/e2e-auto-tls-tests.sh --ambassador-version latest"
       dot-dev: true
       go113: true
     - custom-job: https
-      full-command: "./test/e2e-tests.sh --https"
+      command:
+      - "./test/presubmit-tests.sh"
+      args:
+      - "--run-test"
+      - "./test/e2e-tests.sh --https"
+      - "--run-test"
+      - "./test/e2e-auto-tls-tests.sh --https"
       dot-dev: true
       go113: true
     - nightly: true

--- a/config/prow/jobs/config.yaml
+++ b/config/prow/jobs/config.yaml
@@ -286,6 +286,8 @@ presubmits:
         - "./test/presubmit-tests.sh"
         - "--run-test"
         - "./test/e2e-tests.sh --istio-version 1.5-latest --mesh"
+        - "--run-test"
+        - "./test/e2e-auto-tls-tests.sh --istio-version 1.5-latest --mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -318,6 +320,8 @@ presubmits:
         - "./test/presubmit-tests.sh"
         - "--run-test"
         - "./test/e2e-tests.sh --istio-version 1.5-latest --no-mesh"
+        - "--run-test"
+        - "./test/e2e-auto-tls-tests.sh --istio-version 1.5-latest --no-mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -350,6 +354,8 @@ presubmits:
         - "./test/presubmit-tests.sh"
         - "--run-test"
         - "./test/e2e-tests.sh --istio-version 1.4-latest --mesh"
+        - "--run-test"
+        - "./test/e2e-auto-tls-tests.sh --istio-version 1.4-latest --mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -382,6 +388,8 @@ presubmits:
         - "./test/presubmit-tests.sh"
         - "--run-test"
         - "./test/e2e-tests.sh --istio-version 1.4-latest --no-mesh"
+        - "--run-test"
+        - "./test/e2e-auto-tls-tests.sh --istio-version 1.4-latest --no-mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -414,6 +422,8 @@ presubmits:
         - "./test/presubmit-tests.sh"
         - "--run-test"
         - "./test/e2e-tests.sh --gloo-version 0.17.1"
+        - "--run-test"
+        - "./test/e2e-auto-tls-tests.sh --gloo-version 0.17.1"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -446,6 +456,8 @@ presubmits:
         - "./test/presubmit-tests.sh"
         - "--run-test"
         - "./test/e2e-tests.sh --kourier-version stable"
+        - "--run-test"
+        - "./test/e2e-auto-tls-tests.sh --kourier-version stable"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -478,6 +490,8 @@ presubmits:
         - "./test/presubmit-tests.sh"
         - "--run-test"
         - "./test/e2e-tests.sh --contour-version latest"
+        - "--run-test"
+        - "./test/e2e-auto-tls-tests.sh --contour-version latest"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -510,6 +524,8 @@ presubmits:
         - "./test/presubmit-tests.sh"
         - "--run-test"
         - "./test/e2e-tests.sh --ambassador-version latest"
+        - "--run-test"
+        - "./test/e2e-auto-tls-tests.sh --ambassador-version latest"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -542,6 +558,8 @@ presubmits:
         - "./test/presubmit-tests.sh"
         - "--run-test"
         - "./test/e2e-tests.sh --https"
+        - "--run-test"
+        - "./test/e2e-auto-tls-tests.sh --https"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -4671,18 +4689,14 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "0 8 * * *"
-  name: ci-knative-serving-0.13-continuous
+- cron: "50 */2 * * *"
+  name: ci-knative-serving-istio-1.3-mesh
   agent: kubernetes
-  labels:
-    prow.k8s.io/pubsub.project: knative-tests
-    prow.k8s.io/pubsub.topic: knative-monitoring
-    prow.k8s.io/pubsub.runID: ci-knative-serving-0.13-continuous
   decorate: true
   extra_refs:
   - org: knative
     repo: serving
-    base_ref: release-0.13
+    base_ref: master
     path_alias: knative.dev/serving
   spec:
     containers:
@@ -4691,34 +4705,26 @@ periodics:
       command:
       - runner.sh
       args:
-      - "./hack/release.sh"
-      - "--nopublish"
-      - "--notag-release"
-      securityContext:
-        privileged: true
+      - "./test/presubmit-tests.sh"
+      - "--run-test"
+      - "./test/e2e-tests.sh --istio-version 1.5-latest --mesh"
+      - "--run-test"
+      - "./test/e2e-auto-tls-tests.sh --istio-version 1.5-latest --mesh"
       volumeMounts:
-      - name: docker-graph
-        mountPath: /docker-graph
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
       env:
-      - name: DOCKER_IN_DOCKER_ENABLED
-        value: "true"
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: release-0.13
     volumes:
-    - name: docker-graph
-      emptyDir: {}
     - name: test-account
       secret:
         secretName: test-account
 - cron: "12 */2 * * *"
-  name: ci-knative-serving-istio-1.5-mesh
+  name: ci-knative-serving-istio-1.3-no-mesh
   agent: kubernetes
   decorate: true
   extra_refs:
@@ -4733,43 +4739,11 @@ periodics:
       command:
       - runner.sh
       args:
-      - "./test/e2e-tests.sh"
-      - "--istio-version"
-      - "1.5-latest"
-      - "--mesh"
-      volumeMounts:
-      - name: test-account
-        mountPath: /etc/test-account
-        readOnly: true
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/test-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-    volumes:
-    - name: test-account
-      secret:
-        secretName: test-account
-- cron: "34 */2 * * *"
-  name: ci-knative-serving-istio-1.5-no-mesh
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: knative
-    repo: serving
-    base_ref: master
-    path_alias: knative.dev/serving
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./test/e2e-tests.sh"
-      - "--istio-version"
-      - "1.5-latest"
-      - "--no-mesh"
+      - "./test/presubmit-tests.sh"
+      - "--run-test"
+      - "./test/e2e-tests.sh --istio-version 1.5-latest --no-mesh"
+      - "--run-test"
+      - "./test/e2e-auto-tls-tests.sh --istio-version 1.5-latest --no-mesh"
       volumeMounts:
       - name: test-account
         mountPath: /etc/test-account
@@ -4799,10 +4773,11 @@ periodics:
       command:
       - runner.sh
       args:
-      - "./test/e2e-tests.sh"
-      - "--istio-version"
-      - "1.4-latest"
-      - "--mesh"
+      - "./test/presubmit-tests.sh"
+      - "--run-test"
+      - "./test/e2e-tests.sh --istio-version 1.4-latest --mesh"
+      - "--run-test"
+      - "./test/e2e-auto-tls-tests.sh --istio-version 1.4-latest --mesh"
       volumeMounts:
       - name: test-account
         mountPath: /etc/test-account
@@ -4832,10 +4807,11 @@ periodics:
       command:
       - runner.sh
       args:
-      - "./test/e2e-tests.sh"
-      - "--istio-version"
-      - "1.4-latest"
-      - "--no-mesh"
+      - "./test/presubmit-tests.sh"
+      - "--run-test"
+      - "./test/e2e-tests.sh --istio-version 1.4-latest --no-mesh"
+      - "--run-test"
+      - "./test/e2e-auto-tls-tests.sh --istio-version 1.4-latest --no-mesh"
       volumeMounts:
       - name: test-account
         mountPath: /etc/test-account
@@ -4865,9 +4841,11 @@ periodics:
       command:
       - runner.sh
       args:
-      - "./test/e2e-tests.sh"
-      - "--gloo-version"
-      - "0.17.1"
+      - "./test/presubmit-tests.sh"
+      - "--run-test"
+      - "./test/e2e-tests.sh --gloo-version 0.17.1"
+      - "--run-test"
+      - "./test/e2e-auto-tls-tests.sh --gloo-version 0.17.1"
       volumeMounts:
       - name: test-account
         mountPath: /etc/test-account
@@ -4897,9 +4875,11 @@ periodics:
       command:
       - runner.sh
       args:
-      - "./test/e2e-tests.sh"
-      - "--kourier-version"
-      - "stable"
+      - "./test/presubmit-tests.sh"
+      - "--run-test"
+      - "./test/e2e-tests.sh --kourier-version stable"
+      - "--run-test"
+      - "./test/e2e-auto-tls-tests.sh --kourier-version stable"
       volumeMounts:
       - name: test-account
         mountPath: /etc/test-account
@@ -4929,9 +4909,11 @@ periodics:
       command:
       - runner.sh
       args:
-      - "./test/e2e-tests.sh"
-      - "--contour-version"
-      - "latest"
+      - "./test/presubmit-tests.sh"
+      - "--run-test"
+      - "./test/e2e-tests.sh --contour-version latest"
+      - "--run-test"
+      - "./test/e2e-auto-tls-tests.sh --contour-version latest"
       volumeMounts:
       - name: test-account
         mountPath: /etc/test-account
@@ -4961,9 +4943,11 @@ periodics:
       command:
       - runner.sh
       args:
-      - "./test/e2e-tests.sh"
-      - "--ambassador-version"
-      - "latest"
+      - "./test/presubmit-tests.sh"
+      - "--run-test"
+      - "./test/e2e-tests.sh --ambassador-version latest"
+      - "--run-test"
+      - "./test/e2e-auto-tls-tests.sh --ambassador-version latest"
       volumeMounts:
       - name: test-account
         mountPath: /etc/test-account
@@ -4993,8 +4977,11 @@ periodics:
       command:
       - runner.sh
       args:
-      - "./test/e2e-tests.sh"
-      - "--https"
+      - "./test/presubmit-tests.sh"
+      - "--run-test"
+      - "./test/e2e-tests.sh --https"
+      - "--run-test"
+      - "./test/e2e-auto-tls-tests.sh --https"
       volumeMounts:
       - name: test-account
         mountPath: /etc/test-account

--- a/config/prow/jobs/config.yaml
+++ b/config/prow/jobs/config.yaml
@@ -4689,8 +4689,54 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "50 */2 * * *"
-  name: ci-knative-serving-istio-1.3-mesh
+- cron: "0 8 * * *"
+  name: ci-knative-serving-0.13-continuous
+  agent: kubernetes
+  labels:
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-knative-serving-0.13-continuous
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: release-0.13
+    path_alias: knative.dev/serving
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--nopublish"
+      - "--notag-release"
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - name: docker-graph
+        mountPath: /docker-graph
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.13
+    volumes:
+    - name: docker-graph
+      emptyDir: {}
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "12 */2 * * *"
+  name: ci-knative-serving-istio-1.5-mesh
   agent: kubernetes
   decorate: true
   extra_refs:
@@ -4723,8 +4769,8 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "12 */2 * * *"
-  name: ci-knative-serving-istio-1.3-no-mesh
+- cron: "34 */2 * * *"
+  name: ci-knative-serving-istio-1.5-no-mesh
   agent: kubernetes
   decorate: true
   extra_refs:


### PR DESCRIPTION
/assign @chizhg @coryrc 
/cc @chizhg  @coryrc  @ZhiminXiang 

We haven't been running auto tls tests on all serving network tests for a while, let's get it working.

/hold
waits until #1780 is merged