### PR TITLE
disable templated (containing {{ chars) link check

### DIFF
--- a/scripts/markdown-link-check-config.rc
+++ b/scripts/markdown-link-check-config.rc
@@ -1,5 +1,5 @@
 # For help, see
 # https://github.com/raviqqe/liche/blob/master/README.md
 
-# Don't check localhost links
--x "^https?://localhost($|[:/].*)"
+# Don't check localhost links and don't check templated links
+-x "(^https?://localhost($|[:/].*))|(^https://.*{{.*$)"


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
disable templated (containing {{ chars) link check. This is needed because the documentation supports generating links from a template.


<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #

**Special notes to reviewers**:

**User-visible changes in this PR**:

