### PR TITLE
Dop the Istio add on

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -179,9 +179,6 @@ This is a helper script for Knative E2E test scripts. To use it:
 1. By default `knative_teardown()` and `test_teardown()` will be called after
    the tests finish, use `--skip-teardowns` if you don't want them to be called.
 
-1. By default Istio is installed on the cluster via Addon, use
-   `--skip-istio-addon` if you choose not to have it preinstalled.
-
 1. You can force running the tests against a specific GKE cluster version by
    using the `--cluster-version` flag and passing a full version as the flag
    value.

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -376,8 +376,7 @@ function setup_test_cluster() {
   set +o pipefail
 
   if (( ! SKIP_KNATIVE_SETUP )) && function_exists knative_setup; then
-    # Wait for Istio installation to complete, if necessary, before calling knative_setup.
-    (( ! SKIP_ISTIO_ADDON )) && (wait_until_batch_job_complete istio-system || return 1)
+    wait_until_batch_job_complete istio-system || return 1
     knative_setup || fail_test "Knative setup failed"
   fi
   if function_exists test_setup; then
@@ -422,7 +421,6 @@ function fail_test() {
 
 RUN_TESTS=0
 SKIP_KNATIVE_SETUP=0
-SKIP_ISTIO_ADDON=0
 SKIP_TEARDOWNS=0
 GCP_PROJECT=""
 E2E_SCRIPT=""
@@ -459,7 +457,6 @@ function initialize() {
       --run-tests) RUN_TESTS=1 ;;
       --skip-knative-setup) SKIP_KNATIVE_SETUP=1 ;;
       --skip-teardowns) SKIP_TEARDOWNS=1 ;;
-      --skip-istio-addon) SKIP_ISTIO_ADDON=1 ;;
       *)
         [[ $# -ge 2 ]] || abort "missing parameter after $1"
         shift
@@ -484,8 +481,6 @@ function initialize() {
   fi
 
   (( IS_PROW )) && [[ -z "${GCP_PROJECT}" ]] && IS_BOSKOS=1
-
-  (( SKIP_ISTIO_ADDON )) || GKE_ADDONS="--addons=Istio"
 
   readonly RUN_TESTS
   readonly GCP_PROJECT

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -75,7 +75,6 @@ function create_test_cluster() {
   header "Creating test cluster"
 
   local creation_args=""
-  (( SKIP_ISTIO_ADDON )) || creation_args+=" --addons istio"
   [[ -n "${GCP_PROJECT}" ]] && creation_args+=" --project ${GCP_PROJECT}"
   echo "Creating cluster with args ${creation_args}"
   run_prow_cluster_tool --create ${creation_args} || fail_test "failed creating test cluster"
@@ -156,8 +155,7 @@ function setup_test_cluster() {
   set +o pipefail
 
   if (( ! SKIP_KNATIVE_SETUP )) && function_exists knative_setup; then
-    # Wait for Istio installation to complete, if necessary, before calling knative_setup.
-    (( ! SKIP_ISTIO_ADDON )) && (wait_until_batch_job_complete istio-system || return 1)
+    wait_until_batch_job_complete istio-system || return 1
     knative_setup || fail_test "Knative setup failed"
   fi
   if function_exists test_setup; then


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
This was breaking the [old smoke tests in serving](https://github.com/knative/serving/issues/6810#issuecomment-593000261) (since you had two versions of istio on the cluster). 

Generally serving installs Istio via it's own yaml so we shouldn't need to install it via the add on.

**Special notes to reviewers**:
Thanks for the review

