### PR TITLE
Revert "Dop the Istio add on"

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -180,6 +180,9 @@ This is a helper script for Knative E2E test scripts. To use it:
 1. By default `knative_teardown()` and `test_teardown()` will be called after
    the tests finish, use `--skip-teardowns` if you don't want them to be called.
 
+1. By default Istio is installed on the cluster via Addon, use
+   `--skip-istio-addon` if you choose not to have it preinstalled.
+
 1. You can force running the tests against a specific GKE cluster version by
    using the `--cluster-version` flag and passing a full version as the flag
    value.


### PR DESCRIPTION
Reverts knative/test-infra#1786

As discussed separately, all other Knative projects are either using the `--skip-istio-addon` flag or purposely installing Istio addon in the E2E testing, e.g. https://github.com/google/knative-gcp. So we cannot simply drop it.

Revert this PR and created https://github.com/knative/test-infra/issues/1787 for tracking.

/cc @chaodaiG 
FYI @dprotaso 