### PR TITLE
Fix for incorrect folder in manual release process

### DIFF
--- a/guides/manual_release.md
+++ b/guides/manual_release.md
@@ -212,7 +212,7 @@ This is the preferred method of manually building a new release.
    module name (e.g., `serving` or `eventing`).
 
    ```
-   cd ci/prow
+   cd config/prow
    ./run_job.sh ci-knative-MODULE-dot-release
    ```
 
@@ -225,7 +225,7 @@ This is the preferred method of manually building a new release.
    module name (e.g., `serving` or `eventing`).
 
    ```
-   cd ci/prow
+   cd config/prow
    ./run_job.sh ci-knative-MODULE-nightly-release
    ```
 


### PR DESCRIPTION
## This fixed incorrect folders in the manual release doc ##
In the manual release file, the folder were incorrect states as "ci/prow" which was fixed with "config/prow".
