### PR TITLE
Remove one TODO as prow-tests image has been updated

### DIFF
--- a/config/prow-staging/Makefile
+++ b/config/prow-staging/Makefile
@@ -14,6 +14,8 @@
 
 # Staging cluster configuration
 
+SKIP_CONFIG_BACKUP        := true
+
 PROJECT                   := knative-tests-staging
 PROW_GCS                  := knative-prow-staging
 PROW_HOST                 := https://prow-staging.knative.dev

--- a/config/prow_common.mk
+++ b/config/prow_common.mk
@@ -20,7 +20,7 @@ CLUSTER       ?= prow
 ZONE          ?= us-central1-f
 JOB_NAMESPACE ?= test-pods
 
-SKIP_CONFIG_BACKUP        ?=
+SKIP_CONFIG_BACKUP        ?= false
 GENERATE_MAINTENANCE_JOBS ?= true
 GENERATE_TESTGRID_CONFIG  ?= true
 
@@ -165,4 +165,3 @@ update-testgrid-config: confirm-master
 		--oneshot \
 		--output=gs://$(TESTGRID_GCS)/config \
 		--yaml=$(realpath $(TESTGRID_CONFIG))
-

--- a/config/prow_common.mk
+++ b/config/prow_common.mk
@@ -150,8 +150,7 @@ update-prow-cluster: update-almost-all-cluster-deployments update-all-boskos-dep
 # In emergency, could easily edit this file, deleting all these lines
 confirm-master:
 	@if git diff-index --quiet HEAD; then true; else echo "Git working space is dirty -- will not update server"; false; fi;
-# TODO(chizhg): change to `git branch --show-current` after we update the Git version in prow-tests image.
-ifneq ("$(shell git rev-parse --abbrev-ref HEAD)","master")
+ifneq ("$(shell git branch --show-current)","master")
 	@echo "Branch is not master -- will not update server"
 	@false
 endif


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Remove one TODO in the Makefile as prow-tests image has been updated


