### PR TITLE
Add config for build cluster(s) to run postsubmit jobs for Prow auto-update

### DIFF
--- a/config/prow/cluster/400-deck.yaml
+++ b/config/prow/cluster/400-deck.yaml
@@ -44,6 +44,7 @@ spec:
         - --spyglass
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
+        - --kubeconfig=/etc/kubeconfig/config
         - --oauth-url=/github-login
         - --cookie-secret=/etc/cookie/secret
         ports:
@@ -61,6 +62,9 @@ spec:
           readOnly: true
         - name: cookie-secret
           mountPath: /etc/cookie
+          readOnly: true
+        - name: kubeconfig
+          mountPath: /etc/kubeconfig
           readOnly: true
         livenessProbe:
           httpGet:
@@ -88,6 +92,10 @@ spec:
       - name: cookie-secret
         secret:
           secretName: cookie-secret
+      - name: kubeconfig
+        secret:
+          defaultMode: 0644
+          secretName: kubeconfig
 ---
 apiVersion: v1
 kind: Service

--- a/config/prow/cluster/400-plank.yaml
+++ b/config/prow/cluster/400-plank.yaml
@@ -33,6 +33,7 @@ spec:
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
+        - --kubeconfig=/etc/kubeconfig/config
         - --dry-run=false
         volumeMounts:
         - name: oauth
@@ -44,6 +45,9 @@ spec:
         - name: job-config
           mountPath: /etc/job-config
           readOnly: true
+        - name: kubeconfig
+          mountPath: /etc/kubeconfig
+          readOnly: true
       volumes:
       - name: oauth
         secret:
@@ -54,3 +58,7 @@ spec:
       - name: job-config
         configMap:
           name: job-config
+      - name: kubeconfig
+        secret:
+          defaultMode: 0644
+          secretName: kubeconfig

--- a/config/prow/cluster/400-sinker.yaml
+++ b/config/prow/cluster/400-sinker.yaml
@@ -32,6 +32,7 @@ spec:
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
+        - --kubeconfig=/etc/kubeconfig/config
         - --dry-run=false
         volumeMounts:
         - name: config
@@ -40,6 +41,9 @@ spec:
         - name: job-config
           mountPath: /etc/job-config
           readOnly: true
+        - name: kubeconfig
+          mountPath: /etc/kubeconfig
+          readOnly: true
       volumes:
       - name: config
         configMap:
@@ -47,3 +51,7 @@ spec:
       - name: job-config
         configMap:
           name: job-config
+      - name: kubeconfig
+        secret:
+          defaultMode: 0644
+          secretName: kubeconfig


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
By following the guides in https://github.com/kubernetes/test-infra/blob/master/prow/getting_started_deploy.md#run-test-pods-in-different-clusters, create a build cluster for running postsubmit jobs to update Prow service cluster.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #1758

