### PR TITLE
Allows PRs in test-infra to be automatically merged

### DIFF
--- a/config/prow-staging/core/config.yaml
+++ b/config/prow-staging/core/config.yaml
@@ -108,11 +108,21 @@ tide:
     labels:
     - lgtm
     - approved
-    missingLabels:
+    - "cla: yes"
+    missingLabels: &knative_tide_missing_labels
     - do-not-merge/hold
     - do-not-merge/work-in-progress
     - do-not-merge/invalid-owners-file
     - needs-rebase
+  - repos:
+    # Allow PRs for test-infra to be automatically merged without manual approval.
+    - "knative-prow-robot/test-infra"
+    labels:
+    - "cla: yes"
+    - auto-merge
+    missingLabels: *knative_tide_missing_labels
+    author: knative-prow-robot
+    reviewApprovedRequired: false
   merge_method:
     knative: squash
     google/knative-gcp: squash

--- a/config/prow/core/config.yaml
+++ b/config/prow/core/config.yaml
@@ -125,11 +125,21 @@ tide:
     labels:
     - lgtm
     - approved
-    missingLabels:
+    - "cla: yes"
+    missingLabels: &knative_tide_missing_labels
     - do-not-merge/hold
     - do-not-merge/work-in-progress
     - do-not-merge/invalid-owners-file
     - needs-rebase
+  - repos:
+    # Allow PRs for test-infra to be automatically merged without manual approval.
+    - "knative/test-infra"
+    labels:
+    - "cla: yes"
+    - auto-merge
+    missingLabels: *knative_tide_missing_labels
+    author: knative-prow-robot
+    reviewApprovedRequired: false
   merge_method:
     knative: squash
     google/knative-gcp: squash

--- a/tools/config-generator/main.go
+++ b/tools/config-generator/main.go
@@ -82,6 +82,7 @@ type prowConfigTemplateData struct {
 	GubernatorHost    string
 	TestGridGcsBucket string
 	TideRepos         []string
+	TestInfraRepo     string
 }
 
 // baseProwJobTemplateData contains basic data about a Prow job.
@@ -663,7 +664,11 @@ func getProwConfigData(config yaml.MapSlice) prowConfigTemplateData {
 			continue
 		}
 		for _, repo := range getMapSlice(section.Value) {
-			data.TideRepos = appendIfUnique(data.TideRepos, getString(repo.Key))
+			orgRepoName := getString(repo.Key)
+			data.TideRepos = appendIfUnique(data.TideRepos, orgRepoName)
+			if strings.HasSuffix(orgRepoName, "test-infra") {
+				data.TestInfraRepo = orgRepoName
+			}
 		}
 	}
 	// Sort repos to make output stable.

--- a/tools/config-generator/templates/prow_config.yaml
+++ b/tools/config-generator/templates/prow_config.yaml
@@ -92,11 +92,21 @@ tide:
     labels:
     - lgtm
     - approved
-    missingLabels:
+    - "cla: yes"
+    missingLabels: &knative_tide_missing_labels
     - do-not-merge/hold
     - do-not-merge/work-in-progress
     - do-not-merge/invalid-owners-file
     - needs-rebase
+  - repos:
+    # Allow PRs for test-infra to be automatically merged without manual approval.
+    - "[[.TestInfraRepo]]"
+    labels:
+    - "cla: yes"
+    - auto-merge
+    missingLabels: *knative_tide_missing_labels
+    author: knative-prow-robot
+    reviewApprovedRequired: false
   merge_method:
     knative: squash
     google/knative-gcp: squash


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Allows PRs in test-infra to be automatically merged

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #1762


