### PR TITLE
Run Istio 1.5 tests instead of Istio 1.3 (deprecated).

### DIFF
--- a/config/prow/config_knative.yaml
+++ b/config/prow/config_knative.yaml
@@ -53,14 +53,14 @@ presubmits:
     - go-coverage: true
       go-coverage-threshold: 80
       dot-dev: true
-    - custom-test: istio-1.3-mesh
+    - custom-test: istio-1.5-mesh
       dot-dev: true
       always_run: false
       optional: true
       args:
       - "--run-test"
       - "./test/e2e-tests.sh --istio-version 1.3-latest --mesh"
-    - custom-test: istio-1.3-no-mesh
+    - custom-test: istio-1.5-no-mesh
       dot-dev: true
       always_run: false
       optional: true
@@ -408,11 +408,11 @@ periodics:
       release: "0.12"
       dot-dev: true
       go113: true
-    - custom-job: istio-1.3-mesh
+    - custom-job: istio-1.5-mesh
       full-command: "./test/e2e-tests.sh --istio-version 1.3-latest --mesh"
       dot-dev: true
       go113: true
-    - custom-job: istio-1.3-no-mesh
+    - custom-job: istio-1.5-no-mesh
       full-command: "./test/e2e-tests.sh --istio-version 1.3-latest --no-mesh"
       dot-dev: true
       go113: true

--- a/config/prow/jobs/config.yaml
+++ b/config/prow/jobs/config.yaml
@@ -6034,7 +6034,7 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "50 */2 * * *"
+- cron: "12 */2 * * *"
   name: ci-knative-serving-istio-1.5-mesh
   agent: kubernetes
   decorate: true
@@ -6067,7 +6067,7 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "12 */2 * * *"
+- cron: "34 */2 * * *"
   name: ci-knative-serving-istio-1.5-no-mesh
   agent: kubernetes
   decorate: true

--- a/config/prow/jobs/config.yaml
+++ b/config/prow/jobs/config.yaml
@@ -513,12 +513,12 @@ presubmits:
       - name: covbot-token
         secret:
           secretName: covbot-token
-  - name: pull-knative-serving-istio-1.3-mesh
+  - name: pull-knative-serving-istio-1.5-mesh
     agent: kubernetes
-    context: pull-knative-serving-istio-1.3-mesh
+    context: pull-knative-serving-istio-1.5-mesh
     always_run: false
-    rerun_command: "/test pull-knative-serving-istio-1.3-mesh"
-    trigger: "(?m)^/test (all|pull-knative-serving-istio-1.3-mesh),?(\\s+|$)"
+    rerun_command: "/test pull-knative-serving-istio-1.5-mesh"
+    trigger: "(?m)^/test (all|pull-knative-serving-istio-1.5-mesh),?(\\s+|$)"
     decorate: true
     optional: true
     path_alias: knative.dev/serving
@@ -547,12 +547,12 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-serving-istio-1.3-mesh
+  - name: pull-knative-serving-istio-1.5-mesh
     agent: kubernetes
-    context: pull-knative-serving-istio-1.3-mesh
+    context: pull-knative-serving-istio-1.5-mesh
     always_run: false
-    rerun_command: "/test pull-knative-serving-istio-1.3-mesh"
-    trigger: "(?m)^/test (all|pull-knative-serving-istio-1.3-mesh),?(\\s+|$)"
+    rerun_command: "/test pull-knative-serving-istio-1.5-mesh"
+    trigger: "(?m)^/test (all|pull-knative-serving-istio-1.5-mesh),?(\\s+|$)"
     decorate: true
     optional: true
     path_alias: knative.dev/serving
@@ -581,12 +581,12 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-serving-istio-1.3-no-mesh
+  - name: pull-knative-serving-istio-1.5-no-mesh
     agent: kubernetes
-    context: pull-knative-serving-istio-1.3-no-mesh
+    context: pull-knative-serving-istio-1.5-no-mesh
     always_run: false
-    rerun_command: "/test pull-knative-serving-istio-1.3-no-mesh"
-    trigger: "(?m)^/test (all|pull-knative-serving-istio-1.3-no-mesh),?(\\s+|$)"
+    rerun_command: "/test pull-knative-serving-istio-1.5-no-mesh"
+    trigger: "(?m)^/test (all|pull-knative-serving-istio-1.5-no-mesh),?(\\s+|$)"
     decorate: true
     optional: true
     path_alias: knative.dev/serving
@@ -615,12 +615,12 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-serving-istio-1.3-no-mesh
+  - name: pull-knative-serving-istio-1.5-no-mesh
     agent: kubernetes
-    context: pull-knative-serving-istio-1.3-no-mesh
+    context: pull-knative-serving-istio-1.5-no-mesh
     always_run: false
-    rerun_command: "/test pull-knative-serving-istio-1.3-no-mesh"
-    trigger: "(?m)^/test (all|pull-knative-serving-istio-1.3-no-mesh),?(\\s+|$)"
+    rerun_command: "/test pull-knative-serving-istio-1.5-no-mesh"
+    trigger: "(?m)^/test (all|pull-knative-serving-istio-1.5-no-mesh),?(\\s+|$)"
     decorate: true
     optional: true
     path_alias: knative.dev/serving
@@ -6035,7 +6035,7 @@ periodics:
       secret:
         secretName: test-account
 - cron: "50 */2 * * *"
-  name: ci-knative-serving-istio-1.3-mesh
+  name: ci-knative-serving-istio-1.5-mesh
   agent: kubernetes
   decorate: true
   extra_refs:
@@ -6068,7 +6068,7 @@ periodics:
       secret:
         secretName: test-account
 - cron: "12 */2 * * *"
-  name: ci-knative-serving-istio-1.3-no-mesh
+  name: ci-knative-serving-istio-1.5-no-mesh
   agent: kubernetes
   decorate: true
   extra_refs:

--- a/config/prow/testgrid/testgrid.yaml
+++ b/config/prow/testgrid/testgrid.yaml
@@ -58,11 +58,11 @@ test_groups:
 - name: ci-knative-serving-continuous
   gcs_prefix: knative-prow/logs/ci-knative-serving-continuous
   alert_stale_results_hours: 3
-- name: ci-knative-serving-istio-1.3-mesh
-  gcs_prefix: knative-prow/logs/ci-knative-serving-istio-1.3-mesh
+- name: ci-knative-serving-istio-1.5-mesh
+  gcs_prefix: knative-prow/logs/ci-knative-serving-istio-1.5-mesh
   alert_stale_results_hours: 3
-- name: ci-knative-serving-istio-1.3-no-mesh
-  gcs_prefix: knative-prow/logs/ci-knative-serving-istio-1.3-no-mesh
+- name: ci-knative-serving-istio-1.5-no-mesh
+  gcs_prefix: knative-prow/logs/ci-knative-serving-istio-1.5-no-mesh
   alert_stale_results_hours: 3
 - name: ci-knative-serving-istio-1.4-mesh
   gcs_prefix: knative-prow/logs/ci-knative-serving-istio-1.4-mesh
@@ -337,11 +337,11 @@ dashboards:
   - name: conformance
     test_group_name: ci-knative-serving-continuous
     base_options: "include-filter-by-regex=test/conformance/&sort-by-name="
-  - name: istio-1.3-mesh
-    test_group_name: ci-knative-serving-istio-1.3-mesh
+  - name: istio-1.5-mesh
+    test_group_name: ci-knative-serving-istio-1.5-mesh
     base_options: "sort-by-name="
-  - name: istio-1.3-no-mesh
-    test_group_name: ci-knative-serving-istio-1.3-no-mesh
+  - name: istio-1.5-no-mesh
+    test_group_name: ci-knative-serving-istio-1.5-no-mesh
     base_options: "sort-by-name="
   - name: istio-1.4-mesh
     test_group_name: ci-knative-serving-istio-1.4-mesh

--- a/shared/testgrid/testgrid.go
+++ b/shared/testgrid/testgrid.go
@@ -39,8 +39,8 @@ const (
 // jobNameTestgridURLMap contains harded coded mapping of job name: Testgrid tab URL relative to base URL
 var jobNameTestgridURLMap = map[string]string{
 	"ci-knative-serving-continuous":        "serving#continuous",
-	"ci-knative-serving-istio-1.3-mesh":    "serving#istio-1.3-mesh",
-	"ci-knative-serving-istio-1.3-no-mesh": "serving#istio-1.3-no-mesh",
+	"ci-knative-serving-istio-1.5-mesh":    "serving#istio-1.5-mesh",
+	"ci-knative-serving-istio-1.5-no-mesh": "serving#istio-1.5-no-mesh",
 	"ci-knative-serving-istio-1.4-mesh":    "serving#istio-1.4-mesh",
 	"ci-knative-serving-istio-1.4-no-mesh": "serving#istio-1.4-no-mesh",
 	"ci-knative-serving-gloo-0.17.1":       "serving#gloo-0.17.1",

--- a/tools/flaky-test-reporter/config/config.yaml
+++ b/tools/flaky-test-reporter/config/config.yaml
@@ -20,13 +20,13 @@ jobConfigs:
     slackChannels:
       - name: serving-api
         identity: CA4DNJ9A4
-  - name: ci-knative-serving-istio-1.3-mesh
+  - name: ci-knative-serving-istio-1.5-mesh
     repo: serving
     type: postsubmit
     slackChannels:
       - name: networking
         identity: CA9RHBGJX
-  - name: ci-knative-serving-istio-1.3-no-mesh
+  - name: ci-knative-serving-istio-1.5-no-mesh
     repo: serving
     type: postsubmit
     slackChannels:


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Run Istio 1.5 tests instead of Istio 1.3, which is deprecated.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #

**Special notes to reviewers**:

**User-visible changes in this PR**:

