### PR TITLE
Enable rerun button on Prow

### DIFF
--- a/config/prow-staging/core/config.yaml
+++ b/config/prow-staging/core/config.yaml
@@ -83,6 +83,9 @@ deck:
       required_files:
       - podinfo.json
   tide_update_period: 1s
+  rerun_auth_config:
+    github_team_ids:
+      - 3012514 # Knative Milestone Maintainers
 prowjob_namespace: default
 pod_namespace: test-pods
 log_level: debug

--- a/config/prow/cluster/301-rbac.yaml
+++ b/config/prow/cluster/301-rbac.yaml
@@ -131,9 +131,7 @@ rules:
       - list
       - watch
       # Required when deck runs with `--rerun-creates-job=true`
-      # **Warning:** Only use this for non-public deck instances, this allows
-      # anyone with access to your Deck instance to create new Prowjobs
-      # - create
+      - create
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/config/prow/cluster/400-deck.yaml
+++ b/config/prow/cluster/400-deck.yaml
@@ -42,11 +42,14 @@ spec:
         - --hook-url=http://hook:8888/plugin-help
         - --tide-url=http://tide/
         - --spyglass
+        - --rerun-creates-job
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --kubeconfig=/etc/kubeconfig/config
         - --oauth-url=/github-login
         - --cookie-secret=/etc/cookie/secret
+        - --github-oauth-config-file=/etc/github/secret
+        - --github-token-path=/etc/githubtoken/oauth
         ports:
           - name: http
             containerPort: 8080
@@ -59,6 +62,9 @@ spec:
           readOnly: true
         - name: oauth-config
           mountPath: /etc/github
+          readOnly: true
+        - name: oauth-token
+          mountPath: /etc/githubtoken
           readOnly: true
         - name: cookie-secret
           mountPath: /etc/cookie
@@ -89,6 +95,9 @@ spec:
       - name: oauth-config
         secret:
           secretName: github-oauth-config-secret
+      - name: oauth-token
+        secret:
+            secretName: oauth-token
       - name: cookie-secret
         secret:
           secretName: cookie-secret

--- a/config/prow/core/config.yaml
+++ b/config/prow/core/config.yaml
@@ -83,6 +83,9 @@ deck:
       required_files:
       - podinfo.json
   tide_update_period: 1s
+  rerun_auth_config:
+    github_team_ids:
+      - 3012514 # Knative Milestone Maintainers
 prowjob_namespace: default
 pod_namespace: test-pods
 log_level: debug

--- a/tools/config-generator/templates/prow_config.yaml
+++ b/tools/config-generator/templates/prow_config.yaml
@@ -65,6 +65,9 @@ deck:
       required_files:
       - podinfo.json
   tide_update_period: 1s
+  rerun_auth_config:
+    github_team_ids:
+      - 3012514 # Knative Milestone Maintainers
 
 prowjob_namespace: default
 pod_namespace: test-pods


### PR DESCRIPTION
Based on:
This PR enables rerun button on Prow UI, so that Knative contributors within certain Knative teams can rerun release jobs if needed

- [Setup deck](https://github.com/kubernetes/test-infra/blob/master/prow/cmd/deck/github_oauth_setup.md): utilizes github oauth secrets and cookie secrets set up for checking PR statuses
- [rbac](https://github.com/kubernetes/test-infra/blob/master/prow/cluster/deck_rbac.yaml#L23-L24)
- [control who has access](https://github.com/kubernetes/test-infra/blob/master/config/prow/config.yaml#L65-L67)

Part of: #1653 

/assign @chizhg 