### PR TITLE
Move Prow/Testgrid config generation to update-codegen.sh

### DIFF
--- a/config/prow-staging/Makefile
+++ b/config/prow-staging/Makefile
@@ -19,8 +19,6 @@ PROJECT                   := knative-tests-staging
 PROW_GCS                  := knative-prow-staging
 PROW_HOST                 := https://prow-staging.knative.dev
 TESTGRID_GCS              := knative-testgrid-staging
-GENERATE_TESTGRID_CONFIG  := false
-GENERATE_MAINTENANCE_JOBS := false
 
 KNATIVE_CONFIG   := config_staging.yaml
 

--- a/config/prow_common.mk
+++ b/config/prow_common.mk
@@ -22,10 +22,6 @@ ZONE          ?= us-central1-f
 JOB_NAMESPACE ?= test-pods
 
 SKIP_CONFIG_BACKUP        ?=
-GENERATE_MAINTENANCE_JOBS ?= true
-GENERATE_TESTGRID_CONFIG  ?= true
-
-CONFIG_GENERATOR_DIR ?= ../../tools/config-generator
 
 # Any changes to file location must be made to staging directory also
 # or overridden in the Makefile before this file is included.
@@ -43,7 +39,6 @@ BOSKOS_RESOURCES ?= boskos/boskos_resources.yaml
 
 SET_CONTEXT   := gcloud container clusters get-credentials "$(CLUSTER)" --project="$(PROJECT)" --zone="$(ZONE)"
 UNSET_CONTEXT := kubectl config unset current-context
-MAKE_CONFIG   := go run "${CONFIG_GENERATOR_DIR}"
 
 .PHONY: help get-cluster-credentials unset-cluster-credentials config
 help:
@@ -51,7 +46,6 @@ help:
 	@echo "'Update' means updating the servers and can only be run by oncall staff."
 	@echo "Common usage:"
 	@echo " make update-prow-cluster: Update all Prow things on the server to match the current branch. Errors if not master."
-	@echo " make config: Update all generated files"
 	@echo " make update-testgrid-config: Update the Testgrid config"
 	@echo " make get-cluster-credentials: Setup kubectl to point to Prow cluster"
 	@echo " make unset-cluster-credentials: Clear kubectl context"
@@ -62,22 +56,6 @@ get-cluster-credentials:
 
 unset-cluster-credentials:
 	$(UNSET_CONTEXT)
-
-# Generate the Prow config file
-config $(PROW_JOB_CONFIG) $(PROW_CONFIG) $(PROW_PLUGINS) $(TESTGRID_CONFIG): $(KNATIVE_CONFIG) $(wildcard $(CONFIG_GENERATOR_DIR)/templates/*.yaml)
-	$(MAKE_CONFIG) \
-		--env=$(ENVIRONMENT) \
-		--gcs-bucket=$(PROW_GCS) \
-		--generate-testgrid-config=$(GENERATE_TESTGRID_CONFIG) \
-		--generate-maintenance-jobs=$(GENERATE_MAINTENANCE_JOBS) \
-		--image-docker=gcr.io/$(PROJECT)/test-infra \
-		--plugins-config-output=$(PROW_PLUGINS) \
-		--prow-config-output=$(PROW_CONFIG) \
-		--prow-jobs-config-output=$(PROW_JOB_CONFIG) \
-		--prow-host=$(PROW_HOST) \
-		--testgrid-config-output=$(TESTGRID_CONFIG) \
-		--testgrid-gcs-bucket=$(TESTGRID_GCS) \
-		$(KNATIVE_CONFIG)
 
 .PHONY: update-prow-config update-prow-job-config update-prow-plugins update-all-boskos-deployments update-boskos-resource update-almost-all-cluster-deployments update-single-cluster-deployment update-prow test update-testgrid-config confirm-master
 

--- a/config/prow_common.mk
+++ b/config/prow_common.mk
@@ -40,7 +40,7 @@ BOSKOS_RESOURCES ?= boskos/boskos_resources.yaml
 SET_CONTEXT   := gcloud container clusters get-credentials "$(CLUSTER)" --project="$(PROJECT)" --zone="$(ZONE)"
 UNSET_CONTEXT := kubectl config unset current-context
 
-.PHONY: help get-cluster-credentials unset-cluster-credentials config
+.PHONY: help get-cluster-credentials unset-cluster-credentials
 help:
 	@echo "Help"
 	@echo "'Update' means updating the servers and can only be run by oncall staff."

--- a/guides/prow_setup.md
+++ b/guides/prow_setup.md
@@ -64,7 +64,7 @@
 1. Add the new repo to
    [config_knative.yaml](../config/prow/config_knative.yaml), without any job
    settings. Check the top-level section `presubmits:` and `periodics:` for
-   blueprints for what to add. Then run `make config` to regenerate
+   blueprints for what to add. Then run `./hack/generate-configs.sh` to regenerate
    [config.yaml](../config/prow/jobs/config.yaml), otherwise the presubmit test
    in test-infra will fail. Create a PR with the changes; once it's merged ask
    the [oncall](https://knative.github.io/test-infra/) to update the Prow
@@ -86,7 +86,7 @@
 1. Merge a pull request that updates
    [config_knative.yaml](../config/prow/config_knative.yaml), the Prow config
    file (usually, copy and update the existing configuration from another
-   repository). Run `make config` to regenerate
+   repository). Run `./hack/generate-configs.sh` to regenerate
    [config.yaml](../config/prow/jobs/config.yaml), otherwise the presubmit test
    will fail.
 

--- a/hack/generate-configs.sh
+++ b/hack/generate-configs.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+
+source $(dirname $0)/../scripts/library.sh
+
+# Generate Prow configs since we are using generator
+readonly CONFIG_GENERATOR_DIR="${REPO_ROOT_DIR}/tools/config-generator"
+readonly CONFIG_DIR="${REPO_ROOT_DIR}/config"
+
+# Generate config for production Prow
+go run "${CONFIG_GENERATOR_DIR}" \
+    --gcs-bucket="knative-prow" \
+    --generate-testgrid-config=true \
+    --generate-maintenance-jobs=true \
+    --image-docker=gcr.io/knative-tests/test-infra \
+    --prow-host=https://prow.knative.dev \
+    --testgrid-gcs-bucket="knative-testgrid" \
+    --plugins-config-output="${CONFIG_DIR}/prow/core/plugins.yaml" \
+    --prow-config-output="${CONFIG_DIR}/prow/core/config.yaml" \
+    --prow-jobs-config-output="${CONFIG_DIR}/prow/jobs/config.yaml" \
+    --testgrid-config-output="${CONFIG_DIR}/prow/testgrid/testgrid.yaml" \
+    "${CONFIG_DIR}/prow/config_knative.yaml"
+
+# Generate config for staging Prow
+go run "${CONFIG_GENERATOR_DIR}" \
+    --gcs-bucket="knative-prow-staging" \
+    --generate-testgrid-config=false \
+    --generate-maintenance-jobs=false \
+    --image-docker=gcr.io/knative-tests-staging/test-infra \
+    --prow-host=https://prow-staging.knative.dev \
+    --testgrid-gcs-bucket="knative-testgrid-staging" \
+    --plugins-config-output="${CONFIG_DIR}/prow-staging/core/plugins.yaml" \
+    --prow-config-output="${CONFIG_DIR}/prow-staging/core/config.yaml" \
+    --prow-jobs-config-output="${CONFIG_DIR}/prow-staging/jobs/config.yaml" \
+    --testgrid-config-output="${CONFIG_DIR}/prow-staging/testgrid/testgrid.yaml" \
+    "${CONFIG_DIR}/prow-staging/config_staging.yaml"

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2019 The Knative Authors
+# Copyright 2020 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -20,5 +20,48 @@ set -o pipefail
 
 source $(dirname $0)/../scripts/library.sh
 
+CONFIG_GENERATOR_DIR="${REPO_ROOT_DIR}/tools/config-generator"
+CONFIG_DIR="${REPO_ROOT_DIR}/config/prow"
+PROW_GCS="knative-prow"
+GENERATE_TESTGRID_CONFIG="true"
+GENERATE_MAINTENANCE_JOBS="true"
+PROJECT="knative-tests"
+PROW_HOST="https://prow.knative.dev"
+TESTGRID_GCS="knative-testgrid"
+KNATIVE_CONFIG="config_knative.yaml"
+
+function generate_config() {
+    go run "${CONFIG_GENERATOR_DIR}" \
+		--gcs-bucket=${PROW_GCS} \
+		--generate-testgrid-config=${GENERATE_TESTGRID_CONFIG} \
+		--generate-maintenance-jobs=${GENERATE_MAINTENANCE_JOBS} \
+		--image-docker=gcr.io/${PROJECT}/test-infra \
+		--plugins-config-output="${CONFIG_DIR}/core/plugins.yaml" \
+		--prow-config-output="${CONFIG_DIR}/core/config.yaml" \
+		--prow-jobs-config-output="${CONFIG_DIR}/jobs/config.yaml" \
+		--prow-host=${PROW_HOST} \
+		--testgrid-config-output="${CONFIG_DIR}/testgrid/testgrid.yaml" \
+		--testgrid-gcs-bucket=${TESTGRID_GCS} \
+		"${CONFIG_DIR}/${KNATIVE_CONFIG}"
+}
+
+
 # Make sure our dependencies are up-to-date
 ${REPO_ROOT_DIR}/hack/update-deps.sh
+
+# Generate Prow configs since we are using generator
+
+# Generate config for production Prow
+generate_config
+
+# Generate config for staging Prow
+CONFIG_DIR="${REPO_ROOT_DIR}/config/prow-staging"
+PROW_GCS="knative-prow-staging"
+GENERATE_TESTGRID_CONFIG="false"
+GENERATE_MAINTENANCE_JOBS="false"
+PROJECT="knative-tests-staging"
+PROW_HOST="https://prow-staging.knative.dev"
+TESTGRID_GCS="knative-testgrid-staging"
+KNATIVE_CONFIG="config_staging.yaml"
+
+generate_config

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -20,48 +20,8 @@ set -o pipefail
 
 source $(dirname $0)/../scripts/library.sh
 
-CONFIG_GENERATOR_DIR="${REPO_ROOT_DIR}/tools/config-generator"
-CONFIG_DIR="${REPO_ROOT_DIR}/config/prow"
-PROW_GCS="knative-prow"
-GENERATE_TESTGRID_CONFIG="true"
-GENERATE_MAINTENANCE_JOBS="true"
-PROJECT="knative-tests"
-PROW_HOST="https://prow.knative.dev"
-TESTGRID_GCS="knative-testgrid"
-KNATIVE_CONFIG="config_knative.yaml"
-
-function generate_config() {
-    go run "${CONFIG_GENERATOR_DIR}" \
-		--gcs-bucket=${PROW_GCS} \
-		--generate-testgrid-config=${GENERATE_TESTGRID_CONFIG} \
-		--generate-maintenance-jobs=${GENERATE_MAINTENANCE_JOBS} \
-		--image-docker=gcr.io/${PROJECT}/test-infra \
-		--plugins-config-output="${CONFIG_DIR}/core/plugins.yaml" \
-		--prow-config-output="${CONFIG_DIR}/core/config.yaml" \
-		--prow-jobs-config-output="${CONFIG_DIR}/jobs/config.yaml" \
-		--prow-host=${PROW_HOST} \
-		--testgrid-config-output="${CONFIG_DIR}/testgrid/testgrid.yaml" \
-		--testgrid-gcs-bucket=${TESTGRID_GCS} \
-		"${CONFIG_DIR}/${KNATIVE_CONFIG}"
-}
-
-
 # Make sure our dependencies are up-to-date
 ${REPO_ROOT_DIR}/hack/update-deps.sh
 
-# Generate Prow configs since we are using generator
-
-# Generate config for production Prow
-generate_config
-
-# Generate config for staging Prow
-CONFIG_DIR="${REPO_ROOT_DIR}/config/prow-staging"
-PROW_GCS="knative-prow-staging"
-GENERATE_TESTGRID_CONFIG="false"
-GENERATE_MAINTENANCE_JOBS="false"
-PROJECT="knative-tests-staging"
-PROW_HOST="https://prow-staging.knative.dev"
-TESTGRID_GCS="knative-testgrid-staging"
-KNATIVE_CONFIG="config_staging.yaml"
-
-generate_config
+# Generate configs
+${REPO_ROOT_DIR}/hack/generate-configs.sh

--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -21,6 +21,11 @@ set -o pipefail
 source $(dirname $0)/../scripts/library.sh
 
 readonly TMP_DIFFROOT="$(mktemp -d ${REPO_ROOT_DIR}/tmpdiffroot.XXXXXX)"
+DIRS_TOBE_INSPECTED=(
+  "Gopkg.lock"
+  "vendor"
+  "config"
+)
 
 cleanup() {
   rm -rf "${TMP_DIFFROOT}"
@@ -30,18 +35,23 @@ trap "cleanup" EXIT SIGINT
 
 cleanup
 
-# Save working tree state
 mkdir -p "${TMP_DIFFROOT}/pkg"
-cp -aR "${REPO_ROOT_DIR}/Gopkg.lock" "${REPO_ROOT_DIR}/vendor" "${TMP_DIFFROOT}"
+# Save working tree state
+for dir in ${DIRS_TOBE_INSPECTED[@]}; do
+  cp -aR "${REPO_ROOT_DIR}/${dir}" "${TMP_DIFFROOT}"
+done
 
 "${REPO_ROOT_DIR}/hack/update-codegen.sh"
 echo "Diffing ${REPO_ROOT_DIR} against freshly generated codegen"
 ret=0
-diff -Nupr --no-dereference "${REPO_ROOT_DIR}/vendor" "${TMP_DIFFROOT}/vendor" || ret=1
-diff -Nup --no-dereference "${REPO_ROOT_DIR}/Gopkg.lock" "${TMP_DIFFROOT}/Gopkg.lock" || ret=1
+for dir in ${DIRS_TOBE_INSPECTED[@]}; do
+  diff -Nupr --no-dereference "${REPO_ROOT_DIR}/${dir}" "${TMP_DIFFROOT}/${dir}" || ret=1
+done
 
 # Restore working tree state
-rm -fr "${REPO_ROOT_DIR}/Gopkg.lock" "${REPO_ROOT_DIR}/pkg" "${REPO_ROOT_DIR}/vendor"
+for dir in {DIRS_TOBE_INSPECTED[@]}; do
+  rm -fr "${REPO_ROOT_DIR}/${dir}"
+done
 cp -aR "${TMP_DIFFROOT}"/* "${REPO_ROOT_DIR}"
 
 if [[ $ret -eq 0 ]]

--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2019 The Knative Authors
+# Copyright 2020 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ echo "Diffing ${REPO_ROOT_DIR} against freshly generated codegen"
 ret=0
 for dir in ${DIRS_TOBE_INSPECTED[@]}; do
   diff -Nupr --no-dereference "${REPO_ROOT_DIR}/${dir}" "${TMP_DIFFROOT}/${dir}" || \
-    { ret=1; echo "--- FAIL: file difference ${REPO_ROOT_DIR}/${dir}"; }
+    { ret=1; echo "--- FAIL: ${REPO_ROOT_DIR}/${dir} is not up-to-date"; }
 done
 
 # Restore working tree state

--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -20,7 +20,7 @@ set -o pipefail
 
 source $(dirname $0)/../scripts/library.sh
 
-readonly TMP_DIFFROOT="$(mktemp -d ${REPO_ROOT_DIR}/tmpdiffroot.XXXXXX)"
+readonly TMP_DIFFROOT="$(mktemp -d)"
 DIRS_TOBE_INSPECTED=(
   "Gopkg.lock"
   "vendor"
@@ -45,7 +45,8 @@ done
 echo "Diffing ${REPO_ROOT_DIR} against freshly generated codegen"
 ret=0
 for dir in ${DIRS_TOBE_INSPECTED[@]}; do
-  diff -Nupr --no-dereference "${REPO_ROOT_DIR}/${dir}" "${TMP_DIFFROOT}/${dir}" || ret=1
+  diff -Nupr --no-dereference "${REPO_ROOT_DIR}/${dir}" "${TMP_DIFFROOT}/${dir}" || \
+    { ret=1; echo "--- FAIL: file difference ${REPO_ROOT_DIR}/${dir}"; }
 done
 
 # Restore working tree state

--- a/test/presubmit-config-check.sh
+++ b/test/presubmit-config-check.sh
@@ -16,42 +16,7 @@
 
 source $(dirname $0)/../scripts/library.sh
 
-# Run diff on the two configuration files.
-# Parameters: $1 - the regenerated temp file.
-#             $2 - the existing file.
-function diff_config_files() {
-  diff --ignore-matching-lines="^# Copyright " "$1" "$2"
-}
-
-# Run diff on the Prow configuration files.
-# Parameters: $1 - the environent, can be prow or prow-staging.
-function diff_prow_config_files() {
-  local prow_env="$1"
-  diff_config_files "${PROW_CONFIG}" "config/${prow_env}/core/config.yaml"
-  diff_config_files "${PROW_PLUGINS}" "config/${prow_env}/core/plugins.yaml"
-  diff_config_files "${PROW_JOB_CONFIG}" "config/${prow_env}/jobs/config.yaml"
-}
-
 set -e
-
-trap 'echo "--- FAIL: Please rerun \`make -C config/prow config\`."' ERR
-header "Checking generated config for production prow and testgrid"
-export PROW_CONFIG=$(mktemp)
-export PROW_JOB_CONFIG=$(mktemp)
-export PROW_PLUGINS=$(mktemp)
-export TESTGRID_CONFIG=$(mktemp)
-subheader "Regenerating config for production prow and testgrid"
-make -C config/prow config
-subheader "Comparing the generated config files with the existing config files"
-diff_prow_config_files "prow"
-diff_config_files "${TESTGRID_CONFIG}" "config/prow/testgrid/testgrid.yaml"
-
-trap 'echo "--- FAIL: Please rerun \`make -C config/prow-staging config\`."' ERR
-header "Checking generated config for staging prow"
-subheader "Regenerating config for staging prow"
-make -C config/prow-staging config
-subheader "Comparing the generated config files with the existing config files"
-diff_prow_config_files "prow-staging"
 
 trap 'echo "--- FAIL: Prow config files have errors, please check."' ERR
 header "Validating production Prow config files"


### PR DESCRIPTION
The UX for code generation isn't that friendly, user need to remember run `make config` in 2 different places, and the logic is maintained in 2 different places. Moving them to udpate-codegen.sh so that it's easier to understand

/assign @chizhg @coryrc 