### PR TITLE
Fix istio-1.5 tests for serving

### DIFF
--- a/config/prow/config_knative.yaml
+++ b/config/prow/config_knative.yaml
@@ -59,14 +59,14 @@ presubmits:
       optional: true
       args:
       - "--run-test"
-      - "./test/e2e-tests.sh --istio-version 1.3-latest --mesh"
+      - "./test/e2e-tests.sh --istio-version 1.5-latest --mesh"
     - custom-test: istio-1.5-no-mesh
       dot-dev: true
       always_run: false
       optional: true
       args:
       - "--run-test"
-      - "./test/e2e-tests.sh --istio-version 1.3-latest --no-mesh"
+      - "./test/e2e-tests.sh --istio-version 1.5-latest --no-mesh"
     - custom-test: istio-1.4-mesh
       dot-dev: true
       always_run: false
@@ -409,11 +409,11 @@ periodics:
       dot-dev: true
       go113: true
     - custom-job: istio-1.5-mesh
-      full-command: "./test/e2e-tests.sh --istio-version 1.3-latest --mesh"
+      full-command: "./test/e2e-tests.sh --istio-version 1.5-latest --mesh"
       dot-dev: true
       go113: true
     - custom-job: istio-1.5-no-mesh
-      full-command: "./test/e2e-tests.sh --istio-version 1.3-latest --no-mesh"
+      full-command: "./test/e2e-tests.sh --istio-version 1.5-latest --no-mesh"
       dot-dev: true
       go113: true
     - custom-job: istio-1.4-mesh

--- a/config/prow/jobs/config.yaml
+++ b/config/prow/jobs/config.yaml
@@ -533,7 +533,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.3-latest --mesh"
+        - "./test/e2e-tests.sh --istio-version 1.5-latest --mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -567,7 +567,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.3-latest --mesh"
+        - "./test/e2e-tests.sh --istio-version 1.5-latest --mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -601,7 +601,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.3-latest --no-mesh"
+        - "./test/e2e-tests.sh --istio-version 1.5-latest --no-mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -635,7 +635,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.3-latest --no-mesh"
+        - "./test/e2e-tests.sh --istio-version 1.5-latest --no-mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -6052,7 +6052,7 @@ periodics:
       args:
       - "./test/e2e-tests.sh"
       - "--istio-version"
-      - "1.3-latest"
+      - "1.5-latest"
       - "--mesh"
       volumeMounts:
       - name: test-account
@@ -6085,7 +6085,7 @@ periodics:
       args:
       - "./test/e2e-tests.sh"
       - "--istio-version"
-      - "1.3-latest"
+      - "1.5-latest"
       - "--no-mesh"
       volumeMounts:
       - name: test-account


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
https://github.com/knative/test-infra/pull/1809 only changed the job name, but forgot to change the actual istio version that is passed as flags. This PR fixes it.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @tcnghia 
/cc @chaodaiG 
