### PR TITLE
Move git package from prow-auto-bumper to shared

### DIFF
--- a/shared/git/commit.go
+++ b/shared/git/commit.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package git
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+
+	"knative.dev/pkg/test/helpers"
+)
+
+func call(cmd string, args ...string) error {
+	c := exec.Command(cmd, args...)
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	return c.Run()
+}
+
+func MakeCommit(gi Info, message string, dryrun bool) error {
+	if gi.Head == "" {
+		log.Fatal("pushing to empty branch ref is not allowed")
+	}
+	if err := helpers.Run(
+		"Running 'git add -A'",
+		func() error { return call("git", "add", "-A") },
+		dryrun,
+	); err != nil {
+		return fmt.Errorf("failed to git add: %v", err)
+	}
+	commitArgs := []string{"commit", "-m", message}
+	if gi.UserName != "" && gi.Email != "" {
+		commitArgs = append(commitArgs, "--author", fmt.Sprintf("%s <%s>", gi.UserName, gi.Email))
+	}
+	if err := helpers.Run(
+		fmt.Sprintf("Running 'git %s'", strings.Join(commitArgs, " ")),
+		func() error { return call("git", commitArgs...) },
+		dryrun,
+	); err != nil {
+		return fmt.Errorf("failed to git commit: %v", err)
+	}
+	pushArgs := []string{"push", "-f", fmt.Sprintf("git@github.com:%s/%s.git", gi.UserID, gi.Repo),
+		fmt.Sprintf("HEAD:%s", gi.Head)}
+	if err := helpers.Run(
+		fmt.Sprintf("Running 'git %s'", strings.Join(pushArgs, " ")),
+		func() error { return call("git", pushArgs...) },
+		dryrun,
+	); err != nil {
+		return fmt.Errorf("failed to git push: %v", err)
+	}
+	return nil
+}

--- a/shared/git/commit.go
+++ b/shared/git/commit.go
@@ -33,6 +33,7 @@ func call(cmd string, args ...string) error {
 	return c.Run()
 }
 
+// MakeCommit adds the changed files and create a new Git commit.
 func MakeCommit(gi Info, message string, dryrun bool) error {
 	if gi.Head == "" {
 		log.Fatal("pushing to empty branch ref is not allowed")

--- a/shared/git/info.go
+++ b/shared/git/info.go
@@ -20,17 +20,17 @@ import "fmt"
 
 // Info saves information that can be used to interact with GitHub.
 type Info struct {
-    Org      string
-    Repo     string
-    Head     string // PR head branch
-    Base     string // PR base branch
-    UserID   string // Github User ID of PR creator
-    UserName string // User display name for Git commit
-    Email    string // User email address for Git commit
+	Org      string
+	Repo     string
+	Head     string // PR head branch
+	Base     string // PR base branch
+	UserID   string // Github User ID of PR creator
+	UserName string // User display name for Git commit
+	Email    string // User email address for Git commit
 }
 
 // GetHeadRef returns the HeadRef with the given Git Info.
 // HeadRef is in the form of "user:head", i.e. "github_user:branch_foo"
 func (gi *Info) GetHeadRef() string {
-    return fmt.Sprintf("%s:%s", gi.UserID, gi.Head)
+	return fmt.Sprintf("%s:%s", gi.UserID, gi.Head)
 }

--- a/shared/git/info.go
+++ b/shared/git/info.go
@@ -18,6 +18,7 @@ package git
 
 import "fmt"
 
+// Info saves information that can be used to interact with GitHub.
 type Info struct {
     Org      string
     Repo     string
@@ -28,6 +29,7 @@ type Info struct {
     Email    string // User email address for Git commit
 }
 
+// GetHeadRef returns the HeadRef with the given Git Info.
 // HeadRef is in the form of "user:head", i.e. "github_user:branch_foo"
 func (gi *Info) GetHeadRef() string {
     return fmt.Sprintf("%s:%s", gi.UserID, gi.Head)

--- a/shared/git/info.go
+++ b/shared/git/info.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Knative Authors
+Copyright 2020 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,19 +14,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// run.go controls how to run functions that needs dryrun support
+package git
 
-package main
+import "fmt"
 
-import (
-	"log"
-)
+type Info struct {
+    Org      string
+    Repo     string
+    Head     string // PR head branch
+    Base     string // PR base branch
+    UserID   string // Github User ID of PR creator
+    UserName string // User display name for Git commit
+    Email    string // User email address for Git commit
+}
 
-func run(message string, call func() error, dryrun bool) error {
-	if dryrun {
-		log.Printf("[dry run] %s", message)
-		return nil
-	}
-	log.Printf(message)
-	return call()
+// HeadRef is in the form of "user:head", i.e. "github_user:branch_foo"
+func (gi *Info) GetHeadRef() string {
+    return fmt.Sprintf("%s:%s", gi.UserID, gi.Head)
 }

--- a/tools/prow-auto-bumper/config.go
+++ b/tools/prow-auto-bumper/config.go
@@ -83,21 +83,6 @@ type GHClientWrapper struct {
 	ghutil.GithubOperations
 }
 
-type gitInfo struct {
-	org      string
-	repo     string
-	head     string // PR head branch
-	base     string // PR base branch
-	userID   string // Github User ID of PR creator
-	userName string // User display name for Git commit
-	email    string // User email address for Git commit
-}
-
-// HeadRef is in the form of "user:head", i.e. "github_user:branch_foo"
-func (gi *gitInfo) getHeadRef() string {
-	return fmt.Sprintf("%s:%s", gi.userID, gi.head)
-}
-
 // Versions holds the version change for an image
 // oldVersion and newVersion are both in the format of "vYYYYMMDD-HASH-VARIANT"
 type versions struct {

--- a/tools/prow-auto-bumper/file.go
+++ b/tools/prow-auto-bumper/file.go
@@ -78,7 +78,7 @@ func (pv *PRVersions) updateFile(filename string, imageFilter *regexp.Regexp, dr
 	}
 
 	newContent, msg, msgs := pv.updateAllTags(content, imageFilter)
-	if err := run(
+	if err := helpers.Run(
 		fmt.Sprintf("Update file '%s':%s", filename, msg),
 		func() error {
 			return ioutil.WriteFile(filename, newContent, 0644)

--- a/tools/prow-auto-bumper/getversion_test.go
+++ b/tools/prow-auto-bumper/getversion_test.go
@@ -28,23 +28,25 @@ import (
 	"github.com/google/go-github/github"
 	"knative.dev/pkg/test/ghutil"
 	"knative.dev/pkg/test/ghutil/fakeghutil"
+
+	"knative.dev/test-infra/shared/git"
 )
 
-func getFakeGitInfo() gitInfo {
-	return gitInfo{
-		org:    "fakeorg",
-		repo:   "fakerepo",
-		userID: "fakeuserID",
-		head:   "fakehead",
-		base:   "fakebase",
-		email:  "fake@email",
+func getFakeGitInfo() git.Info {
+	return git.Info{
+		Org:    "fakeorg",
+		Repo:   "fakerepo",
+		UserID: "fakeuserID",
+		Head:   "fakehead",
+		Base:   "fakebase",
+		Email:  "fake@email",
 	}
 }
 
-func createPullRequest(t *testing.T, fgc *fakeghutil.FakeGithubClient, fakeGi gitInfo) *github.PullRequest {
-	PR, err := fgc.CreatePullRequest(fakeGi.org, fakeGi.repo, fakeGi.getHeadRef(), fakeGi.base, "title", "body")
+func createPullRequest(t *testing.T, fgc *fakeghutil.FakeGithubClient, fakeGi git.Info) *github.PullRequest {
+	PR, err := fgc.CreatePullRequest(fakeGi.Org, fakeGi.Repo, fakeGi.GetHeadRef(), fakeGi.Base, "title", "body")
 	if err != nil {
-		t.Fatalf("Create PR in %s/%s, want: no error, got: '%v'", fakeGi.org, fakeGi.org, err)
+		t.Fatalf("Create PR in %s/%s, want: no error, got: '%v'", fakeGi.Org, fakeGi.Org, err)
 	}
 	return PR
 }
@@ -264,8 +266,8 @@ func TestParseChangelist(t *testing.T) {
 		for i, patch := range data.patches {
 			SHA := strconv.Itoa(i)
 			filename := fmt.Sprintf("file_%d", i)
-			fgc.AddCommitToPullRequest(fakeGi.org, fakeGi.repo, *pv.PR.Number, SHA)
-			fgc.AddFileToCommit(fakeGi.org, fakeGi.repo, SHA, filename, patch)
+			fgc.AddCommitToPullRequest(fakeGi.Org, fakeGi.Repo, *pv.PR.Number, SHA)
+			fgc.AddFileToCommit(fakeGi.Org, fakeGi.Repo, SHA, filename, patch)
 		}
 
 		pv.parseChangelist(fcw, fakeGi)
@@ -340,8 +342,8 @@ func TestGetBestVersion(t *testing.T) {
 				- image: gcr.io/k8s-foofoo/bar:%s
 				+ image: gcr.io/k8s-foofoo/bar:%s
 			`, PI.oldVersion, PI.newVersion)
-			fgc.AddCommitToPullRequest(fakeGi.org, fakeGi.repo, *PR.Number, SHA)
-			fgc.AddFileToCommit(fakeGi.org, fakeGi.repo, SHA, filename, patch)
+			fgc.AddCommitToPullRequest(fakeGi.Org, fakeGi.Repo, *PR.Number, SHA)
+			fgc.AddFileToCommit(fakeGi.Org, fakeGi.Repo, SHA, filename, patch)
 		}
 
 		pv, err := getBestVersion(fcw, fakeGi)

--- a/tools/prow-auto-bumper/main.go
+++ b/tools/prow-auto-bumper/main.go
@@ -24,6 +24,8 @@ import (
 	"log"
 
 	"knative.dev/pkg/test/ghutil"
+
+	"knative.dev/test-infra/shared/git"
 )
 
 func main() {
@@ -43,28 +45,28 @@ func main() {
 		log.Fatalf("cannot authenticate to github: %v", err)
 	}
 
-	srcGI := gitInfo{
-		org:    srcOrg,
-		repo:   srcRepo,
-		head:   srcPRHead,
-		base:   srcPRBase,
-		userID: srcPRUserID,
+	srcGI := git.Info{
+		Org:    srcOrg,
+		Repo:   srcRepo,
+		Head:   srcPRHead,
+		Base:   srcPRBase,
+		UserID: srcPRUserID,
 	}
 
-	targetGI := gitInfo{
-		org:      org,
-		repo:     repo,
-		head:     PRHead,
-		base:     PRBase,
-		userID:   *gitUserID,
-		userName: *gitUserName,
-		email:    *gitEmail,
+	targetGI := git.Info{
+		Org:      org,
+		Repo:     repo,
+		Head:     PRHead,
+		Base:     PRBase,
+		UserID:   *gitUserID,
+		UserName: *gitUserName,
+		Email:    *gitEmail,
 	}
 
 	gcw := &GHClientWrapper{gc}
 	bestVersion, err := retryGetBestVersion(gcw, srcGI)
 	if err != nil {
-		log.Fatalf("cannot get best version from %s/%s: '%v'", srcGI.org, srcGI.repo, err)
+		log.Fatalf("cannot get best version from %s/%s: '%v'", srcGI.Org, srcGI.Repo, err)
 	}
 	log.Printf("Found version to update. Old Version: '%s', New Version: '%s'",
 		bestVersion.dominantVersions.oldVersion, bestVersion.dominantVersions.newVersion)

--- a/tools/prow-auto-bumper/parser.go
+++ b/tools/prow-auto-bumper/parser.go
@@ -26,6 +26,8 @@ import (
 	"time"
 
 	"knative.dev/pkg/test/ghutil"
+
+	"knative.dev/test-infra/shared/git"
 )
 
 // Tags could be in the form of: v[YYYYMMDD]-[GIT_HASH](-[VARIANT_PART]),
@@ -81,8 +83,8 @@ func (pv *PRVersions) getDominantVersions() versions {
 }
 
 // Parse changelist, find all version changes, and store them in image name: versions map
-func (pv *PRVersions) parseChangelist(gcw *GHClientWrapper, gi gitInfo) error {
-	fs, err := gcw.ListFiles(gi.org, gi.repo, *pv.PR.Number)
+func (pv *PRVersions) parseChangelist(gcw *GHClientWrapper, gi git.Info) error {
+	fs, err := gcw.ListFiles(gi.Org, gi.Repo, *pv.PR.Number)
 	if err != nil {
 		return err
 	}
@@ -108,12 +110,12 @@ func (pv *PRVersions) parseChangelist(gcw *GHClientWrapper, gi gitInfo) error {
 
 // Query all PRs from "k8s-ci-robot:autobump", find PR roughly 7 days old and was not reverted later.
 // Only return error if it's github related
-func getBestVersion(gcw *GHClientWrapper, gi gitInfo) (*PRVersions, error) {
+func getBestVersion(gcw *GHClientWrapper, gi git.Info) (*PRVersions, error) {
 	visited := make(map[string]PRVersions)
 	var bestPv *PRVersions
 	var overallErr error
 	var bestDelta float64 = maxDelta + 1
-	PRs, err := gcw.ListPullRequests(gi.org, gi.repo, gi.getHeadRef(), gi.base)
+	PRs, err := gcw.ListPullRequests(gi.Org, gi.Repo, gi.GetHeadRef(), gi.Base)
 	if err != nil {
 		return bestPv, fmt.Errorf("failed list pull request: '%v'", err)
 	}
@@ -163,7 +165,7 @@ func getBestVersion(gcw *GHClientWrapper, gi gitInfo) (*PRVersions, error) {
 	return bestPv, overallErr
 }
 
-func retryGetBestVersion(gcw *GHClientWrapper, gi gitInfo) (*PRVersions, error) {
+func retryGetBestVersion(gcw *GHClientWrapper, gi git.Info) (*PRVersions, error) {
 	var bestPv *PRVersions
 	var overallErr error
 	// retry if there is github related error


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Move git package from prow-auto-bumper to shared so that it can be reused.

/cc @chaodaiG 
