### PR TITLE
config-generator: remove all trailing whitespaces from generated configs

### DIFF
--- a/config/prow-staging/core/config.yaml
+++ b/config/prow-staging/core/config.yaml
@@ -20,7 +20,7 @@
 plank:
   job_url_template: 'https://prow-staging.knative.dev/view/gcs/knative-prow-staging/{{if or (eq .Spec.Type "presubmit") (eq .Spec.Type "batch")}}pr-logs/pull{{with .Spec.Refs}}/{{.Org}}_{{.Repo}}{{end}}{{else}}logs{{end}}{{if eq .Spec.Type "presubmit"}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}{{else if eq .Spec.Type "batch"}}/batch{{end}}/{{.Spec.Job}}/{{.Status.BuildID}}/'
   report_template: '[Full PR test history](https://gubernator.knative.dev/pr/{{.Spec.Refs.Org}}_{{.Spec.Refs.Repo}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}). [Your PR dashboard](https://gubernator.knative.dev/pr/{{with index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}).'
-  job_url_prefix_config: 
+  job_url_prefix_config:
     "*": "https://prow-staging.knative.dev/view/gcs/"
   pod_pending_timeout: 60m
   default_decoration_config:

--- a/config/prow/core/config.yaml
+++ b/config/prow/core/config.yaml
@@ -20,7 +20,7 @@
 plank:
   job_url_template: 'https://prow.knative.dev/view/gcs/knative-prow/{{if or (eq .Spec.Type "presubmit") (eq .Spec.Type "batch")}}pr-logs/pull{{with .Spec.Refs}}/{{.Org}}_{{.Repo}}{{end}}{{else}}logs{{end}}{{if eq .Spec.Type "presubmit"}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}{{else if eq .Spec.Type "batch"}}/batch{{end}}/{{.Spec.Job}}/{{.Status.BuildID}}/'
   report_template: '[Full PR test history](https://gubernator.knative.dev/pr/{{.Spec.Refs.Org}}_{{.Spec.Refs.Repo}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}). [Your PR dashboard](https://gubernator.knative.dev/pr/{{with index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}).'
-  job_url_prefix_config: 
+  job_url_prefix_config:
     "*": "https://prow.knative.dev/view/gcs/"
   pod_pending_timeout: 60m
   default_decoration_config:

--- a/config/prow/testgrid/testgrid.yaml
+++ b/config/prow/testgrid/testgrid.yaml
@@ -87,18 +87,18 @@ test_groups:
   alert_stale_results_hours: 3
 - name: ci-knative-serving-nightly-release
   gcs_prefix: knative-prow/logs/ci-knative-serving-nightly-release
-  alert_options: 
+  alert_options:
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 1
 - name: ci-knative-serving-dot-release
   gcs_prefix: knative-prow/logs/ci-knative-serving-dot-release
-  alert_options: 
+  alert_options:
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   alert_stale_results_hours: 170
   num_failures_to_alert: 1
 - name: ci-knative-serving-auto-release
   gcs_prefix: knative-prow/logs/ci-knative-serving-auto-release
-  alert_options: 
+  alert_options:
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 1
 - name: ci-knative-serving-webhook-apicoverage
@@ -115,7 +115,7 @@ test_groups:
   alert_stale_results_hours: 3
 - name: ci-knative-client-nightly-release
   gcs_prefix: knative-prow/logs/ci-knative-client-nightly-release
-  alert_options: 
+  alert_options:
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 1
 - name: ci-knative-client-tekton
@@ -123,13 +123,13 @@ test_groups:
   alert_stale_results_hours: 3
 - name: ci-knative-client-dot-release
   gcs_prefix: knative-prow/logs/ci-knative-client-dot-release
-  alert_options: 
+  alert_options:
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   alert_stale_results_hours: 170
   num_failures_to_alert: 1
 - name: ci-knative-client-auto-release
   gcs_prefix: knative-prow/logs/ci-knative-client-auto-release
-  alert_options: 
+  alert_options:
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 1
 - name: ci-knative-client-test-coverage
@@ -152,18 +152,18 @@ test_groups:
   alert_stale_results_hours: 3
 - name: ci-knative-eventing-nightly-release
   gcs_prefix: knative-prow/logs/ci-knative-eventing-nightly-release
-  alert_options: 
+  alert_options:
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 1
 - name: ci-knative-eventing-dot-release
   gcs_prefix: knative-prow/logs/ci-knative-eventing-dot-release
-  alert_options: 
+  alert_options:
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   alert_stale_results_hours: 170
   num_failures_to_alert: 1
 - name: ci-knative-eventing-auto-release
   gcs_prefix: knative-prow/logs/ci-knative-eventing-auto-release
-  alert_options: 
+  alert_options:
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 1
 - name: ci-knative-eventing-test-coverage
@@ -174,18 +174,18 @@ test_groups:
   alert_stale_results_hours: 3
 - name: ci-knative-eventing-contrib-nightly-release
   gcs_prefix: knative-prow/logs/ci-knative-eventing-contrib-nightly-release
-  alert_options: 
+  alert_options:
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 1
 - name: ci-knative-eventing-contrib-dot-release
   gcs_prefix: knative-prow/logs/ci-knative-eventing-contrib-dot-release
-  alert_options: 
+  alert_options:
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   alert_stale_results_hours: 170
   num_failures_to_alert: 1
 - name: ci-knative-eventing-contrib-auto-release
   gcs_prefix: knative-prow/logs/ci-knative-eventing-contrib-auto-release
-  alert_options: 
+  alert_options:
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 1
 - name: ci-knative-eventing-contrib-test-coverage
@@ -220,18 +220,18 @@ test_groups:
   alert_stale_results_hours: 3
 - name: ci-knative-serving-operator-nightly-release
   gcs_prefix: knative-prow/logs/ci-knative-serving-operator-nightly-release
-  alert_options: 
+  alert_options:
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 1
 - name: ci-knative-serving-operator-dot-release
   gcs_prefix: knative-prow/logs/ci-knative-serving-operator-dot-release
-  alert_options: 
+  alert_options:
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   alert_stale_results_hours: 170
   num_failures_to_alert: 1
 - name: ci-knative-serving-operator-auto-release
   gcs_prefix: knative-prow/logs/ci-knative-serving-operator-auto-release
-  alert_options: 
+  alert_options:
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 1
 - name: ci-knative-serving-operator-test-coverage
@@ -242,18 +242,18 @@ test_groups:
   alert_stale_results_hours: 3
 - name: ci-knative-eventing-operator-nightly-release
   gcs_prefix: knative-prow/logs/ci-knative-eventing-operator-nightly-release
-  alert_options: 
+  alert_options:
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 1
 - name: ci-knative-eventing-operator-dot-release
   gcs_prefix: knative-prow/logs/ci-knative-eventing-operator-dot-release
-  alert_options: 
+  alert_options:
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   alert_stale_results_hours: 170
   num_failures_to_alert: 1
 - name: ci-knative-eventing-operator-auto-release
   gcs_prefix: knative-prow/logs/ci-knative-eventing-operator-auto-release
-  alert_options: 
+  alert_options:
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 1
 - name: ci-knative-eventing-operator-test-coverage
@@ -264,18 +264,18 @@ test_groups:
   alert_stale_results_hours: 3
 - name: ci-knative-net-contour-nightly-release
   gcs_prefix: knative-prow/logs/ci-knative-net-contour-nightly-release
-  alert_options: 
+  alert_options:
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 1
 - name: ci-knative-net-contour-dot-release
   gcs_prefix: knative-prow/logs/ci-knative-net-contour-dot-release
-  alert_options: 
+  alert_options:
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   alert_stale_results_hours: 170
   num_failures_to_alert: 1
 - name: ci-knative-net-contour-auto-release
   gcs_prefix: knative-prow/logs/ci-knative-net-contour-auto-release
-  alert_options: 
+  alert_options:
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 1
 - name: ci-knative-net-contour-test-coverage
@@ -286,18 +286,18 @@ test_groups:
   alert_stale_results_hours: 3
 - name: ci-knative-net-istio-nightly-release
   gcs_prefix: knative-prow/logs/ci-knative-net-istio-nightly-release
-  alert_options: 
+  alert_options:
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 1
 - name: ci-knative-net-istio-dot-release
   gcs_prefix: knative-prow/logs/ci-knative-net-istio-dot-release
-  alert_options: 
+  alert_options:
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   alert_stale_results_hours: 170
   num_failures_to_alert: 1
 - name: ci-knative-net-istio-auto-release
   gcs_prefix: knative-prow/logs/ci-knative-net-istio-auto-release
-  alert_options: 
+  alert_options:
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 1
 - name: ci-knative-net-istio-test-coverage
@@ -308,18 +308,18 @@ test_groups:
   alert_stale_results_hours: 3
 - name: ci-knative-net-kourier-nightly-release
   gcs_prefix: knative-prow/logs/ci-knative-net-kourier-nightly-release
-  alert_options: 
+  alert_options:
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 1
 - name: ci-knative-net-kourier-dot-release
   gcs_prefix: knative-prow/logs/ci-knative-net-kourier-dot-release
-  alert_options: 
+  alert_options:
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   alert_stale_results_hours: 170
   num_failures_to_alert: 1
 - name: ci-knative-net-kourier-auto-release
   gcs_prefix: knative-prow/logs/ci-knative-net-kourier-auto-release
-  alert_options: 
+  alert_options:
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 1
 - name: ci-knative-net-kourier-test-coverage
@@ -327,77 +327,77 @@ test_groups:
   short_text_metric: "coverage"
 - name: ci-knative-serving-0.10-continuous
   gcs_prefix: knative-prow/logs/ci-knative-serving-0.10-continuous
-  alert_options: 
+  alert_options:
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 3
 - name: ci-knative-eventing-0.10-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-0.10-continuous
-  alert_options: 
+  alert_options:
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 3
 - name: ci-knative-eventing-contrib-0.10-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-contrib-0.10-continuous
-  alert_options: 
+  alert_options:
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 3
 - name: ci-knative-serving-0.11-continuous
   gcs_prefix: knative-prow/logs/ci-knative-serving-0.11-continuous
-  alert_options: 
+  alert_options:
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 3
 - name: ci-knative-client-0.11-continuous
   gcs_prefix: knative-prow/logs/ci-knative-client-0.11-continuous
-  alert_options: 
+  alert_options:
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 3
 - name: ci-knative-eventing-0.11-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-0.11-continuous
-  alert_options: 
+  alert_options:
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 3
 - name: ci-knative-eventing-contrib-0.11-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-contrib-0.11-continuous
-  alert_options: 
+  alert_options:
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 3
 - name: ci-knative-serving-operator-0.11-continuous
   gcs_prefix: knative-prow/logs/ci-knative-serving-operator-0.11-continuous
-  alert_options: 
+  alert_options:
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 3
 - name: ci-knative-eventing-operator-0.11-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-operator-0.11-continuous
-  alert_options: 
+  alert_options:
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 3
 - name: ci-knative-serving-0.12-continuous
   gcs_prefix: knative-prow/logs/ci-knative-serving-0.12-continuous
-  alert_options: 
+  alert_options:
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 3
 - name: ci-knative-client-0.12-continuous
   gcs_prefix: knative-prow/logs/ci-knative-client-0.12-continuous
-  alert_options: 
+  alert_options:
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 3
 - name: ci-knative-eventing-0.12-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-0.12-continuous
-  alert_options: 
+  alert_options:
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 3
 - name: ci-knative-eventing-contrib-0.12-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-contrib-0.12-continuous
-  alert_options: 
+  alert_options:
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 3
 - name: ci-knative-serving-operator-0.12-continuous
   gcs_prefix: knative-prow/logs/ci-knative-serving-operator-0.12-continuous
-  alert_options: 
+  alert_options:
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 3
 - name: ci-knative-eventing-operator-0.12-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-operator-0.12-continuous
-  alert_options: 
+  alert_options:
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 3
 - name: ci-google-knative-gcp-continuous
@@ -405,18 +405,18 @@ test_groups:
   alert_stale_results_hours: 3
 - name: ci-google-knative-gcp-nightly-release
   gcs_prefix: knative-prow/logs/ci-google-knative-gcp-nightly-release
-  alert_options: 
+  alert_options:
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 1
 - name: ci-google-knative-gcp-dot-release
   gcs_prefix: knative-prow/logs/ci-google-knative-gcp-dot-release
-  alert_options: 
+  alert_options:
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   alert_stale_results_hours: 170
   num_failures_to_alert: 1
 - name: ci-google-knative-gcp-auto-release
   gcs_prefix: knative-prow/logs/ci-google-knative-gcp-auto-release
-  alert_options: 
+  alert_options:
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 1
 - name: ci-google-knative-gcp-test-coverage
@@ -424,7 +424,7 @@ test_groups:
   short_text_metric: "coverage"
 - name: ci-google-knative-gcp-0.12-continuous
   gcs_prefix: knative-prow/logs/ci-google-knative-gcp-0.12-continuous
-  alert_options: 
+  alert_options:
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 3
 dashboards:
@@ -433,13 +433,13 @@ dashboards:
   - name: continuous
     test_group_name: ci-knative-serving-continuous
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 3
   - name: conformance
     test_group_name: ci-knative-serving-continuous
     base_options: "include-filter-by-regex=test/conformance/&sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 3
   - name: istio-1.5-mesh
@@ -472,19 +472,19 @@ dashboards:
   - name: nightly
     test_group_name: ci-knative-serving-nightly-release
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 1
   - name: dot-release
     test_group_name: ci-knative-serving-dot-release
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 1
   - name: auto-release
     test_group_name: ci-knative-serving-auto-release
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 1
   - name: webhook-apicoverage
@@ -501,13 +501,13 @@ dashboards:
   - name: continuous
     test_group_name: ci-knative-client-continuous
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 3
   - name: nightly
     test_group_name: ci-knative-client-nightly-release
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 1
   - name: tekton
@@ -516,13 +516,13 @@ dashboards:
   - name: dot-release
     test_group_name: ci-knative-client-dot-release
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 1
   - name: auto-release
     test_group_name: ci-knative-client-auto-release
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 1
   - name: coverage
@@ -533,7 +533,7 @@ dashboards:
   - name: continuous
     test_group_name: ci-knative-client-contrib-continuous
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 3
   - name: coverage
@@ -544,7 +544,7 @@ dashboards:
   - name: continuous
     test_group_name: ci-knative-docs-continuous
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 3
   - name: coverage
@@ -555,25 +555,25 @@ dashboards:
   - name: continuous
     test_group_name: ci-knative-eventing-continuous
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 3
   - name: nightly
     test_group_name: ci-knative-eventing-nightly-release
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 1
   - name: dot-release
     test_group_name: ci-knative-eventing-dot-release
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 1
   - name: auto-release
     test_group_name: ci-knative-eventing-auto-release
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 1
   - name: coverage
@@ -584,25 +584,25 @@ dashboards:
   - name: continuous
     test_group_name: ci-knative-eventing-contrib-continuous
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 3
   - name: nightly
     test_group_name: ci-knative-eventing-contrib-nightly-release
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 1
   - name: dot-release
     test_group_name: ci-knative-eventing-contrib-dot-release
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 1
   - name: auto-release
     test_group_name: ci-knative-eventing-contrib-auto-release
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 1
   - name: coverage
@@ -613,7 +613,7 @@ dashboards:
   - name: continuous
     test_group_name: ci-knative-pkg-continuous
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 3
   - name: coverage
@@ -624,7 +624,7 @@ dashboards:
   - name: continuous
     test_group_name: ci-knative-caching-continuous
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 3
   - name: coverage
@@ -635,7 +635,7 @@ dashboards:
   - name: continuous
     test_group_name: ci-knative-observability-continuous
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 3
 - name: sample-controller
@@ -643,7 +643,7 @@ dashboards:
   - name: continuous
     test_group_name: ci-knative-sample-controller-continuous
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 3
 - name: sample-source
@@ -651,7 +651,7 @@ dashboards:
   - name: continuous
     test_group_name: ci-knative-sample-source-continuous
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 3
 - name: test-infra
@@ -659,7 +659,7 @@ dashboards:
   - name: continuous
     test_group_name: ci-knative-test-infra-continuous
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 3
 - name: serving-operator
@@ -667,25 +667,25 @@ dashboards:
   - name: continuous
     test_group_name: ci-knative-serving-operator-continuous
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 3
   - name: nightly
     test_group_name: ci-knative-serving-operator-nightly-release
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 1
   - name: dot-release
     test_group_name: ci-knative-serving-operator-dot-release
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 1
   - name: auto-release
     test_group_name: ci-knative-serving-operator-auto-release
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 1
   - name: coverage
@@ -696,25 +696,25 @@ dashboards:
   - name: continuous
     test_group_name: ci-knative-eventing-operator-continuous
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 3
   - name: nightly
     test_group_name: ci-knative-eventing-operator-nightly-release
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 1
   - name: dot-release
     test_group_name: ci-knative-eventing-operator-dot-release
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 1
   - name: auto-release
     test_group_name: ci-knative-eventing-operator-auto-release
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 1
   - name: coverage
@@ -725,25 +725,25 @@ dashboards:
   - name: continuous
     test_group_name: ci-knative-net-contour-continuous
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 3
   - name: nightly
     test_group_name: ci-knative-net-contour-nightly-release
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 1
   - name: dot-release
     test_group_name: ci-knative-net-contour-dot-release
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 1
   - name: auto-release
     test_group_name: ci-knative-net-contour-auto-release
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 1
   - name: coverage
@@ -754,25 +754,25 @@ dashboards:
   - name: continuous
     test_group_name: ci-knative-net-istio-continuous
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 3
   - name: nightly
     test_group_name: ci-knative-net-istio-nightly-release
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 1
   - name: dot-release
     test_group_name: ci-knative-net-istio-dot-release
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 1
   - name: auto-release
     test_group_name: ci-knative-net-istio-auto-release
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 1
   - name: coverage
@@ -783,25 +783,25 @@ dashboards:
   - name: continuous
     test_group_name: ci-knative-net-kourier-continuous
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 3
   - name: nightly
     test_group_name: ci-knative-net-kourier-nightly-release
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 1
   - name: dot-release
     test_group_name: ci-knative-net-kourier-dot-release
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 1
   - name: auto-release
     test_group_name: ci-knative-net-kourier-auto-release
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 1
   - name: coverage
@@ -812,25 +812,25 @@ dashboards:
   - name: continuous
     test_group_name: ci-google-knative-gcp-continuous
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 3
   - name: nightly
     test_group_name: ci-google-knative-gcp-nightly-release
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 1
   - name: dot-release
     test_group_name: ci-google-knative-gcp-dot-release
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 1
   - name: auto-release
     test_group_name: ci-google-knative-gcp-auto-release
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 1
   - name: coverage
@@ -841,19 +841,19 @@ dashboards:
   - name: serving
     test_group_name: ci-knative-serving-0.10-continuous
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 3
   - name: eventing
     test_group_name: ci-knative-eventing-0.10-continuous
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 3
   - name: eventing-contrib
     test_group_name: ci-knative-eventing-contrib-0.10-continuous
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 3
 - name: knative-0.11
@@ -861,37 +861,37 @@ dashboards:
   - name: serving
     test_group_name: ci-knative-serving-0.11-continuous
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 3
   - name: client
     test_group_name: ci-knative-client-0.11-continuous
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 3
   - name: eventing
     test_group_name: ci-knative-eventing-0.11-continuous
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 3
   - name: eventing-contrib
     test_group_name: ci-knative-eventing-contrib-0.11-continuous
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 3
   - name: serving-operator
     test_group_name: ci-knative-serving-operator-0.11-continuous
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 3
   - name: eventing-operator
     test_group_name: ci-knative-eventing-operator-0.11-continuous
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 3
 - name: knative-0.12
@@ -899,37 +899,37 @@ dashboards:
   - name: serving
     test_group_name: ci-knative-serving-0.12-continuous
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 3
   - name: client
     test_group_name: ci-knative-client-0.12-continuous
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 3
   - name: eventing
     test_group_name: ci-knative-eventing-0.12-continuous
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 3
   - name: eventing-contrib
     test_group_name: ci-knative-eventing-contrib-0.12-continuous
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 3
   - name: serving-operator
     test_group_name: ci-knative-serving-operator-0.12-continuous
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 3
   - name: eventing-operator
     test_group_name: ci-knative-eventing-operator-0.12-continuous
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 3
 - name: google-0.12
@@ -937,7 +937,7 @@ dashboards:
   - name: knative-gcp
     test_group_name: ci-google-knative-gcp-0.12-continuous
     base_options: "sort-by-name="
-    alert_options: 
+    alert_options:
       alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
     num_failures_to_alert: 3
 dashboard_groups:

--- a/tools/config-generator/main.go
+++ b/tools/config-generator/main.go
@@ -781,7 +781,7 @@ func indentMap(indentation int, mp map[string]string) string {
 // outputConfig outputs the given line, if not empty, to stdout.
 func outputConfig(line string) {
 	if strings.TrimSpace(line) != "" {
-		fmt.Fprintln(output, line)
+		fmt.Fprintln(output, strings.TrimRight(line, " "))
 		emittedOutput = true
 	}
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:

Removes the trailing whitespaces generated by the config-generator.
for ex: https://github.com/knative/test-infra/pull/1819

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #

**Special notes to reviewers**:

**User-visible changes in this PR**:

