### PR TITLE
Creating dot-release jobs for old release branches

### DIFF
--- a/config/prow/config_knative.yaml
+++ b/config/prow/config_knative.yaml
@@ -437,8 +437,6 @@ periodics:
       dot-dev: true
       go113: true
       release: "0.10"
-      env-vars:
-      - RELEASE_BRANCH=release-0.10
       resources:
         requests:
           memory: 12Gi
@@ -448,8 +446,6 @@ periodics:
       dot-dev: true
       go113: true
       release: "0.11"
-      env-vars:
-      - RELEASE_BRANCH=release-0.11
       resources:
         requests:
           memory: 12Gi
@@ -459,8 +455,6 @@ periodics:
       dot-dev: true
       go113: true
       release: "0.12"
-      env-vars:
-      - RELEASE_BRANCH=release-0.12
       resources:
         requests:
           memory: 12Gi
@@ -523,14 +517,10 @@ periodics:
       dot-dev: true
       go113: true
       release: "0.11"
-      env-vars:
-      - RELEASE_BRANCH=release-0.11
     - dot-release: true
       dot-dev: true
       go113: true
       release: "0.12"
-      env-vars:
-      - RELEASE_BRANCH=release-0.12
     - dot-release: true
       dot-dev: true
       go113: true
@@ -580,8 +570,6 @@ periodics:
       dot-dev: true
       go113: true
       release: "0.10"
-      env-vars:
-      - RELEASE_BRANCH=release-0.10
       resources:
         requests:
           memory: 12Gi
@@ -591,8 +579,6 @@ periodics:
       dot-dev: true
       go113: true
       release: "0.11"
-      env-vars:
-      - RELEASE_BRANCH=release-0.11
       resources:
         requests:
           memory: 12Gi
@@ -602,8 +588,6 @@ periodics:
       dot-dev: true
       go113: true
       release: "0.12"
-      env-vars:
-      - RELEASE_BRANCH=release-0.12
       resources:
         requests:
           memory: 12Gi
@@ -658,8 +642,6 @@ periodics:
       dot-dev: true
       go113: true
       release: "0.10"
-      env-vars:
-      - RELEASE_BRANCH=release-0.10
       resources:
         requests:
           memory: 12Gi
@@ -669,8 +651,6 @@ periodics:
       dot-dev: true
       go113: true
       release: "0.11"
-      env-vars:
-      - RELEASE_BRANCH=release-0.11
       resources:
         requests:
           memory: 12Gi
@@ -680,8 +660,6 @@ periodics:
       dot-dev: true
       go113: true
       release: "0.12"
-      env-vars:
-      - RELEASE_BRANCH=release-0.12
       resources:
         requests:
           memory: 12Gi
@@ -752,14 +730,10 @@ periodics:
       dot-dev: true
       go113: true
       release: "0.11"
-      env-vars:
-      - RELEASE_BRANCH=release-0.11
     - dot-release: true
       dot-dev: true
       go113: true
       release: "0.12"
-      env-vars:
-      - RELEASE_BRANCH=release-0.12
     - dot-release: true
       dot-dev: true
       go113: true
@@ -786,14 +760,10 @@ periodics:
       dot-dev: true
       go113: true
       release: "0.11"
-      env-vars:
-      - RELEASE_BRANCH=release-0.11
     - dot-release: true
       dot-dev: true
       go113: true
       release: "0.12"
-      env-vars:
-      - RELEASE_BRANCH=release-0.12
     - dot-release: true
       dot-dev: true
       go113: true
@@ -814,7 +784,6 @@ periodics:
       release: "0.12"
       env-vars:
       - ORG_NAME=google
-        RELEASE_BRANCH=release-0.12
     - dot-release: true
       go113: true
       env-vars:

--- a/config/prow/config_knative.yaml
+++ b/config/prow/config_knative.yaml
@@ -436,6 +436,39 @@ periodics:
     - dot-release: true
       dot-dev: true
       go113: true
+      release: "0.10"
+      env-vars:
+      - RELEASE_BRANCH=releaes-0.10
+      resources:
+        requests:
+          memory: 12Gi
+        limits:
+          memory: 16Gi
+    - dot-release: true
+      dot-dev: true
+      go113: true
+      release: "0.11"
+      env-vars:
+      - RELEASE_BRANCH=releaes-0.11
+      resources:
+        requests:
+          memory: 12Gi
+        limits:
+          memory: 16Gi
+    - dot-release: true
+      dot-dev: true
+      go113: true
+      release: "0.12"
+      env-vars:
+      - RELEASE_BRANCH=releaes-0.12
+      resources:
+        requests:
+          memory: 12Gi
+        limits:
+          memory: 16Gi
+    - dot-release: true
+      dot-dev: true
+      go113: true
       resources:
         requests:
           memory: 12Gi
@@ -489,6 +522,18 @@ periodics:
     - dot-release: true
       dot-dev: true
       go113: true
+      release: "0.11"
+      env-vars:
+      - RELEASE_BRANCH=releaes-0.11
+    - dot-release: true
+      dot-dev: true
+      go113: true
+      release: "0.12"
+      env-vars:
+      - RELEASE_BRANCH=releaes-0.12
+    - dot-release: true
+      dot-dev: true
+      go113: true
     - auto-release: true
       dot-dev: true
       go113: true
@@ -534,6 +579,39 @@ periodics:
     - dot-release: true
       dot-dev: true
       go113: true
+      release: "0.10"
+      env-vars:
+      - RELEASE_BRANCH=releaes-0.10
+      resources:
+        requests:
+          memory: 12Gi
+        limits:
+          memory: 16Gi
+    - dot-release: true
+      dot-dev: true
+      go113: true
+      release: "0.11"
+      env-vars:
+      - RELEASE_BRANCH=releaes-0.11
+      resources:
+        requests:
+          memory: 12Gi
+        limits:
+          memory: 16Gi
+    - dot-release: true
+      dot-dev: true
+      go113: true
+      release: "0.12"
+      env-vars:
+      - RELEASE_BRANCH=releaes-0.12
+      resources:
+        requests:
+          memory: 12Gi
+        limits:
+          memory: 16Gi
+    - dot-release: true
+      dot-dev: true
+      go113: true
       resources:
         requests:
           memory: 12Gi
@@ -571,6 +649,39 @@ periodics:
     - nightly: true
       dot-dev: true
       go113: true
+      resources:
+        requests:
+          memory: 12Gi
+        limits:
+          memory: 16Gi
+    - dot-release: true
+      dot-dev: true
+      go113: true
+      release: "0.10"
+      env-vars:
+      - RELEASE_BRANCH=releaes-0.10
+      resources:
+        requests:
+          memory: 12Gi
+        limits:
+          memory: 16Gi
+    - dot-release: true
+      dot-dev: true
+      go113: true
+      release: "0.11"
+      env-vars:
+      - RELEASE_BRANCH=releaes-0.11
+      resources:
+        requests:
+          memory: 12Gi
+        limits:
+          memory: 16Gi
+    - dot-release: true
+      dot-dev: true
+      go113: true
+      release: "0.12"
+      env-vars:
+      - RELEASE_BRANCH=releaes-0.12
       resources:
         requests:
           memory: 12Gi
@@ -640,6 +751,18 @@ periodics:
     - dot-release: true
       dot-dev: true
       go113: true
+      release: "0.11"
+      env-vars:
+      - RELEASE_BRANCH=releaes-0.11
+    - dot-release: true
+      dot-dev: true
+      go113: true
+      release: "0.12"
+      env-vars:
+      - RELEASE_BRANCH=releaes-0.12
+    - dot-release: true
+      dot-dev: true
+      go113: true
     - auto-release: true
       dot-dev: true
       go113: true
@@ -662,6 +785,18 @@ periodics:
     - dot-release: true
       dot-dev: true
       go113: true
+      release: "0.11"
+      env-vars:
+      - RELEASE_BRANCH=releaes-0.11
+    - dot-release: true
+      dot-dev: true
+      go113: true
+      release: "0.12"
+      env-vars:
+      - RELEASE_BRANCH=releaes-0.12
+    - dot-release: true
+      dot-dev: true
+      go113: true
     - auto-release: true
       dot-dev: true
       go113: true
@@ -674,6 +809,12 @@ periodics:
       go113: true
     - nightly: true
       go113: true
+    - dot-release: true
+      go113: true
+      release: "0.12"
+      env-vars:
+      - ORG_NAME=google
+        RELEASE_BRANCH=releaes-0.12
     - dot-release: true
       go113: true
       env-vars:

--- a/config/prow/config_knative.yaml
+++ b/config/prow/config_knative.yaml
@@ -438,7 +438,7 @@ periodics:
       go113: true
       release: "0.10"
       env-vars:
-      - RELEASE_BRANCH=releaes-0.10
+      - RELEASE_BRANCH=release-0.10
       resources:
         requests:
           memory: 12Gi
@@ -449,7 +449,7 @@ periodics:
       go113: true
       release: "0.11"
       env-vars:
-      - RELEASE_BRANCH=releaes-0.11
+      - RELEASE_BRANCH=release-0.11
       resources:
         requests:
           memory: 12Gi
@@ -460,7 +460,7 @@ periodics:
       go113: true
       release: "0.12"
       env-vars:
-      - RELEASE_BRANCH=releaes-0.12
+      - RELEASE_BRANCH=release-0.12
       resources:
         requests:
           memory: 12Gi
@@ -524,13 +524,13 @@ periodics:
       go113: true
       release: "0.11"
       env-vars:
-      - RELEASE_BRANCH=releaes-0.11
+      - RELEASE_BRANCH=release-0.11
     - dot-release: true
       dot-dev: true
       go113: true
       release: "0.12"
       env-vars:
-      - RELEASE_BRANCH=releaes-0.12
+      - RELEASE_BRANCH=release-0.12
     - dot-release: true
       dot-dev: true
       go113: true
@@ -581,7 +581,7 @@ periodics:
       go113: true
       release: "0.10"
       env-vars:
-      - RELEASE_BRANCH=releaes-0.10
+      - RELEASE_BRANCH=release-0.10
       resources:
         requests:
           memory: 12Gi
@@ -592,7 +592,7 @@ periodics:
       go113: true
       release: "0.11"
       env-vars:
-      - RELEASE_BRANCH=releaes-0.11
+      - RELEASE_BRANCH=release-0.11
       resources:
         requests:
           memory: 12Gi
@@ -603,7 +603,7 @@ periodics:
       go113: true
       release: "0.12"
       env-vars:
-      - RELEASE_BRANCH=releaes-0.12
+      - RELEASE_BRANCH=release-0.12
       resources:
         requests:
           memory: 12Gi
@@ -659,7 +659,7 @@ periodics:
       go113: true
       release: "0.10"
       env-vars:
-      - RELEASE_BRANCH=releaes-0.10
+      - RELEASE_BRANCH=release-0.10
       resources:
         requests:
           memory: 12Gi
@@ -670,7 +670,7 @@ periodics:
       go113: true
       release: "0.11"
       env-vars:
-      - RELEASE_BRANCH=releaes-0.11
+      - RELEASE_BRANCH=release-0.11
       resources:
         requests:
           memory: 12Gi
@@ -681,7 +681,7 @@ periodics:
       go113: true
       release: "0.12"
       env-vars:
-      - RELEASE_BRANCH=releaes-0.12
+      - RELEASE_BRANCH=release-0.12
       resources:
         requests:
           memory: 12Gi
@@ -753,13 +753,13 @@ periodics:
       go113: true
       release: "0.11"
       env-vars:
-      - RELEASE_BRANCH=releaes-0.11
+      - RELEASE_BRANCH=release-0.11
     - dot-release: true
       dot-dev: true
       go113: true
       release: "0.12"
       env-vars:
-      - RELEASE_BRANCH=releaes-0.12
+      - RELEASE_BRANCH=release-0.12
     - dot-release: true
       dot-dev: true
       go113: true
@@ -787,13 +787,13 @@ periodics:
       go113: true
       release: "0.11"
       env-vars:
-      - RELEASE_BRANCH=releaes-0.11
+      - RELEASE_BRANCH=release-0.11
     - dot-release: true
       dot-dev: true
       go113: true
       release: "0.12"
       env-vars:
-      - RELEASE_BRANCH=releaes-0.12
+      - RELEASE_BRANCH=release-0.12
     - dot-release: true
       dot-dev: true
       go113: true
@@ -814,7 +814,7 @@ periodics:
       release: "0.12"
       env-vars:
       - ORG_NAME=google
-        RELEASE_BRANCH=releaes-0.12
+        RELEASE_BRANCH=release-0.12
     - dot-release: true
       go113: true
       env-vars:

--- a/config/prow/jobs/config.yaml
+++ b/config/prow/jobs/config.yaml
@@ -4992,6 +4992,7 @@ periodics:
       - "--release-gcs knative-releases/serving"
       - "--release-gcr gcr.io/knative-releases"
       - "--github-token /etc/hub-token/token"
+      - "--branch release-0.10"
       volumeMounts:
       - name: hub-token
         mountPath: /etc/hub-token
@@ -5045,6 +5046,7 @@ periodics:
       - "--release-gcs knative-releases/serving"
       - "--release-gcr gcr.io/knative-releases"
       - "--github-token /etc/hub-token/token"
+      - "--branch release-0.11"
       volumeMounts:
       - name: hub-token
         mountPath: /etc/hub-token
@@ -5098,6 +5100,7 @@ periodics:
       - "--release-gcs knative-releases/serving"
       - "--release-gcr gcr.io/knative-releases"
       - "--github-token /etc/hub-token/token"
+      - "--branch release-0.12"
       volumeMounts:
       - name: hub-token
         mountPath: /etc/hub-token
@@ -5531,6 +5534,7 @@ periodics:
       - "--release-gcs knative-releases/client"
       - "--release-gcr gcr.io/knative-releases"
       - "--github-token /etc/hub-token/token"
+      - "--branch release-0.11"
       volumeMounts:
       - name: hub-token
         mountPath: /etc/hub-token
@@ -5579,6 +5583,7 @@ periodics:
       - "--release-gcs knative-releases/client"
       - "--release-gcr gcr.io/knative-releases"
       - "--github-token /etc/hub-token/token"
+      - "--branch release-0.12"
       volumeMounts:
       - name: hub-token
         mountPath: /etc/hub-token
@@ -6076,6 +6081,7 @@ periodics:
       - "--release-gcs knative-releases/eventing"
       - "--release-gcr gcr.io/knative-releases"
       - "--github-token /etc/hub-token/token"
+      - "--branch release-0.10"
       volumeMounts:
       - name: hub-token
         mountPath: /etc/hub-token
@@ -6129,6 +6135,7 @@ periodics:
       - "--release-gcs knative-releases/eventing"
       - "--release-gcr gcr.io/knative-releases"
       - "--github-token /etc/hub-token/token"
+      - "--branch release-0.11"
       volumeMounts:
       - name: hub-token
         mountPath: /etc/hub-token
@@ -6182,6 +6189,7 @@ periodics:
       - "--release-gcs knative-releases/eventing"
       - "--release-gcr gcr.io/knative-releases"
       - "--github-token /etc/hub-token/token"
+      - "--branch release-0.12"
       volumeMounts:
       - name: hub-token
         mountPath: /etc/hub-token
@@ -6574,6 +6582,7 @@ periodics:
       - "--release-gcs knative-releases/eventing-contrib"
       - "--release-gcr gcr.io/knative-releases"
       - "--github-token /etc/hub-token/token"
+      - "--branch release-0.10"
       volumeMounts:
       - name: hub-token
         mountPath: /etc/hub-token
@@ -6627,6 +6636,7 @@ periodics:
       - "--release-gcs knative-releases/eventing-contrib"
       - "--release-gcr gcr.io/knative-releases"
       - "--github-token /etc/hub-token/token"
+      - "--branch release-0.11"
       volumeMounts:
       - name: hub-token
         mountPath: /etc/hub-token
@@ -6680,6 +6690,7 @@ periodics:
       - "--release-gcs knative-releases/eventing-contrib"
       - "--release-gcr gcr.io/knative-releases"
       - "--github-token /etc/hub-token/token"
+      - "--branch release-0.12"
       volumeMounts:
       - name: hub-token
         mountPath: /etc/hub-token
@@ -7269,6 +7280,7 @@ periodics:
       - "--release-gcs knative-releases/serving-operator"
       - "--release-gcr gcr.io/knative-releases"
       - "--github-token /etc/hub-token/token"
+      - "--branch release-0.11"
       volumeMounts:
       - name: hub-token
         mountPath: /etc/hub-token
@@ -7317,6 +7329,7 @@ periodics:
       - "--release-gcs knative-releases/serving-operator"
       - "--release-gcr gcr.io/knative-releases"
       - "--github-token /etc/hub-token/token"
+      - "--branch release-0.12"
       volumeMounts:
       - name: hub-token
         mountPath: /etc/hub-token
@@ -7638,6 +7651,7 @@ periodics:
       - "--release-gcs knative-releases/eventing-operator"
       - "--release-gcr gcr.io/knative-releases"
       - "--github-token /etc/hub-token/token"
+      - "--branch release-0.11"
       volumeMounts:
       - name: hub-token
         mountPath: /etc/hub-token
@@ -7686,6 +7700,7 @@ periodics:
       - "--release-gcs knative-releases/eventing-operator"
       - "--release-gcr gcr.io/knative-releases"
       - "--github-token /etc/hub-token/token"
+      - "--branch release-0.12"
       volumeMounts:
       - name: hub-token
         mountPath: /etc/hub-token
@@ -7957,6 +7972,7 @@ periodics:
       - "--release-gcs knative-releases/knative-gcp"
       - "--release-gcr gcr.io/knative-releases"
       - "--github-token /etc/hub-token/token"
+      - "--branch release-0.12"
       volumeMounts:
       - name: hub-token
         mountPath: /etc/hub-token

--- a/config/prow/jobs/config.yaml
+++ b/config/prow/jobs/config.yaml
@@ -5001,8 +5001,6 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
-      - name: RELEASE_BRANCH
-        value: release-0.10
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -5055,8 +5053,6 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
-      - name: RELEASE_BRANCH
-        value: release-0.11
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -5109,8 +5105,6 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
-      - name: RELEASE_BRANCH
-        value: release-0.12
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -5543,8 +5537,6 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
-      - name: RELEASE_BRANCH
-        value: release-0.11
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -5592,8 +5584,6 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
-      - name: RELEASE_BRANCH
-        value: release-0.12
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -6090,8 +6080,6 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
-      - name: RELEASE_BRANCH
-        value: release-0.10
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -6144,8 +6132,6 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
-      - name: RELEASE_BRANCH
-        value: release-0.11
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -6198,8 +6184,6 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
-      - name: RELEASE_BRANCH
-        value: release-0.12
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -6591,8 +6575,6 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
-      - name: RELEASE_BRANCH
-        value: release-0.10
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -6645,8 +6627,6 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
-      - name: RELEASE_BRANCH
-        value: release-0.11
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -6699,8 +6679,6 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
-      - name: RELEASE_BRANCH
-        value: release-0.12
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -7289,8 +7267,6 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
-      - name: RELEASE_BRANCH
-        value: release-0.11
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -7338,8 +7314,6 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
-      - name: RELEASE_BRANCH
-        value: release-0.12
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -7660,8 +7634,6 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
-      - name: RELEASE_BRANCH
-        value: release-0.11
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -7709,8 +7681,6 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
-      - name: RELEASE_BRANCH
-        value: release-0.12
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -7982,7 +7952,7 @@ periodics:
         readOnly: true
       env:
       - name: ORG_NAME
-        value: google RELEASE_BRANCH=release-0.12
+        value: google
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION

--- a/config/prow/jobs/config.yaml
+++ b/config/prow/jobs/config.yaml
@@ -5001,7 +5001,7 @@ periodics:
         readOnly: true
       env:
       - name: RELEASE_BRANCH
-        value: releaes-0.10
+        value: release-0.10
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -5054,7 +5054,7 @@ periodics:
         readOnly: true
       env:
       - name: RELEASE_BRANCH
-        value: releaes-0.11
+        value: release-0.11
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -5107,7 +5107,7 @@ periodics:
         readOnly: true
       env:
       - name: RELEASE_BRANCH
-        value: releaes-0.12
+        value: release-0.12
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -5540,7 +5540,7 @@ periodics:
         readOnly: true
       env:
       - name: RELEASE_BRANCH
-        value: releaes-0.11
+        value: release-0.11
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -5588,7 +5588,7 @@ periodics:
         readOnly: true
       env:
       - name: RELEASE_BRANCH
-        value: releaes-0.12
+        value: release-0.12
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -6085,7 +6085,7 @@ periodics:
         readOnly: true
       env:
       - name: RELEASE_BRANCH
-        value: releaes-0.10
+        value: release-0.10
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -6138,7 +6138,7 @@ periodics:
         readOnly: true
       env:
       - name: RELEASE_BRANCH
-        value: releaes-0.11
+        value: release-0.11
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -6191,7 +6191,7 @@ periodics:
         readOnly: true
       env:
       - name: RELEASE_BRANCH
-        value: releaes-0.12
+        value: release-0.12
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -6583,7 +6583,7 @@ periodics:
         readOnly: true
       env:
       - name: RELEASE_BRANCH
-        value: releaes-0.10
+        value: release-0.10
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -6636,7 +6636,7 @@ periodics:
         readOnly: true
       env:
       - name: RELEASE_BRANCH
-        value: releaes-0.11
+        value: release-0.11
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -6689,7 +6689,7 @@ periodics:
         readOnly: true
       env:
       - name: RELEASE_BRANCH
-        value: releaes-0.12
+        value: release-0.12
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -7278,7 +7278,7 @@ periodics:
         readOnly: true
       env:
       - name: RELEASE_BRANCH
-        value: releaes-0.11
+        value: release-0.11
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -7326,7 +7326,7 @@ periodics:
         readOnly: true
       env:
       - name: RELEASE_BRANCH
-        value: releaes-0.12
+        value: release-0.12
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -7647,7 +7647,7 @@ periodics:
         readOnly: true
       env:
       - name: RELEASE_BRANCH
-        value: releaes-0.11
+        value: release-0.11
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -7695,7 +7695,7 @@ periodics:
         readOnly: true
       env:
       - name: RELEASE_BRANCH
-        value: releaes-0.12
+        value: release-0.12
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -7966,7 +7966,7 @@ periodics:
         readOnly: true
       env:
       - name: ORG_NAME
-        value: google RELEASE_BRANCH=releaes-0.12
+        value: google RELEASE_BRANCH=release-0.12
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION

--- a/config/prow/jobs/config.yaml
+++ b/config/prow/jobs/config.yaml
@@ -4967,6 +4967,165 @@ periodics:
     - name: nightly-account
       secret:
         secretName: nightly-account
+- cron: "51 9 * * 2"
+  name: ci-knative-serving-0.10-dot-release
+  agent: kubernetes
+  labels:
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-knative-serving-0.10-dot-release
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: release-0.10
+    path_alias: knative.dev/serving
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--dot-release"
+      - "--release-gcs knative-releases/serving"
+      - "--release-gcr gcr.io/knative-releases"
+      - "--github-token /etc/hub-token/token"
+      volumeMounts:
+      - name: hub-token
+        mountPath: /etc/hub-token
+        readOnly: true
+      - name: release-account
+        mountPath: /etc/release-account
+        readOnly: true
+      env:
+      - name: RELEASE_BRANCH
+        value: releaes-0.10
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.10
+      resources:
+        requests:
+          memory: 12Gi
+        limits:
+          memory: 16Gi
+    volumes:
+    - name: hub-token
+      secret:
+        secretName: hub-token
+    - name: release-account
+      secret:
+        secretName: release-account
+- cron: "2 9 * * 2"
+  name: ci-knative-serving-0.11-dot-release
+  agent: kubernetes
+  labels:
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-knative-serving-0.11-dot-release
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: release-0.11
+    path_alias: knative.dev/serving
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--dot-release"
+      - "--release-gcs knative-releases/serving"
+      - "--release-gcr gcr.io/knative-releases"
+      - "--github-token /etc/hub-token/token"
+      volumeMounts:
+      - name: hub-token
+        mountPath: /etc/hub-token
+        readOnly: true
+      - name: release-account
+        mountPath: /etc/release-account
+        readOnly: true
+      env:
+      - name: RELEASE_BRANCH
+        value: releaes-0.11
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.11
+      resources:
+        requests:
+          memory: 12Gi
+        limits:
+          memory: 16Gi
+    volumes:
+    - name: hub-token
+      secret:
+        secretName: hub-token
+    - name: release-account
+      secret:
+        secretName: release-account
+- cron: "13 9 * * 2"
+  name: ci-knative-serving-0.12-dot-release
+  agent: kubernetes
+  labels:
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-knative-serving-0.12-dot-release
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: release-0.12
+    path_alias: knative.dev/serving
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--dot-release"
+      - "--release-gcs knative-releases/serving"
+      - "--release-gcr gcr.io/knative-releases"
+      - "--github-token /etc/hub-token/token"
+      volumeMounts:
+      - name: hub-token
+        mountPath: /etc/hub-token
+        readOnly: true
+      - name: release-account
+        mountPath: /etc/release-account
+        readOnly: true
+      env:
+      - name: RELEASE_BRANCH
+        value: releaes-0.12
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.12
+      resources:
+        requests:
+          memory: 12Gi
+        limits:
+          memory: 16Gi
+    volumes:
+    - name: hub-token
+      secret:
+        secretName: hub-token
+    - name: release-account
+      secret:
+        secretName: release-account
 - cron: "37 9 * * 2"
   name: ci-knative-serving-dot-release
   agent: kubernetes
@@ -5347,6 +5506,102 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
+- cron: "57 9 * * 2"
+  name: ci-knative-client-0.11-dot-release
+  agent: kubernetes
+  labels:
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-knative-client-0.11-dot-release
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: client
+    base_ref: release-0.11
+    path_alias: knative.dev/client
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--dot-release"
+      - "--release-gcs knative-releases/client"
+      - "--release-gcr gcr.io/knative-releases"
+      - "--github-token /etc/hub-token/token"
+      volumeMounts:
+      - name: hub-token
+        mountPath: /etc/hub-token
+        readOnly: true
+      - name: release-account
+        mountPath: /etc/release-account
+        readOnly: true
+      env:
+      - name: RELEASE_BRANCH
+        value: releaes-0.11
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.11
+    volumes:
+    - name: hub-token
+      secret:
+        secretName: hub-token
+    - name: release-account
+      secret:
+        secretName: release-account
+- cron: "8 9 * * 2"
+  name: ci-knative-client-0.12-dot-release
+  agent: kubernetes
+  labels:
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-knative-client-0.12-dot-release
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: client
+    base_ref: release-0.12
+    path_alias: knative.dev/client
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--dot-release"
+      - "--release-gcs knative-releases/client"
+      - "--release-gcr gcr.io/knative-releases"
+      - "--github-token /etc/hub-token/token"
+      volumeMounts:
+      - name: hub-token
+        mountPath: /etc/hub-token
+        readOnly: true
+      - name: release-account
+        mountPath: /etc/release-account
+        readOnly: true
+      env:
+      - name: RELEASE_BRANCH
+        value: releaes-0.12
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.12
+    volumes:
+    - name: hub-token
+      secret:
+        secretName: hub-token
+    - name: release-account
+      secret:
+        secretName: release-account
 - cron: "21 9 * * 2"
   name: ci-knative-client-dot-release
   agent: kubernetes
@@ -5796,6 +6051,165 @@ periodics:
     - name: nightly-account
       secret:
         secretName: nightly-account
+- cron: "10 9 * * 2"
+  name: ci-knative-eventing-0.10-dot-release
+  agent: kubernetes
+  labels:
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-knative-eventing-0.10-dot-release
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: eventing
+    base_ref: release-0.10
+    path_alias: knative.dev/eventing
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--dot-release"
+      - "--release-gcs knative-releases/eventing"
+      - "--release-gcr gcr.io/knative-releases"
+      - "--github-token /etc/hub-token/token"
+      volumeMounts:
+      - name: hub-token
+        mountPath: /etc/hub-token
+        readOnly: true
+      - name: release-account
+        mountPath: /etc/release-account
+        readOnly: true
+      env:
+      - name: RELEASE_BRANCH
+        value: releaes-0.10
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.10
+      resources:
+        requests:
+          memory: 12Gi
+        limits:
+          memory: 16Gi
+    volumes:
+    - name: hub-token
+      secret:
+        secretName: hub-token
+    - name: release-account
+      secret:
+        secretName: release-account
+- cron: "21 9 * * 2"
+  name: ci-knative-eventing-0.11-dot-release
+  agent: kubernetes
+  labels:
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-knative-eventing-0.11-dot-release
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: eventing
+    base_ref: release-0.11
+    path_alias: knative.dev/eventing
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--dot-release"
+      - "--release-gcs knative-releases/eventing"
+      - "--release-gcr gcr.io/knative-releases"
+      - "--github-token /etc/hub-token/token"
+      volumeMounts:
+      - name: hub-token
+        mountPath: /etc/hub-token
+        readOnly: true
+      - name: release-account
+        mountPath: /etc/release-account
+        readOnly: true
+      env:
+      - name: RELEASE_BRANCH
+        value: releaes-0.11
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.11
+      resources:
+        requests:
+          memory: 12Gi
+        limits:
+          memory: 16Gi
+    volumes:
+    - name: hub-token
+      secret:
+        secretName: hub-token
+    - name: release-account
+      secret:
+        secretName: release-account
+- cron: "32 9 * * 2"
+  name: ci-knative-eventing-0.12-dot-release
+  agent: kubernetes
+  labels:
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-knative-eventing-0.12-dot-release
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: eventing
+    base_ref: release-0.12
+    path_alias: knative.dev/eventing
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--dot-release"
+      - "--release-gcs knative-releases/eventing"
+      - "--release-gcr gcr.io/knative-releases"
+      - "--github-token /etc/hub-token/token"
+      volumeMounts:
+      - name: hub-token
+        mountPath: /etc/hub-token
+        readOnly: true
+      - name: release-account
+        mountPath: /etc/release-account
+        readOnly: true
+      env:
+      - name: RELEASE_BRANCH
+        value: releaes-0.12
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.12
+      resources:
+        requests:
+          memory: 12Gi
+        limits:
+          memory: 16Gi
+    volumes:
+    - name: hub-token
+      secret:
+        secretName: hub-token
+    - name: release-account
+      secret:
+        secretName: release-account
 - cron: "56 9 * * 2"
   name: ci-knative-eventing-dot-release
   agent: kubernetes
@@ -6135,6 +6549,165 @@ periodics:
     - name: nightly-account
       secret:
         secretName: nightly-account
+- cron: "16 9 * * 2"
+  name: ci-knative-eventing-contrib-0.10-dot-release
+  agent: kubernetes
+  labels:
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-knative-eventing-contrib-0.10-dot-release
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: eventing-contrib
+    base_ref: release-0.10
+    path_alias: knative.dev/eventing-contrib
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--dot-release"
+      - "--release-gcs knative-releases/eventing-contrib"
+      - "--release-gcr gcr.io/knative-releases"
+      - "--github-token /etc/hub-token/token"
+      volumeMounts:
+      - name: hub-token
+        mountPath: /etc/hub-token
+        readOnly: true
+      - name: release-account
+        mountPath: /etc/release-account
+        readOnly: true
+      env:
+      - name: RELEASE_BRANCH
+        value: releaes-0.10
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.10
+      resources:
+        requests:
+          memory: 12Gi
+        limits:
+          memory: 16Gi
+    volumes:
+    - name: hub-token
+      secret:
+        secretName: hub-token
+    - name: release-account
+      secret:
+        secretName: release-account
+- cron: "27 9 * * 2"
+  name: ci-knative-eventing-contrib-0.11-dot-release
+  agent: kubernetes
+  labels:
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-knative-eventing-contrib-0.11-dot-release
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: eventing-contrib
+    base_ref: release-0.11
+    path_alias: knative.dev/eventing-contrib
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--dot-release"
+      - "--release-gcs knative-releases/eventing-contrib"
+      - "--release-gcr gcr.io/knative-releases"
+      - "--github-token /etc/hub-token/token"
+      volumeMounts:
+      - name: hub-token
+        mountPath: /etc/hub-token
+        readOnly: true
+      - name: release-account
+        mountPath: /etc/release-account
+        readOnly: true
+      env:
+      - name: RELEASE_BRANCH
+        value: releaes-0.11
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.11
+      resources:
+        requests:
+          memory: 12Gi
+        limits:
+          memory: 16Gi
+    volumes:
+    - name: hub-token
+      secret:
+        secretName: hub-token
+    - name: release-account
+      secret:
+        secretName: release-account
+- cron: "38 9 * * 2"
+  name: ci-knative-eventing-contrib-0.12-dot-release
+  agent: kubernetes
+  labels:
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-knative-eventing-contrib-0.12-dot-release
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: eventing-contrib
+    base_ref: release-0.12
+    path_alias: knative.dev/eventing-contrib
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--dot-release"
+      - "--release-gcs knative-releases/eventing-contrib"
+      - "--release-gcr gcr.io/knative-releases"
+      - "--github-token /etc/hub-token/token"
+      volumeMounts:
+      - name: hub-token
+        mountPath: /etc/hub-token
+        readOnly: true
+      - name: release-account
+        mountPath: /etc/release-account
+        readOnly: true
+      env:
+      - name: RELEASE_BRANCH
+        value: releaes-0.12
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.12
+      resources:
+        requests:
+          memory: 12Gi
+        limits:
+          memory: 16Gi
+    volumes:
+    - name: hub-token
+      secret:
+        secretName: hub-token
+    - name: release-account
+      secret:
+        secretName: release-account
 - cron: "51 9 * * 2"
   name: ci-knative-eventing-contrib-dot-release
   agent: kubernetes
@@ -6671,6 +7244,102 @@ periodics:
     - name: nightly-account
       secret:
         secretName: nightly-account
+- cron: "30 9 * * 2"
+  name: ci-knative-serving-operator-0.11-dot-release
+  agent: kubernetes
+  labels:
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-knative-serving-operator-0.11-dot-release
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: serving-operator
+    base_ref: release-0.11
+    path_alias: knative.dev/serving-operator
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--dot-release"
+      - "--release-gcs knative-releases/serving-operator"
+      - "--release-gcr gcr.io/knative-releases"
+      - "--github-token /etc/hub-token/token"
+      volumeMounts:
+      - name: hub-token
+        mountPath: /etc/hub-token
+        readOnly: true
+      - name: release-account
+        mountPath: /etc/release-account
+        readOnly: true
+      env:
+      - name: RELEASE_BRANCH
+        value: releaes-0.11
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.11
+    volumes:
+    - name: hub-token
+      secret:
+        secretName: hub-token
+    - name: release-account
+      secret:
+        secretName: release-account
+- cron: "40 9 * * 2"
+  name: ci-knative-serving-operator-0.12-dot-release
+  agent: kubernetes
+  labels:
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-knative-serving-operator-0.12-dot-release
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: serving-operator
+    base_ref: release-0.12
+    path_alias: knative.dev/serving-operator
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--dot-release"
+      - "--release-gcs knative-releases/serving-operator"
+      - "--release-gcr gcr.io/knative-releases"
+      - "--github-token /etc/hub-token/token"
+      volumeMounts:
+      - name: hub-token
+        mountPath: /etc/hub-token
+        readOnly: true
+      - name: release-account
+        mountPath: /etc/release-account
+        readOnly: true
+      env:
+      - name: RELEASE_BRANCH
+        value: releaes-0.12
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.12
+    volumes:
+    - name: hub-token
+      secret:
+        secretName: hub-token
+    - name: release-account
+      secret:
+        secretName: release-account
 - cron: "4 9 * * 2"
   name: ci-knative-serving-operator-dot-release
   agent: kubernetes
@@ -6944,6 +7613,102 @@ periodics:
     - name: nightly-account
       secret:
         secretName: nightly-account
+- cron: "59 9 * * 2"
+  name: ci-knative-eventing-operator-0.11-dot-release
+  agent: kubernetes
+  labels:
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-knative-eventing-operator-0.11-dot-release
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: eventing-operator
+    base_ref: release-0.11
+    path_alias: knative.dev/eventing-operator
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--dot-release"
+      - "--release-gcs knative-releases/eventing-operator"
+      - "--release-gcr gcr.io/knative-releases"
+      - "--github-token /etc/hub-token/token"
+      volumeMounts:
+      - name: hub-token
+        mountPath: /etc/hub-token
+        readOnly: true
+      - name: release-account
+        mountPath: /etc/release-account
+        readOnly: true
+      env:
+      - name: RELEASE_BRANCH
+        value: releaes-0.11
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.11
+    volumes:
+    - name: hub-token
+      secret:
+        secretName: hub-token
+    - name: release-account
+      secret:
+        secretName: release-account
+- cron: "0 9 * * 2"
+  name: ci-knative-eventing-operator-0.12-dot-release
+  agent: kubernetes
+  labels:
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-knative-eventing-operator-0.12-dot-release
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: eventing-operator
+    base_ref: release-0.12
+    path_alias: knative.dev/eventing-operator
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--dot-release"
+      - "--release-gcs knative-releases/eventing-operator"
+      - "--release-gcr gcr.io/knative-releases"
+      - "--github-token /etc/hub-token/token"
+      volumeMounts:
+      - name: hub-token
+        mountPath: /etc/hub-token
+        readOnly: true
+      - name: release-account
+        mountPath: /etc/release-account
+        readOnly: true
+      env:
+      - name: RELEASE_BRANCH
+        value: releaes-0.12
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.12
+    volumes:
+    - name: hub-token
+      secret:
+        secretName: hub-token
+    - name: release-account
+      secret:
+        secretName: release-account
 - cron: "23 9 * * 2"
   name: ci-knative-eventing-operator-dot-release
   agent: kubernetes
@@ -7168,6 +7933,53 @@ periodics:
     - name: nightly-account
       secret:
         secretName: nightly-account
+- cron: "32 9 * * 2"
+  name: ci-google-knative-gcp-0.12-dot-release
+  agent: kubernetes
+  labels:
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-google-knative-gcp-0.12-dot-release
+  decorate: true
+  extra_refs:
+  - org: google
+    repo: knative-gcp
+    base_ref: release-0.12
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--dot-release"
+      - "--release-gcs knative-releases/knative-gcp"
+      - "--release-gcr gcr.io/knative-releases"
+      - "--github-token /etc/hub-token/token"
+      volumeMounts:
+      - name: hub-token
+        mountPath: /etc/hub-token
+        readOnly: true
+      - name: release-account
+        mountPath: /etc/release-account
+        readOnly: true
+      env:
+      - name: ORG_NAME
+        value: google RELEASE_BRANCH=releaes-0.12
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.12
+    volumes:
+    - name: hub-token
+      secret:
+        secretName: hub-token
+    - name: release-account
+      secret:
+        secretName: release-account
 - cron: "56 9 * * 2"
   name: ci-google-knative-gcp-dot-release
   agent: kubernetes

--- a/config/prow/testgrid/testgrid.yaml
+++ b/config/prow/testgrid/testgrid.yaml
@@ -330,76 +330,166 @@ test_groups:
   alert_options: 
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 3
+- name: ci-knative-serving-0.10-dot-release
+  gcs_prefix: knative-prow/logs/ci-knative-serving-0.10-dot-release
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+  alert_stale_results_hours: 170
+  num_failures_to_alert: 1
 - name: ci-knative-eventing-0.10-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-0.10-continuous
   alert_options: 
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 3
+- name: ci-knative-eventing-0.10-dot-release
+  gcs_prefix: knative-prow/logs/ci-knative-eventing-0.10-dot-release
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+  alert_stale_results_hours: 170
+  num_failures_to_alert: 1
 - name: ci-knative-eventing-contrib-0.10-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-contrib-0.10-continuous
   alert_options: 
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 3
+- name: ci-knative-eventing-contrib-0.10-dot-release
+  gcs_prefix: knative-prow/logs/ci-knative-eventing-contrib-0.10-dot-release
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+  alert_stale_results_hours: 170
+  num_failures_to_alert: 1
 - name: ci-knative-serving-0.11-continuous
   gcs_prefix: knative-prow/logs/ci-knative-serving-0.11-continuous
   alert_options: 
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 3
+- name: ci-knative-serving-0.11-dot-release
+  gcs_prefix: knative-prow/logs/ci-knative-serving-0.11-dot-release
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+  alert_stale_results_hours: 170
+  num_failures_to_alert: 1
 - name: ci-knative-client-0.11-continuous
   gcs_prefix: knative-prow/logs/ci-knative-client-0.11-continuous
   alert_options: 
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 3
+- name: ci-knative-client-0.11-dot-release
+  gcs_prefix: knative-prow/logs/ci-knative-client-0.11-dot-release
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+  alert_stale_results_hours: 170
+  num_failures_to_alert: 1
 - name: ci-knative-eventing-0.11-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-0.11-continuous
   alert_options: 
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 3
+- name: ci-knative-eventing-0.11-dot-release
+  gcs_prefix: knative-prow/logs/ci-knative-eventing-0.11-dot-release
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+  alert_stale_results_hours: 170
+  num_failures_to_alert: 1
 - name: ci-knative-eventing-contrib-0.11-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-contrib-0.11-continuous
   alert_options: 
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 3
+- name: ci-knative-eventing-contrib-0.11-dot-release
+  gcs_prefix: knative-prow/logs/ci-knative-eventing-contrib-0.11-dot-release
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+  alert_stale_results_hours: 170
+  num_failures_to_alert: 1
 - name: ci-knative-serving-operator-0.11-continuous
   gcs_prefix: knative-prow/logs/ci-knative-serving-operator-0.11-continuous
   alert_options: 
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 3
+- name: ci-knative-serving-operator-0.11-dot-release
+  gcs_prefix: knative-prow/logs/ci-knative-serving-operator-0.11-dot-release
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+  alert_stale_results_hours: 170
+  num_failures_to_alert: 1
 - name: ci-knative-eventing-operator-0.11-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-operator-0.11-continuous
   alert_options: 
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 3
+- name: ci-knative-eventing-operator-0.11-dot-release
+  gcs_prefix: knative-prow/logs/ci-knative-eventing-operator-0.11-dot-release
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+  alert_stale_results_hours: 170
+  num_failures_to_alert: 1
 - name: ci-knative-serving-0.12-continuous
   gcs_prefix: knative-prow/logs/ci-knative-serving-0.12-continuous
   alert_options: 
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 3
+- name: ci-knative-serving-0.12-dot-release
+  gcs_prefix: knative-prow/logs/ci-knative-serving-0.12-dot-release
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+  alert_stale_results_hours: 170
+  num_failures_to_alert: 1
 - name: ci-knative-client-0.12-continuous
   gcs_prefix: knative-prow/logs/ci-knative-client-0.12-continuous
   alert_options: 
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 3
+- name: ci-knative-client-0.12-dot-release
+  gcs_prefix: knative-prow/logs/ci-knative-client-0.12-dot-release
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+  alert_stale_results_hours: 170
+  num_failures_to_alert: 1
 - name: ci-knative-eventing-0.12-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-0.12-continuous
   alert_options: 
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 3
+- name: ci-knative-eventing-0.12-dot-release
+  gcs_prefix: knative-prow/logs/ci-knative-eventing-0.12-dot-release
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+  alert_stale_results_hours: 170
+  num_failures_to_alert: 1
 - name: ci-knative-eventing-contrib-0.12-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-contrib-0.12-continuous
   alert_options: 
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 3
+- name: ci-knative-eventing-contrib-0.12-dot-release
+  gcs_prefix: knative-prow/logs/ci-knative-eventing-contrib-0.12-dot-release
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+  alert_stale_results_hours: 170
+  num_failures_to_alert: 1
 - name: ci-knative-serving-operator-0.12-continuous
   gcs_prefix: knative-prow/logs/ci-knative-serving-operator-0.12-continuous
   alert_options: 
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 3
+- name: ci-knative-serving-operator-0.12-dot-release
+  gcs_prefix: knative-prow/logs/ci-knative-serving-operator-0.12-dot-release
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+  alert_stale_results_hours: 170
+  num_failures_to_alert: 1
 - name: ci-knative-eventing-operator-0.12-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-operator-0.12-continuous
   alert_options: 
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 3
+- name: ci-knative-eventing-operator-0.12-dot-release
+  gcs_prefix: knative-prow/logs/ci-knative-eventing-operator-0.12-dot-release
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+  alert_stale_results_hours: 170
+  num_failures_to_alert: 1
 - name: ci-google-knative-gcp-continuous
   gcs_prefix: knative-prow/logs/ci-google-knative-gcp-continuous
   alert_stale_results_hours: 3
@@ -427,6 +517,12 @@ test_groups:
   alert_options: 
     alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
   num_failures_to_alert: 3
+- name: ci-google-knative-gcp-0.12-dot-release
+  gcs_prefix: knative-prow/logs/ci-google-knative-gcp-0.12-dot-release
+  alert_options: 
+    alert_mail_to_addresses: "knative-productivity-dev@googlegroups.com"
+  alert_stale_results_hours: 170
+  num_failures_to_alert: 1
 dashboards:
 - name: serving
   dashboard_tab:

--- a/tools/config-generator/periodic_config.go
+++ b/tools/config-generator/periodic_config.go
@@ -173,6 +173,9 @@ func generatePeriodic(title string, repoName string, periodicConfig yaml.MapSlic
 			version := getString(item.Value)
 			jobNameSuffix = version + "-" + jobNameSuffix
 			data.Base.RepoBranch = "release-" + version
+			if jobType == "dot-release" {
+				data.Base.Args = append(data.Base.Args, "--branch release-"+version)
+			}
 			isMonitoredJob = true
 		case "webhook-apicoverage":
 			if !getBool(item.Value) {


### PR DESCRIPTION
Add jobs for dot releasing old release branches. 

This is probably the least intrusive way of using current Prow config generator, luckily it also generates testgrid configs correctly

Fix: #1828 

/assign @chizhg 