### PR TITLE
Enable net-http01 e2e tests

### DIFF
--- a/config/prow/config_knative.yaml
+++ b/config/prow/config_knative.yaml
@@ -327,6 +327,16 @@ presubmits:
     - go-coverage: true
       dot-dev: true
 
+  knative/net-http01:
+    - build-tests: true
+      dot-dev: true
+    - unit-tests: true
+      dot-dev: true
+    - integration-tests: false
+      dot-dev: true
+    - go-coverage: true
+      dot-dev: true
+
   knative/net-istio:
     - build-tests: true
       dot-dev: true
@@ -903,6 +913,20 @@ periodics:
       - ORG_NAME=google
 
   knative/net-contour:
+    - continuous: true
+      dot-dev: true
+      go113: true
+    - nightly: true
+      dot-dev: true
+      go113: true
+    - dot-release: true
+      dot-dev: true
+      go113: true
+    - auto-release: true
+      dot-dev: true
+      go113: true
+
+  knative/net-http01:
     - continuous: true
       dot-dev: true
       go113: true

--- a/config/prow/config_knative.yaml
+++ b/config/prow/config_knative.yaml
@@ -322,17 +322,7 @@ presubmits:
       dot-dev: true
     - unit-tests: true
       dot-dev: true
-    - integration-tests: false
-      dot-dev: true
-    - go-coverage: true
-      dot-dev: true
-
-  knative/net-http01:
-    - build-tests: true
-      dot-dev: true
-    - unit-tests: true
-      dot-dev: true
-    - integration-tests: false
+    - integration-tests: true
       dot-dev: true
     - go-coverage: true
       dot-dev: true
@@ -913,20 +903,6 @@ periodics:
       - ORG_NAME=google
 
   knative/net-contour:
-    - continuous: true
-      dot-dev: true
-      go113: true
-    - nightly: true
-      dot-dev: true
-      go113: true
-    - dot-release: true
-      dot-dev: true
-      go113: true
-    - auto-release: true
-      dot-dev: true
-      go113: true
-
-  knative/net-http01:
     - continuous: true
       dot-dev: true
       go113: true

--- a/config/prow/jobs/config.yaml
+++ b/config/prow/jobs/config.yaml
@@ -3822,6 +3822,42 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
+  - name: pull-knative-net-http01-integration-tests
+    agent: kubernetes
+    context: pull-knative-net-http01-integration-tests
+    always_run: true
+    rerun_command: "/test pull-knative-net-http01-integration-tests"
+    trigger: "(?m)^/test (all|pull-knative-net-http01-integration-tests),?(\\s+|$)"
+    decorate: true
+    path_alias: knative.dev/net-http01
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--integration-tests"
+        volumeMounts:
+        - name: repoview-token
+          mountPath: /etc/repoview-token
+          readOnly: true
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: repoview-token
+        secret:
+          secretName: repoview-token
+      - name: test-account
+        secret:
+          secretName: test-account
   - name: pull-knative-net-http01-go-coverage
     agent: kubernetes
     context: pull-knative-net-http01-go-coverage


### PR DESCRIPTION
WIP until https://github.com/knative/test-infra/pull/1840 merges, and the series of changes leading to https://github.com/knative/net-http01/pull/8 merge.