### PR TITLE
Add postsubmit job for Prow config updater

### DIFF
--- a/config/prow/config_knative.yaml
+++ b/config/prow/config_knative.yaml
@@ -253,6 +253,8 @@ presubmits:
       dot-dev: true
     - integration-tests: true
       dot-dev: true
+    - go-coverage: true
+      dot-dev: true
     - custom-test: check-config
       dot-dev: true
       command:

--- a/config/prow/jobs/config.yaml
+++ b/config/prow/jobs/config.yaml
@@ -2484,6 +2484,34 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
+  - name: pull-knative-test-infra-go-coverage
+    agent: kubernetes
+    context: pull-knative-test-infra-go-coverage
+    always_run: true
+    rerun_command: "/test pull-knative-test-infra-go-coverage"
+    trigger: "(?m)^/test (all|pull-knative-test-infra-go-coverage),?(\\s+|$)"
+    optional: true
+    decorate: true
+    path_alias: knative.dev/test-infra
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/coverage:latest
+        imagePullPolicy: Always
+        command:
+        - "/coverage"
+        args:
+        - "--postsubmit-job-name=post-knative-test-infra-go-coverage"
+        - "--artifacts=$(ARTIFACTS)"
+        - "--cov-threshold-percentage=50"
+        - "--github-token=/etc/covbot-token/token"
+        volumeMounts:
+        - name: covbot-token
+          mountPath: /etc/covbot-token
+          readOnly: true
+      volumes:
+      - name: covbot-token
+        secret:
+          secretName: covbot-token
   - name: pull-knative-test-infra-check-config
     agent: kubernetes
     context: pull-knative-test-infra-check-config
@@ -7323,6 +7351,28 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
+- cron: "0 1 * * *"
+  name: ci-knative-test-infra-go-coverage
+  labels:
+      prow.k8s.io/pubsub.project: knative-tests
+      prow.k8s.io/pubsub.topic: knative-monitoring
+      prow.k8s.io/pubsub.runID: ci-knative-test-infra-go-coverage
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: test-infra
+    base_ref: master
+    path_alias: knative.dev/test-infra
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/coverage:latest
+      imagePullPolicy: Always
+      command:
+      - "/coverage"
+      args:
+      - "--artifacts=$(ARTIFACTS)"
+      - "--cov-threshold-percentage=50"
 - cron: "48 * * * *"
   name: ci-knative-serving-operator-continuous
   agent: kubernetes
@@ -9928,6 +9978,69 @@ postsubmits:
         args:
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=0"
+  knative/test-infra:
+  - name: post-knative-test-infra-go-coverage
+    branches:
+    - master
+    agent: kubernetes
+    decorate: true
+    path_alias: knative.dev/test-infra
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/coverage:latest
+        imagePullPolicy: Always
+        command:
+        - "/coverage"
+        args:
+        - "--artifacts=$(ARTIFACTS)"
+        - "--cov-threshold-percentage=0"
+  - name: post-knative-prow-config-updater
+    agent: kubernetes
+    decorate: true
+    max_concurrency: 1
+    run_if_changed: "^(config/(prow|prow-staging)/(cluster|core|jobs|testgrid)/.*.yaml)|(tools/config-generator/templates/(prow|prow-staging)/.*.yaml)$"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-config-updater:latest
+        imagePullPolicy: Always
+        command:
+        - "/prow-config-updater"
+        args:
+        - "--github-token-file=/etc/prow-robot-github-token/token"
+        - "--github-userid=knative-prow-robot"
+        - "--git-username='Knative Prow Robot'"
+        - "--git-email=knative-prow-robot@google.com"
+        - "--comment-github-token-file=/etc/prow-updater-robot-github-token/token"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        - name: prow-robot-github-token
+          mountPath: /etc/prow-robot-github-token
+          readOnly: true
+        - name: prow-updater-robot-github-token
+          mountPath: /etc/prow-updater-robot-github-token
+          readOnly: true
+        - name: prow-robot-ssh-key
+          mountPath: /root/.ssh
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
+      - name: prow-robot-github-token
+        secret:
+          secretName: prow-robot-github-token
+      - name: prow-updater-robot-github-token
+        secret:
+          secretName: prow-updater-robot-github-token
+      - name: prow-robot-ssh-key
+        secret:
+          secretName: prow-robot-ssh-key
+          defaultMode: 0400
   knative/caching:
   - name: post-knative-caching-go-coverage
     branches:

--- a/config/prow/jobs/config.yaml
+++ b/config/prow/jobs/config.yaml
@@ -9999,6 +9999,7 @@ postsubmits:
     decorate: true
     max_concurrency: 1
     run_if_changed: "^(config/(prow|prow-staging)/(cluster|core|jobs|testgrid)/.*.yaml)|(tools/config-generator/templates/(prow|prow-staging)/.*.yaml)$"
+    cluster: "prow-trusted"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-config-updater:latest

--- a/config/prow/testgrid/testgrid.yaml
+++ b/config/prow/testgrid/testgrid.yaml
@@ -215,6 +215,9 @@ test_groups:
 - name: ci-knative-test-infra-continuous
   gcs_prefix: knative-prow/logs/ci-knative-test-infra-continuous
   alert_stale_results_hours: 3
+- name: ci-knative-test-infra-test-coverage
+  gcs_prefix: knative-prow/logs/ci-knative-test-infra-go-coverage
+  short_text_metric: "coverage"
 - name: ci-knative-serving-operator-continuous
   gcs_prefix: knative-prow/logs/ci-knative-serving-operator-continuous
   alert_stale_results_hours: 3
@@ -793,6 +796,9 @@ dashboards:
     alert_options:
       alert_mail_to_addresses: "prime-engprod-sea@google.com"
     num_failures_to_alert: 3
+  - name: coverage
+    test_group_name: ci-knative-test-infra-test-coverage
+    base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
 - name: serving-operator
   dashboard_tab:
   - name: continuous

--- a/tools/config-generator/main.go
+++ b/tools/config-generator/main.go
@@ -116,6 +116,7 @@ type baseProwJobTemplateData struct {
 	Image               string
 	Labels              []string
 	PathAlias           string
+	RunIfChanged        string
 	Optional            string
 	NeedsMonitor        bool
 }
@@ -145,10 +146,10 @@ var (
 	releaseAccount               string
 	flakesreporterDockerImage    string
 	prowversionbumperDockerImage string
+	prowconfigupdaterDockerImage string
 	githubCommenterDockerImage   string
 	coverageDockerImage          string
 	prowTestsDockerImage         string
-	metricsDockerImage           string
 	backupsDockerImage           string
 	presubmitScript              string
 	releaseScript                string
@@ -1130,9 +1131,9 @@ func main() {
 	flag.StringVar(&releaseAccount, "release-account", "/etc/release-account/service-account.json", "Path to the service account JSON for release jobs")
 	var flakesreporterDockerImageName = flag.String("flaky-test-reporter-docker", "flaky-test-reporter:latest", "Docker image for flaky test reporting tool")
 	var prowversionbumperDockerImageName = flag.String("prow-auto-bumper", "prow-auto-bumper:latest", "Docker image for Prow version bumping tool")
+	var prowconfigupdaterDockerImageName = flag.String("prow-config-updater", "prow-config-updater:latest", "Docker image for Prow config updater tool")
 	var coverageDockerImageName = flag.String("coverage-docker", "coverage-go112:latest", "Docker image for coverage tool")
 	var prowTestsDockerImageName = flag.String("prow-tests-docker", "prow-tests-go112:stable", "prow-tests docker image")
-	var metricsDockerImageName = flag.String("metrics-docker", "metrics:latest", "Docker image for the metrics reporting tool")
 	var backupsDockerImageName = flag.String("backups-docker", "backups:latest", "Docker image for the backups job")
 	flag.StringVar(&githubCommenterDockerImage, "github-commenter-docker", "gcr.io/k8s-prow/commenter:v20190731-e3f7b9853", "github commenter docker image")
 	flag.StringVar(&presubmitScript, "presubmit-script", "./test/presubmit-tests.sh", "Executable for running presubmit tests")
@@ -1150,9 +1151,9 @@ func main() {
 
 	flakesreporterDockerImage = path.Join(*dockerImagesBase, *flakesreporterDockerImageName)
 	prowversionbumperDockerImage = path.Join(*dockerImagesBase, *prowversionbumperDockerImageName)
+	prowconfigupdaterDockerImage = path.Join(*dockerImagesBase, *prowconfigupdaterDockerImageName)
 	coverageDockerImage = path.Join(*dockerImagesBase, *coverageDockerImageName)
 	prowTestsDockerImage = path.Join(*dockerImagesBase, *prowTestsDockerImageName)
-	metricsDockerImage = path.Join(*dockerImagesBase, *metricsDockerImageName)
 	backupsDockerImage = path.Join(*dockerImagesBase, *backupsDockerImageName)
 
 	// We use MapSlice instead of maps to keep key order and create predictable output.
@@ -1205,6 +1206,9 @@ func main() {
 		for _, repo := range repositories {
 			if repo.EnableGoCoverage {
 				generateGoCoveragePostsubmit("postsubmits", repo.Name, nil)
+				if repo.Name == "knative/test-infra" && *generateMaintenanceJobs {
+					generateConfigUpdaterToolPostsubmitJob()
+				}
 			}
 			if repo.EnablePerformanceTests {
 				generatePerfClusterPostsubmitJob(repo)

--- a/tools/config-generator/main.go
+++ b/tools/config-generator/main.go
@@ -117,6 +117,7 @@ type baseProwJobTemplateData struct {
 	Labels              []string
 	PathAlias           string
 	RunIfChanged        string
+	Cluster             string
 	Optional            string
 	NeedsMonitor        bool
 }

--- a/tools/config-generator/postsubmit_config.go
+++ b/tools/config-generator/postsubmit_config.go
@@ -31,6 +31,9 @@ const (
 	// perfPostsubmitJob is the template for the performance operations
 	// postsubmit job.
 	perfPostsubmitJob = "prow_postsubmit_perf_job.yaml"
+
+	// Template for postsubmit custom jobs.
+	postsubmitCustomJob = "prow_postsubmit_custom_job.yaml"
 )
 
 // postsubmitJobTemplateData contains data about a postsubmit Prow job.
@@ -68,4 +71,27 @@ func generateGoCoveragePostsubmit(title, repoName string, _ yaml.MapSlice) {
 		data.Base.Image = strings.Replace(data.Base.Image, "coverage:latest", "coverage-dev:latest", -1)
 		executeJobTemplate("postsubmit go coverage", readTemplate(goCoveragePostsubmitJob), title, repoName, data.PostsubmitJobName, false, data)
 	}
+}
+
+func generateConfigUpdaterToolPostsubmitJob() {
+	var data postsubmitJobTemplateData
+	data.Base = newbaseProwJobTemplateData("knative/test-infra")
+	data.Base.Image = prowconfigupdaterDockerImage
+	data.PostsubmitJobName = "post-knative-prow-config-updater"
+	data.Base.RunIfChanged = "run_if_changed: \"^(config/(prow|prow-staging)/(cluster|core|jobs|testgrid)/.*.yaml)|(tools/config-generator/templates/(prow|prow-staging)/.*.yaml)$\""
+	data.Base.Command = "/prow-config-updater"
+	data.Base.Args = []string{
+		"--github-token-file=/etc/prow-robot-github-token/token",
+		"--github-userid=knative-prow-robot",
+		"--git-username='Knative Prow Robot'",
+		"--git-email=knative-prow-robot@google.com",
+		"--comment-github-token-file=/etc/prow-updater-robot-github-token/token",
+	}
+	addExtraEnvVarsToJob(extraEnvVars, &data.Base)
+	configureServiceAccountForJob(&data.Base)
+	addVolumeToJob(&data.Base, "/etc/prow-robot-github-token", "prow-robot-github-token", true, "")
+	addVolumeToJob(&data.Base, "/etc/prow-updater-robot-github-token", "prow-updater-robot-github-token", true, "")
+	addVolumeToJob(&data.Base, "/root/.ssh", "prow-robot-ssh-key", true, "0400")
+	addEnvToJob(&data.Base, "GOOGLE_APPLICATION_CREDENTIALS", "/etc/test-account/service-account.json")
+	executeJobTemplate("postsubmit Prow config updater", readTemplate(postsubmitCustomJob), "postsubmits", "", data.PostsubmitJobName, false, data)
 }

--- a/tools/config-generator/postsubmit_config.go
+++ b/tools/config-generator/postsubmit_config.go
@@ -79,6 +79,8 @@ func generateConfigUpdaterToolPostsubmitJob() {
 	data.Base.Image = prowconfigupdaterDockerImage
 	data.PostsubmitJobName = "post-knative-prow-config-updater"
 	data.Base.RunIfChanged = "run_if_changed: \"^(config/(prow|prow-staging)/(cluster|core|jobs|testgrid)/.*.yaml)|(tools/config-generator/templates/(prow|prow-staging)/.*.yaml)$\""
+	// Run the job on the prow-trusted build cluster.
+	data.Base.Cluster = "cluster: \"prow-trusted\""
 	data.Base.Command = "/prow-config-updater"
 	data.Base.Args = []string{
 		"--github-token-file=/etc/prow-robot-github-token/token",

--- a/tools/config-generator/templates/prow_postsubmit_custom_job.yaml
+++ b/tools/config-generator/templates/prow_postsubmit_custom_job.yaml
@@ -1,0 +1,19 @@
+  - name: [[.PostsubmitJobName]]
+    [[indent_section 6 "labels" .Base.Labels]]
+    agent: kubernetes
+    decorate: true
+    max_concurrency: 1
+    [[indent_array_section 4 "branches" .Base.Branches]]
+    [[indent_array_section 4 "skip_branches" .Base.SkipBranches]]
+    [[.Base.PathAlias]]
+    [[.Base.RunIfChanged]]
+    spec:
+      containers:
+      - image: [[.Base.Image]]
+        imagePullPolicy: Always
+        command:
+        - "[[.Base.Command]]"
+        [[indent_array_section 8 "args" .Base.Args]]
+        [[indent_section 8 "volumeMounts" .Base.VolumeMounts]]
+        [[indent_section 8 "env" .Base.Env]]
+      [[indent_section 6 "volumes" .Base.Volumes]]

--- a/tools/config-generator/templates/prow_postsubmit_custom_job.yaml
+++ b/tools/config-generator/templates/prow_postsubmit_custom_job.yaml
@@ -7,6 +7,7 @@
     [[indent_array_section 4 "skip_branches" .Base.SkipBranches]]
     [[.Base.PathAlias]]
     [[.Base.RunIfChanged]]
+    [[.Base.Cluster]]
     spec:
       containers:
       - image: [[.Base.Image]]


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Add postsubmit job for Prow config updater

Note:
It's becoming quite annoying to use config generator to add a new maintenance job. I strongly feel this kind of jobs should be added manually as it's normally a one-time config and is tied to a specific tool (regardless whether we want to keep maintaining the current config generator, or seek alternative solution)

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @chaodaiG 
