### PR TITLE
Bug fixes for prow-config-updater

### DIFF
--- a/config/prow/jobs/config.yaml
+++ b/config/prow/jobs/config.yaml
@@ -10292,7 +10292,7 @@ postsubmits:
         - "--github-token-file=/etc/prow-robot-github-token/token"
         - "--github-userid=knative-prow-robot"
         - "--git-username='Knative Prow Robot'"
-        - "--git-email=knative-prow-robot@google.com"
+        - "--git-email=adrcunha+knative-prow-robot@google.com"
         - "--comment-github-token-file=/etc/prow-updater-robot-github-token/token"
         volumeMounts:
         - name: test-account

--- a/tools/cleanup/cleanup_test.go
+++ b/tools/cleanup/cleanup_test.go
@@ -251,7 +251,7 @@ func TestNewImageDeleter(t *testing.T) {
 		},
 		{ // Bad service account file.
 			"/boot/foo/bar/nonono",
-			errors.New("No such file or directory"),
+			errors.New("cannot activate service account"),
 		},
 		// TODO: Test with a valid service account file.
 	}

--- a/tools/config-generator/postsubmit_config.go
+++ b/tools/config-generator/postsubmit_config.go
@@ -86,7 +86,7 @@ func generateConfigUpdaterToolPostsubmitJob() {
 		"--github-token-file=/etc/prow-robot-github-token/token",
 		"--github-userid=knative-prow-robot",
 		"--git-username='Knative Prow Robot'",
-		"--git-email=knative-prow-robot@google.com",
+		"--git-email=adrcunha+knative-prow-robot@google.com",
 		"--comment-github-token-file=/etc/prow-updater-robot-github-token/token",
 	}
 	addExtraEnvVarsToJob(extraEnvVars, &data.Base)

--- a/tools/prow-config-updater/config/config.go
+++ b/tools/prow-config-updater/config/config.go
@@ -110,6 +110,8 @@ func UpdateProw(env ProwEnv, dryrun bool) error {
 	return helpers.Run(
 		fmt.Sprintf("Updating Prow configs with command %q", updateCommand),
 		func() error {
+			// Use the default GOOGLE_APPLICATION_CREDENTIALS to authenticate with the gcloud services,
+			// it will fallback to use the local credentials if the env var does not exist.
 			kf := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")
 			if kf != "" {
 				authCommand := "gcloud auth activate-service-account --key-file=" + kf

--- a/tools/prow-config-updater/config/config.go
+++ b/tools/prow-config-updater/config/config.go
@@ -110,7 +110,14 @@ func UpdateProw(env ProwEnv, dryrun bool) error {
 	return helpers.Run(
 		fmt.Sprintf("Updating Prow configs with command %q", updateCommand),
 		func() error {
-			out, err := cmd.RunCommand(updateCommand)
+			kf := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")
+			if kf != "" {
+				authCommand := "gcloud auth activate-service-account --key-file=" + kf
+				if _, err := cmd.RunCommand(authCommand); err != nil {
+					return fmt.Errorf("error activating service account with %q", kf)
+				}
+			}
+			out, err := cmd.RunCommand(updateCommand, cmd.WithEnvs(os.Environ()))
 			log.Println(out)
 			return err
 		},

--- a/tools/prow-config-updater/github_commenter.go
+++ b/tools/prow-config-updater/github_commenter.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	successUpdatedConfigsCommentTemplate = "Updated %s configs with below files being modified: \n%s"
-	failureUpdatedConfigsCommentTemplate = "Failed updating %s configs with below files being modified: \n%s\nSee error details below: %v"
+	failureUpdatedConfigsCommentTemplate = "Failed updating %s configs with below files being modified:\n%s\nSee error details below:\n%v"
 	successStagingCommentTemplate        = "The staging process is completed and succeeded.\nWill create an auto-merge PR to roll out the changes to production."
 	failureStagingCommentTemplate        = "The staging process failed with the error below:\n%v\n\nPlease check if there is anything going wrong."
 	successRolloutCommentTemplate        = "Created #%d to roll out the staging changes to production."
@@ -96,7 +96,7 @@ func (ghc *GitHubCommenter) commentOnRolloutFailure(prnumber int, err error) err
 
 func (ghc *GitHubCommenter) commentOnMainPullRequest(prnumber int, topic, comment string) error {
 	return helpers.Run(
-		fmt.Sprintf("Creating %q comment on PR %q in %s/%s with content:\n%s",
+		fmt.Sprintf("Creating %q comment on PR '%d' in %s/%s with content:\n%s",
 			topic, prnumber, config.OrgName, config.RepoName, comment),
 		func() error {
 			_, err := ghc.client.CreateComment(config.OrgName, config.RepoName, prnumber, comment)

--- a/tools/prow-config-updater/pullrequest.go
+++ b/tools/prow-config-updater/pullrequest.go
@@ -123,7 +123,7 @@ func (gc *GitHubMainHandler) waitForForkPullRequestMerged(forkOrgName string, pn
 	interval := 10 * time.Second
 	timeout := 20 * time.Minute
 	return helpers.Run(
-		fmt.Sprintf("Wait until the fork pull request %d to merged", pn),
+		fmt.Sprintf("Wait until the fork pull request '%d' to merged", pn),
 		func() error {
 			return wait.PollImmediate(interval, timeout, func() (bool, error) {
 				pr, err := gc.client.GetPullRequest(forkOrgName, config.RepoName, pn)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:

1. In the `make` command to update Prow configs, we use `gcloud`. But `gcloud` does not use `GOOGLE_APPLICATION_CREDENTIALS` env var, see the answer [here](https://serverfault.com/questions/848580/how-to-use-google-application-credentials-with-gcloud-on-a-server). So if `GOOGLE_APPLICATION_CREDENTIALS` is provided, run `gcloud auth activate-service-account` to use this key file before running the `make` command.

2. The wildcard `*` needs to be expanded by shell, so the `cp` command has to be run in a shell process. See the answer [here](https://stackoverflow.com/questions/41685393/exec-command-with-cp-exits-with-status-1)

3. A couple of nit fixes and improvements based on the tests result.

4. The `knative-prow-robot` is using a different email address `adrcunha+knative-prow-robot@google.com`, so change the Prow job.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @chaodaiG 

