### PR TITLE
Avoid running go get from the repo root dir

### DIFF
--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -482,7 +482,13 @@ function run_go_tool() {
   if [[ -z "$(which ${tool})" ]]; then
     local action=get
     [[ $1 =~ ^[\./].* ]] && action=install
-    go ${action} $1
+    # Avoid running `go get` from root dir of the repository, as it can change go.sum and go.mod files.
+    # See discussions in https://github.com/golang/go/issues/27643.
+    if [[ ${action} == "get" && $(pwd) == "${REPO_ROOT_DIR}" ]]; then
+      cd .. && go ${action} $1 && cd - || return 1
+    else
+      go ${action} $1
+    fi
   fi
   shift 2
   ${tool} "$@"

--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -485,7 +485,12 @@ function run_go_tool() {
     # Avoid running `go get` from root dir of the repository, as it can change go.sum and go.mod files.
     # See discussions in https://github.com/golang/go/issues/27643.
     if [[ ${action} == "get" && $(pwd) == "${REPO_ROOT_DIR}" ]]; then
-      cd .. && go ${action} $1 && cd - || return 1
+      local temp_dir="$(mktemp -d)"
+      local install_failed=0
+      pushd "${temp_dir}"
+      go ${action} $1 || install_failed=1
+      popd
+      (( install_failed )) && return ${install_failed}
     else
       go ${action} $1
     fi


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Fixes https://github.com/knative/client/issues/758

The reason for this issue is we are using `go get` to install a tool called `hub` in the release process. As since the command is run under the root dir, and `client` is using Go module, this behavior will modify `go.sum` and `go.mod` files. This is a long discussion in https://github.com/golang/go/issues/27643 but no recommended solution. One workaround is avoid running `go get` from the repo root dir, as what this PR does.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @chaodaiG 
/cc @navidshaikh

FYI @rhuss 

