### PR TITLE
Set up https://github.com/knative-sandbox/operator

### DIFF
--- a/config/prow/config_knative.yaml
+++ b/config/prow/config_knative.yaml
@@ -404,13 +404,9 @@ presubmits:
 
   knative-sandbox/operator:
     - build-tests: true
-      dot-dev: true
     - unit-tests: true
-      dot-dev: true
     - integration-tests: true
-      dot-dev: true
     - go-coverage: true
-      dot-dev: true
 
 periodics:
   knative/serving:
@@ -978,14 +974,14 @@ periodics:
 
   knative-sandbox/operator:
     - continuous: true
-      dot-dev: true
       go113: true
     - nightly: true
-      dot-dev: true
       go113: true
     - dot-release: true
-      dot-dev: true
       go113: true
+      env-vars:
+      - ORG_NAME=knative-sandbox
     - auto-release: true
-      dot-dev: true
       go113: true
+      env-vars:
+      - ORG_NAME=knative-sandbox

--- a/config/prow/config_knative.yaml
+++ b/config/prow/config_knative.yaml
@@ -402,6 +402,16 @@ presubmits:
     - integration-tests: false
     - go-coverage: false
 
+  knative-sandbox/operator:
+    - build-tests: true
+      dot-dev: true
+    - unit-tests: true
+      dot-dev: true
+    - integration-tests: true
+      dot-dev: true
+    - go-coverage: true
+      dot-dev: true
+
 periodics:
   knative/serving:
     - continuous: true
@@ -953,6 +963,20 @@ periodics:
       go113: true
 
   knative/net-kourier:
+    - continuous: true
+      dot-dev: true
+      go113: true
+    - nightly: true
+      dot-dev: true
+      go113: true
+    - dot-release: true
+      dot-dev: true
+      go113: true
+    - auto-release: true
+      dot-dev: true
+      go113: true
+
+  knative-sandbox/operator:
     - continuous: true
       dot-dev: true
       go113: true

--- a/config/prow/core/config.yaml
+++ b/config/prow/core/config.yaml
@@ -109,6 +109,7 @@ tide:
   queries:
   - repos:
     - "google/knative-gcp"
+    - "knative-sandbox/operator"
     - "knative/caching"
     - "knative/client"
     - "knative/client-contrib"
@@ -129,7 +130,6 @@ tide:
     - "knative/serving-operator"
     - "knative/test-infra"
     - "knative/website"
-    - "knative-sandbox/operator"
     labels:
     - lgtm
     - approved

--- a/config/prow/core/config.yaml
+++ b/config/prow/core/config.yaml
@@ -129,6 +129,7 @@ tide:
     - "knative/serving-operator"
     - "knative/test-infra"
     - "knative/website"
+    - "knative-sandbox/operator"
     labels:
     - lgtm
     - approved

--- a/config/prow/core/plugins.yaml
+++ b/config/prow/core/plugins.yaml
@@ -35,6 +35,7 @@ approve:
   - "knative/serving-operator"
   - "knative/test-infra"
   - "knative/website"
+  - "knative-sandbox/operator"
   require_self_approval: false
   ignore_review_state: false
 # Settings for the "heart" plugin.
@@ -615,6 +616,31 @@ plugins:
   - welcome
   - wip
   - yuks
+  knative-sandbox/operator:
+  - approve
+  - assign
+  - blunderbuss
+  - buildifier
+  - cat
+  - dog
+  - golint
+  - heart
+  - help
+  - hold
+  - label
+  - lgtm
+  - lifecycle
+  - milestone
+  - owners-label
+  - project
+  - shrug
+  - size
+  - skip
+  - trigger
+  - verify-owners
+  - welcome
+  - wip
+  - yuks
 external_plugins:
   google/knative-gcp:
   - name: needs-rebase
@@ -721,3 +747,8 @@ external_plugins:
     events:
       - issue_comment
       - pull_request
+  knative-sandbox/operator
+  - name: needs-rebase
+    events:
+    - issue_comment
+    - pull_request

--- a/config/prow/core/plugins.yaml
+++ b/config/prow/core/plugins.yaml
@@ -747,7 +747,7 @@ external_plugins:
     events:
       - issue_comment
       - pull_request
-  knative-sandbox/operator
+  knative-sandbox/operator:
   - name: needs-rebase
     events:
     - issue_comment

--- a/config/prow/core/plugins.yaml
+++ b/config/prow/core/plugins.yaml
@@ -15,6 +15,7 @@
 approve:
 - repos:
   - "google/knative-gcp"
+  - "knative-sandbox/operator"
   - "knative/caching"
   - "knative/client"
   - "knative/client-contrib"
@@ -35,7 +36,6 @@ approve:
   - "knative/serving-operator"
   - "knative/test-infra"
   - "knative/website"
-  - "knative-sandbox/operator"
   require_self_approval: false
   ignore_review_state: false
 # Settings for the "heart" plugin.
@@ -116,6 +116,31 @@ plugins:
   - welcome
   - wip
   - yuks
+  knative-sandbox/operator:
+  - approve
+  - assign
+  - blunderbuss
+  - buildifier
+  - cat
+  - dog
+  - golint
+  - heart
+  - help
+  - hold
+  - label
+  - lgtm
+  - lifecycle
+  - milestone
+  - owners-label
+  - project
+  - shrug
+  - size
+  - skip
+  - trigger
+  - verify-owners
+  - welcome
+  - wip
+  - yuks
   knative/caching:
   - approve
   - assign
@@ -592,31 +617,6 @@ plugins:
   - wip
   - yuks
   knative/website:
-  - approve
-  - assign
-  - blunderbuss
-  - buildifier
-  - cat
-  - dog
-  - golint
-  - heart
-  - help
-  - hold
-  - label
-  - lgtm
-  - lifecycle
-  - milestone
-  - owners-label
-  - project
-  - shrug
-  - size
-  - skip
-  - trigger
-  - verify-owners
-  - welcome
-  - wip
-  - yuks
-  knative-sandbox/operator:
   - approve
   - assign
   - blunderbuss
@@ -647,6 +647,11 @@ external_plugins:
     events:
       - issue_comment
       - pull_request
+  knative-sandbox/operator:
+  - name: needs-rebase
+    events:
+      - issue_comment
+      - pull_request
   knative/caching:
   - name: needs-rebase
     events:
@@ -747,8 +752,3 @@ external_plugins:
     events:
       - issue_comment
       - pull_request
-  knative-sandbox/operator:
-  - name: needs-rebase
-    events:
-    - issue_comment
-    - pull_request

--- a/config/prow/jobs/config.yaml
+++ b/config/prow/jobs/config.yaml
@@ -4679,6 +4679,7 @@ presubmits:
     rerun_command: "/test pull-knative-sandbox-operator-build-tests"
     trigger: "(?m)^/test (all|pull-knative-sandbox-operator-build-tests),?(\\s+|$)"
     decorate: true
+    path_alias: knative.dev/operator
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -4688,7 +4689,7 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--build-tests"
-        valumeMounts:
+        volumeMounts:
         - name: repoview-token
           mountPath: /etc/repoview-token
           readOnly: true
@@ -4712,8 +4713,9 @@ presubmits:
     context: pull-knative-sandbox-operator-unit-tests
     always_run: true
     rerun_command: "/test pull-knative-sandbox-operator-unit-tests"
-    trigger: "(?m)/test (all|pull-knative-sandbox-operator-unit-tests),?(\\s+|$)"
+    trigger: "(?m)^/test (all|pull-knative-sandbox-operator-unit-tests),?(\\s+|$)"
     decorate: true
+    path_alias: knative.dev/operator
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -4742,6 +4744,42 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
+  - name: pull-knative-sandbox-operator-integration-tests
+    agent: kubernetes
+    context: pull-knative-sandbox-operator-integration-tests
+    always_run: true
+    rerun_command: "/test pull-knative-sandbox-operator-integration-tests"
+    trigger: "(?m)^/test (all|pull-knative-sandbox-operator-integration-tests),?(\\s+|$)"
+    decorate: true
+    path_alias: knative.dev/operator
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--integration-tests"
+        volumeMounts:
+        - name: repoview-token
+          mountPath: /etc/repoview-token
+          readOnly: true
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: repoview-token
+        secret:
+          secretName: repoview-token
+      - name: test-account
+        secret:
+          secretName: test-account
   - name: pull-knative-sandbox-operator-go-coverage
     agent: kubernetes
     context: pull-knative-sandbox-operator-go-coverage
@@ -4750,6 +4788,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-sandbox-operator-go-coverage),?(\\s+|$)"
     optional: true
     decorate: true
+    path_alias: knative.dev/operator
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/coverage:latest
@@ -4769,7 +4808,6 @@ presubmits:
       - name: covbot-token
         secret:
           secretName: covbot-token
-
 periodics:
 - cron: "10 */2 * * *"
   name: ci-knative-serving-continuous
@@ -9473,6 +9511,187 @@ periodics:
       args:
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
+- cron: "14 * * * *"
+  name: ci-knative-sandbox-operator-continuous
+  agent: kubernetes
+  labels:
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-knative-sandbox-operator-continuous
+  decorate: true
+  extra_refs:
+  - org: knative-sandbox
+    repo: operator
+    base_ref: master
+    path_alias: knative.dev/operator
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./test/presubmit-tests.sh"
+      - "--all-tests"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "50 9 * * *"
+  name: ci-knative-sandbox-operator-nightly-release
+  agent: kubernetes
+  labels:
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-knative-sandbox-operator-nightly-release
+  decorate: true
+  extra_refs:
+  - org: knative-sandbox
+    repo: operator
+    base_ref: master
+    path_alias: knative.dev/operator
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--publish"
+      - "--tag-release"
+      volumeMounts:
+      - name: nightly-account
+        mountPath: /etc/nightly-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/nightly-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: nightly-account
+      secret:
+        secretName: nightly-account
+- cron: "30 9 * * 2"
+  name: ci-knative-sandbox-operator-dot-release
+  agent: kubernetes
+  labels:
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-knative-sandbox-operator-dot-release
+  decorate: true
+  extra_refs:
+  - org: knative-sandbox
+    repo: operator
+    base_ref: master
+    path_alias: knative.dev/operator
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--dot-release"
+      - "--release-gcs knative-releases/operator"
+      - "--release-gcr gcr.io/knative-releases"
+      - "--github-token /etc/hub-token/token"
+      volumeMounts:
+      - name: hub-token
+        mountPath: /etc/hub-token
+        readOnly: true
+      - name: release-account
+        mountPath: /etc/release-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: hub-token
+      secret:
+        secretName: hub-token
+    - name: release-account
+      secret:
+        secretName: release-account
+- cron: "38 */2 * * *"
+  name: ci-knative-sandbox-operator-auto-release
+  agent: kubernetes
+  labels:
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-knative-sandbox-operator-auto-release
+  decorate: true
+  extra_refs:
+  - org: knative-sandbox
+    repo: operator
+    base_ref: master
+    path_alias: knative.dev/operator
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--auto-release"
+      - "--release-gcs knative-releases/operator"
+      - "--release-gcr gcr.io/knative-releases"
+      - "--github-token /etc/hub-token/token"
+      volumeMounts:
+      - name: hub-token
+        mountPath: /etc/hub-token
+        readOnly: true
+      - name: release-account
+        mountPath: /etc/release-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: hub-token
+      secret:
+        secretName: hub-token
+    - name: release-account
+      secret:
+        secretName: release-account
+- cron: "0 1 * * *"
+  name: ci-knative-sandbox-operator-go-coverage
+  labels:
+      prow.k8s.io/pubsub.project: knative-tests
+      prow.k8s.io/pubsub.topic: knative-monitoring
+      prow.k8s.io/pubsub.runID: ci-knative-sandbox-operator-go-coverage
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: knative-sandbox
+    repo: operator
+    base_ref: master
+    path_alias: knative.dev/operator
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/coverage:latest
+      imagePullPolicy: Always
+      command:
+      - "/coverage"
+      args:
+      - "--artifacts=$(ARTIFACTS)"
+      - "--cov-threshold-percentage=50"
 - cron: "0 19 * * 1,3,5"
   name: ci-knative-cleanup
   labels:
@@ -10190,182 +10409,6 @@ periodics:
     - name: performance-test
       secret:
         secretName: performance-test
-- cron: "33 * * * *"
-  name: ci-knative-sandbox-operator-continuous
-  agent: kubernetes
-  labels:
-    prow.k8s.io/pubsub.project: knative-tests
-    prow.k8s.io/pubsub.topic: knative-monitoring
-    prow.k8s.io/pubsub.runID: ci-knative-sandbox-operator-continous
-  decorate: true
-  extra_refs:
-  - org: knative-sandbox
-    repo: operator
-    base_ref: master
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./test/presubmit-tests.sh"
-      - "--all-tests"
-      volumeMounts:
-      - name: test-account
-        mountPath: /etc/test-account
-        readOnly: true
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/test-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-    volumes:
-    - name: test-account
-      secret:
-        secretName: test-account
-- cron: "11 1 * * *"
-  name: ci-knative-sandbox-operator-nightly-release
-  agent: kubernetes
-  labels:
-    prow.k8s.io/pubsub.project: knative-tests
-    prow.k8s.io/pubsub.topic: knative-monitoring
-    prow.k8s.io/pubsub.runID: ci-knative-sandbox-operator-nightly-release
-  decorate: true
-  extra_refs:
-  - org: knative-sandbox
-    repo: operator
-    base_ref: master
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./hack/release.sh"
-      - "--publish"
-      - "--tag-release"
-      volumeMounts:
-      - name: nightly-account
-        mountPath: /etc/nightly-account
-        readOnly: true
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/nightly-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-    volumes:
-    - name: nightly-account
-      secret:
-        secretName: nightly-account
-- cron: "52 1 * * *"
-  name: ci-knative-sandbox-operator-dot-release
-  agent: kubernetes
-  labels:
-    prow.k8s.io/pubsub.project: knative-tests
-    prow.k8s.io/pubsub.topic: knative-monitoring
-    prow.k8s.io/pubsub.runID: ci-knative-sandbox-operator-dot-release
-  decorate: true
-  extra_refs:
-  - org: knative-sandbox
-    repo: operator
-    base_ref: master
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./hack/release.sh"
-      - "--dot-release"
-      - "--release-gcs knative-releases/sandbox-operator"
-      - "--release-gcr gcr.io/knative-releases"
-      - "--github-token /etc/hub-token/token"
-      volumeMounts:
-      - name: hub-token
-        mountPath: /etc/hub-token
-        readOnly: true
-      - name: release-account
-        mountPath: /etc/release-account
-        readOnly: true
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/release-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-    volumes:
-    - name: hub-token
-      secret:
-        secretName: hub-token
-    - name: release-account
-      secret:
-        secretName: release-account
-- cron: "48 */2 * * *"
-  name: ci-knative-sandbox-operator-auto-release
-  agent: kubernetes
-  labels:
-    prow.k8s.io/pubsub.project: knative-tests
-    prow.k8s.io/pubsub.topic: knative-monitoring
-    prow.k8s.io/pubsub.runID: ci-knative-sandbox-operator-auto-release
-  decorate: true
-  extra_refs:
-  - org: knative-sandbox
-    repo: operator
-    base_ref: master
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./hack/release.sh"
-      - "--auto-release"
-      - "--release-gcs knative-releases/sandbox-operator"
-      - "--release-gcr gcr.io/knative-releases"
-      - "--github-token /etc/hub-token/token"
-      volumeMounts:
-      - name: hub-token
-        mountPath: /etc/hub-token
-        readOnly: true
-      - name: release-account
-        mountPath: /etc/release-account
-        readOnly: true
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/release-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-    volumes:
-    - name: hub-token
-      secret:
-        secretName: hub-token
-    - name: release-account
-      secret:
-        secretName: release-account
-- cron: "22 4 * * *"
-  name: ci-knative-sandbox-operator-go-coverage
-  agent: kubernetes
-  labels:
-    prow.k8s.io/pubsub.project: knative-tests
-    prow.k8s.io/pubsub.topic: knative-monitoring
-    prow.k8s.io/pubsub.runID: ci-knative-sandbox-operator-go-coverage
-  decorate: true
-  extra_refs:
-  - org: knative-sandbox
-    repo: operator
-    base_ref: master
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/coverage:latest
-      imagePullPolicy: Always
-      command:
-      - "/coverage"
-      args:
-      - "--artifacts=$(ARTIFACTS)"
-      - "--cov-threshold-percentage=50"
 postsubmits:
   knative/serving:
   - name: post-knative-serving-reconcile-clusters
@@ -10800,6 +10843,7 @@ postsubmits:
     - master
     agent: kubernetes
     decorate: true
+    path_alias: knative.dev/operator
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/coverage:latest

--- a/config/prow/jobs/config.yaml
+++ b/config/prow/jobs/config.yaml
@@ -4671,6 +4671,105 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
+  knative-sandbox/operator:
+  - name: pull-knative-sandbox-operator-build-tests
+    agent: kubernetes
+    context: pull-knative-sandbox-operator-build-tests
+    always_run: true
+    rerun_command: "/test pull-knative-sandbox-operator-build-tests"
+    trigger: "(?m)^/test (all|pull-knative-sandbox-operator-build-tests),?(\\s+|$)"
+    decorate: true
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--build-tests"
+        valumeMounts:
+        - name: repoview-token
+          mountPath: /etc/repoview-token
+          readOnly: true
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: repoview-token
+        secret:
+          secretName: repoview-token
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-sandbox-operator-unit-tests
+    agent: kubernetes
+    context: pull-knative-sandbox-operator-unit-tests
+    always_run: true
+    rerun_command: "/test pull-knative-sandbox-operator-unit-tests"
+    trigger: "(?m)/test (all|pull-knative-sandbox-operator-unit-tests),?(\\s+|$)"
+    decorate: true
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--unit-tests"
+        volumeMounts:
+        - name: repoview-token
+          mountPath: /etc/repoview-token
+          readOnly: true
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: repoview-token
+        secret:
+          secretName: repoview-token
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-sandbox-operator-go-coverage
+    agent: kubernetes
+    context: pull-knative-sandbox-operator-go-coverage
+    always_run: true
+    rerun_command: "/test pull-knative-sandbox-operator-go-coverage"
+    trigger: "(?m)^/test (all|pull-knative-sandbox-operator-go-coverage),?(\\s+|$)"
+    optional: true
+    decorate: true
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/coverage:latest
+        imagePullPolicy: Always
+        command:
+        - "/coverage"
+        args:
+        - "--postsubmit-job-name=post-knative-sandbox-operator-go-coverage"
+        - "--artifacts=$(ARTIFACTS)"
+        - "--cov-threshold-percentage=50"
+        - "--github-token=/etc/covbot-token/token"
+        volumeMounts:
+        - name: covbot-token
+          mountPath: /etc/covbot-token
+          readOnly: true
+      volumes:
+      - name: covbot-token
+        secret:
+          secretName: covbot-token
+    
 periodics:
 - cron: "10 */2 * * *"
   name: ci-knative-serving-continuous
@@ -10091,6 +10190,182 @@ periodics:
     - name: performance-test
       secret:
         secretName: performance-test
+- cron: "33 * * * *"
+  name: ci-knative-sandbox-operator-continuous
+  agent: kubernetes
+  labels:
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-knative-sandbox-operator-continous
+  decorate: true
+  extra_refs:
+  - org: knative-sandbox
+    repo: operator
+    base_ref: master
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./test/presubmit-tests.sh"
+      - "--all-tests"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "11 1 * * *"
+  name: ci-knative-sandbox-operator-nightly-release
+  agent: kubernetes
+  labels:
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-knative-sandbox-operator-nightly-release
+  decorate: true
+  extra_refs:
+  - org: knative-sandbox
+    repo: operator
+    base_ref: master
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--publish"
+      - "--tag-release"
+      volumeMounts:
+      - name: nightly-account
+        mountPath: /etc/nightly-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/nightly-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: nightly-account
+      secret:
+        secretName: nightly-account
+- cron: "52 1 * * *"
+  name: ci-knative-sandbox-operator-dot-release
+  agent: kubernetes
+  labels:
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-knative-sandbox-operator-dot-release
+  decorate: true
+  extra_refs:
+  - org: knative-sandbox
+    repo: operator
+    base_ref: master
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--dot-release"
+      - "--release-gcs knative-releases/sandbox-operator"
+      - "--release-gcr gcr.io/knative-releases"
+      - "--github-token /etc/hub-token/token"
+      volumeMounts:
+      - name: hub-token
+        mountPath: /etc/hub-token
+        readOnly: true
+      - name: release-account
+        mountPath: /etc/release-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: hub-token
+      secret:
+        secretName: hub-token
+    - name: release-account
+      secret:
+        secretName: release-account
+- cron: "48 */2 * * *"
+  name: ci-knative-sandbox-operator-auto-release
+  agent: kubernetes
+  labels:
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-knative-sandbox-operator-auto-release
+  decorate: true
+  extra_refs:
+  - org: knative-sandbox
+    repo: operator
+    base_ref: master
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--auto-release"
+      - "--release-gcs knative-releases/sandbox-operator"
+      - "--release-gcr gcr.io/knative-releases"
+      - "--github-token /etc/hub-token/token"
+      volumeMounts:
+      - name: hub-token
+        mountPath: /etc/hub-token
+        readOnly: true
+      - name: release-account
+        mountPath: /etc/release-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: hub-token
+      secret:
+        secretName: hub-token
+    - name: release-account
+      secret:
+        secretName: release-account
+- cron: "22 4 * * *"
+  name: ci-knative-sandbox-operator-go-coverage
+  agent: kubernetes
+  labels:
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-knative-sandbox-operator-go-coverage
+  decorate: true
+  extra_refs:
+  - org: knative-sandbox
+    repo: operator
+    base_ref: master
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/coverage:latest
+      imagePullPolicy: Always
+      command:
+      - "/coverage"
+      args:
+      - "--artifacts=$(ARTIFACTS)"
+      - "--cov-threshold-percentage=50"
 postsubmits:
   knative/serving:
   - name: post-knative-serving-reconcile-clusters
@@ -10510,6 +10785,21 @@ postsubmits:
     agent: kubernetes
     decorate: true
     path_alias: knative.dev/eventing-operator
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/coverage:latest
+        imagePullPolicy: Always
+        command:
+        - "/coverage"
+        args:
+        - "--artifacts=$(ARTIFACTS)"
+        - "--cov-threshold-percentage=0"
+  knative-sandbox/operator:
+  - name: post-knative-sandbox-operator-go-coverage
+    branches:
+    - master
+    agent: kubernetes
+    decorate: true
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/coverage:latest

--- a/config/prow/jobs/config.yaml
+++ b/config/prow/jobs/config.yaml
@@ -4679,7 +4679,6 @@ presubmits:
     rerun_command: "/test pull-knative-sandbox-operator-build-tests"
     trigger: "(?m)^/test (all|pull-knative-sandbox-operator-build-tests),?(\\s+|$)"
     decorate: true
-    path_alias: knative.dev/operator
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -4715,7 +4714,6 @@ presubmits:
     rerun_command: "/test pull-knative-sandbox-operator-unit-tests"
     trigger: "(?m)^/test (all|pull-knative-sandbox-operator-unit-tests),?(\\s+|$)"
     decorate: true
-    path_alias: knative.dev/operator
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -4751,7 +4749,6 @@ presubmits:
     rerun_command: "/test pull-knative-sandbox-operator-integration-tests"
     trigger: "(?m)^/test (all|pull-knative-sandbox-operator-integration-tests),?(\\s+|$)"
     decorate: true
-    path_alias: knative.dev/operator
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -4788,7 +4785,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-sandbox-operator-go-coverage),?(\\s+|$)"
     optional: true
     decorate: true
-    path_alias: knative.dev/operator
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/coverage:latest
@@ -9523,7 +9519,6 @@ periodics:
   - org: knative-sandbox
     repo: operator
     base_ref: master
-    path_alias: knative.dev/operator
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -9558,7 +9553,6 @@ periodics:
   - org: knative-sandbox
     repo: operator
     base_ref: master
-    path_alias: knative.dev/operator
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -9594,7 +9588,6 @@ periodics:
   - org: knative-sandbox
     repo: operator
     base_ref: master
-    path_alias: knative.dev/operator
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -9615,6 +9608,8 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
+      - name: ORG_NAME
+        value: knative-sandbox
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -9638,7 +9633,6 @@ periodics:
   - org: knative-sandbox
     repo: operator
     base_ref: master
-    path_alias: knative.dev/operator
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -9659,6 +9653,8 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
+      - name: ORG_NAME
+        value: knative-sandbox
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -9682,7 +9678,6 @@ periodics:
   - org: knative-sandbox
     repo: operator
     base_ref: master
-    path_alias: knative.dev/operator
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/coverage:latest
@@ -10843,7 +10838,6 @@ postsubmits:
     - master
     agent: kubernetes
     decorate: true
-    path_alias: knative.dev/operator
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/coverage:latest

--- a/config/prow/jobs/config.yaml
+++ b/config/prow/jobs/config.yaml
@@ -4769,7 +4769,7 @@ presubmits:
       - name: covbot-token
         secret:
           secretName: covbot-token
-    
+
 periodics:
 - cron: "10 */2 * * *"
   name: ci-knative-serving-continuous

--- a/config/prow/testgrid/testgrid.yaml
+++ b/config/prow/testgrid/testgrid.yaml
@@ -583,6 +583,28 @@ test_groups:
   alert_options:
     alert_mail_to_addresses: "prime-engprod-sea@google.com"
   num_failures_to_alert: 3
+- name: ci-knative-sandbox-operator-continuous
+  gcs_prefix: knative-prow/logs/ci-knative-sandbox-operator-continuous
+  alert_stale_results_hours: 3
+- name: ci-knative-sandbox-operator-nightly-release
+  gcs_prefix: knative-prow/logs/ci-knative-sandbox-operator-nightly-release
+  alert_options:
+    alert_mail_to_addresses: "prime-engprod-sea@google.com"
+  num_failures_to_alert: 1
+- name: ci-knative-sandbox-operator-dot-release
+  gcs_prefix: knative-prow/logs/ci-knative-sandbox-operator-dot-release
+  alert_options:
+    alert_mail_to_addresses: "prime-engprod-sea@google.com"
+  alert_stale_results_hours: 170
+  num_failures_to_alert: 1
+- name: ci-knative-sandbox-operator-auto-release
+  gcs_prefix: knative-prow/logs/ci-knative-sandbox-operator-auto-release
+  alert_options:
+    alert_mail_to_addresses: "prime-engprod-sea@google.com"
+  num_failures_to_alert: 1
+- name: ci-knative-sandbox-operator-test-coverage
+  gcs_prefix: knative-prow/logs/ci-knative-sandbox-operator-test-coverage
+  short_text_metric: "coverage"
 dashboards:
 - name: serving
   dashboard_tab:
@@ -995,6 +1017,35 @@ dashboards:
   - name: coverage
     test_group_name: ci-knative-net-kourier-test-coverage
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
+- name: sandbox-operator
+  dashboard_tab:
+  - name: continuous
+    test_group_name: ci-knative-sandbox-operator-continuous
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "prime-engprod-sea@google.com"
+    num_failures_to_alert: 3
+  - name: nightly
+    test_group_name: ci-knative-sandbox-operator-nightly-release
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "prime-engprod-sea@google.com"
+    num_failures_to_alert: 1
+  - name: dot-release
+    test_group_name: ci-knative-sandbox-operator-dot-release
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "prime-engprod-sea@google.com"
+    num_failures_to_alert: 1
+  - name: auto-release
+    test_group_name: ci-knative-sandbox-operator-auto-release
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "prime-engprod-sea@google.com"
+    num_failures_to_alert: 1
+  - name: coverage
+    test_group_name: ci-knative-sandbox-operator-test-coverage
+    base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-group=&sort-by-name="
 - name: knative-gcp
   dashboard_tab:
   - name: continuous
@@ -1291,6 +1342,9 @@ dashboard_groups:
   - "net-http01"
   - "net-istio"
   - "net-kourier"
+- name: knative-sandbox
+  dashboard_names:
+  - "sandbox-operator"
 - name: google
   dashboard_names:
   - "knative-gcp"

--- a/config/prow/testgrid/testgrid.yaml
+++ b/config/prow/testgrid/testgrid.yaml
@@ -583,27 +583,27 @@ test_groups:
   alert_options:
     alert_mail_to_addresses: "prime-engprod-sea@google.com"
   num_failures_to_alert: 3
-- name: ci-knative-sandbox-operator-continuous
-  gcs_prefix: knative-prow/logs/ci-knative-sandbox-operator-continuous
+- name: ci-knative-operator-sandbox-continuous
+  gcs_prefix: knative-prow/logs/ci-knative-operator-sandbox-continuous
   alert_stale_results_hours: 3
-- name: ci-knative-sandbox-operator-nightly-release
-  gcs_prefix: knative-prow/logs/ci-knative-sandbox-operator-nightly-release
+- name: ci-knative-operator-sandbox-nightly-release
+  gcs_prefix: knative-prow/logs/ci-knative-operator-sandbox-nightly-release
   alert_options:
     alert_mail_to_addresses: "prime-engprod-sea@google.com"
   num_failures_to_alert: 1
-- name: ci-knative-sandbox-operator-dot-release
-  gcs_prefix: knative-prow/logs/ci-knative-sandbox-operator-dot-release
+- name: ci-knative-operator-sandbox-dot-release
+  gcs_prefix: knative-prow/logs/ci-knative-operator-sandbox-dot-release
   alert_options:
     alert_mail_to_addresses: "prime-engprod-sea@google.com"
   alert_stale_results_hours: 170
   num_failures_to_alert: 1
-- name: ci-knative-sandbox-operator-auto-release
-  gcs_prefix: knative-prow/logs/ci-knative-sandbox-operator-auto-release
+- name: ci-knative-operator-sandbox-auto-release
+  gcs_prefix: knative-prow/logs/ci-knative-operator-sandbox-auto-release
   alert_options:
     alert_mail_to_addresses: "prime-engprod-sea@google.com"
   num_failures_to_alert: 1
-- name: ci-knative-sandbox-operator-test-coverage
-  gcs_prefix: knative-prow/logs/ci-knative-sandbox-operator-test-coverage
+- name: ci-knative-operator-sandbox-test-coverage
+  gcs_prefix: knative-prow/logs/ci-knative-operator-sandbox-go-coverage
   short_text_metric: "coverage"
 dashboards:
 - name: serving
@@ -1017,35 +1017,6 @@ dashboards:
   - name: coverage
     test_group_name: ci-knative-net-kourier-test-coverage
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
-- name: sandbox-operator
-  dashboard_tab:
-  - name: continuous
-    test_group_name: ci-knative-sandbox-operator-continuous
-    base_options: "sort-by-name="
-    alert_options:
-      alert_mail_to_addresses: "prime-engprod-sea@google.com"
-    num_failures_to_alert: 3
-  - name: nightly
-    test_group_name: ci-knative-sandbox-operator-nightly-release
-    base_options: "sort-by-name="
-    alert_options:
-      alert_mail_to_addresses: "prime-engprod-sea@google.com"
-    num_failures_to_alert: 1
-  - name: dot-release
-    test_group_name: ci-knative-sandbox-operator-dot-release
-    base_options: "sort-by-name="
-    alert_options:
-      alert_mail_to_addresses: "prime-engprod-sea@google.com"
-    num_failures_to_alert: 1
-  - name: auto-release
-    test_group_name: ci-knative-sandbox-operator-auto-release
-    base_options: "sort-by-name="
-    alert_options:
-      alert_mail_to_addresses: "prime-engprod-sea@google.com"
-    num_failures_to_alert: 1
-  - name: coverage
-    test_group_name: ci-knative-sandbox-operator-test-coverage
-    base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-group=&sort-by-name="
 - name: knative-gcp
   dashboard_tab:
   - name: continuous
@@ -1074,6 +1045,35 @@ dashboards:
     num_failures_to_alert: 1
   - name: coverage
     test_group_name: ci-google-knative-gcp-test-coverage
+    base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
+- name: operator
+  dashboard_tab:
+  - name: continuous
+    test_group_name: ci-knative-operator-sandbox-continuous
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "prime-engprod-sea@google.com"
+    num_failures_to_alert: 3
+  - name: nightly
+    test_group_name: ci-knative-operator-sandbox-nightly-release
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "prime-engprod-sea@google.com"
+    num_failures_to_alert: 1
+  - name: dot-release
+    test_group_name: ci-knative-operator-sandbox-dot-release
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "prime-engprod-sea@google.com"
+    num_failures_to_alert: 1
+  - name: auto-release
+    test_group_name: ci-knative-operator-sandbox-auto-release
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "prime-engprod-sea@google.com"
+    num_failures_to_alert: 1
+  - name: coverage
+    test_group_name: ci-knative-operator-sandbox-test-coverage
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
 - name: knative-0.10
   dashboard_tab:
@@ -1342,9 +1342,9 @@ dashboard_groups:
   - "net-http01"
   - "net-istio"
   - "net-kourier"
-- name: knative-sandbox
-  dashboard_names:
-  - "sandbox-operator"
 - name: google
   dashboard_names:
   - "knative-gcp"
+- name: knative-sandbox
+  dashboard_names:
+  - "operator"


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## What this PR does, why we need it:

This sets up initial prow configuration for https://github.com/knative-sandbox/operator, the location of the new unified operator for Knative, sponsored by the operations WG.

## Special notes to reviewers:

I think I passed the typing test, but please double check.

Also, this is set up in a new org, so there may need to be some additional permissions checks and may be even new tokens provisioned (not sure0.

## User-visible changes in this PR:

* Initial automation and testgrid integration for the unified operator.



## Side note

There seems to be a lot of duplication in the Prow configuration. It might be worth suggesting some form of either defaulting or templating support in Prow to the upstream maintainers. I found myself needing to type the same "agent:Kubernetes\ndecorate: true" line many times, as well as repeating the `name` of the configuration stanza at least 3 times within the block.