### PR TITLE
Update prow-tests image to use latest kubekins-e2e

### DIFF
--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -17,7 +17,7 @@
 # sync
 
 # TODO(chizhg): probably build the image from scratch?
-FROM gcr.io/k8s-testimages/kubekins-e2e:v20200302-c921a88-master
+FROM gcr.io/k8s-testimages/kubekins-e2e:v20200326-e946722-master
 LABEL maintainer "Adriano Cunha <adrcunha@google.com>"
 
 # Install extras on top of base image


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Update prow-tests image to pick up the update for kubetest in https://github.com/kubernetes/test-infra/pull/16888

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @chaodaiG 
/cc @grac3gao 