### PR TITLE
chore: Remove gocoverage for client-contrib

### DIFF
--- a/config/prow/config_knative.yaml
+++ b/config/prow/config_knative.yaml
@@ -178,8 +178,6 @@ presubmits:
       dot-dev: true
     - integration-tests: true
       dot-dev: true
-    - go-coverage: true
-      dot-dev: true
 
   knative/eventing:
     - repo-settings:

--- a/config/prow/jobs/config.yaml
+++ b/config/prow/jobs/config.yaml
@@ -1101,34 +1101,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-client-contrib-go-coverage
-    agent: kubernetes
-    context: pull-knative-client-contrib-go-coverage
-    always_run: true
-    rerun_command: "/test pull-knative-client-contrib-go-coverage"
-    trigger: "(?m)^/test (all|pull-knative-client-contrib-go-coverage),?(\\s+|$)"
-    optional: true
-    decorate: true
-    path_alias: knative.dev/client-contrib
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/coverage:latest
-        imagePullPolicy: Always
-        command:
-        - "/coverage"
-        args:
-        - "--postsubmit-job-name=post-knative-client-contrib-go-coverage"
-        - "--artifacts=$(ARTIFACTS)"
-        - "--cov-threshold-percentage=50"
-        - "--github-token=/etc/covbot-token/token"
-        volumeMounts:
-        - name: covbot-token
-          mountPath: /etc/covbot-token
-          readOnly: true
-      volumes:
-      - name: covbot-token
-        secret:
-          secretName: covbot-token
   knative/eventing:
   - name: pull-knative-eventing-build-tests
     agent: kubernetes
@@ -6370,28 +6342,6 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "0 1 * * *"
-  name: ci-knative-client-contrib-go-coverage
-  labels:
-      prow.k8s.io/pubsub.project: knative-tests
-      prow.k8s.io/pubsub.topic: knative-monitoring
-      prow.k8s.io/pubsub.runID: ci-knative-client-contrib-go-coverage
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: knative
-    repo: client-contrib
-    base_ref: master
-    path_alias: knative.dev/client-contrib
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/coverage:latest
-      imagePullPolicy: Always
-      command:
-      - "/coverage"
-      args:
-      - "--artifacts=$(ARTIFACTS)"
-      - "--cov-threshold-percentage=50"
 - cron: "20 * * * *"
   name: ci-knative-docs-continuous
   agent: kubernetes
@@ -10834,22 +10784,6 @@ postsubmits:
     agent: kubernetes
     decorate: true
     path_alias: knative.dev/client
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/coverage:latest
-        imagePullPolicy: Always
-        command:
-        - "/coverage"
-        args:
-        - "--artifacts=$(ARTIFACTS)"
-        - "--cov-threshold-percentage=0"
-  knative/client-contrib:
-  - name: post-knative-client-contrib-go-coverage
-    branches:
-    - master
-    agent: kubernetes
-    decorate: true
-    path_alias: knative.dev/client-contrib
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/coverage:latest

--- a/config/prow/testgrid/testgrid.yaml
+++ b/config/prow/testgrid/testgrid.yaml
@@ -138,9 +138,6 @@ test_groups:
 - name: ci-knative-client-contrib-continuous
   gcs_prefix: knative-prow/logs/ci-knative-client-contrib-continuous
   alert_stale_results_hours: 3
-- name: ci-knative-client-contrib-test-coverage
-  gcs_prefix: knative-prow/logs/ci-knative-client-contrib-go-coverage
-  short_text_metric: "coverage"
 - name: ci-knative-docs-continuous
   gcs_prefix: knative-prow/logs/ci-knative-docs-continuous
   alert_stale_results_hours: 3
@@ -736,9 +733,6 @@ dashboards:
     alert_options:
       alert_mail_to_addresses: "prime-engprod-sea@google.com"
     num_failures_to_alert: 3
-  - name: coverage
-    test_group_name: ci-knative-client-contrib-test-coverage
-    base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
 - name: docs
   dashboard_tab:
   - name: continuous


### PR DESCRIPTION
Client contrib dispatches the build over various sub plugin directories.
This works nicely with shell scripts called, but not
for coverage where go code is expected in the top-level dir.