### PR TITLE
Minor fixes to prow config updater

### DIFF
--- a/tools/prow-config-updater/pullrequest.go
+++ b/tools/prow-config-updater/pullrequest.go
@@ -34,6 +34,11 @@ import (
 	"knative.dev/test-infra/tools/prow-config-updater/config"
 )
 
+const (
+	interval = 10 * time.Second
+	timeout  = 30 * time.Minute
+)
+
 // GitHubMainHandler is used for the performing main operations on GitHub.
 type GitHubMainHandler struct {
 	client *ghutil.GithubClient
@@ -96,32 +101,37 @@ func (gc *GitHubMainHandler) createForkPullRequest(forkOrgName string) (*github.
 
 // Find the pull request created by the pull bot (should be exactly one pull request, otherwise there must be an error)
 func (gc *GitHubMainHandler) findForkPullRequest(forkOrgName string) (*github.PullRequest, error) {
-	prs, _, err := gc.client.Client.PullRequests.List(
-		context.Background(), forkOrgName, config.RepoName,
-		&github.PullRequestListOptions{
-			State: "open",
-			Head:  "knative:master",
-		})
 	orgRepoName := fmt.Sprintf("%s/%s", forkOrgName, config.RepoName)
-	if err != nil {
-		return nil, fmt.Errorf("error listing pull request in repository %s: %v", orgRepoName, err)
-	}
 	var forkpr *github.PullRequest
-	for _, pr := range prs {
-		if *pr.User.Login == config.PullBotName {
-			forkpr = pr
+
+	if err := wait.PollImmediate(interval, timeout, func() (bool, error) {
+		prs, _, err := gc.client.Client.PullRequests.List(
+			context.Background(), forkOrgName, config.RepoName,
+			&github.PullRequestListOptions{
+				State: "open",
+				Head:  "knative:master",
+			})
+		if err != nil {
+			return false, fmt.Errorf("error listing pull request in repository %q: %v", orgRepoName, err)
 		}
-	}
-	if forkpr == nil {
-		return nil, fmt.Errorf("expected one pull request in repository %s but found %d", orgRepoName, len(prs))
+
+		for _, pr := range prs {
+			if *pr.User.Login == config.PullBotName {
+				forkpr = pr
+				// found the PR, return
+				return true, nil
+			}
+		}
+		// PR is not found, continue polling
+		return false, nil
+	}); err != nil {
+		return nil, fmt.Errorf("error finding the pull request in repository %q created by %q", orgRepoName, config.PullBotName)
 	}
 	return forkpr, nil
 }
 
 // Wait for the fork pull request to be merged by polling its state.
 func (gc *GitHubMainHandler) waitForForkPullRequestMerged(forkOrgName string, pn int) error {
-	interval := 10 * time.Second
-	timeout := 20 * time.Minute
 	return helpers.Run(
 		fmt.Sprintf("Wait until the fork pull request '%d' to merged", pn),
 		func() error {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
1. Sometimes the fork PR is not created immediately after calling the endpoint, so also add polling logic to find the PR
2. Change the timeout from `20 mins` to `30 mins` as sometimes it can take longer time for the PR to be merged.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
