### PR TITLE
Append script name to k8s.dump.txt

### DIFF
--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -93,7 +93,7 @@ function dump_cluster_state() {
   echo "***    Start of information dump    ***"
   echo "***************************************"
 
-  local output="${ARTIFACTS}/k8s.dump.txt"
+  local output="${ARTIFACTS}/k8s.dump-$(basename ${E2E_SCRIPT}).txt"
   echo ">>> The dump is located at ${output}"
 
   for crd in $(kubectl api-resources --verbs=list -o name | sort); do


### PR DESCRIPTION
**What this PR does, why we need it**:

This patch appends script name to k8s.dump.txt like
`k8s.dump-e2e-test.sh.txt`.

When two e2e test scripts (e.g e2e-test.sh and e2e-auto-tls-tests.sh)
run, one of test script overwrites another log.

To avoid it, this patch appends the script name to the log file.

Part of https://github.com/knative/test-infra/issues/1859

**Special notes to reviewers**:

https://github.com/knative/serving/pull/7438 has same change for `k8s.log.txt`
and confirmed that it works.
