### PR TITLE
Add presubmit tests job for knative-gcp workload identity tests

### DIFF
--- a/config/prow/config_knative.yaml
+++ b/config/prow/config_knative.yaml
@@ -305,6 +305,13 @@ presubmits:
     - build-tests: true
     - unit-tests: true
     - integration-tests: true
+      args:
+      - "--run-test"
+      - "./test/e2e-tests.sh"
+    - custom-test: wi-tests
+      args:
+      - "--run-test"
+      - "./test/e2e-wi-tests.sh"
     - go-coverage: true
 
   knative/net-certmanager:

--- a/config/prow/jobs/config.yaml
+++ b/config/prow/jobs/config.yaml
@@ -3497,7 +3497,8 @@ presubmits:
         - runner.sh
         args:
         - "./test/presubmit-tests.sh"
-        - "--integration-tests"
+        - "--run-test"
+        - "./test/e2e-tests.sh"
         volumeMounts:
         - name: repoview-token
           mountPath: /etc/repoview-token
@@ -3534,7 +3535,8 @@ presubmits:
         - runner.sh
         args:
         - "./test/presubmit-tests.sh"
-        - "--integration-tests"
+        - "--run-test"
+        - "./test/e2e-tests.sh"
         volumeMounts:
         - name: repoview-token
           mountPath: /etc/repoview-token
@@ -3551,6 +3553,70 @@ presubmits:
       - name: repoview-token
         secret:
           secretName: repoview-token
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-google-knative-gcp-wi-tests
+    agent: kubernetes
+    context: pull-google-knative-gcp-wi-tests
+    always_run: true
+    rerun_command: "/test pull-google-knative-gcp-wi-tests"
+    trigger: "(?m)^/test (all|pull-google-knative-gcp-wi-tests),?(\\s+|$)"
+    decorate: true
+    branches:
+    - "release-0.10"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-wi-tests.sh"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-google-knative-gcp-wi-tests
+    agent: kubernetes
+    context: pull-google-knative-gcp-wi-tests
+    always_run: true
+    rerun_command: "/test pull-google-knative-gcp-wi-tests"
+    trigger: "(?m)^/test (all|pull-google-knative-gcp-wi-tests),?(\\s+|$)"
+    decorate: true
+    skip_branches:
+    - "release-0.10"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-wi-tests.sh"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
       - name: test-account
         secret:
           secretName: test-account


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Separate the job for running normal e2e tests and wi e2e tests for knative-gcp

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @grac3gao 
FYI @yt3liu 

/hold
Please unhold after https://github.com/google/knative-gcp/pull/709 is merged.
