### PR TITLE
Move github.com/knative-sandbox/operator to knative.dev/operator

### DIFF
--- a/config/prow/config_knative.yaml
+++ b/config/prow/config_knative.yaml
@@ -412,9 +412,13 @@ presubmits:
 
   knative-sandbox/operator:
     - build-tests: true
+      dot-dev: true
     - unit-tests: true
+      dot-dev: true
     - integration-tests: true
+      dot-dev: true
     - go-coverage: true
+      dot-dev: true
 
 periodics:
   knative/serving:
@@ -997,13 +1001,17 @@ periodics:
   knative-sandbox/operator:
     - continuous: true
       go113: true
+      dot-dev: true
     - nightly: true
       go113: true
+      dot-dev: true
     - dot-release: true
       go113: true
+      dot-dev: true
       env-vars:
       - ORG_NAME=knative-sandbox
     - auto-release: true
       go113: true
+      dot-dev: true
       env-vars:
       - ORG_NAME=knative-sandbox

--- a/config/prow/jobs/config.yaml
+++ b/config/prow/jobs/config.yaml
@@ -4824,6 +4824,7 @@ presubmits:
     rerun_command: "/test pull-knative-sandbox-operator-build-tests"
     trigger: "(?m)^/test (all|pull-knative-sandbox-operator-build-tests),?(\\s+|$)"
     decorate: true
+    path_alias: knative.dev/operator
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -4859,6 +4860,7 @@ presubmits:
     rerun_command: "/test pull-knative-sandbox-operator-unit-tests"
     trigger: "(?m)^/test (all|pull-knative-sandbox-operator-unit-tests),?(\\s+|$)"
     decorate: true
+    path_alias: knative.dev/operator
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -4894,6 +4896,7 @@ presubmits:
     rerun_command: "/test pull-knative-sandbox-operator-integration-tests"
     trigger: "(?m)^/test (all|pull-knative-sandbox-operator-integration-tests),?(\\s+|$)"
     decorate: true
+    path_alias: knative.dev/operator
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -4930,6 +4933,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-sandbox-operator-go-coverage),?(\\s+|$)"
     optional: true
     decorate: true
+    path_alias: knative.dev/operator
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/coverage:latest
@@ -9823,6 +9827,7 @@ periodics:
   - org: knative-sandbox
     repo: operator
     base_ref: master
+    path_alias: knative.dev/operator
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -9857,6 +9862,7 @@ periodics:
   - org: knative-sandbox
     repo: operator
     base_ref: master
+    path_alias: knative.dev/operator
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -9892,6 +9898,7 @@ periodics:
   - org: knative-sandbox
     repo: operator
     base_ref: master
+    path_alias: knative.dev/operator
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -9937,6 +9944,7 @@ periodics:
   - org: knative-sandbox
     repo: operator
     base_ref: master
+    path_alias: knative.dev/operator
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -9982,6 +9990,7 @@ periodics:
   - org: knative-sandbox
     repo: operator
     base_ref: master
+    path_alias: knative.dev/operator
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/coverage:latest
@@ -11142,6 +11151,7 @@ postsubmits:
     - master
     agent: kubernetes
     decorate: true
+    path_alias: knative.dev/operator
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/coverage:latest


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:

Moves https://github.com/knative-sandbox/operator to the go import path `knative.dev/operator`, per [discussion in #toc-steering-questions on 1 April](https://knative.slack.com/archives/CU9DGL4FM/p1585761511014200)

**Special notes to reviewers**:

**User-visible changes in this PR**:

