### PR TITLE
dep collector works with Go modules

### DIFF
--- a/tools/dep-collector/gobuild.go
+++ b/tools/dep-collector/gobuild.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+    "encoding/json"
+    "fmt"
+    gb "go/build"
+    "path/filepath"
+    "strings"
+
+    "knative.dev/pkg/test/cmd"
+)
+
+// https://golang.org/pkg/cmd/go/internal/modinfo/#ModulePublic
+type modInfo struct {
+    Path string
+    Dir  string
+}
+
+type gobuild struct {
+    mod *modInfo
+}
+
+// moduleInfo returns the module path and module root directory for a project
+// using go modules, otherwise returns nil.
+//
+// Related: https://github.com/golang/go/issues/26504
+func moduleInfo() *modInfo {
+    output, err := cmd.RunCommand("go list -mod=readonly -m -json")
+    if err != nil {
+        return nil
+    }
+    var info modInfo
+    if err := json.Unmarshal([]byte(output), &info); err != nil {
+        return nil
+    }
+    return &info
+}
+
+// importPackage wraps go/build.Import to handle go modules.
+//
+// Note that we will fall back to GOPATH if the project isn't using go modules.
+func (g *gobuild) importPackage(s string) (*gb.Package, error) {
+    if g.mod == nil {
+        return gb.Import(s, gb.Default.GOPATH, gb.ImportComment)
+    }
+
+    // If we're inside a go modules project, try to use the module's directory
+    // as our source root to import:
+    // * paths that match module path prefix (they should be in this project)
+    // * relative paths (they should also be in this project)
+    gp, err := gb.Import(s, g.mod.Dir, gb.ImportComment)
+    return gp, err
+}
+
+func (g *gobuild) qualifyLocalImport(ip string) (string, error) {
+    if g.mod == nil {
+        gopathsrc := filepath.Join(gb.Default.GOPATH, "src")
+        if !strings.HasPrefix(WorkingDir, gopathsrc) {
+            return "", fmt.Errorf("working directory must be on ${GOPATH}/src = %s", gopathsrc)
+        }
+        return filepath.Join(strings.TrimPrefix(WorkingDir, gopathsrc+string(filepath.Separator)), ip), nil
+    } else {
+        return filepath.Join(g.mod.Path, ip), nil
+    }
+}

--- a/tools/dep-collector/gobuild.go
+++ b/tools/dep-collector/gobuild.go
@@ -38,18 +38,19 @@ type gobuild struct {
 
 // moduleInfo returns the module path and module root directory for a project
 // using go modules, otherwise returns nil.
+// If there is something wrong in parsing the json output, it will return an error.
 //
 // Related: https://github.com/golang/go/issues/26504
-func moduleInfo() *modInfo {
+func moduleInfo() (*modInfo, error) {
 	output, err := cmd.RunCommand("go list -mod=readonly -m -json")
 	if err != nil {
-		return nil
+		return nil, nil
 	}
 	var info modInfo
 	if err := json.Unmarshal([]byte(output), &info); err != nil {
-		return nil
+		return nil, err
 	}
-	return &info
+	return &info, nil
 }
 
 // importPackage wraps go/build.Import to handle go modules.

--- a/tools/dep-collector/imports.go
+++ b/tools/dep-collector/imports.go
@@ -31,7 +31,11 @@ type ImportInfo struct {
 func CollectTransitiveImports(binaries []string) ([]ImportInfo, error) {
 	// Perform a simple DFS to collect the binaries' transitive dependencies.
 	visited := make(map[string]ImportInfo)
-	g := &gobuild{moduleInfo()}
+	mi, err := moduleInfo()
+	if err != nil {
+		return nil, fmt.Errorf("failed getting Go module info: %v", err)
+	}
+	g := &gobuild{mi}
 	for _, importpath := range binaries {
 		if gb.IsLocalImport(importpath) {
 			ip, err := g.qualifyLocalImport(importpath)

--- a/tools/dep-collector/imports.go
+++ b/tools/dep-collector/imports.go
@@ -23,14 +23,14 @@ import (
 	"strings"
 )
 
-type importInfo struct {
-	importPath string
-	dir string
+type ImportInfo struct {
+	ImportPath string
+	Dir        string
 }
 
-func CollectTransitiveImports(binaries []string) ([]importInfo, error) {
+func CollectTransitiveImports(binaries []string) ([]ImportInfo, error) {
 	// Perform a simple DFS to collect the binaries' transitive dependencies.
-	visited := make(map[string]importInfo)
+	visited := make(map[string]ImportInfo)
 	g := &gobuild{moduleInfo()}
 	for _, importpath := range binaries {
 		if gb.IsLocalImport(importpath) {
@@ -61,7 +61,7 @@ func CollectTransitiveImports(binaries []string) ([]importInfo, error) {
 	}
 	list.Sort()
 
-	iiList := make([]importInfo, len(list))
+	iiList := make([]ImportInfo, len(list))
 	for i := range iiList {
 		iiList[i] = visited[list[i]]
 	}
@@ -69,11 +69,11 @@ func CollectTransitiveImports(binaries []string) ([]importInfo, error) {
 	return iiList, nil
 }
 
-func visit(g *gobuild, pkg *gb.Package, visited map[string]importInfo) error {
+func visit(g *gobuild, pkg *gb.Package, visited map[string]ImportInfo) error {
 	if _, ok := visited[pkg.Dir]; ok {
 		return nil
 	}
-	visited[pkg.Dir] = importInfo{dir: pkg.Dir, importPath:pkg.ImportPath}
+	visited[pkg.Dir] = ImportInfo{Dir: pkg.Dir, ImportPath: pkg.ImportPath}
 
 	for _, ip := range pkg.Imports {
 		if ip == "C" {

--- a/tools/dep-collector/imports.go
+++ b/tools/dep-collector/imports.go
@@ -19,66 +19,68 @@ package main
 import (
 	"fmt"
 	gb "go/build"
-	"path/filepath"
 	"sort"
 	"strings"
 )
 
-func CollectTransitiveImports(binaries []string) ([]string, error) {
+type importInfo struct {
+	importPath string
+	dir string
+}
+
+func CollectTransitiveImports(binaries []string) ([]importInfo, error) {
 	// Perform a simple DFS to collect the binaries' transitive dependencies.
-	visited := make(map[string]struct{})
+	visited := make(map[string]importInfo)
+	g := &gobuild{moduleInfo()}
 	for _, importpath := range binaries {
 		if gb.IsLocalImport(importpath) {
-			ip, err := qualifyLocalImport(importpath)
+			ip, err := g.qualifyLocalImport(importpath)
 			if err != nil {
 				return nil, err
 			}
 			importpath = ip
 		}
 
-		pkg, err := gb.Import(importpath, WorkingDir, gb.ImportComment)
+		pkg, err := g.importPackage(importpath)
 		if err != nil {
 			return nil, err
 		}
-		if err := visit(pkg, visited); err != nil {
+		if err := visit(g, pkg, visited); err != nil {
 			return nil, err
 		}
 	}
 
 	// Sort the dependencies deterministically.
 	var list sort.StringSlice
-	for ip := range visited {
-		if !strings.Contains(ip, "/vendor/") {
+	for dir := range visited {
+		if !strings.Contains(dir, "/vendor/") {
 			// Skip files outside of vendor
 			continue
 		}
-		list = append(list, ip)
+		list = append(list, dir)
 	}
 	list.Sort()
 
-	return list, nil
-}
-
-func qualifyLocalImport(ip string) (string, error) {
-	gopathsrc := filepath.Join(gb.Default.GOPATH, "src")
-	if !strings.HasPrefix(WorkingDir, gopathsrc) {
-		return "", fmt.Errorf("working directory must be on ${GOPATH}/src = %s", gopathsrc)
+	iiList := make([]importInfo, len(list))
+	for i := range iiList {
+		iiList[i] = visited[list[i]]
 	}
-	return filepath.Join(strings.TrimPrefix(WorkingDir, gopathsrc+string(filepath.Separator)), ip), nil
+
+	return iiList, nil
 }
 
-func visit(pkg *gb.Package, visited map[string]struct{}) error {
-	if _, ok := visited[pkg.ImportPath]; ok {
+func visit(g *gobuild, pkg *gb.Package, visited map[string]importInfo) error {
+	if _, ok := visited[pkg.Dir]; ok {
 		return nil
 	}
-	visited[pkg.ImportPath] = struct{}{}
+	visited[pkg.Dir] = importInfo{dir: pkg.Dir, importPath:pkg.ImportPath}
 
 	for _, ip := range pkg.Imports {
 		if ip == "C" {
 			// skip cgo
 			continue
 		}
-		subpkg, err := gb.Import(ip, WorkingDir, gb.ImportComment)
+		subpkg, err := g.importPackage(ip)
 		if err != nil {
 			return fmt.Errorf("%v\n -> %v", pkg.ImportPath, err)
 		}
@@ -86,7 +88,7 @@ func visit(pkg *gb.Package, visited map[string]struct{}) error {
 			// Skip import paths outside of our workspace (std library)
 			continue
 		}
-		if err := visit(subpkg, visited); err != nil {
+		if err := visit(g, subpkg, visited); err != nil {
 			return fmt.Errorf("%v (%v)\n -> %v", pkg.ImportPath, pkg.Dir, err)
 		}
 	}

--- a/tools/dep-collector/licenses.go
+++ b/tools/dep-collector/licenses.go
@@ -107,9 +107,9 @@ func (lt *LicenseFile) CSVRow(classifier *licenseclassifier.License) (string, er
 	}, ","), nil
 }
 
-func findLicense(ii importInfo) (*LicenseFile, error) {
-	dir := ii.dir
-	ip := ii.importPath
+func findLicense(ii ImportInfo) (*LicenseFile, error) {
+	dir := ii.Dir
+	ip := ii.ImportPath
 	for {
 		// When we reach the root of our workspace, stop searching.
 		if dir == WorkingDir {
@@ -173,7 +173,8 @@ func (lc LicenseCollection) Check(classifier *licenseclassifier.License) error {
 	return fmt.Errorf("Errors validating licenses:\n%v", strings.Join(errors, "\n"))
 }
 
-func CollectLicenses(importInfos []importInfo) (LicenseCollection, error) {
+// CollectLicenses collects a list of licenses for the given imports.
+func CollectLicenses(importInfos []ImportInfo) (LicenseCollection, error) {
 	// for each of the import paths, search for a license file.
 	licenseFiles := make(map[string]*LicenseFile)
 	for _, info := range importInfos {

--- a/tools/dep-collector/licenses.go
+++ b/tools/dep-collector/licenses.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"fmt"
-	gb "go/build"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -72,7 +71,7 @@ func (lt *LicenseFile) Check(classifier *licenseclassifier.License) error {
 	}
 	ms := classifier.MultipleMatch(body, false)
 	for _, m := range ms {
-		return fmt.Errorf("Found matching forbidden license in %q: %v", lt.EnclosingImportPath, m.Name)
+		return fmt.Errorf("found matching forbidden license in %q: %v", lt.EnclosingImportPath, m.Name)
 	}
 	return nil
 }
@@ -108,17 +107,13 @@ func (lt *LicenseFile) CSVRow(classifier *licenseclassifier.License) (string, er
 	}, ","), nil
 }
 
-func findLicense(ip string) (*LicenseFile, error) {
-	pkg, err := gb.Import(ip, WorkingDir, gb.ImportComment)
-	if err != nil {
-		return nil, err
-	}
-	dir := pkg.Dir
-
+func findLicense(ii importInfo) (*LicenseFile, error) {
+	dir := ii.dir
+	ip := ii.importPath
 	for {
 		// When we reach the root of our workspace, stop searching.
 		if dir == WorkingDir {
-			return nil, fmt.Errorf("unable to find license for %q", pkg.ImportPath)
+			return nil, fmt.Errorf("unable to find license for %q", ip)
 		}
 
 		for _, name := range LicenseNames {
@@ -178,11 +173,11 @@ func (lc LicenseCollection) Check(classifier *licenseclassifier.License) error {
 	return fmt.Errorf("Errors validating licenses:\n%v", strings.Join(errors, "\n"))
 }
 
-func CollectLicenses(imports []string) (LicenseCollection, error) {
+func CollectLicenses(importInfos []importInfo) (LicenseCollection, error) {
 	// for each of the import paths, search for a license file.
 	licenseFiles := make(map[string]*LicenseFile)
-	for _, ip := range imports {
-		lf, err := findLicense(ip)
+	for _, info := range importInfos {
+		lf, err := findLicense(info)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Modify `dep-collector` to make it working with Go modules. Most of the ideas are borrowed from https://github.com/google/ko/pull/19, by using https://godoc.org/golang.org/x/tools/go/packages package.

In this PR it tests with Go dep and `third_party/VENDOR-LICENSE` does not change.

In https://github.com/knative/test-infra/pull/1889 it tests with Go modules, the diff can be seen in https://github.com/knative/test-infra/pull/1889/files#diff-da080de4f67002eef05fc37666055a19. 
There are two changes to the `third_party/VENDOR-LICENSE` file:
1. The import path changes, now it does not have `/vendor/`
2. A few extra licenses in the subdirectories are added, primarily because Go modules does not support pruning non-go files. 