### PR TITLE
Require a static `.md` suffix, rather than {any character} followed by `md`

### DIFF
--- a/scripts/presubmit-tests.sh
+++ b/scripts/presubmit-tests.sh
@@ -129,7 +129,7 @@ function markdown_build_tests() {
   (( DISABLE_MD_LINTING && DISABLE_MD_LINK_CHECK )) && return 0
   # Get changed markdown files (ignore /vendor, github templates, and deleted files)
   local mdfiles=""
-  for file in $(echo "${CHANGED_FILES}" | grep \.md$ | grep -v ^vendor/ | grep -v ^.github/); do
+  for file in $(echo "${CHANGED_FILES}" | grep \\.md$ | grep -v ^vendor/ | grep -v ^.github/); do
     [[ -f "${file}" ]] && mdfiles="${mdfiles} ${file}"
   done
   [[ -z "${mdfiles}" ]] && return 0


### PR DESCRIPTION
**What this PR does, why we need it**:

In docs, there is a template file `ReadmeTemplate.gomd`, which triggers the markdown link checker, even though it's only partial markdown:

https://prow.knative.dev/view/gcs/knative-prow/pr-logs/pull/knative_docs/2377/pull-knative-docs-markdown-link-check/1248307022781222913

```
----------------------------------------------
---- Checking links in the markdown files ----
----------------------------------------------
---- Thu Apr  9 10:49:30 PDT 2020
----------------------------------------------
docs/eventing/sources/generator/ReadmeTemplate.gomd
	ERROR	./sources.yaml
		Stat docs/eventing/sources/generator/sources.yaml: no such file or directory
	ERROR	{{ .Url }}
		Stat docs/eventing/sources/generator/{{ .Url }}: no such file or directory
```

It turns out that the `grep` command uses a single `\` character to escape '.', but the shell consumes that `\`, causing the argument to `grep` to be `.md`, not `\.md`.

**Special notes to reviewers**:

**User-visible changes in this PR**:

