### PR TITLE
set merge method to squash for knative-sandbox

### DIFF
--- a/config/prow-staging/core/config.yaml
+++ b/config/prow-staging/core/config.yaml
@@ -132,6 +132,7 @@ tide:
     reviewApprovedRequired: false
   merge_method:
     knative: squash
+    knative-sandbox: squash
     google/knative-gcp: squash
   target_url: https://prow-staging.knative.dev/tide
   pr_status_base_url: https://prow-staging.knative.dev/pr

--- a/tools/config-generator/templates/prow-staging/prow_config.yaml
+++ b/tools/config-generator/templates/prow-staging/prow_config.yaml
@@ -116,6 +116,7 @@ tide:
     reviewApprovedRequired: false
   merge_method:
     knative: squash
+    knative-sandbox: squash
     google/knative-gcp: squash
   target_url: [[.ProwHost]]/tide
   pr_status_base_url: [[.ProwHost]]/pr


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Set merge method to squash for knative-sandbox. This is a configuration setting in Tide.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @houshengbo @evankanderson 