### PR TITLE
Support having multiple Prow job config files

### DIFF
--- a/config/gubernator/Makefile
+++ b/config/gubernator/Makefile
@@ -18,7 +18,7 @@ SRC     := test-infra/gubernator
 deploy:
 	# Fetch latest source, patch for our instance
 	rm -fr test-infra
-	git clone http://github.com/kubernetes/test-infra.git
+	git clone https://github.com/kubernetes/test-infra.git
 	cp config.yaml $(SRC)
 	cp redir_github.py $(SRC)
 	sed -i -e '/^runtime: .*/a service: gubernator' $(SRC)/app.yaml

--- a/config/prow-staging/config_staging.yaml
+++ b/config/prow-staging/config_staging.yaml
@@ -14,32 +14,26 @@
 
 presubmits:
   knative-prow-robot/serving:
-    - repo-settings:
-      go112-branches:
-      - legacy  # Doesn't exist, for compatibility purposes only
-    - build-tests: true
-      dot-dev: true
-    - unit-tests: true
-      dot-dev: true
-    - integration-tests: true
-      dot-dev: true
+  - build-tests: true
+    dot-dev: true
+  - unit-tests: true
+    dot-dev: true
+  - integration-tests: true
+    dot-dev: true
 
   knative-prow-robot/test-infra:
-    - repo-settings:
-      go112-branches:
-        - legacy  # Doesn't exist, for compatibility purposes only
-    - build-tests: true
-      dot-dev: true
-    - unit-tests: true
-      dot-dev: true
-    - integration-tests: true
-      dot-dev: true
+  - build-tests: true
+    dot-dev: true
+  - unit-tests: true
+    dot-dev: true
+  - integration-tests: true
+    dot-dev: true
 
 periodics:
   knative-prow-robot/serving:
-    - continuous: false
-      dot-dev: true
+  - continuous: false
+    dot-dev: true
 
   knative-prow-robot/test-infra:
-    - continuous: false
-      dot-dev: true
+  - continuous: false
+    dot-dev: true

--- a/config/prow-staging/jobs/config.yaml
+++ b/config/prow-staging/jobs/config.yaml
@@ -27,46 +27,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-prow-robot-serving-build-tests),?(\\s+|$)"
     decorate: true
     path_alias: knative.dev/serving
-    branches:
-    - "legacy"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests-staging/test-infra/prow-tests-go112:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--build-tests"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: test-account
-        secret:
-          secretName: test-account
-  - name: pull-knative-prow-robot-serving-build-tests
-    agent: kubernetes
-    context: pull-knative-prow-robot-serving-build-tests
-    always_run: true
-    rerun_command: "/test pull-knative-prow-robot-serving-build-tests"
-    trigger: "(?m)^/test (all|pull-knative-prow-robot-serving-build-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/serving
-    skip_branches:
-    - "legacy"
     spec:
       containers:
       - image: gcr.io/knative-tests-staging/test-infra/prow-tests:stable
@@ -103,46 +63,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-prow-robot-serving-unit-tests),?(\\s+|$)"
     decorate: true
     path_alias: knative.dev/serving
-    branches:
-    - "legacy"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests-staging/test-infra/prow-tests-go112:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--unit-tests"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: test-account
-        secret:
-          secretName: test-account
-  - name: pull-knative-prow-robot-serving-unit-tests
-    agent: kubernetes
-    context: pull-knative-prow-robot-serving-unit-tests
-    always_run: true
-    rerun_command: "/test pull-knative-prow-robot-serving-unit-tests"
-    trigger: "(?m)^/test (all|pull-knative-prow-robot-serving-unit-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/serving
-    skip_branches:
-    - "legacy"
     spec:
       containers:
       - image: gcr.io/knative-tests-staging/test-infra/prow-tests:stable
@@ -179,46 +99,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-prow-robot-serving-integration-tests),?(\\s+|$)"
     decorate: true
     path_alias: knative.dev/serving
-    branches:
-    - "legacy"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests-staging/test-infra/prow-tests-go112:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--integration-tests"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: test-account
-        secret:
-          secretName: test-account
-  - name: pull-knative-prow-robot-serving-integration-tests
-    agent: kubernetes
-    context: pull-knative-prow-robot-serving-integration-tests
-    always_run: true
-    rerun_command: "/test pull-knative-prow-robot-serving-integration-tests"
-    trigger: "(?m)^/test (all|pull-knative-prow-robot-serving-integration-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/serving
-    skip_branches:
-    - "legacy"
     spec:
       containers:
       - image: gcr.io/knative-tests-staging/test-infra/prow-tests:stable
@@ -256,46 +136,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-prow-robot-test-infra-build-tests),?(\\s+|$)"
     decorate: true
     path_alias: knative.dev/test-infra
-    branches:
-    - "legacy"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests-staging/test-infra/prow-tests-go112:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--build-tests"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: test-account
-        secret:
-          secretName: test-account
-  - name: pull-knative-prow-robot-test-infra-build-tests
-    agent: kubernetes
-    context: pull-knative-prow-robot-test-infra-build-tests
-    always_run: true
-    rerun_command: "/test pull-knative-prow-robot-test-infra-build-tests"
-    trigger: "(?m)^/test (all|pull-knative-prow-robot-test-infra-build-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/test-infra
-    skip_branches:
-    - "legacy"
     spec:
       containers:
       - image: gcr.io/knative-tests-staging/test-infra/prow-tests:stable
@@ -332,46 +172,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-prow-robot-test-infra-unit-tests),?(\\s+|$)"
     decorate: true
     path_alias: knative.dev/test-infra
-    branches:
-    - "legacy"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests-staging/test-infra/prow-tests-go112:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--unit-tests"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: test-account
-        secret:
-          secretName: test-account
-  - name: pull-knative-prow-robot-test-infra-unit-tests
-    agent: kubernetes
-    context: pull-knative-prow-robot-test-infra-unit-tests
-    always_run: true
-    rerun_command: "/test pull-knative-prow-robot-test-infra-unit-tests"
-    trigger: "(?m)^/test (all|pull-knative-prow-robot-test-infra-unit-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/test-infra
-    skip_branches:
-    - "legacy"
     spec:
       containers:
       - image: gcr.io/knative-tests-staging/test-infra/prow-tests:stable
@@ -408,46 +208,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-prow-robot-test-infra-integration-tests),?(\\s+|$)"
     decorate: true
     path_alias: knative.dev/test-infra
-    branches:
-    - "legacy"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests-staging/test-infra/prow-tests-go112:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--integration-tests"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: test-account
-        secret:
-          secretName: test-account
-  - name: pull-knative-prow-robot-test-infra-integration-tests
-    agent: kubernetes
-    context: pull-knative-prow-robot-test-infra-integration-tests
-    always_run: true
-    rerun_command: "/test pull-knative-prow-robot-test-infra-integration-tests"
-    trigger: "(?m)^/test (all|pull-knative-prow-robot-test-infra-integration-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/test-infra
-    skip_branches:
-    - "legacy"
     spec:
       containers:
       - image: gcr.io/knative-tests-staging/test-infra/prow-tests:stable

--- a/config/prow_common.mk
+++ b/config/prow_common.mk
@@ -26,7 +26,7 @@ SKIP_CONFIG_BACKUP        ?=
 # or overridden in the Makefile before this file is included.
 PROW_PLUGINS     ?= core/plugins.yaml
 PROW_CONFIG      ?= core/config.yaml
-PROW_JOB_CONFIG  ?= jobs/config.yaml
+PROW_JOB_CONFIG  ?= jobs
 
 PROW_DEPLOYS     ?= cluster
 PROW_GCS         ?= knative-prow
@@ -56,42 +56,17 @@ get-cluster-credentials:
 unset-cluster-credentials:
 	$(UNSET_CONTEXT)
 
-.PHONY: update-prow-config update-prow-job-config update-prow-plugins update-all-boskos-deployments update-boskos-resource update-almost-all-cluster-deployments update-single-cluster-deployment update-prow test update-testgrid-config confirm-master
+.PHONY: update-prow-config update-all-boskos-deployments update-boskos-resource update-almost-all-cluster-deployments update-single-cluster-deployment test update-testgrid-config confirm-master
 
 # Update prow config
-update-prow-config: confirm-master
+update-prow-config: $(eval SHELL:=/bin/bash) confirm-master
 	$(SET_CONTEXT)
-	kubectl create configmap config --from-file=config.yaml=$(PROW_CONFIG) --dry-run --save-config -o yaml | kubectl apply -f -
-	$(UNSET_CONTEXT)
-
-# Update all prow job configs
-update-prow-job-config: confirm-master
-	$(SET_CONTEXT)
-ifndef SKIP_CONFIG_BACKUP
-	$(eval OLD_YAML_CONFIG := $(shell mktemp))
-	$(eval NEW_YAML_CONFIG := $(shell mktemp))
-	$(eval GCS_DEST := $(PROW_CONFIG_GCS)/config-$(shell date '+%Y_%m_%d_%H:%M:%S').yaml)
-	@kubectl get configmap job-config -o jsonpath="{.data['config\.yaml']}" 2>/dev/null > "${OLD_YAML_CONFIG}"
-	@gsutil cp "${OLD_YAML_CONFIG}" "${GCS_DEST}" > /dev/null
-	@cp "$(PROW_JOB_CONFIG)" "${NEW_YAML_CONFIG}"
-	@echo "# FROM COMMIT: $(shell git rev-parse HEAD)" >> "${NEW_YAML_CONFIG}"
-else
-	$(eval NEW_YAML_CONFIG := $(PROW_JOB_CONFIG))
-endif
-# We'll have to use `kubectl replace` here because `kubectl apply` will add the whole original configmap to the
-# `last-applied-configuration` annotation, but k8s has a maxmium 256kb limit for it, see https://github.com/kubernetes/kubectl/issues/712
-	kubectl create configmap job-config --from-file=config.yaml=$(NEW_YAML_CONFIG) --dry-run -o yaml | kubectl replace configmap job-config -f -
-	$(UNSET_CONTEXT)
-ifndef SKIP_CONFIG_BACKUP
-	diff "${OLD_YAML_CONFIG}" "${NEW_YAML_CONFIG}" --color=auto || true
-	@echo "Inspect uploaded config file at: ${NEW_YAML_CONFIG}"
-	@echo "Old config file saved at: ${GCS_DEST}"
-endif
-
-# Update prow plugins
-update-prow-plugins: confirm-master
-	$(SET_CONTEXT)
-	kubectl create configmap plugins --from-file=plugins.yaml=$(PROW_PLUGINS) --dry-run --save-config -o yaml | kubectl apply -f -
+	python2 <(curl -sSfL https://raw.githubusercontent.com/istio/test-infra/master/prow/recreate_prow_configmaps.py) \
+		--prow-config-path=$(realpath $(PROW_CONFIG)) \
+		--plugins-config-path=$(realpath $(PROW_PLUGINS)) \
+		--job-config-dir=$(realpath $(PROW_JOB_CONFIG)) \
+		--wet \
+		--silent
 	$(UNSET_CONTEXT)
 
 # Update all deployments of boskos
@@ -123,7 +98,7 @@ update-single-cluster-deployment: confirm-master
 	$(UNSET_CONTEXT)
 
 # Update all resources on Prow cluster
-update-prow-cluster: update-almost-all-cluster-deployments update-all-boskos-deployments update-boskos-resource update-prow-plugins update-prow-config update-prow-job-config
+update-prow-cluster: update-almost-all-cluster-deployments update-all-boskos-deployments update-boskos-resource update-prow-config
 
 # Do not allow server update from wrong branch or dirty working space
 # In emergency, could easily edit this file, deleting all these lines

--- a/config/prow_common.mk
+++ b/config/prow_common.mk
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+SHELL := /bin/bash
+
 # This file is used by prod and staging Makefiles
 
 # Default settings for the CI/CD system.
@@ -59,7 +61,7 @@ unset-cluster-credentials:
 .PHONY: update-prow-config update-all-boskos-deployments update-boskos-resource update-almost-all-cluster-deployments update-single-cluster-deployment test update-testgrid-config confirm-master
 
 # Update prow config
-update-prow-config: $(eval SHELL:=/bin/bash) confirm-master
+update-prow-config: confirm-master
 	$(SET_CONTEXT)
 	python2 <(curl -sSfL https://raw.githubusercontent.com/istio/test-infra/master/prow/recreate_prow_configmaps.py) \
 		--prow-config-path=$(realpath $(PROW_CONFIG)) \

--- a/config/prow_common.mk
+++ b/config/prow_common.mk
@@ -63,7 +63,7 @@ unset-cluster-credentials:
 # Update prow config
 update-prow-config: confirm-master
 	$(SET_CONTEXT)
-	python2 <(curl -sSfL https://raw.githubusercontent.com/istio/test-infra/master/prow/recreate_prow_configmaps.py) \
+	python3 <(curl -sSfL https://raw.githubusercontent.com/istio/test-infra/master/prow/recreate_prow_configmaps.py) \
 		--prow-config-path=$(realpath $(PROW_CONFIG)) \
 		--plugins-config-path=$(realpath $(PROW_PLUGINS)) \
 		--job-config-dir=$(realpath $(PROW_JOB_CONFIG)) \

--- a/scripts/presubmit-tests.sh
+++ b/scripts/presubmit-tests.sh
@@ -306,6 +306,8 @@ function main() {
     kubectl version --client
     echo ">> go version"
     go version
+    echo ">> python3 version"
+    python3 --version
     echo ">> git version"
     git version
     echo ">> ko version"


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Support having multiple Prow job config files.

This should be merged after https://github.com/istio/test-infra/pull/2599 is merged.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @chaodaiG 
/hold
