### PR TITLE
Small fixes to the Prow config updater tool

### DIFF
--- a/tools/prow-config-updater/config/config.go
+++ b/tools/prow-config-updater/config/config.go
@@ -52,6 +52,7 @@ const (
 	core    = "core"
 	jobs    = "jobs"
 	cluster = "cluster"
+	boskos  = "boskos"
 )
 
 var (
@@ -76,11 +77,13 @@ var (
 		filepath.Join(ProdProwConfigRoot, core),
 		filepath.Join(ProdProwConfigRoot, jobs),
 		filepath.Join(ProdProwConfigRoot, cluster),
+		filepath.Join(ProdProwConfigRoot, boskos),
 	}
 	StagingProwConfigPaths = []string{
 		filepath.Join(StagingProwConfigRoot, core),
 		filepath.Join(StagingProwConfigRoot, jobs),
 		filepath.Join(StagingProwConfigRoot, cluster),
+		filepath.Join(StagingProwConfigRoot, boskos),
 	}
 	ProdTestgridConfigPath = filepath.Join(ProdProwConfigRoot, "testgrid")
 
@@ -151,10 +154,14 @@ func GenerateConfigFiles() error {
 	return err
 }
 
-// CollectRelevantFiles can filter out all files that are under the given paths.
-func CollectRelevantFiles(files []string, paths []string) []string {
+// CollectRelevantConfigFiles can filter out all config files that are under the given paths.
+func CollectRelevantConfigFiles(files []string, paths []string) []string {
 	rfs := make([]string, 0)
 	for _, f := range files {
+		// Only consider .yaml files.
+		if !strings.HasSuffix(f, ".yaml") {
+			continue
+		}
 		for _, p := range paths {
 			if !strings.HasSuffix(p, string(filepath.Separator)) {
 				p = p + string(filepath.Separator)

--- a/tools/prow-config-updater/config/config_test.go
+++ b/tools/prow-config-updater/config/config_test.go
@@ -78,10 +78,15 @@ func TestCollectRelevantFiles(t *testing.T) {
 		files:    []string{"test/test1/file1.yaml", "test/test2/file2.yaml", "test111/file3.yaml"},
 		paths:    []string{"test"},
 		expected: []string{"test/test1/file1.yaml", "test/test2/file2.yaml"},
+	}, {
+		name:     "non-yaml files will be ignored",
+		files:    []string{"test/test1/file1.yaml", "test/test2/file2.yaml", "test111/file3.yaml", "test/test.sh"},
+		paths:    []string{"test"},
+		expected: []string{"test/test1/file1.yaml", "test/test2/file2.yaml"},
 	}}
 
 	for _, test := range tests {
-		res := CollectRelevantFiles(test.files, test.paths)
+		res := CollectRelevantConfigFiles(test.files, test.paths)
 		cmpRes := cmp.Diff(res, test.expected)
 		if cmpRes != "" {
 			t.Fatalf("expect and actual are different:\n%s", cmpRes)

--- a/tools/prow-config-updater/presubmit-checker/main.go
+++ b/tools/prow-config-updater/presubmit-checker/main.go
@@ -73,7 +73,7 @@ func main() {
 		for i, f := range files {
 			fns[i] = f.GetFilename()
 		}
-		bannedFiles := config.CollectRelevantFiles(fns, config.ProdProwKeyConfigPaths)
+		bannedFiles := config.CollectRelevantConfigFiles(fns, config.ProdProwKeyConfigPaths)
 
 		// If any of the production Prow key config files are changed, report the error.
 		if len(bannedFiles) != 0 {

--- a/tools/prow-config-updater/updater.go
+++ b/tools/prow-config-updater/updater.go
@@ -54,8 +54,12 @@ func (cli *Client) initialize() error {
 func (cli *Client) runProwConfigUpdate() error {
 	// If no staging process if needed, we can directly update the changed Prow configs.
 	if !cli.needsStaging() {
-		if err := cli.updateProw(); err != nil {
-			return fmt.Errorf("error updating Prow configs: %v", err)
+		// Try to update both staging and production Prow.
+		// If no config changes need to be updated, the function call will be just a no-op.
+		for _, env := range []config.ProwEnv{config.StagingProwEnv, config.ProdProwEnv} {
+			if err := cli.updateProw(env); err != nil {
+				return fmt.Errorf("error updating Prow configs: %v", err)
+			}
 		}
 	} else {
 		if err := cli.startStaging(); err != nil {
@@ -87,28 +91,25 @@ func (cli *Client) needsStaging() bool {
 		return false
 	}
 	// If any key config files for staging Prow are changed, the staging process will be needed.
-	fs := config.CollectRelevantFiles(cli.files, config.StagingProwKeyConfigPaths)
+	fs := config.CollectRelevantConfigFiles(cli.files, config.StagingProwKeyConfigPaths)
 	return len(fs) != 0
 }
 
 // Update Prow with the changed config files and send message for the update result.
 // If no config changes need to be updated, this function call will be just a no-op.
-func (cli *Client) updateProw() error {
-	for _, env := range []config.ProwEnv{config.StagingProwEnv, config.ProdProwEnv} {
-		updatedFiles, err := cli.doProwUpdate(env)
-		prnumber := *cli.pr.Number
-		if err == nil {
-			if len(updatedFiles) != 0 {
-				// Best effort, won't fail the process if the comment fails.
-				cli.githubcommenter.commentOnUpdateConfigsSuccess(prnumber, env, updatedFiles)
-			}
-		} else {
+func (cli *Client) updateProw(env config.ProwEnv) error {
+	updatedFiles, err := cli.doProwUpdate(env)
+	prnumber := *cli.pr.Number
+	if err == nil {
+		if len(updatedFiles) != 0 {
 			// Best effort, won't fail the process if the comment fails.
-			cli.githubcommenter.commentOnUpdateConfigsFailure(prnumber, env, updatedFiles, err)
+			cli.githubcommenter.commentOnUpdateConfigsSuccess(prnumber, env, updatedFiles)
 		}
-		return err
+	} else {
+		// Best effort, won't fail the process if the comment fails.
+		cli.githubcommenter.commentOnUpdateConfigsFailure(prnumber, env, updatedFiles, err)
 	}
-	return nil
+	return err
 }
 
 // Start running the staging process to update and test staging Prow.
@@ -140,9 +141,9 @@ func (cli *Client) doProwUpdate(env config.ProwEnv) ([]string, error) {
 	relevantFiles := make([]string, 0)
 	switch env {
 	case config.ProdProwEnv:
-		relevantFiles = append(relevantFiles, config.CollectRelevantFiles(cli.files, config.ProdProwConfigPaths)...)
+		relevantFiles = append(relevantFiles, config.CollectRelevantConfigFiles(cli.files, config.ProdProwConfigPaths)...)
 	case config.StagingProwEnv:
-		relevantFiles = append(relevantFiles, config.CollectRelevantFiles(cli.files, config.StagingProwConfigPaths)...)
+		relevantFiles = append(relevantFiles, config.CollectRelevantConfigFiles(cli.files, config.StagingProwConfigPaths)...)
 	default:
 		return relevantFiles, fmt.Errorf("unsupported Prow environement: %q, cannot make the update", env)
 	}
@@ -153,7 +154,7 @@ func (cli *Client) doProwUpdate(env config.ProwEnv) ([]string, error) {
 	}
 
 	// For production Prow, we also need to update Testgrid config if it's changed.
-	tfs := config.CollectRelevantFiles(cli.files, []string{config.ProdTestgridConfigPath})
+	tfs := config.CollectRelevantConfigFiles(cli.files, []string{config.ProdTestgridConfigPath})
 	if len(tfs) != 0 {
 		relevantFiles = append(relevantFiles, tfs...)
 		if err := config.UpdateTestgrid(env, cli.dryrun); err != nil {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
1. Always try to both staging and production Prow configs if staging process is not needed.
2. If no config file is changed that needed to be updated, the function call will be just a no-op thus will not leave comments on the pull request.
3. Prow config updater tool also update boskos config changes.

This fixes the comment in https://github.com/knative/test-infra/pull/1918#issuecomment-616693118

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @chaodaiG 
