### PR TITLE
Add service accounts for Boskos in build cluster

### DIFF
--- a/config/build-cluster/cluster/200-cpu-limitrange.yaml
+++ b/config/build-cluster/cluster/200-cpu-limitrange.yaml
@@ -1,0 +1,26 @@
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: cpu-limit-range
+  namespace: test-pods
+spec:
+  limits:
+    - default:
+        cpu: 4000m
+      defaultRequest:
+        cpu: 2000m
+      type: Container

--- a/config/build-cluster/cluster/200-memory-limitrange.yaml
+++ b/config/build-cluster/cluster/200-memory-limitrange.yaml
@@ -1,0 +1,26 @@
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: mem-limit-range
+  namespace: test-pods
+spec:
+  limits:
+    - default:
+        memory: 8Gi
+      defaultRequest:
+        memory: 4Gi
+      type: Container

--- a/config/build-cluster/cluster/301-rbac.yaml
+++ b/config/build-cluster/cluster/301-rbac.yaml
@@ -1,0 +1,84 @@
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# RBAC resources needed on the Prow cluster.
+# All the settings come from the Kubernetes Prow cluster configs
+# at https://github.com/kubernetes/test-infra/tree/master/prow/cluster
+
+# Service accounts, roles and bindings
+
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: "boskos"
+  namespace: test-pods
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: crd-creator
+subjects:
+- kind: ServiceAccount
+  name: boskos
+  namespace: test-pods
+roleRef:
+  kind: ClusterRole
+  name: boskos
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: boskos
+rules:
+- apiGroups: ["apiextensions.k8s.io"]
+  verbs: ["*"]
+  resources: ["customresourcedefinitions"]
+- apiGroups: ["boskos.k8s.io"]
+  verbs: ["*"]
+  resources: ["*"]
+---
+
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: "default"
+  namespace: test-pods
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: "test-pods-default"
+  namespace: test-pods
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "test-pods-default"
+subjects:
+- kind: ServiceAccount
+  name: "default"
+  namespace: test-pods
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: "test-pods-default"
+  namespace: test-pods
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get


### PR DESCRIPTION
Forgot to add this in previous PR

By the way setting default cpu/memory in `test-pods` namespace

/assign chizhg
/cc chizhg