### PR TITLE
Enable dind for eventing-kafka repo

### DIFF
--- a/config/prow/config_knative.yaml
+++ b/config/prow/config_knative.yaml
@@ -1053,6 +1053,7 @@ periodics:
       needs-dind: true
     - dot-release: true
       go113: true
+      dot-dev: true
       needs-dind: true
       env-vars:
       - ORG_NAME=knative-sandbox

--- a/config/prow/config_knative.yaml
+++ b/config/prow/config_knative.yaml
@@ -435,12 +435,16 @@ presubmits:
   knative-sandbox/eventing-kafka:
     - build-tests: true
       dot-dev: true
+      needs-dind: true
     - unit-tests: true
       dot-dev: true
+      needs-dind: true
     - integration-tests: true
       dot-dev: true
+      needs-dind: true
     - go-coverage: true
       dot-dev: true
+      needs-dind: true
 
 periodics:
   knative/serving:
@@ -1042,15 +1046,19 @@ periodics:
     - continuous: true
       go113: true
       dot-dev: true
+      needs-dind: true
     - nightly: true
       go113: true
       dot-dev: true
+      needs-dind: true
     - dot-release: true
       go113: true
+      needs-dind: true
       env-vars:
       - ORG_NAME=knative-sandbox
     - auto-release: true
       go113: true
       dot-dev: true
+      needs-dind: true
       env-vars:
       - ORG_NAME=knative-sandbox

--- a/config/prow/jobs/config.yaml
+++ b/config/prow/jobs/config.yaml
@@ -5134,14 +5134,20 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--build-tests"
+        securityContext:
+          privileged: true
         volumeMounts:
         - name: repoview-token
           mountPath: /etc/repoview-token
           readOnly: true
+        - name: docker-graph
+          mountPath: /docker-graph
         - name: test-account
           mountPath: /etc/test-account
           readOnly: true
         env:
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: "true"
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
@@ -5150,6 +5156,8 @@ presubmits:
       - name: repoview-token
         secret:
           secretName: repoview-token
+      - name: docker-graph
+        emptyDir: {}
       - name: test-account
         secret:
           secretName: test-account
@@ -5171,14 +5179,20 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--unit-tests"
+        securityContext:
+          privileged: true
         volumeMounts:
         - name: repoview-token
           mountPath: /etc/repoview-token
           readOnly: true
+        - name: docker-graph
+          mountPath: /docker-graph
         - name: test-account
           mountPath: /etc/test-account
           readOnly: true
         env:
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: "true"
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
@@ -5187,6 +5201,8 @@ presubmits:
       - name: repoview-token
         secret:
           secretName: repoview-token
+      - name: docker-graph
+        emptyDir: {}
       - name: test-account
         secret:
           secretName: test-account
@@ -5208,14 +5224,20 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--integration-tests"
+        securityContext:
+          privileged: true
         volumeMounts:
         - name: repoview-token
           mountPath: /etc/repoview-token
           readOnly: true
+        - name: docker-graph
+          mountPath: /docker-graph
         - name: test-account
           mountPath: /etc/test-account
           readOnly: true
         env:
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: "true"
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
@@ -5224,6 +5246,8 @@ presubmits:
       - name: repoview-token
         secret:
           secretName: repoview-token
+      - name: docker-graph
+        emptyDir: {}
       - name: test-account
         secret:
           secretName: test-account
@@ -5252,10 +5276,17 @@ presubmits:
         - name: covbot-token
           mountPath: /etc/covbot-token
           readOnly: true
+        - name: docker-graph
+          mountPath: /docker-graph
+        env:
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: "true"
       volumes:
       - name: covbot-token
         secret:
           secretName: covbot-token
+      - name: docker-graph
+        emptyDir: {}
 periodics:
 - cron: "10 */2 * * *"
   name: ci-knative-serving-continuous
@@ -10333,16 +10364,24 @@ periodics:
       args:
       - "./test/presubmit-tests.sh"
       - "--all-tests"
+      securityContext:
+        privileged: true
       volumeMounts:
+      - name: docker-graph
+        mountPath: /docker-graph
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
       env:
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
     volumes:
+    - name: docker-graph
+      emptyDir: {}
     - name: test-account
       secret:
         secretName: test-account
@@ -10370,16 +10409,24 @@ periodics:
       - "./hack/release.sh"
       - "--publish"
       - "--tag-release"
+      securityContext:
+        privileged: true
       volumeMounts:
+      - name: docker-graph
+        mountPath: /docker-graph
       - name: nightly-account
         mountPath: /etc/nightly-account
         readOnly: true
       env:
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
     volumes:
+    - name: docker-graph
+      emptyDir: {}
     - name: nightly-account
       secret:
         secretName: nightly-account
@@ -10408,14 +10455,20 @@ periodics:
       - "--release-gcs knative-releases/eventing-kafka"
       - "--release-gcr gcr.io/knative-releases"
       - "--github-token /etc/hub-token/token"
+      securityContext:
+        privileged: true
       volumeMounts:
       - name: hub-token
         mountPath: /etc/hub-token
         readOnly: true
+      - name: docker-graph
+        mountPath: /docker-graph
       - name: release-account
         mountPath: /etc/release-account
         readOnly: true
       env:
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
       - name: ORG_NAME
         value: knative-sandbox
       - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -10426,6 +10479,8 @@ periodics:
     - name: hub-token
       secret:
         secretName: hub-token
+    - name: docker-graph
+      emptyDir: {}
     - name: release-account
       secret:
         secretName: release-account
@@ -10455,14 +10510,20 @@ periodics:
       - "--release-gcs knative-releases/eventing-kafka"
       - "--release-gcr gcr.io/knative-releases"
       - "--github-token /etc/hub-token/token"
+      securityContext:
+        privileged: true
       volumeMounts:
       - name: hub-token
         mountPath: /etc/hub-token
         readOnly: true
+      - name: docker-graph
+        mountPath: /docker-graph
       - name: release-account
         mountPath: /etc/release-account
         readOnly: true
       env:
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
       - name: ORG_NAME
         value: knative-sandbox
       - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -10473,6 +10534,8 @@ periodics:
     - name: hub-token
       secret:
         secretName: hub-token
+    - name: docker-graph
+      emptyDir: {}
     - name: release-account
       secret:
         secretName: release-account

--- a/config/prow/jobs/config.yaml
+++ b/config/prow/jobs/config.yaml
@@ -10443,6 +10443,7 @@ periodics:
   - org: knative-sandbox
     repo: eventing-kafka
     base_ref: master
+    path_alias: knative.dev/eventing-kafka
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable


### PR DESCRIPTION
knative-sandbox/eventing-kafka repo needs DIND(docker in docker) for testing, enable this in all of its Prow jobs

/assign chizhg
/cc davyodom