### PR TITLE
Move another 20 Boskos to build cluster

### DIFF
--- a/config/build-cluster/boskos/boskos_resources.yaml
+++ b/config/build-cluster/boskos/boskos_resources.yaml
@@ -14,6 +14,26 @@
 
 resources:
 - names:
+  - knative-boskos-41
+  - knative-boskos-42
+  - knative-boskos-43
+  - knative-boskos-44
+  - knative-boskos-45
+  - knative-boskos-46
+  - knative-boskos-47
+  - knative-boskos-48
+  - knative-boskos-49
+  - knative-boskos-50
+  - knative-boskos-51
+  - knative-boskos-52
+  - knative-boskos-53
+  - knative-boskos-54
+  - knative-boskos-55
+  - knative-boskos-56
+  - knative-boskos-57
+  - knative-boskos-58
+  - knative-boskos-59
+  - knative-boskos-60
   - knative-boskos-61
   - knative-boskos-62
   - knative-boskos-63

--- a/config/prow/boskos/boskos_resources.yaml
+++ b/config/prow/boskos/boskos_resources.yaml
@@ -54,25 +54,5 @@ resources:
   - knative-boskos-38
   - knative-boskos-39
   - knative-boskos-40
-  - knative-boskos-41
-  - knative-boskos-42
-  - knative-boskos-43
-  - knative-boskos-44
-  - knative-boskos-45
-  - knative-boskos-46
-  - knative-boskos-47
-  - knative-boskos-48
-  - knative-boskos-49
-  - knative-boskos-50
-  - knative-boskos-51
-  - knative-boskos-52
-  - knative-boskos-53
-  - knative-boskos-54
-  - knative-boskos-55
-  - knative-boskos-56
-  - knative-boskos-57
-  - knative-boskos-58
-  - knative-boskos-59
-  - knative-boskos-60
   state: dirty
   type: gke-project


### PR DESCRIPTION
In preparation for migrating all workloads to build cluster. I believe 60 projects are sufficient in normal circumstances

/assign chizhg
/cc chizhg

Now that only jobs from serving remain in old cluster, 40 Boskos should be sufficient, so don't hold