### PR TITLE
Do not generate most of the maintenance jobs with config-generator

### DIFF
--- a/config/prow/jobs/config.yaml
+++ b/config/prow/jobs/config.yaml
@@ -10757,190 +10757,242 @@ periodics:
       args:
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
-- cron: "0 19 * * 1,3,5"
-  name: ci-knative-cleanup
+- cron: "30 07 * * *"
+  name: ci-knative-serving-recreate-clusters
+  agent: kubernetes
   labels:
-      prow.k8s.io/pubsub.project: knative-tests
-      prow.k8s.io/pubsub.topic: knative-monitoring
-      prow.k8s.io/pubsub.runID: ci-knative-cleanup
-  agent: kubernetes
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-knative-serving-recreate-clusters
   decorate: true
-  cluster: "build-knative"
-  decoration_config:
-    timeout: 21600000000000
   extra_refs:
   - org: knative
-    repo: test-infra
+    repo: serving
     base_ref: master
+    path_alias: knative.dev/serving
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
       command:
-      - "go"
+      - runner.sh
       args:
-      - "run"
-      - "./tools/cleanup/cleanup.go"
-      - "--project-resource-yaml=config/prow/boskos_resources.yaml"
-      - "--days-to-keep-images=30"
-      - "--hours-to-keep-clusters=24"
-      - "--service-account=/etc/test-account/service-account.json"
+      - "./test/performance/performance-tests.sh"
+      - "--recreate-clusters"
       volumeMounts:
-      - name: test-account
-        mountPath: /etc/test-account
+      - name: performance-test
+        mountPath: /etc/performance-test
         readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/performance-test/service-account.json
+      - name: GITHUB_TOKEN
+        value: /etc/performance-test/github-token
+      - name: SLACK_READ_TOKEN
+        value: /etc/performance-test/slack-read-token
+      - name: SLACK_WRITE_TOKEN
+        value: /etc/performance-test/slack-write-token
     volumes:
-    - name: test-account
+    - name: performance-test
       secret:
-        secretName: test-account
-- cron: "0 12 * * *"
-  name: ci-knative-flakes-reporter
+        secretName: performance-test
+- cron: "5 * * * *"
+  name: ci-knative-serving-update-clusters
+  agent: kubernetes
   labels:
-      prow.k8s.io/pubsub.project: knative-tests
-      prow.k8s.io/pubsub.topic: knative-monitoring
-      prow.k8s.io/pubsub.runID: ci-knative-flakes-reporter
-  agent: kubernetes
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-knative-serving-update-clusters
   decorate: true
-  cluster: "build-knative"
   extra_refs:
   - org: knative
-    repo: test-infra
+    repo: serving
     base_ref: master
+    path_alias: knative.dev/serving
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/flaky-test-reporter:latest
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
       command:
-      - "/flaky-test-reporter"
+      - runner.sh
       args:
-      - "--service-account=/etc/test-account/service-account.json"
-      - "--github-account=/etc/flaky-test-reporter-github-token/token"
-      - "--slack-account=/etc/flaky-test-reporter-slack-token/token"
+      - "./test/performance/performance-tests.sh"
+      - "--update-clusters"
       volumeMounts:
-      - name: test-account
-        mountPath: /etc/test-account
+      - name: performance-test
+        mountPath: /etc/performance-test
         readOnly: true
-      - name: flaky-test-reporter-github-token
-        mountPath: /etc/flaky-test-reporter-github-token
-        readOnly: true
-      - name: flaky-test-reporter-slack-token
-        mountPath: /etc/flaky-test-reporter-slack-token
-        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/performance-test/service-account.json
+      - name: GITHUB_TOKEN
+        value: /etc/performance-test/github-token
+      - name: SLACK_READ_TOKEN
+        value: /etc/performance-test/slack-read-token
+      - name: SLACK_WRITE_TOKEN
+        value: /etc/performance-test/slack-write-token
     volumes:
-    - name: test-account
+    - name: performance-test
       secret:
-        secretName: test-account
-    - name: flaky-test-reporter-github-token
-      secret:
-        secretName: flaky-test-reporter-github-token
-    - name: flaky-test-reporter-slack-token
-      secret:
-        secretName: flaky-test-reporter-slack-token
-- cron: "0 * * * *"
-  name: ci-knative-flakes-resultsrecorder
+        secretName: performance-test
+- cron: "30 07 * * *"
+  name: ci-knative-eventing-recreate-clusters
+  agent: kubernetes
   labels:
-      prow.k8s.io/pubsub.project: knative-tests
-      prow.k8s.io/pubsub.topic: knative-monitoring
-      prow.k8s.io/pubsub.runID: ci-knative-flakes-reporter
-  agent: kubernetes
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-knative-eventing-recreate-clusters
   decorate: true
   cluster: "build-knative"
   extra_refs:
   - org: knative
-    repo: test-infra
+    repo: eventing
     base_ref: master
+    path_alias: knative.dev/eventing
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/flaky-test-reporter:latest
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
       command:
-      - "/flaky-test-reporter"
+      - runner.sh
       args:
-      - "--service-account=/etc/test-account/service-account.json"
-      - "--skip-report"
-      - "--build-count=20"
+      - "./test/performance/performance-tests.sh"
+      - "--recreate-clusters"
       volumeMounts:
-      - name: test-account
-        mountPath: /etc/test-account
+      - name: performance-test
+        mountPath: /etc/performance-test
         readOnly: true
-      - name: flaky-test-reporter-github-token
-        mountPath: /etc/flaky-test-reporter-github-token
-        readOnly: true
-      - name: flaky-test-reporter-slack-token
-        mountPath: /etc/flaky-test-reporter-slack-token
-        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/performance-test/service-account.json
+      - name: GITHUB_TOKEN
+        value: /etc/performance-test/github-token
+      - name: SLACK_READ_TOKEN
+        value: /etc/performance-test/slack-read-token
+      - name: SLACK_WRITE_TOKEN
+        value: /etc/performance-test/slack-write-token
     volumes:
-    - name: test-account
+    - name: performance-test
       secret:
-        secretName: test-account
-    - name: flaky-test-reporter-github-token
-      secret:
-        secretName: flaky-test-reporter-github-token
-    - name: flaky-test-reporter-slack-token
-      secret:
-        secretName: flaky-test-reporter-slack-token
-- cron: "0 20 * * 1"
-  name: ci-knative-prow-auto-bumper
+        secretName: performance-test
+- cron: "5 * * * *"
+  name: ci-knative-eventing-update-clusters
   agent: kubernetes
+  labels:
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-knative-eventing-update-clusters
   decorate: true
   cluster: "build-knative"
   extra_refs:
   - org: knative
-    repo: test-infra
+    repo: eventing
+    base_ref: master
+    path_alias: knative.dev/eventing
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./test/performance/performance-tests.sh"
+      - "--update-clusters"
+      volumeMounts:
+      - name: performance-test
+        mountPath: /etc/performance-test
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/performance-test/service-account.json
+      - name: GITHUB_TOKEN
+        value: /etc/performance-test/github-token
+      - name: SLACK_READ_TOKEN
+        value: /etc/performance-test/slack-read-token
+      - name: SLACK_WRITE_TOKEN
+        value: /etc/performance-test/slack-write-token
+    volumes:
+    - name: performance-test
+      secret:
+        secretName: performance-test
+- cron: "30 07 * * *"
+  name: ci-google-knative-gcp-recreate-clusters
+  agent: kubernetes
+  labels:
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-google-knative-gcp-recreate-clusters
+  decorate: true
+  cluster: "build-knative"
+  extra_refs:
+  - org: google
+    repo: knative-gcp
     base_ref: master
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-auto-bumper:latest
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
       command:
-      - "/prow-auto-bumper"
+      - runner.sh
       args:
-      - "--github-account=/etc/prow-auto-bumper-github-token/token"
-      - "--git-userid=knative-prow-updater-robot"
-      - "--git-username='Knative Prow Updater Robot'"
-      - "--git-email=knative-prow-updater-robot@google.com"
+      - "./test/performance/performance-tests.sh"
+      - "--recreate-clusters"
       volumeMounts:
-      - name: test-account
-        mountPath: /etc/test-account
+      - name: performance-test
+        mountPath: /etc/performance-test
         readOnly: true
-      - name: prow-auto-bumper-github-token
-        mountPath: /etc/prow-auto-bumper-github-token
-        readOnly: true
-      - name: prow-updater-robot-ssh-key
-        mountPath: /root/.ssh
-        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/performance-test/service-account.json
+      - name: GITHUB_TOKEN
+        value: /etc/performance-test/github-token
+      - name: SLACK_READ_TOKEN
+        value: /etc/performance-test/slack-read-token
+      - name: SLACK_WRITE_TOKEN
+        value: /etc/performance-test/slack-write-token
     volumes:
-    - name: test-account
+    - name: performance-test
       secret:
-        secretName: test-account
-    - name: prow-auto-bumper-github-token
-      secret:
-        secretName: prow-auto-bumper-github-token
-    - name: prow-updater-robot-ssh-key
-      secret:
-        secretName: prow-updater-robot-ssh-key
-        defaultMode: 0400
-- cron: "15 9 * * *"
-  name: ci-knative-backup-artifacts
+        secretName: performance-test
+- cron: "5 * * * *"
+  name: ci-google-knative-gcp-update-clusters
   agent: kubernetes
+  labels:
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-google-knative-gcp-update-clusters
   decorate: true
   cluster: "build-knative"
+  extra_refs:
+  - org: google
+    repo: knative-gcp
+    base_ref: master
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/backups:latest
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
       command:
-      - "/backup.sh"
+      - runner.sh
       args:
-      - "/etc/backup-account/service-account.json"
+      - "./test/performance/performance-tests.sh"
+      - "--update-clusters"
       volumeMounts:
-      - name: backup-account
-        mountPath: /etc/backup-account
+      - name: performance-test
+        mountPath: /etc/performance-test
         readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/performance-test/service-account.json
+      - name: GITHUB_TOKEN
+        value: /etc/performance-test/github-token
+      - name: SLACK_READ_TOKEN
+        value: /etc/performance-test/slack-read-token
+      - name: SLACK_WRITE_TOKEN
+        value: /etc/performance-test/slack-write-token
     volumes:
-    - name: backup-account
+    - name: performance-test
       secret:
-        secretName: backup-account
+        secretName: performance-test
 - cron: "0 */12 * * *"
   name: ci-knative-test-infra-issue-tracker-stale
   agent: kubernetes
@@ -11256,242 +11308,6 @@ periodics:
     - name: housekeeping-github-token
       secret:
         secretName: housekeeping-github-token
-- cron: "30 07 * * *"
-  name: ci-knative-serving-recreate-clusters
-  agent: kubernetes
-  labels:
-    prow.k8s.io/pubsub.project: knative-tests
-    prow.k8s.io/pubsub.topic: knative-monitoring
-    prow.k8s.io/pubsub.runID: ci-knative-serving-recreate-clusters
-  decorate: true
-  extra_refs:
-  - org: knative
-    repo: serving
-    base_ref: master
-    path_alias: knative.dev/serving
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./test/performance/performance-tests.sh"
-      - "--recreate-clusters"
-      volumeMounts:
-      - name: performance-test
-        mountPath: /etc/performance-test
-        readOnly: true
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/performance-test/service-account.json
-      - name: GITHUB_TOKEN
-        value: /etc/performance-test/github-token
-      - name: SLACK_READ_TOKEN
-        value: /etc/performance-test/slack-read-token
-      - name: SLACK_WRITE_TOKEN
-        value: /etc/performance-test/slack-write-token
-    volumes:
-    - name: performance-test
-      secret:
-        secretName: performance-test
-- cron: "5 * * * *"
-  name: ci-knative-serving-update-clusters
-  agent: kubernetes
-  labels:
-    prow.k8s.io/pubsub.project: knative-tests
-    prow.k8s.io/pubsub.topic: knative-monitoring
-    prow.k8s.io/pubsub.runID: ci-knative-serving-update-clusters
-  decorate: true
-  extra_refs:
-  - org: knative
-    repo: serving
-    base_ref: master
-    path_alias: knative.dev/serving
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./test/performance/performance-tests.sh"
-      - "--update-clusters"
-      volumeMounts:
-      - name: performance-test
-        mountPath: /etc/performance-test
-        readOnly: true
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/performance-test/service-account.json
-      - name: GITHUB_TOKEN
-        value: /etc/performance-test/github-token
-      - name: SLACK_READ_TOKEN
-        value: /etc/performance-test/slack-read-token
-      - name: SLACK_WRITE_TOKEN
-        value: /etc/performance-test/slack-write-token
-    volumes:
-    - name: performance-test
-      secret:
-        secretName: performance-test
-- cron: "30 07 * * *"
-  name: ci-knative-eventing-recreate-clusters
-  agent: kubernetes
-  labels:
-    prow.k8s.io/pubsub.project: knative-tests
-    prow.k8s.io/pubsub.topic: knative-monitoring
-    prow.k8s.io/pubsub.runID: ci-knative-eventing-recreate-clusters
-  decorate: true
-  cluster: "build-knative"
-  extra_refs:
-  - org: knative
-    repo: eventing
-    base_ref: master
-    path_alias: knative.dev/eventing
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./test/performance/performance-tests.sh"
-      - "--recreate-clusters"
-      volumeMounts:
-      - name: performance-test
-        mountPath: /etc/performance-test
-        readOnly: true
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/performance-test/service-account.json
-      - name: GITHUB_TOKEN
-        value: /etc/performance-test/github-token
-      - name: SLACK_READ_TOKEN
-        value: /etc/performance-test/slack-read-token
-      - name: SLACK_WRITE_TOKEN
-        value: /etc/performance-test/slack-write-token
-    volumes:
-    - name: performance-test
-      secret:
-        secretName: performance-test
-- cron: "5 * * * *"
-  name: ci-knative-eventing-update-clusters
-  agent: kubernetes
-  labels:
-    prow.k8s.io/pubsub.project: knative-tests
-    prow.k8s.io/pubsub.topic: knative-monitoring
-    prow.k8s.io/pubsub.runID: ci-knative-eventing-update-clusters
-  decorate: true
-  cluster: "build-knative"
-  extra_refs:
-  - org: knative
-    repo: eventing
-    base_ref: master
-    path_alias: knative.dev/eventing
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./test/performance/performance-tests.sh"
-      - "--update-clusters"
-      volumeMounts:
-      - name: performance-test
-        mountPath: /etc/performance-test
-        readOnly: true
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/performance-test/service-account.json
-      - name: GITHUB_TOKEN
-        value: /etc/performance-test/github-token
-      - name: SLACK_READ_TOKEN
-        value: /etc/performance-test/slack-read-token
-      - name: SLACK_WRITE_TOKEN
-        value: /etc/performance-test/slack-write-token
-    volumes:
-    - name: performance-test
-      secret:
-        secretName: performance-test
-- cron: "30 07 * * *"
-  name: ci-google-knative-gcp-recreate-clusters
-  agent: kubernetes
-  labels:
-    prow.k8s.io/pubsub.project: knative-tests
-    prow.k8s.io/pubsub.topic: knative-monitoring
-    prow.k8s.io/pubsub.runID: ci-google-knative-gcp-recreate-clusters
-  decorate: true
-  cluster: "build-knative"
-  extra_refs:
-  - org: google
-    repo: knative-gcp
-    base_ref: master
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./test/performance/performance-tests.sh"
-      - "--recreate-clusters"
-      volumeMounts:
-      - name: performance-test
-        mountPath: /etc/performance-test
-        readOnly: true
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/performance-test/service-account.json
-      - name: GITHUB_TOKEN
-        value: /etc/performance-test/github-token
-      - name: SLACK_READ_TOKEN
-        value: /etc/performance-test/slack-read-token
-      - name: SLACK_WRITE_TOKEN
-        value: /etc/performance-test/slack-write-token
-    volumes:
-    - name: performance-test
-      secret:
-        secretName: performance-test
-- cron: "5 * * * *"
-  name: ci-google-knative-gcp-update-clusters
-  agent: kubernetes
-  labels:
-    prow.k8s.io/pubsub.project: knative-tests
-    prow.k8s.io/pubsub.topic: knative-monitoring
-    prow.k8s.io/pubsub.runID: ci-google-knative-gcp-update-clusters
-  decorate: true
-  cluster: "build-knative"
-  extra_refs:
-  - org: google
-    repo: knative-gcp
-    base_ref: master
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./test/performance/performance-tests.sh"
-      - "--update-clusters"
-      volumeMounts:
-      - name: performance-test
-        mountPath: /etc/performance-test
-        readOnly: true
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/performance-test/service-account.json
-      - name: GITHUB_TOKEN
-        value: /etc/performance-test/github-token
-      - name: SLACK_READ_TOKEN
-        value: /etc/performance-test/slack-read-token
-      - name: SLACK_WRITE_TOKEN
-        value: /etc/performance-test/slack-write-token
-    volumes:
-    - name: performance-test
-      secret:
-        secretName: performance-test
 postsubmits:
   knative/serving:
   - name: post-knative-serving-reconcile-clusters
@@ -11700,54 +11516,6 @@ postsubmits:
         args:
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=0"
-  - name: post-knative-prow-config-updater
-    agent: kubernetes
-    decorate: true
-    max_concurrency: 1
-    cluster: "prow-trusted"
-    run_if_changed: "^(config/(prow|prow-staging)/(cluster|core|jobs|boskos|testgrid)/.*.yaml)|(tools/config-generator/templates/(prow|prow-staging)/.*.yaml)$"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-config-updater:latest
-        imagePullPolicy: Always
-        command:
-        - "/prow-config-updater"
-        args:
-        - "--github-token-file=/etc/prow-robot-github-token/token"
-        - "--github-userid=knative-prow-robot"
-        - "--git-username='Knative Prow Robot'"
-        - "--git-email=adrcunha+knative-prow-robot@google.com"
-        - "--comment-github-token-file=/etc/prow-updater-robot-github-token/token"
-        volumeMounts:
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        - name: prow-robot-github-token
-          mountPath: /etc/prow-robot-github-token
-          readOnly: true
-        - name: prow-updater-robot-github-token
-          mountPath: /etc/prow-updater-robot-github-token
-          readOnly: true
-        - name: prow-robot-ssh-key
-          mountPath: /root/.ssh
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-      volumes:
-      - name: test-account
-        secret:
-          secretName: test-account
-      - name: prow-robot-github-token
-        secret:
-          secretName: prow-robot-github-token
-      - name: prow-updater-robot-github-token
-        secret:
-          secretName: prow-updater-robot-github-token
-      - name: prow-robot-ssh-key
-        secret:
-          secretName: prow-robot-ssh-key
-          defaultMode: 0400
   knative/caching:
   - name: post-knative-caching-go-coverage
     branches:

--- a/config/prow/jobs/custom-jobs.yaml
+++ b/config/prow/jobs/custom-jobs.yaml
@@ -1,0 +1,250 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+periodics:
+- cron: "15 9 * * *"
+  name: ci-knative-backup-artifacts
+  agent: kubernetes
+  decorate: true
+  cluster: "build-knative"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/backups:latest
+      imagePullPolicy: Always
+      command:
+      - "/backup.sh"
+      args:
+      - "/etc/backup-account/service-account.json"
+      volumeMounts:
+      - name: backup-account
+        mountPath: /etc/backup-account
+        readOnly: true
+    volumes:
+    - name: backup-account
+      secret:
+        secretName: backup-account
+- cron: "0 19 * * 1,3,5"
+  name: ci-knative-cleanup
+  labels:
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-knative-cleanup
+  agent: kubernetes
+  decorate: true
+  cluster: "build-knative"
+  decoration_config:
+    timeout: 21600000000000
+  extra_refs:
+  - org: knative
+    repo: test-infra
+    base_ref: master
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go112:stable
+      imagePullPolicy: Always
+      command:
+      - "go"
+      args:
+      - "run"
+      - "./tools/cleanup/cleanup.go"
+      - "--project-resource-yaml=config/prow/boskos_resources.yaml"
+      - "--days-to-keep-images=30"
+      - "--hours-to-keep-clusters=24"
+      - "--service-account=/etc/test-account/service-account.json"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "0 12 * * *"
+  name: ci-knative-flakes-reporter
+  labels:
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-knative-flakes-reporter
+  agent: kubernetes
+  decorate: true
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative
+    repo: test-infra
+    base_ref: master
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/flaky-test-reporter:latest
+      imagePullPolicy: Always
+      command:
+      - "/flaky-test-reporter"
+      args:
+      - "--service-account=/etc/test-account/service-account.json"
+      - "--github-account=/etc/flaky-test-reporter-github-token/token"
+      - "--slack-account=/etc/flaky-test-reporter-slack-token/token"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      - name: flaky-test-reporter-github-token
+        mountPath: /etc/flaky-test-reporter-github-token
+        readOnly: true
+      - name: flaky-test-reporter-slack-token
+        mountPath: /etc/flaky-test-reporter-slack-token
+        readOnly: true
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
+    - name: flaky-test-reporter-github-token
+      secret:
+        secretName: flaky-test-reporter-github-token
+    - name: flaky-test-reporter-slack-token
+      secret:
+        secretName: flaky-test-reporter-slack-token
+- cron: "0 * * * *"
+  name: ci-knative-flakes-resultsrecorder
+  labels:
+    prow.k8s.io/pubsub.project: knative-tests
+    prow.k8s.io/pubsub.topic: knative-monitoring
+    prow.k8s.io/pubsub.runID: ci-knative-flakes-reporter
+  agent: kubernetes
+  decorate: true
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative
+    repo: test-infra
+    base_ref: master
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/flaky-test-reporter:latest
+      imagePullPolicy: Always
+      command:
+      - "/flaky-test-reporter"
+      args:
+      - "--service-account=/etc/test-account/service-account.json"
+      - "--skip-report"
+      - "--build-count=20"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      - name: flaky-test-reporter-github-token
+        mountPath: /etc/flaky-test-reporter-github-token
+        readOnly: true
+      - name: flaky-test-reporter-slack-token
+        mountPath: /etc/flaky-test-reporter-slack-token
+        readOnly: true
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
+    - name: flaky-test-reporter-github-token
+      secret:
+        secretName: flaky-test-reporter-github-token
+    - name: flaky-test-reporter-slack-token
+      secret:
+        secretName: flaky-test-reporter-slack-token
+- cron: "0 20 * * 1"
+  name: ci-knative-prow-auto-bumper
+  agent: kubernetes
+  decorate: true
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative
+    repo: test-infra
+    base_ref: master
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-auto-bumper:latest
+      imagePullPolicy: Always
+      command:
+      - "/prow-auto-bumper"
+      args:
+      - "--github-account=/etc/prow-auto-bumper-github-token/token"
+      - "--git-userid=knative-prow-updater-robot"
+      - "--git-username='Knative Prow Updater Robot'"
+      - "--git-email=knative-prow-updater-robot@google.com"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      - name: prow-auto-bumper-github-token
+        mountPath: /etc/prow-auto-bumper-github-token
+        readOnly: true
+      - name: prow-updater-robot-ssh-key
+        mountPath: /root/.ssh
+        readOnly: true
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
+    - name: prow-auto-bumper-github-token
+      secret:
+        secretName: prow-auto-bumper-github-token
+    - name: prow-updater-robot-ssh-key
+      secret:
+        secretName: prow-updater-robot-ssh-key
+        defaultMode: 0400
+
+postsubmits:
+  knative/test-infra:
+  - name: post-knative-prow-config-updater
+    agent: kubernetes
+    decorate: true
+    max_concurrency: 1
+    cluster: "prow-trusted"
+    run_if_changed: "^(config/(prow|prow-staging)/(cluster|core|jobs|boskos|testgrid)/.*.yaml)|(tools/config-generator/templates/(prow|prow-staging)/.*.yaml)$"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-config-updater:latest
+        imagePullPolicy: Always
+        command:
+        - "/prow-config-updater"
+        args:
+        - "--github-token-file=/etc/prow-robot-github-token/token"
+        - "--github-userid=knative-prow-robot"
+        - "--git-username='Knative Prow Robot'"
+        - "--git-email=adrcunha+knative-prow-robot@google.com"
+        - "--comment-github-token-file=/etc/prow-updater-robot-github-token/token"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        - name: prow-robot-github-token
+          mountPath: /etc/prow-robot-github-token
+          readOnly: true
+        - name: prow-updater-robot-github-token
+          mountPath: /etc/prow-updater-robot-github-token
+          readOnly: true
+        - name: prow-robot-ssh-key
+          mountPath: /root/.ssh
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
+      - name: prow-robot-github-token
+        secret:
+          secretName: prow-robot-github-token
+      - name: prow-updater-robot-github-token
+        secret:
+          secretName: prow-updater-robot-github-token
+      - name: prow-robot-ssh-key
+        secret:
+          secretName: prow-robot-ssh-key
+          defaultMode: 0400

--- a/tools/config-generator/main.go
+++ b/tools/config-generator/main.go
@@ -134,27 +134,23 @@ type stringArrayFlag []string
 
 var (
 	// Values used in the jobs that can be changed through command-line flags.
-	output                       *os.File
-	prowHost                     string
-	testGridHost                 string
-	gubernatorHost               string
-	gcsBucket                    string
-	testGridGcsBucket            string
-	logsDir                      string
-	presubmitLogsDir             string
-	testAccount                  string
-	nightlyAccount               string
-	releaseAccount               string
-	flakesreporterDockerImage    string
-	prowversionbumperDockerImage string
-	prowconfigupdaterDockerImage string
-	githubCommenterDockerImage   string
-	coverageDockerImage          string
-	prowTestsDockerImage         string
-	backupsDockerImage           string
-	presubmitScript              string
-	releaseScript                string
-	webhookAPICoverageScript     string
+	output                     *os.File
+	prowHost                   string
+	testGridHost               string
+	gubernatorHost             string
+	gcsBucket                  string
+	testGridGcsBucket          string
+	logsDir                    string
+	presubmitLogsDir           string
+	testAccount                string
+	nightlyAccount             string
+	releaseAccount             string
+	githubCommenterDockerImage string
+	coverageDockerImage        string
+	prowTestsDockerImage       string
+	presubmitScript            string
+	releaseScript              string
+	webhookAPICoverageScript   string
 
 	// #########################################################################
 	// ############## data used for generating prow configuration ##############
@@ -1131,12 +1127,8 @@ func main() {
 	flag.StringVar(&testAccount, "test-account", "/etc/test-account/service-account.json", "Path to the service account JSON for test jobs")
 	flag.StringVar(&nightlyAccount, "nightly-account", "/etc/nightly-account/service-account.json", "Path to the service account JSON for nightly release jobs")
 	flag.StringVar(&releaseAccount, "release-account", "/etc/release-account/service-account.json", "Path to the service account JSON for release jobs")
-	var flakesreporterDockerImageName = flag.String("flaky-test-reporter-docker", "flaky-test-reporter:latest", "Docker image for flaky test reporting tool")
-	var prowversionbumperDockerImageName = flag.String("prow-auto-bumper", "prow-auto-bumper:latest", "Docker image for Prow version bumping tool")
-	var prowconfigupdaterDockerImageName = flag.String("prow-config-updater", "prow-config-updater:latest", "Docker image for Prow config updater tool")
 	var coverageDockerImageName = flag.String("coverage-docker", "coverage-go112:latest", "Docker image for coverage tool")
 	var prowTestsDockerImageName = flag.String("prow-tests-docker", "prow-tests-go112:stable", "prow-tests docker image")
-	var backupsDockerImageName = flag.String("backups-docker", "backups:latest", "Docker image for the backups job")
 	flag.StringVar(&githubCommenterDockerImage, "github-commenter-docker", "gcr.io/k8s-prow/commenter:v20190731-e3f7b9853", "github commenter docker image")
 	flag.StringVar(&presubmitScript, "presubmit-script", "./test/presubmit-tests.sh", "Executable for running presubmit tests")
 	flag.StringVar(&releaseScript, "release-script", "./hack/release.sh", "Executable for creating releases")
@@ -1151,12 +1143,8 @@ func main() {
 		log.Fatal("Pass the config file as parameter")
 	}
 
-	flakesreporterDockerImage = path.Join(*dockerImagesBase, *flakesreporterDockerImageName)
-	prowversionbumperDockerImage = path.Join(*dockerImagesBase, *prowversionbumperDockerImageName)
-	prowconfigupdaterDockerImage = path.Join(*dockerImagesBase, *prowconfigupdaterDockerImageName)
 	coverageDockerImage = path.Join(*dockerImagesBase, *coverageDockerImageName)
 	prowTestsDockerImage = path.Join(*dockerImagesBase, *prowTestsDockerImageName)
-	backupsDockerImage = path.Join(*dockerImagesBase, *backupsDockerImageName)
 
 	// We use MapSlice instead of maps to keep key order and create predictable output.
 	config := yaml.MapSlice{}
@@ -1197,20 +1185,13 @@ func main() {
 				generateGoCoveragePeriodic("periodics", repo.Name, nil)
 			}
 		}
+		generatePerfClusterUpdatePeriodicJobs()
 		if *generateMaintenanceJobs {
-			generateCleanupPeriodicJob()
-			generateFlakytoolPeriodicJob()
-			generateVersionBumpertoolPeriodicJob()
-			generateBackupPeriodicJob()
 			generateIssueTrackerPeriodicJobs()
-			generatePerfClusterUpdatePeriodicJobs()
 		}
 		for _, repo := range repositories {
 			if repo.EnableGoCoverage {
 				generateGoCoveragePostsubmit("postsubmits", repo.Name, nil)
-				if repo.Name == "knative/test-infra" && *generateMaintenanceJobs {
-					generateConfigUpdaterToolPostsubmitJob()
-				}
 			}
 			if repo.EnablePerformanceTests {
 				generatePerfClusterPostsubmitJob(repo)

--- a/tools/config-generator/postsubmit_config.go
+++ b/tools/config-generator/postsubmit_config.go
@@ -72,28 +72,3 @@ func generateGoCoveragePostsubmit(title, repoName string, _ yaml.MapSlice) {
 		executeJobTemplate("postsubmit go coverage", readTemplate(goCoveragePostsubmitJob), title, repoName, data.PostsubmitJobName, false, data)
 	}
 }
-
-func generateConfigUpdaterToolPostsubmitJob() {
-	var data postsubmitJobTemplateData
-	data.Base = newbaseProwJobTemplateData("knative/test-infra")
-	data.Base.Image = prowconfigupdaterDockerImage
-	data.PostsubmitJobName = "post-knative-prow-config-updater"
-	data.Base.RunIfChanged = "run_if_changed: \"^(config/(prow|prow-staging)/(cluster|core|jobs|boskos|testgrid)/.*.yaml)|(tools/config-generator/templates/(prow|prow-staging)/.*.yaml)$\""
-	// Run the job on the prow-trusted build cluster.
-	data.Base.Cluster = "cluster: \"prow-trusted\""
-	data.Base.Command = "/prow-config-updater"
-	data.Base.Args = []string{
-		"--github-token-file=/etc/prow-robot-github-token/token",
-		"--github-userid=knative-prow-robot",
-		"--git-username='Knative Prow Robot'",
-		"--git-email=adrcunha+knative-prow-robot@google.com",
-		"--comment-github-token-file=/etc/prow-updater-robot-github-token/token",
-	}
-	addExtraEnvVarsToJob(extraEnvVars, &data.Base)
-	configureServiceAccountForJob(&data.Base)
-	addVolumeToJob(&data.Base, "/etc/prow-robot-github-token", "prow-robot-github-token", true, "")
-	addVolumeToJob(&data.Base, "/etc/prow-updater-robot-github-token", "prow-updater-robot-github-token", true, "")
-	addVolumeToJob(&data.Base, "/root/.ssh", "prow-robot-ssh-key", true, "0400")
-	addEnvToJob(&data.Base, "GOOGLE_APPLICATION_CREDENTIALS", "/etc/test-account/service-account.json")
-	executeJobTemplate("postsubmit Prow config updater", readTemplate(postsubmitCustomJob), "postsubmits", "", data.PostsubmitJobName, false, data)
-}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Do not generate most of the maintenance jobs with config-generator. Instead, move them to a separate Prow job config file.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #1936

**Special notes to reviewers**:

**User-visible changes in this PR**:

