### PR TITLE
Fix run_job.sh and pj-on-kind.sh

### DIFF
--- a/config/prow/pj-on-kind.sh
+++ b/config/prow/pj-on-kind.sh
@@ -26,6 +26,6 @@ set -o pipefail
 
 prowdir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 export CONFIG_PATH="${prowdir}/core/config.yaml"
-export JOB_CONFIG_PATH="${prowdir}/jobs/config.yaml"
+export JOB_CONFIG_PATH="${prowdir}/jobs"
 
 bash <(curl -sSfL https://raw.githubusercontent.com/kubernetes/test-infra/master/prow/pj-on-kind.sh) "$@"

--- a/config/prow/run_job.sh
+++ b/config/prow/run_job.sh
@@ -31,7 +31,7 @@ run_mkpj="mkpj"
 
 JOB_YAML=$(mktemp)
 CONFIG_YAML=${REPO_ROOT_DIR}/config/prow/core/config.yaml
-JOB_CONFIG_YAML=${REPO_ROOT_DIR}/config/prow/jobs/config.yaml
+JOB_CONFIG_YAML=${REPO_ROOT_DIR}/config/prow/jobs
 ${run_mkpj} --job=$1 --config-path=${CONFIG_YAML} --job-config-path=${JOB_CONFIG_YAML} > ${JOB_YAML}
 echo "Job YAML file saved to ${JOB_YAML}"
 kubectl apply -f ${JOB_YAML}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Now that we have multiple job config files, the script we use to run jobs should also use the job directory instead of one single job file.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
