### PR TITLE
Use go114 in knative-gcp continuous and nightly

### DIFF
--- a/config/prow/config_knative.yaml
+++ b/config/prow/config_knative.yaml
@@ -915,7 +915,7 @@ periodics:
 
   google/knative-gcp:
     - continuous: true
-      go113: true
+      go114: true
     - branch-ci: true
       release: "0.12"
       go113: true
@@ -926,7 +926,7 @@ periodics:
       release: "0.14"
       go113: true
     - nightly: true
-      go113: true
+      go114: true
     - dot-release: true
       go113: true
       release: "0.12"

--- a/config/prow/jobs/config.yaml
+++ b/config/prow/jobs/config.yaml
@@ -7582,7 +7582,7 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go114:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -7755,7 +7755,7 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go114:stable
       imagePullPolicy: Always
       command:
       - runner.sh


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Bumps go version in knative-gcp to allow us to use new go test functionality.
