### PR TITLE
Send net-* flaky tests to #net-* channels instead of #networking.

### DIFF
--- a/tools/flaky-test-reporter/config/config.yaml
+++ b/tools/flaky-test-reporter/config/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2019 The Knative Authors
+x# Copyright 2019 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,49 +24,49 @@ jobConfigs:
     repo: serving
     type: postsubmit
     slackChannels:
-      - name: networking
+      - name: net-istio
         identity: CA9RHBGJX
   - name: ci-knative-serving-istio-1.5-no-mesh
     repo: serving
     type: postsubmit
     slackChannels:
-      - name: networking
+      - name: net-istio
         identity: CA9RHBGJX
   - name: ci-knative-serving-istio-1.4-mesh
     repo: serving
     type: postsubmit
     slackChannels:
-      - name: networking
+      - name: net-istio
         identity: CA9RHBGJX
   - name: ci-knative-serving-istio-1.4-no-mesh
     repo: serving
     type: postsubmit
     slackChannels:
-      - name: networking
+      - name: net-istio
         identity: CA9RHBGJX
   - name: ci-knative-serving-gloo-0.17.1
     repo: serving
     type: postsubmit
     slackChannels:
-      - name: networking
+      - name: net-gloo
         identity: CA9RHBGJX
   - name: ci-knative-serving-contour-latest
     repo: serving
     type: postsubmit
     slackChannels:
-      - name: networking
+      - name: net-contour
         identity: CA9RHBGJX
   - name: ci-knative-serving-kourier-stable
     repo: serving
     type: postsubmit
     slackChannels:
-      - name: networking
+      - name: net-kourier
         identity: CA9RHBGJX
   - name: ci-knative-serving-ambassador-latest
     repo: serving
     type: postsubmit
     slackChannels:
-      - name: networking
+      - name: net-ambassador
         identity: CA9RHBGJX
   - name: ci-knative-eventing-continuous
     repo: eventing

--- a/tools/flaky-test-reporter/config/config.yaml
+++ b/tools/flaky-test-reporter/config/config.yaml
@@ -25,49 +25,49 @@ jobConfigs:
     type: postsubmit
     slackChannels:
       - name: net-istio
-        identity: CA9RHBGJX
+        identity: C012AK2FPK7
   - name: ci-knative-serving-istio-1.5-no-mesh
     repo: serving
     type: postsubmit
     slackChannels:
       - name: net-istio
-        identity: CA9RHBGJX
+        identity: C012AK2FPK7
   - name: ci-knative-serving-istio-1.4-mesh
     repo: serving
     type: postsubmit
     slackChannels:
       - name: net-istio
-        identity: CA9RHBGJX
+        identity C012AK2FPK7
   - name: ci-knative-serving-istio-1.4-no-mesh
     repo: serving
     type: postsubmit
     slackChannels:
       - name: net-istio
-        identity: CA9RHBGJX
+        identity: C012AK2FPK7
   - name: ci-knative-serving-gloo-0.17.1
     repo: serving
     type: postsubmit
     slackChannels:
       - name: net-gloo
-        identity: CA9RHBGJX
+        identity: C011X8RKZBR
   - name: ci-knative-serving-contour-latest
     repo: serving
     type: postsubmit
     slackChannels:
       - name: net-contour
-        identity: CA9RHBGJX
+        identity: C012J5TCS6Q
   - name: ci-knative-serving-kourier-stable
     repo: serving
     type: postsubmit
     slackChannels:
       - name: net-kourier
-        identity: CA9RHBGJX
+        identity: C012C0VQJAW
   - name: ci-knative-serving-ambassador-latest
     repo: serving
     type: postsubmit
     slackChannels:
       - name: net-ambassador
-        identity: CA9RHBGJX
+        identity: C011X8SPF8X
   - name: ci-knative-eventing-continuous
     repo: eventing
     type: postsubmit

--- a/tools/flaky-test-reporter/config/config.yaml
+++ b/tools/flaky-test-reporter/config/config.yaml
@@ -1,4 +1,4 @@
-x# Copyright 2019 The Knative Authors
+# Copyright 2019 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:

Send net-* flaky tests to #net-* channels instead of #networking.

See thread https://knative.slack.com/archives/CA9RHBGJX/p1587572619150500 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
