### PR TITLE
Fixing staging Prow: don't use build cluster

### DIFF
--- a/config/prow-staging/jobs/config.yaml
+++ b/config/prow-staging/jobs/config.yaml
@@ -27,7 +27,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-prow-robot-serving-build-tests),?(\\s+|$)"
     decorate: true
     path_alias: knative.dev/serving
-    cluster: "build-knative"
     spec:
       containers:
       - image: gcr.io/knative-tests-staging/test-infra/prow-tests:stable
@@ -64,7 +63,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-prow-robot-serving-unit-tests),?(\\s+|$)"
     decorate: true
     path_alias: knative.dev/serving
-    cluster: "build-knative"
     spec:
       containers:
       - image: gcr.io/knative-tests-staging/test-infra/prow-tests:stable
@@ -101,7 +99,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-prow-robot-serving-integration-tests),?(\\s+|$)"
     decorate: true
     path_alias: knative.dev/serving
-    cluster: "build-knative"
     spec:
       containers:
       - image: gcr.io/knative-tests-staging/test-infra/prow-tests:stable
@@ -139,7 +136,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-prow-robot-test-infra-build-tests),?(\\s+|$)"
     decorate: true
     path_alias: knative.dev/test-infra
-    cluster: "build-knative"
     spec:
       containers:
       - image: gcr.io/knative-tests-staging/test-infra/prow-tests:stable
@@ -176,7 +172,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-prow-robot-test-infra-unit-tests),?(\\s+|$)"
     decorate: true
     path_alias: knative.dev/test-infra
-    cluster: "build-knative"
     spec:
       containers:
       - image: gcr.io/knative-tests-staging/test-infra/prow-tests:stable
@@ -213,7 +208,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-prow-robot-test-infra-integration-tests),?(\\s+|$)"
     decorate: true
     path_alias: knative.dev/test-infra
-    cluster: "build-knative"
     spec:
       containers:
       - image: gcr.io/knative-tests-staging/test-infra/prow-tests:stable

--- a/tools/config-generator/main.go
+++ b/tools/config-generator/main.go
@@ -446,7 +446,7 @@ func newbaseProwJobTemplateData(repo string) baseProwJobTemplateData {
 	data.Optional = ""
 
 	// Temporary solution for migrating repos to use build cluster step by step
-	if repo != "knative/serving" {
+	if repo != "knative/serving" && data.OrgName != "knative-prow-robot" {
 		data.Cluster = "cluster: \"build-knative\""
 	}
 	return data


### PR DESCRIPTION
Auto config updater failed in the past few days, this caused by all staging Prow jobs were pointing to build cluster and they don't have access to the build cluster.

/assign chizhg
/cc chizhg

/hold
There is a potential race condition between the current auto bumping PR https://github.com/knative-prow-robot/test-infra/pull/35 and the PR kicked off by this PR