### PR TITLE
GOFLAGS='' before go get

### DIFF
--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -489,11 +489,11 @@ function run_go_tool() {
       local install_failed=0
       # Swallow the output as we are returning the stdout in the end.
       pushd "${temp_dir}" > /dev/null 2>&1
-      go ${action} $1 || install_failed=1
+      GOFLAGS="" go ${action} $1 || install_failed=1
       popd > /dev/null 2>&1
       (( install_failed )) && return ${install_failed}
     else
-      go ${action} $1
+      GOFLAGS="" go ${action} $1
     fi
   fi
   shift 2
@@ -515,7 +515,7 @@ function update_licenses() {
 function check_licenses() {
   # Fetch the google/licenseclassifier for its license db
   rm -fr ${GOPATH}/src/github.com/google/licenseclassifier
-  go get -u github.com/google/licenseclassifier
+  GOFLAGS="" go get -u github.com/google/licenseclassifier
   # Check that we don't have any forbidden licenses in our images.
   run_go_tool knative.dev/test-infra/tools/dep-collector dep-collector -check $@
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
After projects are switched to Go modules, it would be better to set `-mod=vendor` in the Go commands, so that Go modules will use the dependencies in the `vendor/` directory instead of downloading from scratch. One easy way to do this is set `GOFLAGS='-mod=vendor'` as a global env var. However, `go get` does not like it and will give an error. 

Adding `GOFLAGS="" ` before running `go get` to address this issue. It does not impact other `go dep` projects as it has always been empty.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @chaodaiG 

