### PR TITLE
Cleanup image Makefiles and add security check.

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -1,0 +1,24 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Do not allow server update from wrong branch or dirty working space
+# In emergency, could easily edit this file, deleting all these lines
+confirm-master:
+	@if git diff-index --quiet HEAD; then true; else echo "Git working space is dirty -- will not update server"; false; fi;
+# TODO(chizhg): change to `git branch --show-current` after we update the Git version in prow-tests image.
+ifneq ("$(shell git rev-parse --abbrev-ref HEAD)","master")
+	@echo "Branch is not master -- will not update server"
+	@false
+endif
+

--- a/config/prow_common.mk
+++ b/config/prow_common.mk
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 SHELL := /bin/bash
+include ../common.mk
 
 # This file is used by prod and staging Makefiles
 
@@ -101,16 +102,6 @@ update-single-cluster-deployment: confirm-master
 
 # Update all resources on Prow cluster
 update-prow-cluster: update-almost-all-cluster-deployments update-all-boskos-deployments update-boskos-resource update-prow-config
-
-# Do not allow server update from wrong branch or dirty working space
-# In emergency, could easily edit this file, deleting all these lines
-confirm-master:
-	@if git diff-index --quiet HEAD; then true; else echo "Git working space is dirty -- will not update server"; false; fi;
-# TODO(chizhg): change to `git branch --show-current` after we update the Git version in prow-tests image.
-ifneq ("$(shell git rev-parse --abbrev-ref HEAD)","master")
-	@echo "Branch is not master -- will not update server"
-	@false
-endif
 
 # Update TestGrid config.
 # Application Default Credentials must be set, otherwise the upload will fail.

--- a/config/prow_common.mk
+++ b/config/prow_common.mk
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 SHELL := /bin/bash
-include ../common.mk
+SELF_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+include $(SELF_DIR)../common.mk
 
 # This file is used by prod and staging Makefiles
 

--- a/images/README.md
+++ b/images/README.md
@@ -1,3 +1,20 @@
 # Prow Job Images
 
 This directory contains custom Docker images used by our Prow jobs.
+
+## Building and publishing a new image
+
+To build and push a new image, you can run `make push` from an image directory. This should only be
+done once a PR is approved and from the master branch.
+
+Users typically keep their working directory at the repo root and run relative make commands, like
+`make -C images/prow-tests push`, but for brevity's sake this document just mentions the short way.
+
+For testing purposes, you can build with --no-cache, which does not rerun a step in the Dockerfile
+if the text in the Dockerfile does not change (which, note, if you are doing `go install` or
+similar, and you update files, the image will not change! Either `make build` to rebuild everything
+or add/remove a no-op flag to the command you care about). Do this by running `make
+iterative-build`. Run `make iterative-shell` to get a shell in this image.
+
+Note that you must have proper permission in the `knative-tests` project to push new images to the
+GCR.

--- a/images/README.md
+++ b/images/README.md
@@ -4,17 +4,19 @@ This directory contains custom Docker images used by our Prow jobs.
 
 ## Building and publishing a new image
 
-To build and push a new image, you can run `make push` from an image directory. This should only be
-done once a PR is approved and from the master branch.
+To build and push a new image, you can run `make push` from an image directory.
+This should only be done once a PR is approved and from the master branch.
 
-Users typically keep their working directory at the repo root and run relative make commands, like
-`make -C images/prow-tests push`, but for brevity's sake this document just mentions the short way.
+Users typically keep their working directory at the repo root and run relative
+make commands, like `make -C images/prow-tests push`, but for brevity's sake
+this document just mentions the short way.
 
-For testing purposes, you can build with --no-cache, which does not rerun a step in the Dockerfile
-if the text in the Dockerfile does not change (which, note, if you are doing `go install` or
-similar, and you update files, the image will not change! Either `make build` to rebuild everything
-or add/remove a no-op flag to the command you care about). Do this by running `make
-iterative-build`. Run `make iterative-shell` to get a shell in this image.
+For testing purposes, you can build with --no-cache, which does not rerun a step
+in the Dockerfile if the text in the Dockerfile does not change (which, note, if
+you are doing `go install` or similar, and you update files, the image will not
+change! Either `make build` to rebuild everything or add/remove a no-op flag to
+the command you care about). Do this by running `make iterative-build`. Run
+`make iterative-shell` to get a shell in this image.
 
-Note that you must have proper permission in the `knative-tests` project to push new images to the
-GCR.
+Note that you must have proper permission in the `knative-tests` project to push
+new images to the GCR.

--- a/images/backups/Makefile
+++ b/images/backups/Makefile
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 IMAGE_NAME = backups
-include ../Makefile.simple-image
+include ../simple-image.mk

--- a/images/clear-test-infra-alerts/Makefile
+++ b/images/clear-test-infra-alerts/Makefile
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 IMAGE_NAME = monitoring/clear-alerts
-include ../Makefile.simple-image
+include ../simple-image.mk

--- a/images/coverage-go112/Makefile
+++ b/images/coverage-go112/Makefile
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 IMAGE_NAME ?= coverage-go112
-include ../Makefile.simple-image
+include ../simple-image.mk

--- a/images/coverage/Makefile
+++ b/images/coverage/Makefile
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 IMAGE_NAME ?= coverage
-include ../Makefile.simple-image
+include ../simple-image.mk

--- a/images/flaky-test-reporter/Makefile
+++ b/images/flaky-test-reporter/Makefile
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 IMAGE_NAME = flaky-test-reporter
-include ../Makefile.simple-image
+include ../simple-image.mk

--- a/images/flaky-test-retryer/Makefile
+++ b/images/flaky-test-retryer/Makefile
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 IMAGE_NAME = flaky-test-retryer
-include ../Makefile.simple-image
+include ../simple-image.mk

--- a/images/monitoring/Makefile
+++ b/images/monitoring/Makefile
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 IMAGE_NAME = monitoring
-include ../Makefile.simple-image
+include ../simple-image.mk

--- a/images/prow-auto-bumper/Makefile
+++ b/images/prow-auto-bumper/Makefile
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 IMAGE_NAME = prow-auto-bumper
-include ../Makefile.simple-image
+include ../simple-image.mk

--- a/images/prow-config-updater/Makefile
+++ b/images/prow-config-updater/Makefile
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 IMAGE_NAME = prow-config-updater
-include ../Makefile.simple-image
+include ../simple-image.mk
 

--- a/images/prow-tests-go112/Makefile
+++ b/images/prow-tests-go112/Makefile
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 IMAGE_NAME = prow-tests-go112
-include ../Makefile.simple-image
+include ../simple-image.mk

--- a/images/prow-tests-go114/Makefile
+++ b/images/prow-tests-go114/Makefile
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 IMAGE_NAME = prow-tests-go114
-include ../Makefile.simple-image
+include ../simple-image.mk

--- a/images/prow-tests/Makefile
+++ b/images/prow-tests/Makefile
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 IMAGE_NAME = prow-tests
-include ../Makefile.simple-image
+include ../simple-image.mk

--- a/images/prow-tests/README.md
+++ b/images/prow-tests/README.md
@@ -1,26 +1,15 @@
 # Prow Test Job Image
 
-This directory contains the custom Docker image used by our Prow test jobs. A
-fork of this image with go1.12 installed is defined in
-[`prow-tests-go112`](../prow-tests-go112)
-
-## Building and publishing a new image
-
-To build and push a new image, just run `make push`.
-
-For testing purposes you can build an image but not push it; to do so, run
-`make build`.
-
-`make build_no_cache` is similar to `make build` except it does not use the
-cache when building images with docker. This ensures the image is built with the
-latest version of each tool.
-
-The Prow jobs are configured to use the `prow-tests` image tagged with `stable`.
-This tag must be manually set in GCR using the Cloud Console.
-
-Note that you must have proper permission in the `knative-tests` project to push
-new images to the GCR.
+This directory contains the custom Docker image used by our Prow test jobs.
+Some forks of this images exist under images/.
 
 The `prow-tests` image is pinned on a specific `kubekins` image; update
 `Dockerfile` if you need to use a newer/different image. This will basically
 define the versions of `bazel`, `go`, `kubectl` and other build tools.
+
+The Prow jobs are configured to use the `prow-tests` image tagged with `stable`.
+This tag must be manually set in GCR using the Cloud Console.
+
+## Building and publishing a new image
+
+See parent README.md

--- a/images/prow-tests/README.md
+++ b/images/prow-tests/README.md
@@ -1,7 +1,7 @@
 # Prow Test Job Image
 
-This directory contains the custom Docker image used by our Prow test jobs.
-Some forks of this images exist under images/.
+This directory contains the custom Docker image used by our Prow test jobs. Some
+forks of this images exist under images/.
 
 The `prow-tests` image is pinned on a specific `kubekins` image; update
 `Dockerfile` if you need to use a newer/different image. This will basically

--- a/images/simple-image.mk
+++ b/images/simple-image.mk
@@ -25,7 +25,8 @@
 REGISTRY ?= gcr.io
 PROJECT  ?= knative-tests
 
-include ../common.mk
+SELF_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+include $(SELF_DIR)../common.mk
 
 IMG = $(REGISTRY)/$(PROJECT)/test-infra/$(IMAGE_NAME)
 TAG := $(shell date +v%Y%m%d)-$(shell git describe --always --dirty --match '^$$')

--- a/images/simple-image.mk
+++ b/images/simple-image.mk
@@ -14,34 +14,37 @@
 
 # Rules for creating simple docker images.
 
-# This is not a real Makefile. It should be included by another Makefile,
-# and IMAGE_NAME set appropriately. You must also provide a Dockerfile
-# together with the Makefile.
+# This should be included by another Makefile
+#  and IMAGE_NAME set appropriately. You must also provide a Dockerfile
+#  together with a Makefile in each subdirectory.
+
+# Due to the relative path in the docker build commands, all image directories
+#  must be a direct child of the images directory. If someone wanted to change
+#  this, they'd need to write a little shell to calculate the repo root dir.
 
 REGISTRY ?= gcr.io
 PROJECT  ?= knative-tests
 
+include ../common.mk
+
 IMG = $(REGISTRY)/$(PROJECT)/test-infra/$(IMAGE_NAME)
 TAG := $(shell date +v%Y%m%d)-$(shell git describe --always --dirty --match '^$$')
 
-# build_helper: build the image with docker
-#	$1 = [optional] additional flags to be applied to the build
-define build_helper
-	docker build $(1) -t $(IMG):$(TAG) -f Dockerfile ../..
-endef
-
-all: build
-
 build:
-	$(call build_helper)
+	docker build --no-cache --pull -t $(IMG):$(TAG) -f Dockerfile ../..
 
-build_no_cache:
-	$(call build_helper,--no-cache)
+# You can build locally without --no-cache to save time
+iterative-build:
+	docker build --pull -t $(IMG):local -f Dockerfile ../..
 
-push_versioned: build_no_cache
+# And get a shell in the container
+iterative-shell:
+	docker run -it --entrypoint bash $(IMG_PATH):local
+
+push_versioned: confirm-master build
 	docker push $(IMG):$(TAG)
 
-push_latest: build_no_cache
+push_latest: confirm-master build
 	docker tag $(IMG):$(TAG) $(IMG):latest
 	docker push $(IMG):latest
 


### PR DESCRIPTION
Should upload images once they've been reviewed and approved. Make it
a little harder to not do that.

Clean and simplify the Makefiles. Add convenience function for
launching a shell in your local image.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
