### PR TITLE
use go-licenses to check forbidden licenses

### DIFF
--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -502,20 +502,16 @@ function run_go_tool() {
 # Parameters: $1 - output file, relative to repo root dir.
 #             $2...$n - directories and files to inspect.
 function update_licenses() {
-  cd ${REPO_ROOT_DIR} || return 1
+  cd "${REPO_ROOT_DIR}" || return 1
   local dst=$1
   shift
   run_go_tool knative.dev/test-infra/tools/dep-collector dep-collector $@ > ./${dst}
 }
 
-# Run dep-collector to check for forbidden liceses.
-# Parameters: $1...$n - directories and files to inspect.
+# Run go-licenses to check for forbidden liceses.
 function check_licenses() {
-  # Fetch the google/licenseclassifier for its license db
-  rm -fr ${GOPATH}/src/github.com/google/licenseclassifier
-  GOFLAGS="" go get -u github.com/google/licenseclassifier
-  # Check that we don't have any forbidden licenses in our images.
-  run_go_tool knative.dev/test-infra/tools/dep-collector dep-collector -check $@
+  # Check that we don't have any forbidden licenses.
+  go-licenses check "${REPO_ROOT_DIR}/..." || return 1
 }
 
 # Run the given linter on the given files, checking it exists first.

--- a/scripts/presubmit-tests.sh
+++ b/scripts/presubmit-tests.sh
@@ -201,7 +201,7 @@ function default_build_test_runner() {
   create_junit_xml _build_tests Build_Go "${errors_go}"
   # Check that we don't have any forbidden licenses in our images.
   subheader "Checking for forbidden licenses"
-  report_build_test Check_Licenses check_licenses ${go_pkg_dirs} || failed=1
+  report_build_test Check_Licenses check_licenses || failed=1
   return ${failed}
 }
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
The `dep-collector` tool needs to have the `db` file from https://github.com/google/licenseclassifier to work, but `go mod` will trim all the non-go files so there is not a good way to get it if we switch to Go modules. Tekton also had this issue and they tried some hack and finally switched to go-licenses - https://github.com/tektoncd/plumbing/pull/349. 

This PR switches to go-licenses to check forbidden licenses.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @chaodaiG 
/hold
I need to build the image with the change in https://github.com/knative/test-infra/pull/1990 before getting this in.
