### PR TITLE
replace kubectl with version 1.17.4

### DIFF
--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -29,6 +29,13 @@ RUN gcloud components update
 RUN gcloud components install docker-credential-gcr
 RUN docker-credential-gcr configure-docker
 
+# Replace kubectl with a working version
+# TODO(chizhg): remove once https://github.com/knative/test-infra/issues/1858 is fixed
+ARG K8S_RELEASE=v1.17.4
+RUN rm -f $(which kubectl) && \
+    wget https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl && \
+    chmod +x /usr/local/bin/kubectl
+
 # Extra tools through apt-get
 RUN apt-get install -y uuid-runtime  # for uuidgen
 RUN apt-get install -y rubygems      # for mdl


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Temporarily pin kubectl with version 1.17.4, so we can unblock updating prow-tests image. This change can be removed once https://github.com/knative/test-infra/issues/1858 is fixed.

I have tested it in https://prow.knative.dev/view/gcs/knative-prow/logs/ci-knative-test-infra-continuous/1255358844696006656 and it's working.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @chaodaiG 