### PR TITLE
Update build cluster instructions, and move Boskos

### DIFF
--- a/config/prod/build-cluster/README.md
+++ b/config/prod/build-cluster/README.md
@@ -11,7 +11,7 @@ Create build cluster:
 ./create-build-cluster.sh
 
 # Connect to knative-prow cluster
-pushd ../
+pushd ../prow
 make get-cluster-credentials
 popd
 

--- a/config/staging/build-cluster/add-secrets.sh
+++ b/config/staging/build-cluster/add-secrets.sh
@@ -20,4 +20,4 @@
 export KUBECONFIG_SERVICE_CLUSTER="gke_knative-tests-staging_us-central1-f_prow"
 export KUBECONFIG_BUILD_CLUSTER="gke_knative-tests-staging_us-central1-f_knative-prow-build-cluster"
 
-../build-cluster/add-secrets.sh
+../../prod/build-cluster/add-secrets.sh

--- a/config/staging/build-cluster/boskos/boskos_resources.yaml
+++ b/config/staging/build-cluster/boskos/boskos_resources.yaml
@@ -16,6 +16,5 @@ resources:
 - names:
   - knative-boskos-staging-01
   - knative-boskos-staging-02
-  - knative-boskos-staging-03
   state: dirty
   type: gke-project

--- a/config/staging/build-cluster/create-build-cluster.sh
+++ b/config/staging/build-cluster/create-build-cluster.sh
@@ -27,4 +27,4 @@ set -o pipefail
 export PROJECT="knative-tests-staging"
 export GCSBUCKET="knative-prow-staging"
 
-../build-cluster/create-build-cluster.sh
+../../prod/build-cluster/create-build-cluster.sh

--- a/config/staging/prow/boskos/boskos_resources.yaml
+++ b/config/staging/prow/boskos/boskos_resources.yaml
@@ -14,8 +14,6 @@
 
 resources:
 - names:
-  - knative-boskos-staging-01
-  - knative-boskos-staging-02
   - knative-boskos-staging-03
   state: dirty
   type: gke-project


### PR DESCRIPTION
Updated instructions for creating build cluster for staging Prow.

Build cluster for staging Prow is already created: https://pantheon.corp.google.com/kubernetes/clusters/details/us-central1-f/knative-prow-build-cluster?project=knative-tests-staging&tab=details&persistent_volumes_tablesize=50&storage_class_tablesize=50&nodes_tablesize=50&node_pool_tablesize=10

Will update Boskos once this PR is merged

/assign chizhg
/cc chizhg