### PR TITLE
Add a new wait function that also confirms HTTP connection.

### DIFF
--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -225,14 +225,14 @@ function wait_until_service_has_external_ip() {
 function wait_until_service_has_external_http_address() {
   local ns=$1
   local svc=$2
-  local sleep_seconds=20
+  local sleep_seconds=6
   local attempts=150
 
   echo -n "Waiting until service $ns/$svc has an external address (IP/hostname)"
   for attempt in $(seq 1 $attempts); do  # timeout after 15 minutes
     local address=$(kubectl get svc $svc -n $ns -o jsonpath="{.status.loadBalancer.ingress[0].ip}")
     if [[ -n "${address}" ]]; then
-      echo -e "Service $2.$1 has IP $address"
+      echo -e "Service $ns/$svc has IP $address"
     else
       address=$(kubectl get svc $svc -n $ns -o jsonpath="{.status.loadBalancer.ingress[0].hostname}")
       if [[ -n "${hostname}" ]]; then
@@ -249,10 +249,9 @@ function wait_until_service_has_external_http_address() {
       fi
     fi
     echo -n "."
-    sleep 6
+    sleep $sleep_seconds
   done
-  echo -e "\n\nERROR: timeout waiting for service $2.$1 to have an external HTTP address"
-  kubectl get pods -n $1
+  echo -e "\n\nERROR: timeout waiting for service $ns/$svc to have an external HTTP address"
   return 1
 }
 

--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -219,6 +219,43 @@ function wait_until_service_has_external_ip() {
   return 1
 }
 
+# Waits until the given service has an external address (IP/hostname) that allow HTTP connections.
+# Parameters: $1 - namespace.
+#             $2 - service name.
+function wait_until_service_has_external_http_address() {
+  local ns=$1
+  local svc=$2
+  local sleep_seconds=20
+  local attempts=150
+
+  echo -n "Waiting until service $ns/$svc has an external address (IP/hostname)"
+  for attempt in $(seq 1 $attempts); do  # timeout after 15 minutes
+    local address=$(kubectl get svc $svc -n $ns -o jsonpath="{.status.loadBalancer.ingress[0].ip}")
+    if [[ -n "${address}" ]]; then
+      echo -e "Service $2.$1 has IP $address"
+    else
+      address=$(kubectl get svc $svc -n $ns -o jsonpath="{.status.loadBalancer.ingress[0].hostname}")
+      if [[ -n "${hostname}" ]]; then
+        echo -e "Service $ns/$svc has hostname $address"
+      fi
+    fi
+    if [[ -n "${address}" ]]; then
+      local status=$(curl -s -o /dev/null -w "%{http_code}" http://"${address}")
+      if [[ $status != "" && $status != "000" ]]; then
+        echo -e "$address is ready: prober observed HTTP $status"
+        return 0
+      else
+        echo -e "$address is not ready: prober observed HTTP $status"
+      fi
+    fi
+    echo -n "."
+    sleep 6
+  done
+  echo -e "\n\nERROR: timeout waiting for service $2.$1 to have an external HTTP address"
+  kubectl get pods -n $1
+  return 1
+}
+
 # Waits for the endpoint to be routable.
 # Parameters: $1 - External ingress IP address.
 #             $2 - cluster hostname.
@@ -357,7 +394,7 @@ function create_junit_xml() {
   local failure=""
   if [[ "$3" != "" ]]; then
     # Transform newlines into HTML code.
-    # Also escape `<` and `>` as here: https://github.com/golang/go/blob/50bd1c4d4eb4fac8ddeb5f063c099daccfb71b26/src/encoding/json/encode.go#L48, 
+    # Also escape `<` and `>` as here: https://github.com/golang/go/blob/50bd1c4d4eb4fac8ddeb5f063c099daccfb71b26/src/encoding/json/encode.go#L48,
     # this is temporary solution for fixing https://github.com/knative/test-infra/issues/1204,
     # which should be obsolete once Test-infra 2.0 is in place
     local msg="$(echo -n "$3" | sed 's/$/\&#xA;/g' | sed 's/</\\u003c/' | sed 's/>/\\u003e/' | sed 's/&/\\u0026/' | tr -d '\n')"


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:

Some times static IP is available, but it is not yet accessible due to requests not going all the way to the proxy Pod.

This new wait function will confirms that we can receive some HTTP status (like 404, 503, etc) from the proxy before proceeding.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #

**Special notes to reviewers**:

**User-visible changes in this PR**:

