### PR TITLE
Revert "No op update to Prow job"

### DIFF
--- a/config/prod/prow/jobs/custom-jobs.yaml
+++ b/config/prod/prow/jobs/custom-jobs.yaml
@@ -262,7 +262,7 @@ periodics:
       - "go"
       args:
       - "run"
-      - "./tools/prow-auto-bumper"
+      - "./tools/prow-auto-bumper/."
       - "--github-account=/etc/prow-auto-bumper-github-token/token"
       - "--git-userid=knative-prow-updater-robot"
       - "--git-username='Knative Prow Updater Robot'"


### PR DESCRIPTION
Reverts knative/test-infra#2025 to kick post-knative-prow-config-updater again after #2027 is merged

/assign chizhg
/cc chizhg

/hold