### PR TITLE
Add shellcheck presubmit files

### DIFF
--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # This is the base Dockerfile for knative-tests images, please remember to also
-# do `make push` in `../prow-tests-go112` directory to make sure these 2 images are in
+# do `make push` in `../prow-tests-*` directories to make sure these images are in
 # sync
 
 # TODO(chizhg): probably build the image from scratch?
@@ -32,8 +32,8 @@ RUN docker-credential-gcr configure-docker
 # Replace kubectl with a working version
 # TODO(chizhg): remove once https://github.com/knative/test-infra/issues/1858 is fixed
 ARG KUBECTL_VERSION=v1.17.4
-RUN rm -f $(which kubectl) && \
-    wget https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl && \
+RUN rm -f "$(which kubectl)" && \
+    wget "https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" -O /usr/local/bin/kubectl && \
     chmod +x /usr/local/bin/kubectl
 
 # Extra tools through apt-get
@@ -71,8 +71,11 @@ RUN gem install mdl -v 0.5  # required because later version of mdl requires rub
 # Install our own tools
 RUN go get knative.dev/pkg/testutils/junithelper
 
+# And our scripts
+COPY scripts /scripts
+
 # Temporarily add test-infra to the image to build custom tools
-ADD . /go/src/knative.dev/test-infra
+COPY . /go/src/knative.dev/test-infra
 
 # Build custom tools in the container
 RUN make -C /go/src/knative.dev/test-infra/tools/githubhelper

--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -72,6 +72,7 @@ RUN gem install mdl -v 0.5  # required because later version of mdl requires rub
 RUN go get knative.dev/pkg/testutils/junithelper
 
 # And our scripts
+ENV SCRIPTS /scripts
 COPY scripts /scripts
 
 # Temporarily add test-infra to the image to build custom tools

--- a/images/simple-image.mk
+++ b/images/simple-image.mk
@@ -40,7 +40,7 @@ iterative-build:
 
 # And get a shell in the container
 iterative-shell:
-	docker run -it --entrypoint bash $(IMG_PATH):local
+	docker run -it --entrypoint bash $(IMG):local
 
 push_versioned: confirm-master build
 	docker push $(IMG):$(TAG)

--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -26,7 +26,7 @@ readonly SERVING_GKE_VERSION=gke-latest
 readonly SERVING_GKE_IMAGE=cos
 
 # Conveniently set GOPATH if unset
-if [[ -z "${GOPATH:-}" ]]; then
+if [[ ! -v GOPATH ]]; then
   export GOPATH="$(go env GOPATH)"
   if [[ -z "${GOPATH}" ]]; then
     echo "WARNING: GOPATH not set and go binary unable to provide it"
@@ -34,9 +34,9 @@ if [[ -z "${GOPATH:-}" ]]; then
 fi
 
 # Useful environment variables
-[[ -n "${PROW_JOB_ID:-}" ]] && IS_PROW=1 || IS_PROW=0
+[[ -v PROW_JOB_ID ]] && IS_PROW=1 || IS_PROW=0
 readonly IS_PROW
-[[ -z "${REPO_ROOT_DIR:-}" ]] && REPO_ROOT_DIR="$(git rev-parse --show-toplevel)"
+[[ ! -v REPO_ROOT_DIR ]] && REPO_ROOT_DIR="$(git rev-parse --show-toplevel)"
 readonly REPO_ROOT_DIR
 readonly REPO_NAME="$(basename ${REPO_ROOT_DIR})"
 
@@ -652,6 +652,21 @@ function get_canonical_path() {
   echo "$(cd ${path%/*} && echo $PWD/${path##*/})"
 }
 
+# List changed files in the current PR.
+# This is implemented as a function so it can be mocked in unit tests.
+# It will fail if a file ever contained a newline character (which is bad practice anyway)
+function list_changed_files() {
+  if [[ -v PULL_BASE_SHA ]] && [[ -v PULL_PULL_SHA ]]; then
+    # Avoid warning when there are more than 1085 files renamed:
+    # https://stackoverflow.com/questions/7830728/warning-on-diff-renamelimit-variable-when-doing-git-push
+    git config diff.renames 0
+    git --no-pager diff --name-only ${PULL_BASE_SHA}..${PULL_PULL_SHA}
+  else
+    # Do our best if not running in Prow
+    git diff --name-only HEAD^
+  fi
+}
+
 # Returns the current branch.
 function current_branch() {
   local branch_name=""
@@ -692,6 +707,29 @@ function get_latest_knative_yaml_source() {
     # Otherwise, fall back to nightly.
   fi
   echo "https://storage.googleapis.com/knative-nightly/${repo_name}/latest/${yaml_name}.yaml"
+}
+
+function shellcheck_new_files() {
+  declare -a array_of_files
+  local failed=0
+  readarray -t -d '\n' array_of_files < <(list_changed_files)
+  for filename in "${array_of_files[@]}"; do
+    if echo "${filename}" | grep -q "^vendor/"; then
+      continue
+    fi
+    if file "${filename}" | grep -q "shell script"; then
+      # SC1090 is "Can't follow non-constant source"; we will scan files individually
+      if shellcheck -e SC1090 "${filename}"; then
+        echo "--- PASS: shellcheck on ${filename}"
+      else
+        echo "--- FAIL: shellcheck on ${filename}"
+        failed=1
+      fi
+    fi
+  done
+  if [[ ${failed} -eq 1 ]]; then
+    fail_script "shellcheck failures"
+  fi
 }
 
 # Initializations that depend on previous functions.

--- a/scripts/presubmit-tests.sh
+++ b/scripts/presubmit-tests.sh
@@ -46,15 +46,6 @@ function pr_only_contains() {
   [[ -z "$(echo "${CHANGED_FILES}" | grep -v "\(${1// /\\|}\)$")" ]]
 }
 
-# List changed files in the current PR.
-# This is implemented as a function so it can be mocked in unit tests.
-function list_changed_files() {
-  # Avoid warning when there are more than 1085 files renamed:
-  # https://stackoverflow.com/questions/7830728/warning-on-diff-renamelimit-variable-when-doing-git-push
-  git config diff.renames 0
-  git --no-pager diff --name-only ${PULL_BASE_SHA}..${PULL_SHA}
-}
-
 # Initialize flags and context for presubmit tests:
 # CHANGED_FILES, IS_PRESUBMIT_EXEMPT_PR and IS_DOCUMENTATION_PR.
 function initialize_environment() {

--- a/scripts/shellcheck-presubmit.sh
+++ b/scripts/shellcheck-presubmit.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -e
+
+source "$(dirname "${BASH_SOURCE[0]}")/library.sh"
+
+if [[ IS_PROW -eq 0 ]]; then
+  echo "Local run of shellcheck-presubmit detected"
+  echo "This notably DOES NOT ACT LIKE THE GITHUB PRESUBMIT"
+  echo "The Github presubmit job only runs shellcheck on files you touch"
+  echo "There's no way to locally determine which files you touched:"
+  echo " as git is a distributed VCS, there is no notion of parent until merge"
+  echo " is attempted."
+  echo "So it checks the current content of all files changed in the previous commit"
+  echo " and/or currently staged."
+fi
+
+shellcheck_new_files

--- a/test/unit/presubmit-tests.sh
+++ b/test/unit/presubmit-tests.sh
@@ -15,9 +15,9 @@
 # limitations under the License.
 
 # Fake we're in a Prow job, if running locally.
-[[ -z "${PROW_JOB_ID:-}" ]] && PROW_JOB_ID=123
-[[ -z "${PULL_PULL_SHA:-}" ]] && PULL_PULL_SHA=456
-[[ -z "${ARTIFATCS:-}" ]] && ARTIFACTS=/tmp
+[[ ! -v PROW_JOB_ID ]] && PROW_JOB_ID=123
+[[ ! -v PULL_PULL_SHA ]] && PULL_PULL_SHA=456
+[[ ! -v ARTIFACTS ]] && ARTIFACTS=/tmp
 
 source $(dirname $0)/test-helper.sh
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:

Add the files needed to run a presubmit job with shellcheck to this repo and to the prow-tests image.

Also fix `list_changed_files` function to use the correct variable, though it seems to have been working anyway

/cc @chizhg 
/assign @chizhg 