### PR TITLE
Fix config updater

### DIFF
--- a/config/prod/prow/jobs/custom-jobs.yaml
+++ b/config/prod/prow/jobs/custom-jobs.yaml
@@ -290,10 +290,11 @@ periodics:
         defaultMode: 0400
 
 postsubmits:
-  knative/test-infra:
+  chizhg/test-infra:
   - name: post-knative-prow-config-updater
     agent: kubernetes
     decorate: true
+    path_alias: knative.dev/test-infra
     max_concurrency: 1
     cluster: "prow-trusted"
     run_if_changed: "^(config/(prod|staging)/(prow|build-cluster)/(cluster|core|jobs|boskos|testgrid)/.*.yaml)|(tools/config-generator/templates/(prow|prow-staging)/.*.yaml)$"

--- a/config/prod/prow/jobs/custom-jobs.yaml
+++ b/config/prod/prow/jobs/custom-jobs.yaml
@@ -290,7 +290,7 @@ periodics:
         defaultMode: 0400
 
 postsubmits:
-  chizhg/test-infra:
+  knative/test-infra:
   - name: post-knative-prow-config-updater
     agent: kubernetes
     decorate: true

--- a/tools/prow-config-updater/config/config.go
+++ b/tools/prow-config-updater/config/config.go
@@ -60,6 +60,7 @@ const (
 )
 
 var (
+	repoRoot, _ = helpers.GetRootDir()
 	// Env path
 	ProdConfigRoot    = filepath.Join(configPath, prodConfigDirName)
 	StagingConfigRoot = filepath.Join(configPath, stagingConfigDirName)
@@ -139,7 +140,7 @@ func UpdateProw(env ProwEnv, dryrun bool) error {
 					return fmt.Errorf("error activating service account with %q", kf)
 				}
 			}
-			out, err := cmd.RunCommand(updateCommand, cmd.WithEnvs(os.Environ()))
+			out, err := cmd.RunCommand(updateCommand, cmd.WithEnvs(os.Environ()), cmd.WithDir(repoRoot))
 			log.Println(out)
 			return err
 		},
@@ -157,7 +158,7 @@ func UpdateTestgrid(env ProwEnv, dryrun bool) error {
 	return helpers.Run(
 		fmt.Sprintf("Updating Testgrid config with command %q", updateTestgridCommand),
 		func() error {
-			out, err := cmd.RunCommand(updateTestgridCommand, cmd.WithEnvs(os.Environ()))
+			out, err := cmd.RunCommand(updateTestgridCommand, cmd.WithEnvs(os.Environ()), cmd.WithDir(repoRoot))
 			log.Println(out)
 			return err
 		},

--- a/tools/prow-config-updater/pullrequest.go
+++ b/tools/prow-config-updater/pullrequest.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/google/go-github/v27/github"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"knative.dev/pkg/test/cmd"
 	"knative.dev/pkg/test/ghutil"
 	"knative.dev/pkg/test/helpers"
 
@@ -51,12 +52,11 @@ type GitHubMainHandler struct {
 // TODO(chizhg): get rid of this hack once Prow supports setting PR number as an env var for postsubmit jobs.
 func (gc *GitHubMainHandler) getLatestPullRequest() (*github.PullRequest, error) {
 	// Use git command to get the latest commit ID.
-	// ci, err := cmd.RunCommand("git rev-parse HEAD")
-	// if err != nil {
-	// 	return nil, fmt.Errorf("error getting the last commit ID: %v", err)
-	// }
+	ci, err := cmd.RunCommand("git rev-parse HEAD")
+	if err != nil {
+		return nil, fmt.Errorf("error getting the last commit ID: %v", err)
+	}
 	// As we always use squash in merging PRs, we can get the pull request with the commit ID.
-	ci := "c8dd15bb7f0b81c73c59880c07fffab897698fca"
 	pr, err := gc.client.GetPullRequestByCommitID(config.OrgName, config.RepoName, strings.TrimSpace(ci))
 	if err != nil {
 		return nil, fmt.Errorf("error getting the PR with commit ID %q: %v", strings.TrimSpace(ci), err)

--- a/tools/prow-config-updater/pullrequest.go
+++ b/tools/prow-config-updater/pullrequest.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/google/go-github/v27/github"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"knative.dev/pkg/test/cmd"
 	"knative.dev/pkg/test/ghutil"
 	"knative.dev/pkg/test/helpers"
 
@@ -52,11 +51,12 @@ type GitHubMainHandler struct {
 // TODO(chizhg): get rid of this hack once Prow supports setting PR number as an env var for postsubmit jobs.
 func (gc *GitHubMainHandler) getLatestPullRequest() (*github.PullRequest, error) {
 	// Use git command to get the latest commit ID.
-	ci, err := cmd.RunCommand("git rev-parse HEAD")
-	if err != nil {
-		return nil, fmt.Errorf("error getting the last commit ID: %v", err)
-	}
+	// ci, err := cmd.RunCommand("git rev-parse HEAD")
+	// if err != nil {
+	// 	return nil, fmt.Errorf("error getting the last commit ID: %v", err)
+	// }
 	// As we always use squash in merging PRs, we can get the pull request with the commit ID.
+	ci := "c8dd15bb7f0b81c73c59880c07fffab897698fca"
 	pr, err := gc.client.GetPullRequestByCommitID(config.OrgName, config.RepoName, strings.TrimSpace(ci))
 	if err != nil {
 		return nil, fmt.Errorf("error getting the PR with commit ID %q: %v", strings.TrimSpace(ci), err)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Not entirely sure if this can fix the issue, but changing to `go run` makes it almost impossible to test a postsubmit job.

/cc @chaodaiG 