### PR TITLE
Revert some changes to kntest

### DIFF
--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -389,8 +389,25 @@ function mktemp_with_extension() {
 #             $2 - check name as an identifier (e.g., GoBuild)
 #             $3 - failure message (can contain newlines), optional (means success)
 function create_junit_xml() {
-  local xml="$(mktemp_with_extension "${ARTIFACTS}"/junit_XXXXXXXX xml)"
-  run_kntest junit --suite="$1" --name="$2" --err-msg="$3" --dest="${xml}" || return 1
+  local xml="$(mktemp_with_extension ${ARTIFACTS}/junit_XXXXXXXX xml)"
+  local failure=""
+  if [[ "$3" != "" ]]; then
+    # Transform newlines into HTML code.
+    # Also escape `<` and `>` as here: https://github.com/golang/go/blob/50bd1c4d4eb4fac8ddeb5f063c099daccfb71b26/src/encoding/json/encode.go#L48,
+    # this is temporary solution for fixing https://github.com/knative/test-infra/issues/1204,
+    # which should be obsolete once Test-infra 2.0 is in place
+    local msg="$(echo -n "$3" | sed 's/$/\&#xA;/g' | sed 's/</\\u003c/' | sed 's/>/\\u003e/' | sed 's/&/\\u0026/' | tr -d '\n')"
+    failure="<failure message=\"Failed\" type=\"\">${msg}</failure>"
+  fi
+  cat << EOF > "${xml}"
+<testsuites>
+	<testsuite tests="1" failures="1" time="0.000" name="$1">
+		<testcase classname="" name="$2" time="0.0">
+			${failure}
+		</testcase>
+	</testsuite>
+</testsuites>
+EOF
 }
 
 # Runs a go test and generate a junit summary.
@@ -498,41 +515,25 @@ function start_latest_knative_eventing() {
 #             $3..$n - parameters passed to the tool.
 function run_go_tool() {
   local tool=$2
-  local install_failed=0
-  local action="get"
-  [[ $1 =~ ^[\./].* ]] && action="install"
-  # Install the tool in the following situations:
-  #   - The tool does not exist.
-  #   - The tool needs to be installed from a local path.
-  #   - Version of the tool is specificied in the given tool path.
-  # TODO(chizhg): derive a better versioning story for the tools being used.
-  if [[ -z "$(which "${tool}")" || "${action}" == "install" || "${tool}" =~ "@" ]]; then
+  if [[ -z "$(which ${tool})" ]]; then
+    local action=get
+    [[ $1 =~ ^[\./].* ]] && action=install
+    local install_failed=0
     # Avoid running `go get` from root dir of the repository, as it can change go.sum and go.mod files.
     # See discussions in https://github.com/golang/go/issues/27643.
     if [[ ${action} == "get" && $(pwd) == "${REPO_ROOT_DIR}" ]]; then
       local temp_dir="$(mktemp -d)"
       # Swallow the output as we are returning the stdout in the end.
       pushd "${temp_dir}" > /dev/null 2>&1
-      GOFLAGS="" go ${action} $1 || install_failed=1
+      GOFLAGS="" go ${action} "$1" || install_failed=1
       popd > /dev/null 2>&1
     else
-      GOFLAGS="" go ${action} $1 || install_failed=1
+      GOFLAGS="" go ${action} "$1" || install_failed=1
     fi
   fi
   (( install_failed )) && return ${install_failed}
   shift 2
   ${tool} "$@"
-}
-
-# Run "kntest" tool
-# Parameters: $1..$n - parameters passed to the tool
-function run_kntest() {
-  if [[ "${REPO_NAME}" == "test-infra" ]]; then
-    go run "${REPO_ROOT_DIR}"/kntest/cmd/kntest "$@"
-  else
-    # Always run the latest version.
-    run_go_tool knative.dev/test-infra/kntest/cmd/kntest@master "$@"
-  fi
 }
 
 # Run go-licenses to update licenses.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Go modules has a caveat that makes it hard to install kntest via `go get`:
https://github.com/golang/go/issues/30354
https://github.com/kubernetes/test-infra/issues/14712

So revert the current use of kntest, until we find a more reliable way for users to get it.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @chaodaiG 

