### PR TITLE
Partially revert 2029: Prow config updater use image instead of go run

### DIFF
--- a/config/prod/prow/jobs/custom-jobs.yaml
+++ b/config/prod/prow/jobs/custom-jobs.yaml
@@ -299,13 +299,11 @@ postsubmits:
     run_if_changed: "^(config/(prod|staging)/(prow|build-cluster)/(cluster|core|jobs|boskos|testgrid)/.*.yaml)|(tools/config-generator/templates/(prow|prow-staging)/.*.yaml)$"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests-go114:stable
+      - image: gcr.io/knative-tests/test-infra/prow-config-updater:latest
         imagePullPolicy: Always
         command:
-        - "go"
+        - "/prow-config-updater"
         args:
-        - "run"
-        - "./tools/prow-config-updater"
         - "--github-token-file=/etc/prow-robot-github-token/token"
         - "--github-userid=knative-prow-robot"
         - "--git-username='Knative Prow Robot'"


### PR DESCRIPTION
/assign chizhg
/cc chizhg