### PR TITLE
Tide usess ghproxy

### DIFF
--- a/config/staging/prow/cluster/400-tide.yaml
+++ b/config/staging/prow/cluster/400-tide.yaml
@@ -45,6 +45,9 @@ spec:
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
+        - --github-endpoint=http://ghproxy
+        - --github-endpoint=https://api.github.com
+        - --github-token-path=/etc/github/oauth
         - --dry-run=false
         ports:
           - name: http


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Tide should also uses ghproxy

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @peterfeifanchen @chaodaiG 