### PR TITLE
Update Prow jobs to include GO_VERSION env var

### DIFF
--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -6975,6 +6975,8 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -7203,6 +7205,8 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -7238,6 +7242,8 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -7273,6 +7279,8 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -7308,6 +7316,8 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -7343,6 +7353,8 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -7378,6 +7390,8 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -7413,6 +7427,8 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -7448,6 +7464,8 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -7483,6 +7501,8 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -7520,6 +7540,8 @@ periodics:
         mountPath: /etc/nightly-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -7726,6 +7748,8 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -7776,6 +7800,8 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -7817,6 +7843,8 @@ periodics:
       env:
       - name: SYSTEM_NAMESPACE
         value: knative-serving
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -7876,6 +7904,8 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -8101,6 +8131,8 @@ periodics:
         mountPath: /etc/nightly-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -8132,6 +8164,8 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -8318,6 +8352,8 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -8363,6 +8399,8 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -8425,6 +8463,8 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -8526,6 +8566,8 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -8756,6 +8798,8 @@ periodics:
         mountPath: /etc/nightly-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -8962,6 +9006,8 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -9012,6 +9058,8 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -9079,6 +9127,8 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -9309,6 +9359,8 @@ periodics:
         mountPath: /etc/nightly-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -9515,6 +9567,8 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -9565,6 +9619,8 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -9632,6 +9688,8 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -9691,6 +9749,8 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -9750,6 +9810,8 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -9786,6 +9848,8 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -9822,6 +9886,8 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -9858,6 +9924,8 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -9917,6 +9985,8 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -10142,6 +10212,8 @@ periodics:
         mountPath: /etc/nightly-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -10328,6 +10400,8 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -10373,6 +10447,8 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -10435,6 +10511,8 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -10660,6 +10738,8 @@ periodics:
         mountPath: /etc/nightly-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -10846,6 +10926,8 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -10891,6 +10973,8 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -10952,6 +11036,8 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -11126,6 +11212,8 @@ periodics:
         mountPath: /etc/nightly-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -11267,6 +11355,8 @@ periodics:
       env:
       - name: ORG_NAME
         value: google
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -11313,6 +11403,8 @@ periodics:
       env:
       - name: ORG_NAME
         value: google
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -11374,6 +11466,8 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -11411,6 +11505,8 @@ periodics:
         mountPath: /etc/nightly-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -11453,6 +11549,8 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -11498,6 +11596,8 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -11560,6 +11660,8 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -11597,6 +11699,8 @@ periodics:
         mountPath: /etc/nightly-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -11639,6 +11743,8 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -11684,6 +11790,8 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -11746,6 +11854,8 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -11783,6 +11893,8 @@ periodics:
         mountPath: /etc/nightly-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -11825,6 +11937,8 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -11870,6 +11984,8 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -11932,6 +12048,8 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -11969,6 +12087,8 @@ periodics:
         mountPath: /etc/nightly-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -12011,6 +12131,8 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -12056,6 +12178,8 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -12118,6 +12242,8 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -12155,6 +12281,8 @@ periodics:
         mountPath: /etc/nightly-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -12197,6 +12325,8 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -12242,6 +12372,8 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -12304,6 +12436,8 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -12341,6 +12475,8 @@ periodics:
         mountPath: /etc/nightly-account
         readOnly: true
       env:
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -12385,6 +12521,8 @@ periodics:
       env:
       - name: ORG_NAME
         value: knative-sandbox
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -12432,6 +12570,8 @@ periodics:
       env:
       - name: ORG_NAME
         value: knative-sandbox
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -12500,6 +12640,8 @@ periodics:
       env:
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -12545,6 +12687,8 @@ periodics:
       env:
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -12597,6 +12741,8 @@ periodics:
         value: "true"
       - name: ORG_NAME
         value: knative-sandbox
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -12652,6 +12798,8 @@ periodics:
         value: "true"
       - name: ORG_NAME
         value: knative-sandbox
+      - name: GO_VERSION
+        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION

--- a/config/staging/prow/jobs/config.yaml
+++ b/config/staging/prow/jobs/config.yaml
@@ -45,6 +45,8 @@ presubmits:
           mountPath: /etc/test-account
           readOnly: true
         env:
+        - name: GO_VERSION
+          value: go1.14
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
@@ -82,6 +84,8 @@ presubmits:
           mountPath: /etc/test-account
           readOnly: true
         env:
+        - name: GO_VERSION
+          value: go1.14
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
@@ -119,6 +123,8 @@ presubmits:
           mountPath: /etc/test-account
           readOnly: true
         env:
+        - name: GO_VERSION
+          value: go1.14
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
@@ -157,6 +163,8 @@ presubmits:
           mountPath: /etc/test-account
           readOnly: true
         env:
+        - name: GO_VERSION
+          value: go1.14
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
@@ -194,6 +202,8 @@ presubmits:
           mountPath: /etc/test-account
           readOnly: true
         env:
+        - name: GO_VERSION
+          value: go1.14
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
@@ -231,6 +241,8 @@ presubmits:
           mountPath: /etc/test-account
           readOnly: true
         env:
+        - name: GO_VERSION
+          value: go1.14
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION

--- a/tools/config-generator/main.go
+++ b/tools/config-generator/main.go
@@ -302,20 +302,9 @@ func exclusiveSlices(a1, a2 []string) []string {
 	return res
 }
 
-// getGo112ID returns image identifier for go113 images
-func getGo112ID() string {
-	return "-go112"
-}
-
 // getGo114ID returns image identifier for go114 images
 func getGo114ID() string {
 	return "-go114"
-}
-
-// Get go113 image name from base image name, following the contract of
-// [IMAGE]:[DIGEST]-> [IMAGE]-go112:[DIGEST]
-func getGo113ImageName(name string) string {
-	return stripSuffixFromImageName(name, []string{getGo112ID()})
 }
 
 // strip out all suffixes from the image name
@@ -345,12 +334,8 @@ func addSuffixToImageName(name string, suffix string) string {
 	return strings.Join(parts, ":")
 }
 
-func getGo112ImageName(name string) string {
-	return addSuffixToImageName(name, getGo112ID())
-}
-
 func getGo114ImageName(name string) string {
-	return addSuffixToImageName(stripSuffixFromImageName(name, []string{getGo112ID()}), getGo114ID())
+	return addSuffixToImageName(name, getGo114ID())
 }
 
 // Consolidate whitelisted and skipped branches with newly added
@@ -463,13 +448,13 @@ func createCommand(data baseProwJobTemplateData) []string {
 }
 
 // addEnvToJob adds the given key/pair environment variable to the job.
-func addEnvToJob(data *baseProwJobTemplateData, key, value string) {
+func (data *baseProwJobTemplateData) addEnvToJob(key, value string) {
 	// Value should always be string. Add quotes if we get a number
 	if isNum(value) {
 		value = "\"" + value + "\""
 	}
 
-	(*data).Env = append((*data).Env, []string{"- name: " + key, "  value: " + value}...)
+	data.Env = append(data.Env, "- name: "+key, "  value: "+value)
 }
 
 // addLabelToJob adds extra labels to a job
@@ -523,14 +508,14 @@ func addExtraEnvVarsToJob(envVars []string, data *baseProwJobTemplateData) {
 		if len(pair) != 2 {
 			log.Fatalf("Environment variable %q is expected to be \"key=value\"", env)
 		}
-		addEnvToJob(data, pair[0], pair[1])
+		data.addEnvToJob(pair[0], pair[1])
 	}
 }
 
 // setupDockerInDockerForJob enables docker-in-docker for the given job.
 func setupDockerInDockerForJob(data *baseProwJobTemplateData) {
 	addVolumeToJob(data, "/docker-graph", "docker-graph", false, "")
-	addEnvToJob(data, "DOCKER_IN_DOCKER_ENABLED", "\"true\"")
+	data.addEnvToJob("DOCKER_IN_DOCKER_ENABLED", "\"true\"")
 	(*data).SecurityContext = []string{"privileged: true"}
 }
 
@@ -619,9 +604,10 @@ func parseBasicJobConfigOverrides(data *baseProwJobTemplateData, config yaml.Map
 		(*data).ExtraRefs = append((*data).ExtraRefs, "  "+(*data).PathAlias)
 	}
 	if needGo113 {
-		(*data).Image = getGo113ImageName((*data).Image)
+		data.addEnvToJob("GO_VERSION", "go1.13")
 	}
 	if needGo114 {
+		data.addEnvToJob("GO_VERSION", "go1.14")
 		(*data).Image = getGo114ImageName((*data).Image)
 	}
 	// Override any values if provided by command-line flags.
@@ -848,7 +834,7 @@ func executeJobTemplateWrapper(repoName string, data interface{}, generateOneJob
 	}
 
 	var go113Branches []string
-	// Find out if Go112Branches is set in repo settings
+	// Find out if Go113Branches is set in repo settings
 	for _, repo := range repositories {
 		if repo.Name == repoName {
 			if len(repo.Go113Branches) > 0 {
@@ -863,12 +849,8 @@ func executeJobTemplateWrapper(repoName string, data interface{}, generateOneJob
 				base.Image = getGo114ImageName(base.Image)
 			},
 			restore: func(base *baseProwJobTemplateData) {
-				base.Image = getGo113ImageName(base.Image)
 			},
 		})
-	} else {
-		base := getBase(data)
-		base.Image = getGo113ImageName(base.Image)
 	}
 
 	if len(sbs) == 0 { // Generate single job if there is no special branch logic

--- a/tools/config-generator/perf_config.go
+++ b/tools/config-generator/perf_config.go
@@ -105,9 +105,9 @@ func perfClusterBaseProwJob(command string, args []string, fullRepoName, sa stri
 	base.Command = command
 	base.Args = args
 	addVolumeToJob(&base, "/etc/performance-test", sa, true, "")
-	addEnvToJob(&base, "GOOGLE_APPLICATION_CREDENTIALS", "/etc/performance-test/service-account.json")
-	addEnvToJob(&base, "GITHUB_TOKEN", "/etc/performance-test/github-token")
-	addEnvToJob(&base, "SLACK_READ_TOKEN", "/etc/performance-test/slack-read-token")
-	addEnvToJob(&base, "SLACK_WRITE_TOKEN", "/etc/performance-test/slack-write-token")
+	base.addEnvToJob("GOOGLE_APPLICATION_CREDENTIALS", "/etc/performance-test/service-account.json")
+	base.addEnvToJob("GITHUB_TOKEN", "/etc/performance-test/github-token")
+	base.addEnvToJob("SLACK_READ_TOKEN", "/etc/performance-test/slack-read-token")
+	base.addEnvToJob("SLACK_WRITE_TOKEN", "/etc/performance-test/slack-write-token")
 	return base
 }

--- a/tools/config-generator/periodic_config.go
+++ b/tools/config-generator/periodic_config.go
@@ -185,7 +185,7 @@ func generatePeriodic(title string, repoName string, periodicConfig yaml.MapSlic
 			jobType = getString(item.Key)
 			jobNameSuffix = "webhook-apicoverage"
 			data.Base.Command = webhookAPICoverageScript
-			addEnvToJob(&data.Base, "SYSTEM_NAMESPACE", data.Base.RepoNameForJob)
+			data.Base.addEnvToJob("SYSTEM_NAMESPACE", data.Base.RepoNameForJob)
 		default:
 			continue
 		}
@@ -216,13 +216,13 @@ func generatePeriodic(title string, repoName string, periodicConfig yaml.MapSlic
 	// Generate config itself.
 	data.PeriodicCommand = createCommand(data.Base)
 	if data.Base.ServiceAccount != "" {
-		addEnvToJob(&data.Base, "GOOGLE_APPLICATION_CREDENTIALS", data.Base.ServiceAccount)
-		addEnvToJob(&data.Base, "E2E_CLUSTER_REGION", "us-central1")
+		data.Base.addEnvToJob("GOOGLE_APPLICATION_CREDENTIALS", data.Base.ServiceAccount)
+		data.Base.addEnvToJob("E2E_CLUSTER_REGION", "us-central1")
 	}
 	if data.Base.RepoBranch != "" && data.Base.RepoBranch != "master" {
 		// If it's a release version, add env var PULL_BASE_REF as ref name of the base branch.
 		// The reason for having it is in https://github.com/knative/test-infra/issues/780.
-		addEnvToJob(&data.Base, "PULL_BASE_REF", data.Base.RepoBranch)
+		data.Base.addEnvToJob("PULL_BASE_REF", data.Base.RepoBranch)
 	}
 	addExtraEnvVarsToJob(extraEnvVars, &data.Base)
 	configureServiceAccountForJob(&data.Base)

--- a/tools/config-generator/presubmit_config.go
+++ b/tools/config-generator/presubmit_config.go
@@ -93,8 +93,8 @@ func generatePresubmit(title string, repoName string, presubmitConfig yaml.MapSl
 	data.PresubmitPullJobName = "pull-" + data.PresubmitJobName
 	data.PresubmitPostJobName = "post-" + data.PresubmitJobName
 	if data.Base.ServiceAccount != "" {
-		addEnvToJob(&data.Base, "GOOGLE_APPLICATION_CREDENTIALS", data.Base.ServiceAccount)
-		addEnvToJob(&data.Base, "E2E_CLUSTER_REGION", "us-central1")
+		data.Base.addEnvToJob("GOOGLE_APPLICATION_CREDENTIALS", data.Base.ServiceAccount)
+		data.Base.addEnvToJob("E2E_CLUSTER_REGION", "us-central1")
 	}
 	if data.Base.NeedsMonitor {
 		addMonitoringPubsubLabelsToJob(&data.Base, data.PresubmitPullJobName)


### PR DESCRIPTION
Informs gvm how to choose which version of Go to use

Is a no-op until we switch the image.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:

Only have to maintain a single prow-tests image

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
progress toward #1823 
