### PR TITLE
Add --github-token-path config for crier and hook

### DIFF
--- a/config/staging/prow/cluster/400-crier.yaml
+++ b/config/staging/prow/cluster/400-crier.yaml
@@ -37,6 +37,7 @@ spec:
         - --kubernetes-gcs-workers=1
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
+        - --github-token-path=/etc/github/oauth
         - --github-workers=5
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com

--- a/config/staging/prow/cluster/400-hook.yaml
+++ b/config/staging/prow/cluster/400-hook.yaml
@@ -44,6 +44,7 @@ spec:
         - --dry-run=false
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
+        - --github-token-path=/etc/github/oauth
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
         ports:

--- a/config/staging/prow/cluster/400-tide.yaml
+++ b/config/staging/prow/cluster/400-tide.yaml
@@ -45,6 +45,9 @@ spec:
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
+        - --github-endpoint=http://ghproxy
+        - --github-endpoint=https://api.github.com
+        - --github-token-path=/etc/github/oauth
         - --dry-run=false
         ports:
           - name: http


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Add --github-token-path config for crier and hook

/cc @peterfeifanchen 

