### PR TITLE
Change number of crier github workers to 1

### DIFF
--- a/config/staging/prow/cluster/400-crier.yaml
+++ b/config/staging/prow/cluster/400-crier.yaml
@@ -38,7 +38,7 @@ spec:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --github-token-path=/etc/github/oauth
-        - --github-workers=5
+        - --github-workers=1
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
         volumeMounts:


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Prow team recommends 1 worker so there isn't a chance of races. 


**Special notes to reviewers**:

**User-visible changes in this PR**:
/cc @chizhg 
