### PR TITLE
Fix CI/CD flows on release branches

### DIFF
--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -619,12 +619,20 @@ periodics:
           memory: 16Gi
     - dot-release: true
       dot-dev: true
-      go114: true
+      release: "0.14"
       resources:
         requests:
           memory: 12Gi
         limits:
           memory: 16Gi
+#    - dot-release: true
+#      dot-dev: true
+#      go114: true
+#      resources:
+#        requests:
+#          memory: 12Gi
+#        limits:
+#          memory: 16Gi
     - auto-release: true
       dot-dev: true
       go114: true
@@ -675,7 +683,10 @@ periodics:
       release: "0.13"
     - dot-release: true
       dot-dev: true
-      go114: true
+      release: "0.14"
+#    - dot-release: true
+#      dot-dev: true
+#      go114: true
     - auto-release: true
       dot-dev: true
       go114: true
@@ -745,12 +756,20 @@ periodics:
           memory: 16Gi
     - dot-release: true
       dot-dev: true
-      go114: true
+      release: "0.14"
       resources:
         requests:
           memory: 12Gi
         limits:
           memory: 16Gi
+#    - dot-release: true
+#      dot-dev: true
+#      go114: true
+#      resources:
+#        requests:
+#          memory: 12Gi
+#        limits:
+#          memory: 16Gi
     - auto-release: true
       dot-dev: true
       go114: true
@@ -815,12 +834,20 @@ periodics:
           memory: 16Gi
     - dot-release: true
       dot-dev: true
-      go114: true
+      release: "0.14"
       resources:
         requests:
           memory: 12Gi
         limits:
           memory: 16Gi
+#    - dot-release: true
+#      dot-dev: true
+#      go114: true
+#      resources:
+#        requests:
+#          memory: 12Gi
+#        limits:
+#          memory: 16Gi
     - auto-release: true
       dot-dev: true
       go114: true
@@ -885,7 +912,10 @@ periodics:
       release: "0.13"
     - dot-release: true
       dot-dev: true
-      go114: true
+      release: "0.14"
+#    - dot-release: true
+#      dot-dev: true
+#      go114: true
     - auto-release: true
       dot-dev: true
       go114: true
@@ -920,7 +950,10 @@ periodics:
       release: "0.13"
     - dot-release: true
       dot-dev: true
-      go114: true
+      release: "0.14"
+#    - dot-release: true
+#      dot-dev: true
+#      go114: true
     - auto-release: true
       dot-dev: true
       go114: true
@@ -945,9 +978,13 @@ periodics:
       env-vars:
         - ORG_NAME=google
     - dot-release: true
-      go114: true
+      release: "0.14"
       env-vars:
       - ORG_NAME=google
+#    - dot-release: true
+#      go114: true
+#      env-vars:
+#      - ORG_NAME=google
     - auto-release: true
       go114: true
       env-vars:

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -7605,23 +7605,23 @@ periodics:
     - name: release-account
       secret:
         secretName: release-account
-- cron: "37 9 * * 2"
-  name: ci-knative-serving-dot-release
+- cron: "35 9 * * 2"
+  name: ci-knative-serving-0.14-dot-release
   agent: kubernetes
   labels:
     prow.k8s.io/pubsub.project: knative-tests
     prow.k8s.io/pubsub.topic: knative-monitoring
-    prow.k8s.io/pubsub.runID: ci-knative-serving-dot-release
+    prow.k8s.io/pubsub.runID: ci-knative-serving-0.14-dot-release
   decorate: true
   cluster: "build-knative"
   extra_refs:
   - org: knative
     repo: serving
-    base_ref: master
+    base_ref: release-0.14
     path_alias: knative.dev/serving
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests-go114:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -7631,6 +7631,7 @@ periodics:
       - "--release-gcs knative-releases/serving"
       - "--release-gcr gcr.io/knative-releases"
       - "--github-token /etc/hub-token/token"
+      - "--branch release-0.14"
       volumeMounts:
       - name: hub-token
         mountPath: /etc/hub-token
@@ -7639,12 +7640,12 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.14
       resources:
         requests:
           memory: 12Gi
@@ -8209,23 +8210,23 @@ periodics:
     - name: release-account
       secret:
         secretName: release-account
-- cron: "21 9 * * 2"
-  name: ci-knative-client-dot-release
+- cron: "20 9 * * 2"
+  name: ci-knative-client-0.14-dot-release
   agent: kubernetes
   labels:
     prow.k8s.io/pubsub.project: knative-tests
     prow.k8s.io/pubsub.topic: knative-monitoring
-    prow.k8s.io/pubsub.runID: ci-knative-client-dot-release
+    prow.k8s.io/pubsub.runID: ci-knative-client-0.14-dot-release
   decorate: true
   cluster: "build-knative"
   extra_refs:
   - org: knative
     repo: client
-    base_ref: master
+    base_ref: release-0.14
     path_alias: knative.dev/client
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests-go114:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -8235,6 +8236,7 @@ periodics:
       - "--release-gcs knative-releases/client"
       - "--release-gcr gcr.io/knative-releases"
       - "--github-token /etc/hub-token/token"
+      - "--branch release-0.14"
       volumeMounts:
       - name: hub-token
         mountPath: /etc/hub-token
@@ -8243,12 +8245,12 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.14
     volumes:
     - name: hub-token
       secret:
@@ -8863,23 +8865,23 @@ periodics:
     - name: release-account
       secret:
         secretName: release-account
-- cron: "56 9 * * 2"
-  name: ci-knative-eventing-dot-release
+- cron: "54 9 * * 2"
+  name: ci-knative-eventing-0.14-dot-release
   agent: kubernetes
   labels:
     prow.k8s.io/pubsub.project: knative-tests
     prow.k8s.io/pubsub.topic: knative-monitoring
-    prow.k8s.io/pubsub.runID: ci-knative-eventing-dot-release
+    prow.k8s.io/pubsub.runID: ci-knative-eventing-0.14-dot-release
   decorate: true
   cluster: "build-knative"
   extra_refs:
   - org: knative
     repo: eventing
-    base_ref: master
+    base_ref: release-0.14
     path_alias: knative.dev/eventing
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests-go114:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -8889,6 +8891,7 @@ periodics:
       - "--release-gcs knative-releases/eventing"
       - "--release-gcr gcr.io/knative-releases"
       - "--github-token /etc/hub-token/token"
+      - "--branch release-0.14"
       volumeMounts:
       - name: hub-token
         mountPath: /etc/hub-token
@@ -8897,12 +8900,12 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.14
       resources:
         requests:
           memory: 12Gi
@@ -9424,23 +9427,23 @@ periodics:
     - name: release-account
       secret:
         secretName: release-account
-- cron: "51 9 * * 2"
-  name: ci-knative-eventing-contrib-dot-release
+- cron: "50 9 * * 2"
+  name: ci-knative-eventing-contrib-0.14-dot-release
   agent: kubernetes
   labels:
     prow.k8s.io/pubsub.project: knative-tests
     prow.k8s.io/pubsub.topic: knative-monitoring
-    prow.k8s.io/pubsub.runID: ci-knative-eventing-contrib-dot-release
+    prow.k8s.io/pubsub.runID: ci-knative-eventing-contrib-0.14-dot-release
   decorate: true
   cluster: "build-knative"
   extra_refs:
   - org: knative
     repo: eventing-contrib
-    base_ref: master
+    base_ref: release-0.14
     path_alias: knative.dev/eventing-contrib
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests-go114:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -9450,6 +9453,7 @@ periodics:
       - "--release-gcs knative-releases/eventing-contrib"
       - "--release-gcr gcr.io/knative-releases"
       - "--github-token /etc/hub-token/token"
+      - "--branch release-0.14"
       volumeMounts:
       - name: hub-token
         mountPath: /etc/hub-token
@@ -9458,12 +9462,12 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.14
       resources:
         requests:
           memory: 12Gi
@@ -10219,23 +10223,23 @@ periodics:
     - name: release-account
       secret:
         secretName: release-account
-- cron: "4 19 * * 2"
-  name: ci-knative-serving-operator-dot-release
+- cron: "2 19 * * 2"
+  name: ci-knative-serving-operator-0.14-dot-release
   agent: kubernetes
   labels:
     prow.k8s.io/pubsub.project: knative-tests
     prow.k8s.io/pubsub.topic: knative-monitoring
-    prow.k8s.io/pubsub.runID: ci-knative-serving-operator-dot-release
+    prow.k8s.io/pubsub.runID: ci-knative-serving-operator-0.14-dot-release
   decorate: true
   cluster: "build-knative"
   extra_refs:
   - org: knative
     repo: serving-operator
-    base_ref: master
+    base_ref: release-0.14
     path_alias: knative.dev/serving-operator
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests-go114:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -10245,6 +10249,7 @@ periodics:
       - "--release-gcs knative-releases/serving-operator"
       - "--release-gcr gcr.io/knative-releases"
       - "--github-token /etc/hub-token/token"
+      - "--branch release-0.14"
       volumeMounts:
       - name: hub-token
         mountPath: /etc/hub-token
@@ -10253,12 +10258,12 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.14
     volumes:
     - name: hub-token
       secret:
@@ -10745,23 +10750,23 @@ periodics:
     - name: release-account
       secret:
         secretName: release-account
-- cron: "23 19 * * 2"
-  name: ci-knative-eventing-operator-dot-release
+- cron: "21 19 * * 2"
+  name: ci-knative-eventing-operator-0.14-dot-release
   agent: kubernetes
   labels:
     prow.k8s.io/pubsub.project: knative-tests
     prow.k8s.io/pubsub.topic: knative-monitoring
-    prow.k8s.io/pubsub.runID: ci-knative-eventing-operator-dot-release
+    prow.k8s.io/pubsub.runID: ci-knative-eventing-operator-0.14-dot-release
   decorate: true
   cluster: "build-knative"
   extra_refs:
   - org: knative
     repo: eventing-operator
-    base_ref: master
+    base_ref: release-0.14
     path_alias: knative.dev/eventing-operator
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests-go114:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -10771,6 +10776,7 @@ periodics:
       - "--release-gcs knative-releases/eventing-operator"
       - "--release-gcr gcr.io/knative-releases"
       - "--github-token /etc/hub-token/token"
+      - "--branch release-0.14"
       volumeMounts:
       - name: hub-token
         mountPath: /etc/hub-token
@@ -10779,12 +10785,12 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.14
     volumes:
     - name: hub-token
       secret:
@@ -11173,22 +11179,22 @@ periodics:
     - name: release-account
       secret:
         secretName: release-account
-- cron: "56 9 * * 2"
-  name: ci-google-knative-gcp-dot-release
+- cron: "54 9 * * 2"
+  name: ci-google-knative-gcp-0.14-dot-release
   agent: kubernetes
   labels:
     prow.k8s.io/pubsub.project: knative-tests
     prow.k8s.io/pubsub.topic: knative-monitoring
-    prow.k8s.io/pubsub.runID: ci-google-knative-gcp-dot-release
+    prow.k8s.io/pubsub.runID: ci-google-knative-gcp-0.14-dot-release
   decorate: true
   cluster: "build-knative"
   extra_refs:
   - org: google
     repo: knative-gcp
-    base_ref: master
+    base_ref: release-0.14
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests-go114:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -11198,6 +11204,7 @@ periodics:
       - "--release-gcs knative-releases/knative-gcp"
       - "--release-gcr gcr.io/knative-releases"
       - "--github-token /etc/hub-token/token"
+      - "--branch release-0.14"
       volumeMounts:
       - name: hub-token
         mountPath: /etc/hub-token
@@ -11208,12 +11215,12 @@ periodics:
       env:
       - name: ORG_NAME
         value: google
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.14
     volumes:
     - name: hub-token
       secret:

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -35,7 +35,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -133,7 +133,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -225,7 +225,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -319,7 +319,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -401,7 +401,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -582,7 +582,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -662,7 +662,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -742,7 +742,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -822,7 +822,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -902,7 +902,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -982,7 +982,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -1062,7 +1062,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -1142,7 +1142,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -1222,7 +1222,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -1302,7 +1302,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -1386,7 +1386,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -1470,7 +1470,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -1622,7 +1622,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -1688,7 +1688,7 @@ presubmits:
     cluster: "build-knative"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -1725,7 +1725,7 @@ presubmits:
     cluster: "build-knative"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -1762,7 +1762,7 @@ presubmits:
     cluster: "build-knative"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -1805,7 +1805,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -1899,7 +1899,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -1983,7 +1983,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -2136,7 +2136,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -2230,7 +2230,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -2314,7 +2314,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -2461,7 +2461,7 @@ presubmits:
     cluster: "build-knative"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -2497,7 +2497,7 @@ presubmits:
     cluster: "build-knative"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -2533,7 +2533,7 @@ presubmits:
     cluster: "build-knative"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -2606,7 +2606,7 @@ presubmits:
     cluster: "build-knative"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -2642,7 +2642,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -2726,7 +2726,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -2810,7 +2810,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -2963,7 +2963,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -3047,7 +3047,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -3131,7 +3131,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -3279,7 +3279,7 @@ presubmits:
     cluster: "build-knative"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -3316,7 +3316,7 @@ presubmits:
     cluster: "build-knative"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -3353,7 +3353,7 @@ presubmits:
     cluster: "build-knative"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -3420,7 +3420,7 @@ presubmits:
     cluster: "build-knative"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -3457,7 +3457,7 @@ presubmits:
     cluster: "build-knative"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -3495,7 +3495,7 @@ presubmits:
     cluster: "build-knative"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -3532,7 +3532,7 @@ presubmits:
     cluster: "build-knative"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -3574,7 +3574,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -3656,7 +3656,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -3738,7 +3738,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -3822,7 +3822,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -3962,7 +3962,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -4046,7 +4046,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -4130,7 +4130,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -4283,7 +4283,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -4367,7 +4367,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -4451,7 +4451,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -4604,7 +4604,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -4688,7 +4688,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -4772,7 +4772,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -4925,7 +4925,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -5009,7 +5009,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -5093,7 +5093,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -5246,7 +5246,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -5322,7 +5322,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -5406,7 +5406,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -5490,7 +5490,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -5643,7 +5643,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -5727,7 +5727,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -5811,7 +5811,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -5963,7 +5963,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -6038,7 +6038,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -6122,7 +6122,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -6206,7 +6206,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -6358,7 +6358,7 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -6428,7 +6428,7 @@ presubmits:
     cluster: "build-knative"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -6465,7 +6465,7 @@ presubmits:
     cluster: "build-knative"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -6502,7 +6502,7 @@ presubmits:
     cluster: "build-knative"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -6568,7 +6568,7 @@ presubmits:
     cluster: "build-knative"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -6601,7 +6601,7 @@ presubmits:
     cluster: "build-knative"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -6646,7 +6646,7 @@ presubmits:
     cluster: "build-knative"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -6691,7 +6691,7 @@ presubmits:
     cluster: "build-knative"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -6737,7 +6737,7 @@ presubmits:
     cluster: "build-knative"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -6774,7 +6774,7 @@ presubmits:
     cluster: "build-knative"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -6811,7 +6811,7 @@ presubmits:
     cluster: "build-knative"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -6897,7 +6897,7 @@ periodics:
     path_alias: knative.dev/serving
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -6944,7 +6944,7 @@ periodics:
     path_alias: knative.dev/serving
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -6991,7 +6991,7 @@ periodics:
     path_alias: knative.dev/serving
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -7038,7 +7038,7 @@ periodics:
     path_alias: knative.dev/serving
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -7462,7 +7462,7 @@ periodics:
     path_alias: knative.dev/serving
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -7515,7 +7515,7 @@ periodics:
     path_alias: knative.dev/serving
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -7568,7 +7568,7 @@ periodics:
     path_alias: knative.dev/serving
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -7821,7 +7821,7 @@ periodics:
     path_alias: knative.dev/client
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -7868,7 +7868,7 @@ periodics:
     path_alias: knative.dev/client
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -7915,7 +7915,7 @@ periodics:
     path_alias: knative.dev/client
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -7962,7 +7962,7 @@ periodics:
     path_alias: knative.dev/client
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -8081,7 +8081,7 @@ periodics:
     path_alias: knative.dev/client
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -8129,7 +8129,7 @@ periodics:
     path_alias: knative.dev/client
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -8177,7 +8177,7 @@ periodics:
     path_alias: knative.dev/client
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -8379,7 +8379,7 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -8488,7 +8488,7 @@ periodics:
     path_alias: knative.dev/eventing
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -8535,7 +8535,7 @@ periodics:
     path_alias: knative.dev/eventing
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -8582,7 +8582,7 @@ periodics:
     path_alias: knative.dev/eventing
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -8629,7 +8629,7 @@ periodics:
     path_alias: knative.dev/eventing
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -8720,7 +8720,7 @@ periodics:
     path_alias: knative.dev/eventing
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -8773,7 +8773,7 @@ periodics:
     path_alias: knative.dev/eventing
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -8826,7 +8826,7 @@ periodics:
     path_alias: knative.dev/eventing
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -9049,7 +9049,7 @@ periodics:
     path_alias: knative.dev/eventing-contrib
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -9096,7 +9096,7 @@ periodics:
     path_alias: knative.dev/eventing-contrib
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -9143,7 +9143,7 @@ periodics:
     path_alias: knative.dev/eventing-contrib
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -9190,7 +9190,7 @@ periodics:
     path_alias: knative.dev/eventing-contrib
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -9281,7 +9281,7 @@ periodics:
     path_alias: knative.dev/eventing-contrib
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -9334,7 +9334,7 @@ periodics:
     path_alias: knative.dev/eventing-contrib
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -9387,7 +9387,7 @@ periodics:
     path_alias: knative.dev/eventing-contrib
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -9864,7 +9864,7 @@ periodics:
     path_alias: knative.dev/serving-operator
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -9911,7 +9911,7 @@ periodics:
     path_alias: knative.dev/serving-operator
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -9958,7 +9958,7 @@ periodics:
     path_alias: knative.dev/serving-operator
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -10005,7 +10005,7 @@ periodics:
     path_alias: knative.dev/serving-operator
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -10091,7 +10091,7 @@ periodics:
     path_alias: knative.dev/serving-operator
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -10139,7 +10139,7 @@ periodics:
     path_alias: knative.dev/serving-operator
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -10187,7 +10187,7 @@ periodics:
     path_alias: knative.dev/serving-operator
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -10390,7 +10390,7 @@ periodics:
     path_alias: knative.dev/eventing-operator
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -10437,7 +10437,7 @@ periodics:
     path_alias: knative.dev/eventing-operator
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -10484,7 +10484,7 @@ periodics:
     path_alias: knative.dev/eventing-operator
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -10531,7 +10531,7 @@ periodics:
     path_alias: knative.dev/eventing-operator
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -10617,7 +10617,7 @@ periodics:
     path_alias: knative.dev/eventing-operator
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -10665,7 +10665,7 @@ periodics:
     path_alias: knative.dev/eventing-operator
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -10713,7 +10713,7 @@ periodics:
     path_alias: knative.dev/eventing-operator
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -10914,7 +10914,7 @@ periodics:
     base_ref: release-0.12
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -10960,7 +10960,7 @@ periodics:
     base_ref: release-0.13
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -11006,7 +11006,7 @@ periodics:
     base_ref: release-0.14
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -11090,7 +11090,7 @@ periodics:
     base_ref: release-0.12
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -11139,7 +11139,7 @@ periodics:
     base_ref: release-0.13
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests-go113:stable
       imagePullPolicy: Always
       command:
       - runner.sh

--- a/config/prod/prow/testgrid/testgrid.yaml
+++ b/config/prod/prow/testgrid/testgrid.yaml
@@ -90,12 +90,6 @@ test_groups:
   alert_options:
     alert_mail_to_addresses: "prime-engprod-sea@google.com"
   num_failures_to_alert: 1
-- name: ci-knative-serving-dot-release
-  gcs_prefix: knative-prow/logs/ci-knative-serving-dot-release
-  alert_options:
-    alert_mail_to_addresses: "prime-engprod-sea@google.com"
-  alert_stale_results_hours: 170
-  num_failures_to_alert: 1
 - name: ci-knative-serving-auto-release
   gcs_prefix: knative-prow/logs/ci-knative-serving-auto-release
   alert_options:
@@ -118,12 +112,6 @@ test_groups:
 - name: ci-knative-client-tekton
   gcs_prefix: knative-prow/logs/ci-knative-client-tekton
   alert_stale_results_hours: 3
-- name: ci-knative-client-dot-release
-  gcs_prefix: knative-prow/logs/ci-knative-client-dot-release
-  alert_options:
-    alert_mail_to_addresses: "prime-engprod-sea@google.com"
-  alert_stale_results_hours: 170
-  num_failures_to_alert: 1
 - name: ci-knative-client-auto-release
   gcs_prefix: knative-prow/logs/ci-knative-client-auto-release
   alert_options:
@@ -149,12 +137,6 @@ test_groups:
   alert_options:
     alert_mail_to_addresses: "prime-engprod-sea@google.com"
   num_failures_to_alert: 1
-- name: ci-knative-eventing-dot-release
-  gcs_prefix: knative-prow/logs/ci-knative-eventing-dot-release
-  alert_options:
-    alert_mail_to_addresses: "prime-engprod-sea@google.com"
-  alert_stale_results_hours: 170
-  num_failures_to_alert: 1
 - name: ci-knative-eventing-auto-release
   gcs_prefix: knative-prow/logs/ci-knative-eventing-auto-release
   alert_options:
@@ -170,12 +152,6 @@ test_groups:
   gcs_prefix: knative-prow/logs/ci-knative-eventing-contrib-nightly-release
   alert_options:
     alert_mail_to_addresses: "prime-engprod-sea@google.com"
-  num_failures_to_alert: 1
-- name: ci-knative-eventing-contrib-dot-release
-  gcs_prefix: knative-prow/logs/ci-knative-eventing-contrib-dot-release
-  alert_options:
-    alert_mail_to_addresses: "prime-engprod-sea@google.com"
-  alert_stale_results_hours: 170
   num_failures_to_alert: 1
 - name: ci-knative-eventing-contrib-auto-release
   gcs_prefix: knative-prow/logs/ci-knative-eventing-contrib-auto-release
@@ -217,12 +193,6 @@ test_groups:
   alert_options:
     alert_mail_to_addresses: "prime-engprod-sea@google.com"
   num_failures_to_alert: 1
-- name: ci-knative-serving-operator-dot-release
-  gcs_prefix: knative-prow/logs/ci-knative-serving-operator-dot-release
-  alert_options:
-    alert_mail_to_addresses: "prime-engprod-sea@google.com"
-  alert_stale_results_hours: 170
-  num_failures_to_alert: 1
 - name: ci-knative-serving-operator-auto-release
   gcs_prefix: knative-prow/logs/ci-knative-serving-operator-auto-release
   alert_options:
@@ -238,12 +208,6 @@ test_groups:
   gcs_prefix: knative-prow/logs/ci-knative-eventing-operator-nightly-release
   alert_options:
     alert_mail_to_addresses: "prime-engprod-sea@google.com"
-  num_failures_to_alert: 1
-- name: ci-knative-eventing-operator-dot-release
-  gcs_prefix: knative-prow/logs/ci-knative-eventing-operator-dot-release
-  alert_options:
-    alert_mail_to_addresses: "prime-engprod-sea@google.com"
-  alert_stale_results_hours: 170
   num_failures_to_alert: 1
 - name: ci-knative-eventing-operator-auto-release
   gcs_prefix: knative-prow/logs/ci-knative-eventing-operator-auto-release
@@ -566,31 +530,67 @@ test_groups:
   alert_options:
     alert_mail_to_addresses: "prime-engprod-sea@google.com"
   num_failures_to_alert: 3
+- name: ci-knative-serving-0.14-dot-release
+  gcs_prefix: knative-prow/logs/ci-knative-serving-0.14-dot-release
+  alert_options:
+    alert_mail_to_addresses: "prime-engprod-sea@google.com"
+  alert_stale_results_hours: 170
+  num_failures_to_alert: 1
 - name: ci-knative-client-0.14-continuous
   gcs_prefix: knative-prow/logs/ci-knative-client-0.14-continuous
   alert_options:
     alert_mail_to_addresses: "prime-engprod-sea@google.com"
   num_failures_to_alert: 3
+- name: ci-knative-client-0.14-dot-release
+  gcs_prefix: knative-prow/logs/ci-knative-client-0.14-dot-release
+  alert_options:
+    alert_mail_to_addresses: "prime-engprod-sea@google.com"
+  alert_stale_results_hours: 170
+  num_failures_to_alert: 1
 - name: ci-knative-eventing-0.14-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-0.14-continuous
   alert_options:
     alert_mail_to_addresses: "prime-engprod-sea@google.com"
   num_failures_to_alert: 3
+- name: ci-knative-eventing-0.14-dot-release
+  gcs_prefix: knative-prow/logs/ci-knative-eventing-0.14-dot-release
+  alert_options:
+    alert_mail_to_addresses: "prime-engprod-sea@google.com"
+  alert_stale_results_hours: 170
+  num_failures_to_alert: 1
 - name: ci-knative-eventing-contrib-0.14-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-contrib-0.14-continuous
   alert_options:
     alert_mail_to_addresses: "prime-engprod-sea@google.com"
   num_failures_to_alert: 3
+- name: ci-knative-eventing-contrib-0.14-dot-release
+  gcs_prefix: knative-prow/logs/ci-knative-eventing-contrib-0.14-dot-release
+  alert_options:
+    alert_mail_to_addresses: "prime-engprod-sea@google.com"
+  alert_stale_results_hours: 170
+  num_failures_to_alert: 1
 - name: ci-knative-serving-operator-0.14-continuous
   gcs_prefix: knative-prow/logs/ci-knative-serving-operator-0.14-continuous
   alert_options:
     alert_mail_to_addresses: "prime-engprod-sea@google.com"
   num_failures_to_alert: 3
+- name: ci-knative-serving-operator-0.14-dot-release
+  gcs_prefix: knative-prow/logs/ci-knative-serving-operator-0.14-dot-release
+  alert_options:
+    alert_mail_to_addresses: "prime-engprod-sea@google.com"
+  alert_stale_results_hours: 170
+  num_failures_to_alert: 1
 - name: ci-knative-eventing-operator-0.14-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-operator-0.14-continuous
   alert_options:
     alert_mail_to_addresses: "prime-engprod-sea@google.com"
   num_failures_to_alert: 3
+- name: ci-knative-eventing-operator-0.14-dot-release
+  gcs_prefix: knative-prow/logs/ci-knative-eventing-operator-0.14-dot-release
+  alert_options:
+    alert_mail_to_addresses: "prime-engprod-sea@google.com"
+  alert_stale_results_hours: 170
+  num_failures_to_alert: 1
 - name: ci-google-knative-gcp-continuous
   gcs_prefix: knative-prow/logs/ci-google-knative-gcp-continuous
   alert_stale_results_hours: 3
@@ -598,12 +598,6 @@ test_groups:
   gcs_prefix: knative-prow/logs/ci-google-knative-gcp-nightly-release
   alert_options:
     alert_mail_to_addresses: "prime-engprod-sea@google.com"
-  num_failures_to_alert: 1
-- name: ci-google-knative-gcp-dot-release
-  gcs_prefix: knative-prow/logs/ci-google-knative-gcp-dot-release
-  alert_options:
-    alert_mail_to_addresses: "prime-engprod-sea@google.com"
-  alert_stale_results_hours: 170
   num_failures_to_alert: 1
 - name: ci-google-knative-gcp-auto-release
   gcs_prefix: knative-prow/logs/ci-google-knative-gcp-auto-release
@@ -640,6 +634,12 @@ test_groups:
   alert_options:
     alert_mail_to_addresses: "prime-engprod-sea@google.com"
   num_failures_to_alert: 3
+- name: ci-google-knative-gcp-0.14-dot-release
+  gcs_prefix: knative-prow/logs/ci-google-knative-gcp-0.14-dot-release
+  alert_options:
+    alert_mail_to_addresses: "prime-engprod-sea@google.com"
+  alert_stale_results_hours: 170
+  num_failures_to_alert: 1
 - name: ci-knative-operator-sandbox-continuous
   gcs_prefix: knative-prow/logs/ci-knative-operator-sandbox-continuous
   alert_stale_results_hours: 3
@@ -729,12 +729,6 @@ dashboards:
     alert_options:
       alert_mail_to_addresses: "prime-engprod-sea@google.com"
     num_failures_to_alert: 1
-  - name: dot-release
-    test_group_name: ci-knative-serving-dot-release
-    base_options: "sort-by-name="
-    alert_options:
-      alert_mail_to_addresses: "prime-engprod-sea@google.com"
-    num_failures_to_alert: 1
   - name: auto-release
     test_group_name: ci-knative-serving-auto-release
     base_options: "sort-by-name="
@@ -764,12 +758,6 @@ dashboards:
   - name: tekton
     test_group_name: ci-knative-client-tekton
     base_options: "sort-by-name="
-  - name: dot-release
-    test_group_name: ci-knative-client-dot-release
-    base_options: "sort-by-name="
-    alert_options:
-      alert_mail_to_addresses: "prime-engprod-sea@google.com"
-    num_failures_to_alert: 1
   - name: auto-release
     test_group_name: ci-knative-client-auto-release
     base_options: "sort-by-name="
@@ -812,12 +800,6 @@ dashboards:
     alert_options:
       alert_mail_to_addresses: "prime-engprod-sea@google.com"
     num_failures_to_alert: 1
-  - name: dot-release
-    test_group_name: ci-knative-eventing-dot-release
-    base_options: "sort-by-name="
-    alert_options:
-      alert_mail_to_addresses: "prime-engprod-sea@google.com"
-    num_failures_to_alert: 1
   - name: auto-release
     test_group_name: ci-knative-eventing-auto-release
     base_options: "sort-by-name="
@@ -837,12 +819,6 @@ dashboards:
     num_failures_to_alert: 3
   - name: nightly
     test_group_name: ci-knative-eventing-contrib-nightly-release
-    base_options: "sort-by-name="
-    alert_options:
-      alert_mail_to_addresses: "prime-engprod-sea@google.com"
-    num_failures_to_alert: 1
-  - name: dot-release
-    test_group_name: ci-knative-eventing-contrib-dot-release
     base_options: "sort-by-name="
     alert_options:
       alert_mail_to_addresses: "prime-engprod-sea@google.com"
@@ -919,12 +895,6 @@ dashboards:
     alert_options:
       alert_mail_to_addresses: "prime-engprod-sea@google.com"
     num_failures_to_alert: 1
-  - name: dot-release
-    test_group_name: ci-knative-serving-operator-dot-release
-    base_options: "sort-by-name="
-    alert_options:
-      alert_mail_to_addresses: "prime-engprod-sea@google.com"
-    num_failures_to_alert: 1
   - name: auto-release
     test_group_name: ci-knative-serving-operator-auto-release
     base_options: "sort-by-name="
@@ -944,12 +914,6 @@ dashboards:
     num_failures_to_alert: 3
   - name: nightly
     test_group_name: ci-knative-eventing-operator-nightly-release
-    base_options: "sort-by-name="
-    alert_options:
-      alert_mail_to_addresses: "prime-engprod-sea@google.com"
-    num_failures_to_alert: 1
-  - name: dot-release
-    test_group_name: ci-knative-eventing-operator-dot-release
     base_options: "sort-by-name="
     alert_options:
       alert_mail_to_addresses: "prime-engprod-sea@google.com"
@@ -1118,12 +1082,6 @@ dashboards:
     num_failures_to_alert: 3
   - name: nightly
     test_group_name: ci-google-knative-gcp-nightly-release
-    base_options: "sort-by-name="
-    alert_options:
-      alert_mail_to_addresses: "prime-engprod-sea@google.com"
-    num_failures_to_alert: 1
-  - name: dot-release
-    test_group_name: ci-google-knative-gcp-dot-release
     base_options: "sort-by-name="
     alert_options:
       alert_mail_to_addresses: "prime-engprod-sea@google.com"
@@ -1422,8 +1380,20 @@ dashboards:
     alert_options:
       alert_mail_to_addresses: "prime-engprod-sea@google.com"
     num_failures_to_alert: 3
+  - name: serving-dot-release
+    test_group_name: ci-knative-serving-0.14-dot-release
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "prime-engprod-sea@google.com"
+    num_failures_to_alert: 3
   - name: client-continuous
     test_group_name: ci-knative-client-0.14-continuous
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "prime-engprod-sea@google.com"
+    num_failures_to_alert: 3
+  - name: client-dot-release
+    test_group_name: ci-knative-client-0.14-dot-release
     base_options: "sort-by-name="
     alert_options:
       alert_mail_to_addresses: "prime-engprod-sea@google.com"
@@ -1434,8 +1404,20 @@ dashboards:
     alert_options:
       alert_mail_to_addresses: "prime-engprod-sea@google.com"
     num_failures_to_alert: 3
+  - name: eventing-dot-release
+    test_group_name: ci-knative-eventing-0.14-dot-release
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "prime-engprod-sea@google.com"
+    num_failures_to_alert: 3
   - name: eventing-contrib-continuous
     test_group_name: ci-knative-eventing-contrib-0.14-continuous
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "prime-engprod-sea@google.com"
+    num_failures_to_alert: 3
+  - name: eventing-contrib-dot-release
+    test_group_name: ci-knative-eventing-contrib-0.14-dot-release
     base_options: "sort-by-name="
     alert_options:
       alert_mail_to_addresses: "prime-engprod-sea@google.com"
@@ -1446,8 +1428,20 @@ dashboards:
     alert_options:
       alert_mail_to_addresses: "prime-engprod-sea@google.com"
     num_failures_to_alert: 3
+  - name: serving-operator-dot-release
+    test_group_name: ci-knative-serving-operator-0.14-dot-release
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "prime-engprod-sea@google.com"
+    num_failures_to_alert: 3
   - name: eventing-operator-continuous
     test_group_name: ci-knative-eventing-operator-0.14-continuous
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "prime-engprod-sea@google.com"
+    num_failures_to_alert: 3
+  - name: eventing-operator-dot-release
+    test_group_name: ci-knative-eventing-operator-0.14-dot-release
     base_options: "sort-by-name="
     alert_options:
       alert_mail_to_addresses: "prime-engprod-sea@google.com"
@@ -1484,6 +1478,12 @@ dashboards:
   dashboard_tab:
   - name: knative-gcp-continuous
     test_group_name: ci-google-knative-gcp-0.14-continuous
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "prime-engprod-sea@google.com"
+    num_failures_to_alert: 3
+  - name: knative-gcp-dot-release
+    test_group_name: ci-google-knative-gcp-0.14-dot-release
     base_options: "sort-by-name="
     alert_options:
       alert_mail_to_addresses: "prime-engprod-sea@google.com"

--- a/images/prow-tests-go113/Dockerfile
+++ b/images/prow-tests-go113/Dockerfile
@@ -1,0 +1,88 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is the base Dockerfile for knative-tests images, please remember to also
+# do `make push` in `../prow-tests-*` directories to make sure these images are in
+# sync
+
+# TODO(chizhg): probably build the image from scratch?
+FROM gcr.io/k8s-testimages/kubekins-e2e:v20200326-e946722-master
+
+# Install extras on top of base image
+
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update
+RUN gcloud components update
+
+# Docker
+RUN gcloud components install docker-credential-gcr
+RUN docker-credential-gcr configure-docker
+
+# Replace kubectl with a working version
+# TODO(chizhg): remove once https://github.com/knative/test-infra/issues/1858 is fixed
+ARG KUBECTL_VERSION=v1.17.4
+RUN rm -f "$(which kubectl)" && \
+    wget "https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" -O /usr/local/bin/kubectl && \
+    chmod +x /usr/local/bin/kubectl
+
+# Extra tools through apt-get
+RUN apt-get install -y uuid-runtime  # for uuidgen
+RUN apt-get install -y rubygems      # for mdl
+RUN apt-get install -y shellcheck    # for presubmit
+
+# Install go at 1.13 same as how it's installed in kubekins-e2e image, reference code here:
+# https://github.com/kubernetes/test-infra/blob/1e9b5dc3de4b268aab57c9c48120aa3dcf096bc6/images/kubekins-e2e/Dockerfile#L64
+ENV GO_TARBALL "go1.13.linux-amd64.tar.gz"
+RUN rm -rf /usr/local/go && \
+    wget -q "https://storage.googleapis.com/golang/${GO_TARBALL}" && \
+    tar xzf "${GO_TARBALL}" -C /usr/local && \
+    rm "${GO_TARBALL}"
+
+# Extra tools through go get
+RUN GO111MODULE=on go get github.com/google/ko/cmd/ko@v0.5.1
+RUN GO111MODULE=on go get github.com/boz/kail/cmd/kail
+RUN go get -u github.com/golang/dep/cmd/dep
+RUN go get -u github.com/jstemmer/go-junit-report
+RUN GO111MODULE=on go get -u github.com/raviqqe/liche@v0.0.0-20200229003944-f57a5d1c5be4  # stable liche version for checking md links
+RUN GO111MODULE=on go get -u github.com/google/go-licenses
+
+# Extract bazel version
+RUN bazel version > /bazel_version
+RUN bazel shutdown
+
+# Extract ko version
+RUN ko version > /ko_version
+
+# Extra tools through gem
+RUN gem install mixlib-config -v 2.2.4  # required because ruby is 2.1
+RUN gem install mdl -v 0.5  # required because later version of mdl requires ruby >= 2.4
+
+# Install our own tools
+RUN go get knative.dev/pkg/testutils/junithelper
+
+# And our scripts
+ENV SCRIPTS /scripts
+COPY scripts /scripts
+
+# Temporarily add test-infra to the image to build custom tools
+COPY . /go/src/knative.dev/test-infra
+
+# Build custom tools in the container
+RUN make -C /go/src/knative.dev/test-infra/tools/githubhelper
+RUN cp /go/src/knative.dev/test-infra/tools/githubhelper/githubhelper .
+# RUN go install knative.dev/test-infra/kntest/cmd/kntest # Uncomment when you wish to have kntest installed
+RUN cd /go/src/knative.dev/test-infra && git checkout release-0.14 && go install /go/src/knative.dev/test-infra/tools/dep-collector
+
+# Remove test-infra from the container
+RUN rm -fr /go/src/knative.dev/test-infra

--- a/images/prow-tests-go113/Makefile
+++ b/images/prow-tests-go113/Makefile
@@ -1,0 +1,16 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+IMAGE_NAME = prow-tests-go113
+include ../simple-image.mk

--- a/images/prow-tests-go113/README.md
+++ b/images/prow-tests-go113/README.md
@@ -3,4 +3,4 @@ projects switched to use Go modules. Unless urgent fixes are needed, this image
 should never be touched.
 
 This image should be deleted when we stop supporting non Go modules branches,
-and the latest one is `release-0.14`. 
+and the latest one is `release-0.14`.

--- a/images/prow-tests-go113/README.md
+++ b/images/prow-tests-go113/README.md
@@ -1,0 +1,6 @@
+This is an image used in the CI/CD flows for release branches before Knative
+projects switched to use Go modules. Unless urgent fixes are needed, this image
+should never be touched.
+
+This image should be deleted when we stop supporting non Go modules branches,
+and the latest one is `release-0.14`. 

--- a/tools/config-generator/main.go
+++ b/tools/config-generator/main.go
@@ -307,6 +307,11 @@ func getGo114ID() string {
 	return "-go114"
 }
 
+// getGo113ID returns image identifier for go113 images
+func getGo113ID() string {
+	return "-go113"
+}
+
 // strip out all suffixes from the image name
 func stripSuffixFromImageName(name string, suffixes []string) string {
 	parts := strings.SplitN(name, ":", 2)
@@ -335,7 +340,7 @@ func addSuffixToImageName(name string, suffix string) string {
 }
 
 func getGo114ImageName(name string) string {
-	return addSuffixToImageName(name, getGo114ID())
+	return addSuffixToImageName(stripSuffixFromImageName(name, []string{getGo113ID()}), getGo114ID())
 }
 
 // Consolidate whitelisted and skipped branches with newly added
@@ -1101,7 +1106,7 @@ func main() {
 	flag.StringVar(&nightlyAccount, "nightly-account", "/etc/nightly-account/service-account.json", "Path to the service account JSON for nightly release jobs")
 	flag.StringVar(&releaseAccount, "release-account", "/etc/release-account/service-account.json", "Path to the service account JSON for release jobs")
 	var coverageDockerImageName = flag.String("coverage-docker", "coverage:latest", "Docker image for coverage tool")
-	var prowTestsDockerImageName = flag.String("prow-tests-docker", "prow-tests:stable", "prow-tests docker image")
+	var prowTestsDockerImageName = flag.String("prow-tests-docker", "prow-tests-go113:stable", "prow-tests docker image")
 	flag.StringVar(&githubCommenterDockerImage, "github-commenter-docker", "gcr.io/k8s-prow/commenter:v20190731-e3f7b9853", "github commenter docker image")
 	flag.StringVar(&presubmitScript, "presubmit-script", "./test/presubmit-tests.sh", "Executable for running presubmit tests")
 	flag.StringVar(&releaseScript, "release-script", "./hack/release.sh", "Executable for creating releases")


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
https://github.com/knative/test-infra/pull/2057 didn't fix the issue. 

It's the way we installed `dep-collector` that caused this issue. After we switched test-infra to Go modules, the way we install `dep-collector` should be changed to `GO111MODULE=on go get knative.dev/test-infra/tools/dep-collector`, otherwise it will look for the license db file in the non Go modules way, which is from the vendor path where the tool resides, that's why we are seeing it looking for the db in `/home/prow/go/src/knative.dev/test-infra/vendor/github.com/google/licenseclassifier/licenses/licenses.db`.

However, the way we install `dep-collector` is hardcoded in the test script, so it's unpractical to make changes to every release branch to fix the issue. Since the tool will not be installed again if it already exists, we can install the tool from the prow-tests image. But also since `gvm` will change the GOPATH when it installs a new Go version, the current `prow-tests` image will not work well with non Go modules projects.

So this PR is adding a temporary `prow-tests-go113` image to fix the issue on all existing release branches (<= 0.14). After we only support release branches that is >= 0.15, this image can be safely deleted.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @chaodaiG 
