### PR TITLE
Create script to "vendor" test-infra/scripts

### DIFF
--- a/scripts/update-test-infra.sh
+++ b/scripts/update-test-infra.sh
@@ -39,7 +39,7 @@ declare SCRIPTS_REF=master
 while [[ $# -ne 0 ]]; do
   parameter="$1"
   case ${parameter} in
-    --branch)
+    --ref)
       shift
       SCRIPTS_REF="$1"
       ;;
@@ -49,7 +49,10 @@ while [[ $# -ne 0 ]]; do
     --update)
       DO_UPDATE=1
       ;;
-    *) abort "unknown option ${parameter}" ;;
+    *)
+      echo "unknown option ${parameter}"
+      exit 1
+      ;;
   esac
   shift
 done
@@ -72,7 +75,7 @@ function run() {
     git fetch test-infra "${SCRIPTS_REF}"
     do_read_tree
     echo "Attempting to point all scripts to use this new path"
-    grep -RiIl vendor/knative.dev/test-infra | grep -v ^vendor | xargs sed -i 's+vendor/knative.dev/test-infra/scripts+scripts/test-infra+'
+    grep -RiIl vendor/knative.dev/test-infra | grep -v ^vendor | grep -v ^scripts/test-infra | xargs sed -i 's+vendor/knative.dev/test-infra/scripts+scripts/test-infra+'
   elif (( DO_UPDATE )); then
     pushd "$(dirname "${BASH_SOURCE[0]}")/../.."
     trap popd EXIT

--- a/scripts/update-test-infra.sh
+++ b/scripts/update-test-infra.sh
@@ -56,9 +56,7 @@ function run() {
     git read-tree --prefix=scripts/test-infra -u "test-infra/${SCRIPTS_BRANCH}:scripts"
     echo "test-infra scripts installed to scripts/test-infra from branch ${SCRIPTS_BRANCH}"
   else
-    local REPO_ROOT="$(dirname "${BASH_SOURCE[0]}")/../.."
-
-    pushd "${REPO_ROOT}"
+    pushd "$(dirname "${BASH_SOURCE[0]}")/../.."
     trap popd EXIT
 
     git remote add test-infra https://github.com/knative/test-infra.git || true

--- a/scripts/update-test-infra.sh
+++ b/scripts/update-test-infra.sh
@@ -21,6 +21,8 @@ set -e
 # Scripts are installed to REPO_ROOT/scripts/test-infra
 
 # The following arguments are accepted:
+# --update
+#  Do the update
 # --ref X
 #  Defines which ref (branch, tag, commit) of test-infra to get scripts from; defaults to master
 # --first-time
@@ -31,6 +33,7 @@ set -e
 #  One can verify manually by running the script with '--ref $(cat scripts/test-infra/COMMIT)' and ensuring no files are staged
 
 declare -i FIRST_TIME_SETUP=0
+declare -i DO_UPDATE=0
 declare SCRIPTS_REF=master
 
 while [[ $# -ne 0 ]]; do
@@ -42,6 +45,9 @@ while [[ $# -ne 0 ]]; do
       ;;
     --first-time)
       FIRST_TIME_SETUP=1
+      ;;
+    --update)
+      DO_UPDATE=1
       ;;
     *) abort "unknown option ${parameter}" ;;
   esac
@@ -67,7 +73,7 @@ function run() {
     do_read_tree
     echo "Attempting to point all scripts to use this new path"
     grep -RiIl vendor/knative.dev/test-infra | grep -v ^vendor | xargs sed -i 's+vendor/knative.dev/test-infra/scripts+scripts/test-infra+'
-  else
+  elif (( DO_UPDATE )); then
     pushd "$(dirname "${BASH_SOURCE[0]}")/../.."
     trap popd EXIT
 

--- a/scripts/update-test-infra.sh
+++ b/scripts/update-test-infra.sh
@@ -71,7 +71,7 @@ function run() {
       echo "I don't believe you are in a repo root; exiting"
       exit 5
     fi
-    git remote add test-infra https://github.com/knative/test-infra.git || true
+    git remote add test-infra https://github.com/knative/test-infra.git || echo "test-infra remote already set; not changing"
     git fetch test-infra "${SCRIPTS_REF}"
     do_read_tree
     echo "Attempting to point all scripts to use this new path"

--- a/scripts/update-test-infra.sh
+++ b/scripts/update-test-infra.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+# This script updates test-infra scripts in-repo.
+# Run it to update (usually from hack/update-deps.sh) the current scripts.
+# Scripts are installed to REPO_ROOT/scripts/test-infra
+
+# The following arguments are accepted:
+# --branch X
+#  Defines which branch of test-infra to get scripts from; defaults to master
+# --first-time
+#  Run this script from your repo root directory to install scripts for the first time
+
+declare -i FIRST_TIME_SETUP=0
+declare SCRIPTS_BRANCH=master
+
+while [[ $# -ne 0 ]]; do
+  parameter="$1"
+  case ${parameter} in
+    --branch)
+      shift
+      SCRIPTS_BRANCH="$1"
+      ;;
+    --first-time)
+      FIRST_TIME_SETUP=1
+      ;;
+    *) abort "unknown option ${parameter}" ;;
+  esac
+  shift
+done
+
+function run() {
+  if (( FIRST_TIME_SETUP )); then
+    if [[ ! -d .git ]]; then
+      echo "I don't believe you are in a repo root; exiting"
+      exit 5
+    fi
+    git remote add test-infra https://github.com/knative/test-infra.git || true
+    git fetch test-infra "${SCRIPTS_BRANCH}"
+    mkdir -p scripts/test-infra
+    git read-tree --prefix=scripts/test-infra -u "test-infra/${SCRIPTS_BRANCH}:scripts"
+    echo "test-infra scripts installed to scripts/test-infra from branch ${SCRIPTS_BRANCH}"
+  else
+    local REPO_ROOT="$(dirname "${BASH_SOURCE[0]}")/../.."
+
+    pushd "${REPO_ROOT}"
+    trap popd EXIT
+
+    git remote add test-infra https://github.com/knative/test-infra.git || true
+    git fetch test-infra "${SCRIPTS_BRANCH}"
+    git rm -fr scripts/test-infra
+    rm -fR scripts/test-infra
+    mkdir -p scripts/test-infra
+    git read-tree --prefix=scripts/test-infra -u "test-infra/${SCRIPTS_BRANCH}:scripts"
+    echo "test-infra scripts updated in scripts/test-infra from branch ${SCRIPTS_BRANCH}"
+  fi
+}
+
+run


### PR DESCRIPTION
Tracks the contents of test-infra/scripts into each repo at
scripts/test-infra directory.

The script provides both installation assistance (with --first-time
command-line argument) as well as its usual function of updating
scripts/test-infra directory and is intended to be called by
hack/update-deps.sh in each repo. The --branch option lets you choose
a particular branch (instead of master) if desired.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
Helps with #1823 (because knative/client is preventing rollout of new image through every release and needs script updates)
