### PR TITLE
Enable flaky test retryer for knative-gcp

### DIFF
--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -287,10 +287,12 @@ presubmits:
     - build-tests: true
     - unit-tests: true
     - integration-tests: true
+      needs-monitor: true
       args:
       - "--run-test"
       - "./test/e2e-tests.sh"
     - custom-test: wi-tests
+      needs-monitor: true
       args:
       - "--run-test"
       - "./test/e2e-wi-tests.sh"

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -3725,6 +3725,10 @@ presubmits:
           secretName: test-account
   - name: pull-google-knative-gcp-integration-tests
     agent: kubernetes
+    labels:
+      prow.k8s.io/pubsub.project: knative-tests
+      prow.k8s.io/pubsub.topic: knative-monitoring
+      prow.k8s.io/pubsub.runID: pull-google-knative-gcp-integration-tests
     context: pull-google-knative-gcp-integration-tests
     always_run: true
     rerun_command: "/test pull-google-knative-gcp-integration-tests"
@@ -3767,6 +3771,10 @@ presubmits:
           secretName: test-account
   - name: pull-google-knative-gcp-integration-tests
     agent: kubernetes
+    labels:
+      prow.k8s.io/pubsub.project: knative-tests
+      prow.k8s.io/pubsub.topic: knative-monitoring
+      prow.k8s.io/pubsub.runID: pull-google-knative-gcp-integration-tests
     context: pull-google-knative-gcp-integration-tests
     always_run: true
     rerun_command: "/test pull-google-knative-gcp-integration-tests"
@@ -3809,6 +3817,10 @@ presubmits:
           secretName: test-account
   - name: pull-google-knative-gcp-wi-tests
     agent: kubernetes
+    labels:
+      prow.k8s.io/pubsub.project: knative-tests
+      prow.k8s.io/pubsub.topic: knative-monitoring
+      prow.k8s.io/pubsub.runID: pull-google-knative-gcp-wi-tests
     context: pull-google-knative-gcp-wi-tests
     always_run: true
     rerun_command: "/test pull-google-knative-gcp-wi-tests"
@@ -3845,6 +3857,10 @@ presubmits:
           secretName: test-account
   - name: pull-google-knative-gcp-wi-tests
     agent: kubernetes
+    labels:
+      prow.k8s.io/pubsub.project: knative-tests
+      prow.k8s.io/pubsub.topic: knative-monitoring
+      prow.k8s.io/pubsub.runID: pull-google-knative-gcp-wi-tests
     context: pull-google-knative-gcp-wi-tests
     always_run: true
     rerun_command: "/test pull-google-knative-gcp-wi-tests"

--- a/tools/flaky-test-reporter/config/config.go
+++ b/tools/flaky-test-reporter/config/config.go
@@ -39,8 +39,9 @@ type Config struct {
 
 // JobConfig is initial configuration for a given repo, defines which job to scan
 type JobConfig struct {
-	Name          string         `yaml:"name"` // name of job to analyze
-	Repo          string         `yaml:"repo"` // repository to test job on
+	Name          string         `yaml:"name"`                  // name of job to analyze
+	Org           string         `yaml:"org" default:"knative"` // org to test job on
+	Repo          string         `yaml:"repo"`                  // repository to test job on
 	Type          string         `yaml:"type"`
 	IssueRepo     string         `yaml:"issueRepo,omitempty"`
 	SlackChannels []SlackChannel `yaml:"slackChannels,omitempty"`

--- a/tools/flaky-test-reporter/config/config.go
+++ b/tools/flaky-test-reporter/config/config.go
@@ -39,9 +39,9 @@ type Config struct {
 
 // JobConfig is initial configuration for a given repo, defines which job to scan
 type JobConfig struct {
-	Name          string         `yaml:"name"`                  // name of job to analyze
-	Org           string         `yaml:"org" default:"knative"` // org to test job on
-	Repo          string         `yaml:"repo"`                  // repository to test job on
+	Name          string         `yaml:"name"` // name of job to analyze
+	Org           string         `yaml:"org"`  // org to test job on
+	Repo          string         `yaml:"repo"` // repository to test job on
 	Type          string         `yaml:"type"`
 	IssueRepo     string         `yaml:"issueRepo,omitempty"`
 	SlackChannels []SlackChannel `yaml:"slackChannels,omitempty"`

--- a/tools/flaky-test-reporter/config/config.yaml
+++ b/tools/flaky-test-reporter/config/config.yaml
@@ -87,3 +87,7 @@ jobConfigs:
   - name: ci-knative-test-infra-continuous
     repo: test-infra
     type: postsubmit
+  - name: ci-google-knative-gcp-continuous
+    org: google
+    repo: knative-gcp
+    type: postsubmit

--- a/tools/flaky-test-reporter/config/config.yaml
+++ b/tools/flaky-test-reporter/config/config.yaml
@@ -14,6 +14,7 @@
 
 jobConfigs:
   - name: ci-knative-serving-continuous
+    org: knative
     repo: serving
     type: postsubmit
     issueRepo: serving
@@ -21,54 +22,63 @@ jobConfigs:
       - name: serving-api
         identity: CA4DNJ9A4
   - name: ci-knative-serving-istio-1.5-mesh
+    org: knative
     repo: serving
     type: postsubmit
     slackChannels:
       - name: net-istio
         identity: C012AK2FPK7
   - name: ci-knative-serving-istio-1.5-no-mesh
+    org: knative
     repo: serving
     type: postsubmit
     slackChannels:
       - name: net-istio
         identity: C012AK2FPK7
   - name: ci-knative-serving-istio-1.4-mesh
+    org: knative
     repo: serving
     type: postsubmit
     slackChannels:
       - name: net-istio
         identity: C012AK2FPK7
   - name: ci-knative-serving-istio-1.4-no-mesh
+    org: knative
     repo: serving
     type: postsubmit
     slackChannels:
       - name: net-istio
         identity: C012AK2FPK7
   - name: ci-knative-serving-gloo-0.17.1
+    org: knative
     repo: serving
     type: postsubmit
     slackChannels:
       - name: net-gloo
         identity: C011X8RKZBR
   - name: ci-knative-serving-contour-latest
+    org: knative
     repo: serving
     type: postsubmit
     slackChannels:
       - name: net-contour
         identity: C012J5TCS6Q
   - name: ci-knative-serving-kourier-stable
+    org: knative
     repo: serving
     type: postsubmit
     slackChannels:
       - name: net-kourier
         identity: C012C0VQJAW
   - name: ci-knative-serving-ambassador-latest
+    org: knative
     repo: serving
     type: postsubmit
     slackChannels:
       - name: net-ambassador
         identity: C011X8SPF8X
   - name: ci-knative-eventing-continuous
+    org: knative
     repo: eventing
     type: postsubmit
     issueRepo: eventing
@@ -76,6 +86,7 @@ jobConfigs:
       - name: eventing
         identity: C9JP909F0
   - name: ci-knative-eventing-contrib-continuous
+    org: knative
     repo: eventing-contrib
     type: postsubmit
     issueRepo: eventing-contrib
@@ -85,6 +96,7 @@ jobConfigs:
       - name: eventing-channels
         identity: CR2141CGY
   - name: ci-knative-test-infra-continuous
+    org: knative
     repo: test-infra
     type: postsubmit
   - name: ci-google-knative-gcp-continuous

--- a/tools/flaky-test-reporter/constants.go
+++ b/tools/flaky-test-reporter/constants.go
@@ -22,6 +22,4 @@ const (
 	// Don't do anything if found more than 5 tests flaky, or 1% tests flaky, whichever comes first
 	countThreshold   = 5
 	percentThreshold = 0.01
-
-	org = "knative"
 )

--- a/tools/flaky-test-reporter/github_issue_test.go
+++ b/tools/flaky-test-reporter/github_issue_test.go
@@ -132,10 +132,10 @@ func TestCreateIssue(t *testing.T) {
 func TestExistingIssue(t *testing.T) {
 	fgih := getFakeGithubIssueHandler()
 	repoData := createRepoData(200, 2, 0, 0, fakeRepo, int64(0))
-	flakyIssuesMap, _ := fgih.getFlakyIssues()
+	flakyIssuesMap, _ := fgih.getFlakyIssues([]RepoData{repoData})
 	fgih.processGithubIssuesForRepo(repoData, flakyIssuesMap, dryrun)
 	existIssues, _ := fgih.client.ListIssuesByRepo(fakeOrg, fakeRepo, []string{})
-	flakyIssuesMap, _ = fgih.getFlakyIssues()
+	flakyIssuesMap, _ = fgih.getFlakyIssues([]RepoData{repoData})
 
 	*repoData.LastBuildStartTime++
 	fgih.processGithubIssuesForRepo(repoData, flakyIssuesMap, dryrun)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
The tests in knative-gcp have been quite flaky, so it would be valuable to enable the flaky test retryer for it. 

One noticeable change in the PR is I removed the logic that
```
Collect all flaky test issues from all knative repos, in case issues are moved around
```
as there is no way we can collect all flaky test issues from all google repos.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #1769 

/cc @chaodaiG @nachocano 

