### PR TITLE
Revert "Cleanup images"

### DIFF
--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -490,12 +490,11 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/coverage:latest
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--postsubmit-job-name=post-knative-serving-go-coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=80"
@@ -525,12 +524,11 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--postsubmit-job-name=post-knative-serving-go-coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=80"
@@ -563,12 +561,11 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:coverage-dev
+      - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--postsubmit-job-name=post-knative-serving-go-coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=80"
@@ -1598,12 +1595,11 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/coverage:latest
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--postsubmit-job-name=post-knative-client-go-coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=50"
@@ -1633,12 +1629,11 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--postsubmit-job-name=post-knative-client-go-coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=50"
@@ -2124,12 +2119,11 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/coverage:latest
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--postsubmit-job-name=post-knative-eventing-go-coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=50"
@@ -2159,12 +2153,11 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--postsubmit-job-name=post-knative-eventing-go-coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=50"
@@ -2466,12 +2459,11 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/coverage:latest
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--postsubmit-job-name=post-knative-eventing-contrib-go-coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=50"
@@ -2501,12 +2493,11 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--postsubmit-job-name=post-knative-eventing-contrib-go-coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=50"
@@ -2650,12 +2641,11 @@ presubmits:
     cluster: "build-knative"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/coverage:latest
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--postsubmit-job-name=post-knative-docs-go-coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=50"
@@ -2974,12 +2964,11 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/coverage:latest
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--postsubmit-job-name=post-knative-pkg-go-coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=50"
@@ -3009,12 +2998,11 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--postsubmit-job-name=post-knative-pkg-go-coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=50"
@@ -3306,12 +3294,11 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/coverage:latest
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--postsubmit-job-name=post-knative-test-infra-go-coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=50"
@@ -3341,12 +3328,11 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--postsubmit-job-name=post-knative-test-infra-go-coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=50"
@@ -3486,12 +3472,11 @@ presubmits:
     cluster: "build-knative"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/coverage:latest
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--postsubmit-job-name=post-knative-caching-go-coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=50"
@@ -4015,12 +4000,11 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/coverage:latest
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--postsubmit-job-name=post-google-knative-gcp-go-coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=50"
@@ -4049,12 +4033,11 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--postsubmit-job-name=post-google-knative-gcp-go-coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=50"
@@ -4346,12 +4329,11 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/coverage:latest
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--postsubmit-job-name=post-knative-net-certmanager-go-coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=50"
@@ -4381,12 +4363,11 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--postsubmit-job-name=post-knative-net-certmanager-go-coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=50"
@@ -4678,12 +4659,11 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/coverage:latest
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--postsubmit-job-name=post-knative-net-contour-go-coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=50"
@@ -4713,12 +4693,11 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--postsubmit-job-name=post-knative-net-contour-go-coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=50"
@@ -5010,12 +4989,11 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/coverage:latest
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--postsubmit-job-name=post-knative-net-http01-go-coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=50"
@@ -5045,12 +5023,11 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--postsubmit-job-name=post-knative-net-http01-go-coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=50"
@@ -5342,12 +5319,11 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/coverage:latest
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--postsubmit-job-name=post-knative-net-istio-go-coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=50"
@@ -5377,12 +5353,11 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--postsubmit-job-name=post-knative-net-istio-go-coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=50"
@@ -5752,12 +5727,11 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/coverage:latest
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--postsubmit-job-name=post-knative-net-kourier-go-coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=50"
@@ -5787,12 +5761,11 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--postsubmit-job-name=post-knative-net-kourier-go-coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=50"
@@ -6084,12 +6057,11 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/coverage:latest
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--postsubmit-job-name=post-knative-serving-operator-go-coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=50"
@@ -6119,12 +6091,11 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--postsubmit-job-name=post-knative-serving-operator-go-coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=50"
@@ -6492,12 +6463,11 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/coverage:latest
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--postsubmit-job-name=post-knative-eventing-operator-go-coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=50"
@@ -6527,12 +6497,11 @@ presubmits:
     - "release-0.14"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--postsubmit-job-name=post-knative-eventing-operator-go-coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=50"
@@ -6748,12 +6717,11 @@ presubmits:
     cluster: "build-knative"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/coverage:latest
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--postsubmit-job-name=post-knative-operator-go-coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=50"
@@ -6946,12 +6914,11 @@ presubmits:
     cluster: "build-knative"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/coverage:latest
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--postsubmit-job-name=post-knative-sandbox-eventing-kafka-go-coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=50"
@@ -8238,12 +8205,11 @@ periodics:
     path_alias: knative.dev/serving
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
       imagePullPolicy: Always
       command:
-      - "runner.sh"
+      - "/coverage"
       args:
-      - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=80"
       env:
@@ -8265,12 +8231,11 @@ periodics:
     path_alias: knative.dev/serving
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:beta
+    - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
       imagePullPolicy: Always
       command:
-      - "runner.sh"
+      - "/coverage"
       args:
-      - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=80"
       env:
@@ -9055,12 +9020,11 @@ periodics:
     path_alias: knative.dev/client
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
       imagePullPolicy: Always
       command:
-      - "runner.sh"
+      - "/coverage"
       args:
-      - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
       env:
@@ -9082,12 +9046,11 @@ periodics:
     path_alias: knative.dev/client
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:beta
+    - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
       imagePullPolicy: Always
       command:
-      - "runner.sh"
+      - "/coverage"
       args:
-      - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
       env:
@@ -9270,12 +9233,11 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/coverage:latest
       imagePullPolicy: Always
       command:
-      - "runner.sh"
+      - "/coverage"
       args:
-      - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
 - cron: "11 7 * * *"
@@ -9293,12 +9255,11 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:beta
+    - image: gcr.io/knative-tests/test-infra/coverage:latest
       imagePullPolicy: Always
       command:
-      - "runner.sh"
+      - "/coverage"
       args:
-      - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
 - cron: "52 */2 * * *"
@@ -10087,12 +10048,11 @@ periodics:
     path_alias: knative.dev/eventing
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
       imagePullPolicy: Always
       command:
-      - "runner.sh"
+      - "/coverage"
       args:
-      - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
       env:
@@ -10114,12 +10074,11 @@ periodics:
     path_alias: knative.dev/eventing
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:beta
+    - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
       imagePullPolicy: Always
       command:
-      - "runner.sh"
+      - "/coverage"
       args:
-      - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
       env:
@@ -10911,12 +10870,11 @@ periodics:
     path_alias: knative.dev/eventing-contrib
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
       imagePullPolicy: Always
       command:
-      - "runner.sh"
+      - "/coverage"
       args:
-      - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
       env:
@@ -10938,12 +10896,11 @@ periodics:
     path_alias: knative.dev/eventing-contrib
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:beta
+    - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
       imagePullPolicy: Always
       command:
-      - "runner.sh"
+      - "/coverage"
       args:
-      - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
       env:
@@ -11041,12 +10998,11 @@ periodics:
     path_alias: knative.dev/pkg
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
       imagePullPolicy: Always
       command:
-      - "runner.sh"
+      - "/coverage"
       args:
-      - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
       env:
@@ -11068,12 +11024,11 @@ periodics:
     path_alias: knative.dev/pkg
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:beta
+    - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
       imagePullPolicy: Always
       command:
-      - "runner.sh"
+      - "/coverage"
       args:
-      - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
       env:
@@ -11171,12 +11126,11 @@ periodics:
     path_alias: knative.dev/caching
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
       imagePullPolicy: Always
       command:
-      - "runner.sh"
+      - "/coverage"
       args:
-      - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
       env:
@@ -11198,12 +11152,11 @@ periodics:
     path_alias: knative.dev/caching
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:beta
+    - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
       imagePullPolicy: Always
       command:
-      - "runner.sh"
+      - "/coverage"
       args:
-      - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
       env:
@@ -11453,12 +11406,11 @@ periodics:
     path_alias: knative.dev/test-infra
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
       imagePullPolicy: Always
       command:
-      - "runner.sh"
+      - "/coverage"
       args:
-      - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
       env:
@@ -11480,12 +11432,11 @@ periodics:
     path_alias: knative.dev/test-infra
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:beta
+    - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
       imagePullPolicy: Always
       command:
-      - "runner.sh"
+      - "/coverage"
       args:
-      - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
       env:
@@ -12237,12 +12188,11 @@ periodics:
     path_alias: knative.dev/serving-operator
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
       imagePullPolicy: Always
       command:
-      - "runner.sh"
+      - "/coverage"
       args:
-      - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
       env:
@@ -12264,12 +12214,11 @@ periodics:
     path_alias: knative.dev/serving-operator
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:beta
+    - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
       imagePullPolicy: Always
       command:
-      - "runner.sh"
+      - "/coverage"
       args:
-      - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
       env:
@@ -13021,12 +12970,11 @@ periodics:
     path_alias: knative.dev/eventing-operator
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
       imagePullPolicy: Always
       command:
-      - "runner.sh"
+      - "/coverage"
       args:
-      - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
       env:
@@ -13048,12 +12996,11 @@ periodics:
     path_alias: knative.dev/eventing-operator
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:beta
+    - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
       imagePullPolicy: Always
       command:
-      - "runner.sh"
+      - "/coverage"
       args:
-      - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
       env:
@@ -13657,12 +13604,11 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
       imagePullPolicy: Always
       command:
-      - "runner.sh"
+      - "/coverage"
       args:
-      - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
       env:
@@ -13683,12 +13629,11 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:beta
+    - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
       imagePullPolicy: Always
       command:
-      - "runner.sh"
+      - "/coverage"
       args:
-      - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
       env:
@@ -13919,12 +13864,11 @@ periodics:
     path_alias: knative.dev/net-certmanager
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
       imagePullPolicy: Always
       command:
-      - "runner.sh"
+      - "/coverage"
       args:
-      - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
       env:
@@ -13946,12 +13890,11 @@ periodics:
     path_alias: knative.dev/net-certmanager
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:beta
+    - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
       imagePullPolicy: Always
       command:
-      - "runner.sh"
+      - "/coverage"
       args:
-      - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
       env:
@@ -14182,12 +14125,11 @@ periodics:
     path_alias: knative.dev/net-contour
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
       imagePullPolicy: Always
       command:
-      - "runner.sh"
+      - "/coverage"
       args:
-      - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
       env:
@@ -14209,12 +14151,11 @@ periodics:
     path_alias: knative.dev/net-contour
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:beta
+    - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
       imagePullPolicy: Always
       command:
-      - "runner.sh"
+      - "/coverage"
       args:
-      - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
       env:
@@ -14445,12 +14386,11 @@ periodics:
     path_alias: knative.dev/net-http01
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
       imagePullPolicy: Always
       command:
-      - "runner.sh"
+      - "/coverage"
       args:
-      - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
       env:
@@ -14472,12 +14412,11 @@ periodics:
     path_alias: knative.dev/net-http01
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:beta
+    - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
       imagePullPolicy: Always
       command:
-      - "runner.sh"
+      - "/coverage"
       args:
-      - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
       env:
@@ -14708,12 +14647,11 @@ periodics:
     path_alias: knative.dev/net-istio
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
       imagePullPolicy: Always
       command:
-      - "runner.sh"
+      - "/coverage"
       args:
-      - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
       env:
@@ -14735,12 +14673,11 @@ periodics:
     path_alias: knative.dev/net-istio
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:beta
+    - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
       imagePullPolicy: Always
       command:
-      - "runner.sh"
+      - "/coverage"
       args:
-      - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
       env:
@@ -14971,12 +14908,11 @@ periodics:
     path_alias: knative.dev/net-kourier
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
       imagePullPolicy: Always
       command:
-      - "runner.sh"
+      - "/coverage"
       args:
-      - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
       env:
@@ -14998,12 +14934,11 @@ periodics:
     path_alias: knative.dev/net-kourier
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:beta
+    - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
       imagePullPolicy: Always
       command:
-      - "runner.sh"
+      - "/coverage"
       args:
-      - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
       env:
@@ -15238,12 +15173,11 @@ periodics:
     path_alias: knative.dev/operator
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
       imagePullPolicy: Always
       command:
-      - "runner.sh"
+      - "/coverage"
       args:
-      - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
       env:
@@ -15265,12 +15199,11 @@ periodics:
     path_alias: knative.dev/operator
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:beta
+    - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
       imagePullPolicy: Always
       command:
-      - "runner.sh"
+      - "/coverage"
       args:
-      - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
       env:
@@ -15545,12 +15478,11 @@ periodics:
     path_alias: knative.dev/eventing-kafka
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
       imagePullPolicy: Always
       command:
-      - "runner.sh"
+      - "/coverage"
       args:
-      - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
       env:
@@ -15572,12 +15504,11 @@ periodics:
     path_alias: knative.dev/eventing-kafka
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:beta
+    - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
       imagePullPolicy: Always
       command:
-      - "runner.sh"
+      - "/coverage"
       args:
-      - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
       env:
@@ -16199,12 +16130,11 @@ postsubmits:
     path_alias: knative.dev/serving
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=0"
         env:
@@ -16219,12 +16149,11 @@ postsubmits:
     path_alias: knative.dev/serving
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:coverage-dev
+      - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=0"
         env:
@@ -16240,12 +16169,11 @@ postsubmits:
     path_alias: knative.dev/client
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=0"
         env:
@@ -16301,12 +16229,11 @@ postsubmits:
     path_alias: knative.dev/eventing
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=0"
         env:
@@ -16322,12 +16249,11 @@ postsubmits:
     path_alias: knative.dev/eventing-contrib
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=0"
         env:
@@ -16342,12 +16268,11 @@ postsubmits:
     cluster: "build-knative"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/coverage:latest
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=0"
   knative/pkg:
@@ -16360,12 +16285,11 @@ postsubmits:
     path_alias: knative.dev/pkg
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=0"
         env:
@@ -16381,12 +16305,11 @@ postsubmits:
     path_alias: knative.dev/test-infra
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=0"
         env:
@@ -16402,12 +16325,11 @@ postsubmits:
     path_alias: knative.dev/caching
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=0"
         env:
@@ -16461,12 +16383,11 @@ postsubmits:
     cluster: "build-knative"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=0"
         env:
@@ -16482,12 +16403,11 @@ postsubmits:
     path_alias: knative.dev/net-certmanager
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=0"
         env:
@@ -16503,12 +16423,11 @@ postsubmits:
     path_alias: knative.dev/net-contour
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=0"
         env:
@@ -16524,12 +16443,11 @@ postsubmits:
     path_alias: knative.dev/net-http01
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=0"
         env:
@@ -16545,12 +16463,11 @@ postsubmits:
     path_alias: knative.dev/net-istio
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=0"
         env:
@@ -16566,12 +16483,11 @@ postsubmits:
     path_alias: knative.dev/net-kourier
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=0"
         env:
@@ -16587,12 +16503,11 @@ postsubmits:
     path_alias: knative.dev/serving-operator
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=0"
         env:
@@ -16608,12 +16523,11 @@ postsubmits:
     path_alias: knative.dev/eventing-operator
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=0"
         env:
@@ -16629,12 +16543,11 @@ postsubmits:
     path_alias: knative.dev/operator
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=0"
         env:
@@ -16650,12 +16563,11 @@ postsubmits:
     path_alias: knative.dev/eventing-kafka
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/coverage-go114:latest
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=0"
         env:

--- a/images/coverage-go114/Dockerfile
+++ b/images/coverage-go114/Dockerfile
@@ -12,11 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-IMAGE_NAME = prow-tests
-include ../simple-image.mk
+FROM golang:1.14
+LABEL maintainer="Stephen Lu <syzf@google.com>"
 
-push_beta: confirm-master build
-	docker tag $(IMG):$(TAG) $(IMG):beta
-	docker push $(IMG):beta
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    git
 
-push:: push_beta
+# Temporarily add test-infra to the image to build custom tools
+COPY . /go/src/knative.dev/test-infra
+
+# Build tool in the container
+RUN go install ${TEMP_REPO_DIR}/tools/coverage
+RUN cp "$(which coverage)" /
+
+# Remove test-infra from the container
+RUN rm -fr /go/src/knative.dev/test-infra
+
+ENTRYPOINT ["/coverage"]

--- a/images/coverage-go114/Makefile
+++ b/images/coverage-go114/Makefile
@@ -12,11 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-IMAGE_NAME = prow-tests
+IMAGE_NAME ?= coverage-go114
 include ../simple-image.mk
-
-push_beta: confirm-master build
-	docker tag $(IMG):$(TAG) $(IMG):beta
-	docker push $(IMG):beta
-
-push:: push_beta

--- a/images/coverage/Dockerfile
+++ b/images/coverage/Dockerfile
@@ -12,11 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-IMAGE_NAME = prow-tests
-include ../simple-image.mk
+FROM golang:1.13
+LABEL maintainer="Stephen Lu <syzf@google.com>"
 
-push_beta: confirm-master build
-	docker tag $(IMG):$(TAG) $(IMG):beta
-	docker push $(IMG):beta
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    git
 
-push:: push_beta
+# Temporarily add test-infra to the image to build custom tools
+COPY . /go/src/knative.dev/test-infra
+
+# Build tool in the container
+RUN go install ${TEMP_REPO_DIR}/tools/coverage
+RUN cp "$(which coverage)" /
+
+# Remove test-infra from the container
+RUN rm -fr /go/src/knative.dev/test-infra
+
+ENTRYPOINT ["/coverage"]

--- a/images/coverage/Makefile
+++ b/images/coverage/Makefile
@@ -12,11 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-IMAGE_NAME = prow-tests
+IMAGE_NAME ?= coverage
 include ../simple-image.mk
-
-push_beta: confirm-master build
-	docker tag $(IMG):$(TAG) $(IMG):beta
-	docker push $(IMG):beta
-
-push:: push_beta

--- a/images/prow-tests-go113/Dockerfile
+++ b/images/prow-tests-go113/Dockerfile
@@ -1,0 +1,88 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is the base Dockerfile for knative-tests images, please remember to also
+# do `make push` in `../prow-tests-*` directories to make sure these images are in
+# sync
+
+# TODO(chizhg): probably build the image from scratch?
+FROM gcr.io/k8s-testimages/kubekins-e2e:v20200326-e946722-master
+
+# Install extras on top of base image
+
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update
+RUN gcloud components update
+
+# Docker
+RUN gcloud components install docker-credential-gcr
+RUN docker-credential-gcr configure-docker
+
+# Replace kubectl with a working version
+# TODO(chizhg): remove once https://github.com/knative/test-infra/issues/1858 is fixed
+ARG KUBECTL_VERSION=v1.17.4
+RUN rm -f "$(which kubectl)" && \
+    wget "https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" -O /usr/local/bin/kubectl && \
+    chmod +x /usr/local/bin/kubectl
+
+# Extra tools through apt-get
+RUN apt-get install -y uuid-runtime  # for uuidgen
+RUN apt-get install -y rubygems      # for mdl
+RUN apt-get install -y shellcheck    # for presubmit
+
+# Install go at 1.13 same as how it's installed in kubekins-e2e image, reference code here:
+# https://github.com/kubernetes/test-infra/blob/1e9b5dc3de4b268aab57c9c48120aa3dcf096bc6/images/kubekins-e2e/Dockerfile#L64
+ENV GO_TARBALL "go1.13.linux-amd64.tar.gz"
+RUN rm -rf /usr/local/go && \
+    wget -q "https://storage.googleapis.com/golang/${GO_TARBALL}" && \
+    tar xzf "${GO_TARBALL}" -C /usr/local && \
+    rm "${GO_TARBALL}"
+
+# Extra tools through go get
+RUN GO111MODULE=on go get github.com/google/ko/cmd/ko@v0.5.1
+RUN GO111MODULE=on go get github.com/boz/kail/cmd/kail
+RUN go get -u github.com/golang/dep/cmd/dep
+RUN go get -u github.com/jstemmer/go-junit-report
+RUN GO111MODULE=on go get -u github.com/raviqqe/liche@v0.0.0-20200229003944-f57a5d1c5be4  # stable liche version for checking md links
+RUN GO111MODULE=on go get -u github.com/google/go-licenses
+
+# Extract bazel version
+RUN bazel version > /bazel_version
+RUN bazel shutdown
+
+# Extract ko version
+RUN ko version > /ko_version
+
+# Extra tools through gem
+RUN gem install mixlib-config -v 2.2.4  # required because ruby is 2.1
+RUN gem install mdl -v 0.5  # required because later version of mdl requires ruby >= 2.4
+
+# Install our own tools
+RUN go get knative.dev/pkg/testutils/junithelper
+
+# And our scripts
+ENV SCRIPTS /scripts
+COPY scripts /scripts
+
+# Temporarily add test-infra to the image to build custom tools
+COPY . /go/src/knative.dev/test-infra
+
+# Build custom tools in the container
+RUN make -C /go/src/knative.dev/test-infra/tools/githubhelper
+RUN cp /go/src/knative.dev/test-infra/tools/githubhelper/githubhelper .
+# RUN go install knative.dev/test-infra/kntest/cmd/kntest # Uncomment when you wish to have kntest installed
+RUN cd /go/src/knative.dev/test-infra && git checkout release-0.14 && go install /go/src/knative.dev/test-infra/tools/dep-collector
+
+# Remove test-infra from the container
+RUN rm -fr /go/src/knative.dev/test-infra

--- a/images/prow-tests-go113/Makefile
+++ b/images/prow-tests-go113/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2019 The Knative Authors
+# Copyright 2020 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,11 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-IMAGE_NAME = prow-tests
+IMAGE_NAME = prow-tests-go113
 include ../simple-image.mk
-
-push_beta: confirm-master build
-	docker tag $(IMG):$(TAG) $(IMG):beta
-	docker push $(IMG):beta
-
-push:: push_beta

--- a/images/prow-tests-go113/README.md
+++ b/images/prow-tests-go113/README.md
@@ -1,0 +1,6 @@
+This is an image used in the CI/CD flows for release branches before Knative
+projects switched to use Go modules. Unless urgent fixes are needed, this image
+should never be touched.
+
+This image should be deleted when we stop supporting non Go modules branches,
+and the latest one is `release-0.14`.

--- a/images/prow-tests-go114/Dockerfile
+++ b/images/prow-tests-go114/Dockerfile
@@ -1,0 +1,27 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/knative-tests/test-infra/prow-tests:v20200506-431dda29
+
+# Install go at 1.14 same as how it's installed in kubekins-e2e image, reference code here:
+# https://github.com/kubernetes/test-infra/blob/1e9b5dc3de4b268aab57c9c48120aa3dcf096bc6/images/kubekins-e2e/Dockerfile#L64
+ENV GO_TARBALL_HOST "https://dl.google.com/go"
+ENV GO_TARBALL "go1.14.linux-amd64.tar.gz"
+RUN rm -rf /usr/local/go && \
+    wget -q "${GO_TARBALL_HOST}/${GO_TARBALL}" && \
+    tar xzf "${GO_TARBALL}" -C /usr/local && \
+    rm "${GO_TARBALL}"
+
+# Temporarily pin ko for a hot fix.
+RUN GO111MODULE=on go get github.com/google/ko/cmd/ko@v0.5.1

--- a/images/prow-tests-go114/Makefile
+++ b/images/prow-tests-go114/Makefile
@@ -12,11 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-IMAGE_NAME = prow-tests
+IMAGE_NAME = prow-tests-go114
 include ../simple-image.mk
-
-push_beta: confirm-master build
-	docker tag $(IMG):$(TAG) $(IMG):beta
-	docker push $(IMG):beta
-
-push:: push_beta

--- a/images/prow-tests-go114/README.md
+++ b/images/prow-tests-go114/README.md
@@ -1,0 +1,2 @@
+This is a new beta image, see [prow-test](../prow-tests/README.md) for more
+details

--- a/tools/config-generator/main.go
+++ b/tools/config-generator/main.go
@@ -148,6 +148,7 @@ var (
 	nightlyAccount             string
 	releaseAccount             string
 	githubCommenterDockerImage string
+	coverageDockerImage        string
 	prowTestsDockerImage       string
 	presubmitScript            string
 	releaseScript              string
@@ -468,6 +469,11 @@ func (data *baseProwJobTemplateData) SetGoVersion(version GoVersion) {
 		}
 	}
 	data.addEnvToJob("GO_VERSION", version.String())
+
+	// TODO: get coverage unified and cleaned up
+	if strings.Contains(data.Image, "coverage:") && version.Equals(GoVersion{1, 14}) {
+		data.Image = strings.ReplaceAll(data.Image, "coverage:", "coverage-go114:")
+	}
 }
 
 // addLabelToJob adds extra labels to a job
@@ -1093,6 +1099,7 @@ func main() {
 	flag.StringVar(&testAccount, "test-account", "/etc/test-account/service-account.json", "Path to the service account JSON for test jobs")
 	flag.StringVar(&nightlyAccount, "nightly-account", "/etc/nightly-account/service-account.json", "Path to the service account JSON for nightly release jobs")
 	flag.StringVar(&releaseAccount, "release-account", "/etc/release-account/service-account.json", "Path to the service account JSON for release jobs")
+	var coverageDockerImageName = flag.String("coverage-docker", "coverage:latest", "Docker image for coverage tool")
 	var prowTestsDockerImageName = flag.String("prow-tests-docker", "prow-tests:stable", "prow-tests docker image")
 	flag.StringVar(&githubCommenterDockerImage, "github-commenter-docker", "gcr.io/k8s-prow/commenter:v20190731-e3f7b9853", "github commenter docker image")
 	flag.StringVar(&presubmitScript, "presubmit-script", "./test/presubmit-tests.sh", "Executable for running presubmit tests")
@@ -1108,6 +1115,7 @@ func main() {
 		log.Fatal("Pass the config file as parameter")
 	}
 
+	coverageDockerImage = path.Join(*dockerImagesBase, *coverageDockerImageName)
 	prowTestsDockerImage = path.Join(*dockerImagesBase, *prowTestsDockerImageName)
 
 	// We use MapSlice instead of maps to keep key order and create predictable output.

--- a/tools/config-generator/periodic_config.go
+++ b/tools/config-generator/periodic_config.go
@@ -318,12 +318,12 @@ func generateGoCoveragePeriodic(title string, repoName string, _ yaml.MapSlice) 
 		repo.Processed = true
 		var data periodicJobTemplateData
 		data.Base = newbaseProwJobTemplateData(repoName)
+		data.Base.Image = coverageDockerImage
 		data.PeriodicJobName = fmt.Sprintf("ci-%s-go-coverage", data.Base.RepoNameForJob)
 		data.CronString = goCoveragePeriodicJobCron
 		data.Base.GoCoverageThreshold = repo.GoCoverageThreshold
-		data.Base.Command = "runner.sh"
+		data.Base.Command = "/coverage"
 		data.Base.Args = []string{
-			"coverage",
 			"--artifacts=$(ARTIFACTS)",
 			fmt.Sprintf("--cov-threshold-percentage=%d", data.Base.GoCoverageThreshold)}
 		data.Base.ServiceAccount = ""

--- a/tools/config-generator/postsubmit_config.go
+++ b/tools/config-generator/postsubmit_config.go
@@ -44,6 +44,7 @@ type postsubmitJobTemplateData struct {
 func generateGoCoveragePostsubmit(title, repoName string, _ yaml.MapSlice) {
 	var data postsubmitJobTemplateData
 	data.Base = newbaseProwJobTemplateData(repoName)
+	data.Base.Image = coverageDockerImage
 	data.PostsubmitJobName = fmt.Sprintf("post-%s-go-coverage", data.Base.RepoNameForJob)
 	for _, repo := range repositories {
 		if repo.Name == repoName && repo.DotDev {
@@ -61,7 +62,7 @@ func generateGoCoveragePostsubmit(title, repoName string, _ yaml.MapSlice) {
 	// this job is mainly for debugging purpose.
 	if data.PostsubmitJobName == "post-knative-serving-go-coverage" {
 		data.PostsubmitJobName += "-dev"
-		data.Base.Image = strings.ReplaceAll(data.Base.Image, ":stable", ":coverage-dev")
+		data.Base.Image = strings.Replace(data.Base.Image, "coverage:latest", "coverage-dev:latest", -1)
 		executeJobTemplate("postsubmit go coverage", readTemplate(goCoveragePostsubmitJob), title, repoName, data.PostsubmitJobName, false, data)
 	}
 }

--- a/tools/config-generator/presubmit_config.go
+++ b/tools/config-generator/presubmit_config.go
@@ -27,7 +27,7 @@ const (
 	presubmitJob = "prow_presubmit_job.yaml"
 
 	// presubmitGoCoverageJob is the template for go coverage presubmit jobs.
-	presubmitGoCoverageJob = "prow_presubmit_gocoverage_job.yaml"
+	presubmitGoCoverageJob = "prow_presubmit_gocoverate_job.yaml"
 )
 
 // presubmitJobTemplateData contains data about a presubmit Prow job.
@@ -71,6 +71,7 @@ func generatePresubmit(title string, repoName string, presubmitConfig yaml.MapSl
 			}
 			jobTemplate = readTemplate(presubmitGoCoverageJob)
 			data.PresubmitJobName = data.Base.RepoNameForJob + "-go-coverage"
+			data.Base.Image = coverageDockerImage
 			data.Base.ServiceAccount = ""
 			repoData.EnableGoCoverage = true
 			addVolumeToJob(&data.Base, "/etc/covbot-token", "covbot-token", true, "")
@@ -113,10 +114,11 @@ func generatePresubmit(title string, repoName string, presubmitConfig yaml.MapSl
 
 	// Generate config for pull-knative-serving-go-coverage-dev right after pull-knative-serving-go-coverage,
 	// this job is mainly for debugging purpose.
+	// TODO: make this a static job in config/prod/prow/jobs/custom_jobs.yaml so the generator can be simplified
 	if data.PresubmitPullJobName == "pull-knative-serving-go-coverage" {
 		data.PresubmitPullJobName += "-dev"
 		data.Base.AlwaysRun = false
-		data.Base.Image = strings.ReplaceAll(data.Base.Image, ":stable", ":coverage-dev")
+		data.Base.Image = strings.Replace(data.Base.Image, "coverage:latest", "coverage-dev:latest", -1)
 		template := strings.Replace(readTemplate(presubmitGoCoverageJob), "(all|", "(", 1)
 		executeJobTemplate("presubmit", template, title, repoName, data.PresubmitPullJobName, true, data)
 	}

--- a/tools/config-generator/templates/prow_postsubmit_gocoverage_job.yaml
+++ b/tools/config-generator/templates/prow_postsubmit_gocoverage_job.yaml
@@ -11,9 +11,8 @@
       - image: [[.Base.Image]]
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=0"
         [[indent_section 8 "resources" .Base.Resources]]

--- a/tools/config-generator/templates/prow_presubmit_gocoverate_job.yaml
+++ b/tools/config-generator/templates/prow_presubmit_gocoverate_job.yaml
@@ -16,9 +16,8 @@
       - image: [[.Base.Image]]
         imagePullPolicy: Always
         command:
-        - runner.sh
+        - "/coverage"
         args:
-        - "coverage"
         - "--postsubmit-job-name=[[.PresubmitPostJobName]]"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=[[.Base.GoCoverageThreshold]]"

--- a/tools/coverage/README.md
+++ b/tools/coverage/README.md
@@ -16,9 +16,9 @@ See the [design document](design.md).
 
 ## Build and Release
 
-In the `/images/prow-tests` directory, run `make push_coverage_dev` to build and
-upload a staging version, intended for testing and debugging. The staging
-version can be triggered on a PR through the comment
+In the `/images/coverage` directory, run `make IMAGE_NAME=coverage-dev push` to
+build and upload a staging version, intended for testing and debugging. The
+staging version can be triggered on a PR through the comment
 `/test pull-knative-serving-go-coverage-dev`. Note that staging version can only
 be tested against the serving repository because the staging jobs only exist in
 the serving repository.
@@ -29,4 +29,5 @@ the serving repository.
   `/test pull-knative-serving-go-coverage-dev` to a PR.
 - To run the periodic workflow, (re)run a `post-knative-serving-go-coverage-dev`
   job.
-- The beta-prow-tests dashboard also has coverage running from prow-tests:beta
+
+To publish a new version of the code coverage tool, run `make push`.


### PR DESCRIPTION
Reverts knative/test-infra#2112

This change broke all coverage jobs, reverting it temporarily until further investigation

/assign chizhg coryrc