### PR TITLE
Revert "Use updateconfig plugin for updating prow job configs"

### DIFF
--- a/config/staging/prow/core/plugins.yaml
+++ b/config/staging/prow/core/plugins.yaml
@@ -69,11 +69,6 @@ label:
   - source/github
   - source/kafka
   - source/prometheus
-config_updater:
-  maps:
-    config/prod/staging/jobs/*.yaml:
-      name: job-config
-      gzip: true
 # Plugins enabled for each repo.
 plugins:
   knative-prow-robot/serving:
@@ -102,32 +97,6 @@ plugins:
   - wip
   - yuks
   knative-prow-robot/test-infra:
-  - approve
-  - assign
-  - blunderbuss
-  - buildifier
-  - cat
-  - dog
-  - golint
-  - heart
-  - help
-  - hold
-  - label
-  - lgtm
-  - lifecycle
-  - milestone
-  - owners-label
-  - project
-  - shrug
-  - size
-  - skip
-  - trigger
-  - verify-owners
-  - welcome
-  - wip
-  - yuks
-  knative-prow-robot/test-infra:
-  - config-updater
   - approve
   - assign
   - blunderbuss

--- a/tools/config-generator/main.go
+++ b/tools/config-generator/main.go
@@ -84,7 +84,6 @@ type prowConfigTemplateData struct {
 	TideRepos         []string
 	ManagedRepos      []string
 	ManagedOrgs       []string
-	JobConfigPath     string
 	TestInfraRepo     string
 }
 
@@ -659,15 +658,11 @@ func getProwConfigData(config yaml.MapSlice) prowConfigTemplateData {
 			}
 		}
 	}
-	// TODO: Remove all of these once prow core and plugins configs are not
-	// generated any more
 	if isProd {
 		data.ManagedOrgs = []string{"knative", "knative-sandbox"}
 		data.ManagedRepos = []string{"google/knative-gcp"}
-		data.JobConfigPath = "config/prod/prow/jobs/*.yaml"
 	} else {
 		data.ManagedRepos = []string{"knative-prow-robot/serving", "knative-prow-robot/test-infra"}
-		data.JobConfigPath = "config/prod/staging/jobs/*.yaml"
 	}
 	// Sort repos to make output stable.
 	sort.Strings(data.TideRepos)

--- a/tools/config-generator/templates/prow-staging/prow_plugins.yaml
+++ b/tools/config-generator/templates/prow-staging/prow_plugins.yaml
@@ -79,13 +79,6 @@ label:
   - source/github
   - source/kafka
   - source/prometheus
-
-config_updater:
-  maps:
-    [[.JobConfigPath]]:
-      name: job-config
-      gzip: true
-
 # Plugins enabled for each repo.
 
 plugins:
@@ -147,32 +140,6 @@ plugins:
   - yuks
 [[end]]
 [[end]]
-  [[.TestInfraRepo]]:
-  - config-updater
-  - approve
-  - assign
-  - blunderbuss
-  - buildifier
-  - cat
-  - dog
-  - golint
-  - heart
-  - help
-  - hold
-  - label
-  - lgtm
-  - lifecycle
-  - milestone
-  - owners-label
-  - project
-  - shrug
-  - size
-  - skip
-  - trigger
-  - verify-owners
-  - welcome
-  - wip
-  - yuks
 
 external_plugins:
 [[if .ManagedOrgs]]


### PR DESCRIPTION
Reverts knative/test-infra#2127

This change failed to roll out to prod: https://github.com/knative/test-infra/pull/2133, due to config check failed. Revert it first while investigating