### PR TITLE
Use configupdater

### DIFF
--- a/config/staging/prow/core/config.yaml
+++ b/config/staging/prow/core/config.yaml
@@ -119,9 +119,8 @@ branch-protection:
       enforce_admins: false
 tide:
   queries:
-  - repos:
-    - "knative-prow-robot/serving"
-    - "knative-prow-robot/test-infra"
+  - orgs:
+    - "knative-prow-robot"
     labels:
     - lgtm
     - approved

--- a/config/staging/prow/core/plugins.yaml
+++ b/config/staging/prow/core/plugins.yaml
@@ -69,6 +69,11 @@ label:
   - source/github
   - source/kafka
   - source/prometheus
+config_updater:
+  maps:
+    config/prod/staging/jobs/*.yaml:
+      name: job-config
+      gzip: true
 # Plugins enabled for each repo.
 plugins:
   knative-prow-robot/serving:
@@ -97,6 +102,32 @@ plugins:
   - wip
   - yuks
   knative-prow-robot/test-infra:
+  - approve
+  - assign
+  - blunderbuss
+  - buildifier
+  - cat
+  - dog
+  - golint
+  - heart
+  - help
+  - hold
+  - label
+  - lgtm
+  - lifecycle
+  - milestone
+  - owners-label
+  - project
+  - shrug
+  - size
+  - skip
+  - trigger
+  - verify-owners
+  - welcome
+  - wip
+  - yuks
+  knative-prow-robot/test-infra:
+  - config-updater
   - approve
   - assign
   - blunderbuss

--- a/config/staging/prow/core/plugins.yaml
+++ b/config/staging/prow/core/plugins.yaml
@@ -14,8 +14,7 @@
 # Settings for the "approve" plugin.
 approve:
 - repos:
-  - "knative-prow-robot/serving"
-  - "knative-prow-robot/test-infra"
+  - "knative-prow-robot"
   require_self_approval: false
   ignore_review_state: false
 # Settings for the "heart" plugin.
@@ -76,32 +75,7 @@ config_updater:
       gzip: true
 # Plugins enabled for each repo.
 plugins:
-  knative-prow-robot/serving:
-  - approve
-  - assign
-  - blunderbuss
-  - buildifier
-  - cat
-  - dog
-  - golint
-  - heart
-  - help
-  - hold
-  - label
-  - lgtm
-  - lifecycle
-  - milestone
-  - owners-label
-  - project
-  - shrug
-  - size
-  - skip
-  - trigger
-  - verify-owners
-  - welcome
-  - wip
-  - yuks
-  knative-prow-robot/test-infra:
+  knative-prow-robot:
   - approve
   - assign
   - blunderbuss
@@ -129,12 +103,7 @@ plugins:
   knative-prow-robot/test-infra:
   - config-updater
 external_plugins:
-  knative-prow-robot/serving:
-  - name: needs-rebase
-    events:
-      - issue_comment
-      - pull_request
-  knative-prow-robot/test-infra:
+  knative-prow-robot:
   - name: needs-rebase
     events:
       - issue_comment

--- a/config/staging/prow/core/plugins.yaml
+++ b/config/staging/prow/core/plugins.yaml
@@ -128,30 +128,6 @@ plugins:
   - yuks
   knative-prow-robot/test-infra:
   - config-updater
-  - approve
-  - assign
-  - blunderbuss
-  - buildifier
-  - cat
-  - dog
-  - golint
-  - heart
-  - help
-  - hold
-  - label
-  - lgtm
-  - lifecycle
-  - milestone
-  - owners-label
-  - project
-  - shrug
-  - size
-  - skip
-  - trigger
-  - verify-owners
-  - welcome
-  - wip
-  - yuks
 external_plugins:
   knative-prow-robot/serving:
   - name: needs-rebase

--- a/tools/config-generator/main.go
+++ b/tools/config-generator/main.go
@@ -666,7 +666,7 @@ func getProwConfigData(config yaml.MapSlice) prowConfigTemplateData {
 		data.ManagedRepos = []string{"google/knative-gcp"}
 		data.JobConfigPath = "config/prod/prow/jobs/*.yaml"
 	} else {
-		data.ManagedRepos = []string{"knative-prow-robot/serving", "knative-prow-robot/test-infra"}
+		data.ManagedOrgs = []string{"knative-prow-robot"}
 		data.JobConfigPath = "config/prod/staging/jobs/*.yaml"
 	}
 	// Sort repos to make output stable.

--- a/tools/config-generator/main.go
+++ b/tools/config-generator/main.go
@@ -84,6 +84,7 @@ type prowConfigTemplateData struct {
 	TideRepos         []string
 	ManagedRepos      []string
 	ManagedOrgs       []string
+	JobConfigPath     string
 	TestInfraRepo     string
 }
 
@@ -658,11 +659,15 @@ func getProwConfigData(config yaml.MapSlice) prowConfigTemplateData {
 			}
 		}
 	}
+	// TODO: Remove all of these once prow core and plugins configs are not
+	// generated any more
 	if isProd {
 		data.ManagedOrgs = []string{"knative", "knative-sandbox"}
 		data.ManagedRepos = []string{"google/knative-gcp"}
+		data.JobConfigPath = "config/prod/prow/jobs/*.yaml"
 	} else {
 		data.ManagedRepos = []string{"knative-prow-robot/serving", "knative-prow-robot/test-infra"}
+		data.JobConfigPath = "config/prod/staging/jobs/*.yaml"
 	}
 	// Sort repos to make output stable.
 	sort.Strings(data.TideRepos)

--- a/tools/config-generator/templates/prow-staging/prow_plugins.yaml
+++ b/tools/config-generator/templates/prow-staging/prow_plugins.yaml
@@ -79,6 +79,13 @@ label:
   - source/github
   - source/kafka
   - source/prometheus
+
+config_updater:
+  maps:
+    [[.JobConfigPath]]:
+      name: job-config
+      gzip: true
+
 # Plugins enabled for each repo.
 
 plugins:
@@ -140,6 +147,32 @@ plugins:
   - yuks
 [[end]]
 [[end]]
+  [[.TestInfraRepo]]:
+  - config-updater
+  - approve
+  - assign
+  - blunderbuss
+  - buildifier
+  - cat
+  - dog
+  - golint
+  - heart
+  - help
+  - hold
+  - label
+  - lgtm
+  - lifecycle
+  - milestone
+  - owners-label
+  - project
+  - shrug
+  - size
+  - skip
+  - trigger
+  - verify-owners
+  - welcome
+  - wip
+  - yuks
 
 external_plugins:
 [[if .ManagedOrgs]]

--- a/tools/config-generator/templates/prow-staging/prow_plugins.yaml
+++ b/tools/config-generator/templates/prow-staging/prow_plugins.yaml
@@ -149,30 +149,6 @@ plugins:
 [[end]]
   [[.TestInfraRepo]]:
   - config-updater
-  - approve
-  - assign
-  - blunderbuss
-  - buildifier
-  - cat
-  - dog
-  - golint
-  - heart
-  - help
-  - hold
-  - label
-  - lgtm
-  - lifecycle
-  - milestone
-  - owners-label
-  - project
-  - shrug
-  - size
-  - skip
-  - trigger
-  - verify-owners
-  - welcome
-  - wip
-  - yuks
 
 external_plugins:
 [[if .ManagedOrgs]]


### PR DESCRIPTION
This is retrying #2127 , the previous PR failed to be pushed to prod because of it failed to be rolled out to prod in #2133 
```
{"component":"unset","error":"plugins [approve assign blunderbuss buildifier cat dog golint heart help hold label lgtm lifecycle milestone owners-label project shrug size skip trigger verify-owners welcome wip yuks] are duplicated for knative/test-infra and knative","file":"prow/cmd/checkconfig/main.go:220","func":"main.main","level":"fatal","msg":"Error loading Prow plugin config.","time":"2020-06-01T18:53:01Z"}
```

This PR removed duplicated plugins

/assign chizhg
/cc chizhg