### PR TITLE
Also update prow core/plugin using configupdater

### DIFF
--- a/config/staging/prow/core/plugins.yaml
+++ b/config/staging/prow/core/plugins.yaml
@@ -73,6 +73,10 @@ config_updater:
     config/prod/staging/jobs/*.yaml:
       name: job-config
       gzip: true
+    config/prod/staging/core/config.yaml:
+      name: config
+    config/prod/staging/core/plugins.yaml:
+      name: plugins
 # Plugins enabled for each repo.
 plugins:
   knative-prow-robot:

--- a/tools/config-generator/main.go
+++ b/tools/config-generator/main.go
@@ -85,6 +85,8 @@ type prowConfigTemplateData struct {
 	ManagedRepos      []string
 	ManagedOrgs       []string
 	JobConfigPath     string
+	CoreConfigPath    string
+	PluginConfigPath  string
 	TestInfraRepo     string
 }
 
@@ -665,9 +667,13 @@ func getProwConfigData(config yaml.MapSlice) prowConfigTemplateData {
 		data.ManagedOrgs = []string{"knative", "knative-sandbox"}
 		data.ManagedRepos = []string{"google/knative-gcp"}
 		data.JobConfigPath = "config/prod/prow/jobs/*.yaml"
+		data.CoreConfigPath = "config/prod/prow/core/config.yaml"
+		data.PluginConfigPath = "config/prod/prow/core/plugins.yaml"
 	} else {
 		data.ManagedOrgs = []string{"knative-prow-robot"}
 		data.JobConfigPath = "config/prod/staging/jobs/*.yaml"
+		data.CoreConfigPath = "config/prod/staging/core/config.yaml"
+		data.PluginConfigPath = "config/prod/staging/core/plugins.yaml"
 	}
 	// Sort repos to make output stable.
 	sort.Strings(data.TideRepos)

--- a/tools/config-generator/templates/prow-staging/prow_plugins.yaml
+++ b/tools/config-generator/templates/prow-staging/prow_plugins.yaml
@@ -85,6 +85,10 @@ config_updater:
     [[.JobConfigPath]]:
       name: job-config
       gzip: true
+    [[.CoreConfigPath]]:
+      name: config
+    [[.PluginConfigPath]]:
+      name: plugins
 
 # Plugins enabled for each repo.
 


### PR DESCRIPTION
This is in preparing for stopping using in house auto config updater. After this change, the postsubmit jobs just need to do `make -C config/prod update-prow-cluster` etc.

/assign chizhg