### PR TITLE
Updating prow configs straight in postsubmit jobs instead of auto con…

### DIFF
--- a/config/prod/prow/jobs/custom-jobs.yaml
+++ b/config/prod/prow/jobs/custom-jobs.yaml
@@ -274,7 +274,7 @@ postsubmits:
     path_alias: knative.dev/test-infra
     max_concurrency: 1
     cluster: "prow-trusted"
-    run_if_changed: "^config/prod/prow/cluster/.*.yaml$"
+    run_if_changed: "^config/prod/(prow/cluster/.*.yaml|build-cluster/(cluster|boskos)/.*.yaml|prow/testgrid/testgrid.yaml)$"
     branches:
     - "master"
     spec:
@@ -286,115 +286,7 @@ postsubmits:
         args:
         - "-C"
         - "./config/prod"
-        - "update-almost-all-cluster-deployments"
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: DOCKER_IN_DOCKER_ENABLED
-          value: "true"
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-      volumes:
-      - name: docker-graph
-        emptyDir: {}
-      - name: test-account
-        secret:
-          secretName: test-account
-  - name: post-knative-prow-build-cluster-config-updater
-    agent: kubernetes
-    decorate: true
-    path_alias: knative.dev/test-infra
-    max_concurrency: 1
-    cluster: "prow-trusted"
-    run_if_changed: "^config/prod/build-cluster/cluster/.*.yaml$"
-    branches:
-    - "master"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests-go114:stable
-        imagePullPolicy: Always
-        command:
-        - "make"
-        args:
-        - "-C"
-        - "./config/prod"
-        - "update-all-build-cluster-deployments"
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: DOCKER_IN_DOCKER_ENABLED
-          value: "true"
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-      volumes:
-      - name: docker-graph
-        emptyDir: {}
-      - name: test-account
-        secret:
-          secretName: test-account
-  - name: post-knative-boskos-resource-updater
-    agent: kubernetes
-    decorate: true
-    path_alias: knative.dev/test-infra
-    max_concurrency: 1
-    cluster: "prow-trusted"
-    run_if_changed: "^config/prod/build-cluster/boskos/.*.yaml$"
-    branches:
-    - "master"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests-go114:stable
-        imagePullPolicy: Always
-        command:
-        - "make"
-        args:
-        - "-C"
-        - "./config/prod"
-        - "update-boskos-resource"
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: DOCKER_IN_DOCKER_ENABLED
-          value: "true"
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-      volumes:
-      - name: docker-graph
-        emptyDir: {}
-      - name: test-account
-        secret:
-          secretName: test-account
-  - name: post-knative-testgrid-config-updater
-    agent: kubernetes
-    decorate: true
-    path_alias: knative.dev/test-infra
-    max_concurrency: 1
-    cluster: "prow-trusted"
-    run_if_changed: "^config/prod/prow/testgrid/testgrid.yaml$"
-    branches:
-    - "master"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests-go114:stable
-        imagePullPolicy: Always
-        command:
-        - "make"
-        args:
-        - "-C"
-        - "./config/prod"
-        - "update-testgrid-config"
+        - "update-all"
         securityContext:
           privileged: true
         volumeMounts:

--- a/config/prod/prow/jobs/custom-jobs.yaml
+++ b/config/prod/prow/jobs/custom-jobs.yaml
@@ -14,29 +14,6 @@
 
 presubmits:
   knative/test-infra:
-  - name: pull-test-infra-config-changes-checker
-    decorate: true
-    path_alias: knative.dev/test-infra
-    run_if_changed: "^(config/(prod/staging)/prow/cluster/.*.yaml)|(tools/config-generator/templates/(prow|prow-staging)/.*.yaml)$"
-    cluster: "build-knative"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests-go114:stable
-        command:
-        - "go"
-        args:
-        - "run"
-        - "./tools/prow-config-updater/presubmit-checker"
-        - "--github-bot-name=knative-prow-robot"
-        - "--github-token=/etc/repoview-token/token"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
   - name: pull-test-infra-validate-prow-yaml
     decorate: true
     run_if_changed: "^config/prod/prow/(cluster|core|jobs)/.*.yaml$"
@@ -291,13 +268,13 @@ periodics:
 
 postsubmits:
   knative/test-infra:
-  - name: post-knative-prow-config-updater
+  - name: post-knative-prow-cluster-config-updater
     agent: kubernetes
     decorate: true
     path_alias: knative.dev/test-infra
     max_concurrency: 1
     cluster: "prow-trusted"
-    run_if_changed: "^(config/(prod|staging)/(prow|build-cluster)/(cluster|core|jobs|boskos|testgrid)/.*.yaml)|(tools/config-generator/templates/(prow|prow-staging)/.*.yaml)$"
+    run_if_changed: "^config/prod/prow/cluster/.*.yaml$"
     branches:
     - "master"
     spec:
@@ -305,29 +282,16 @@ postsubmits:
       - image: gcr.io/knative-tests/test-infra/prow-tests-go114:stable
         imagePullPolicy: Always
         command:
-        - "go"
+        - "make"
         args:
-        - "run"
-        - "./tools/prow-config-updater"
-        - "--github-token-file=/etc/prow-robot-github-token/token"
-        - "--github-userid=knative-prow-robot"
-        - "--git-username='Knative Prow Robot'"
-        - "--git-email=adrcunha+knative-prow-robot@google.com"
-        - "--comment-github-token-file=/etc/prow-updater-robot-github-token/token"
+        - "-C"
+        - "./config/prod"
+        - "update-almost-all-cluster-deployments"
         securityContext:
           privileged: true
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
-          readOnly: true
-        - name: prow-robot-github-token
-          mountPath: /etc/prow-robot-github-token
-          readOnly: true
-        - name: prow-updater-robot-github-token
-          mountPath: /etc/prow-updater-robot-github-token
-          readOnly: true
-        - name: prow-robot-ssh-key
-          mountPath: /root/.ssh
           readOnly: true
         env:
         - name: DOCKER_IN_DOCKER_ENABLED
@@ -340,13 +304,111 @@ postsubmits:
       - name: test-account
         secret:
           secretName: test-account
-      - name: prow-robot-github-token
+  - name: post-knative-prow-build-cluster-config-updater
+    agent: kubernetes
+    decorate: true
+    path_alias: knative.dev/test-infra
+    max_concurrency: 1
+    cluster: "prow-trusted"
+    run_if_changed: "^config/prod/build-cluster/cluster/.*.yaml$"
+    branches:
+    - "master"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go114:stable
+        imagePullPolicy: Always
+        command:
+        - "make"
+        args:
+        - "-C"
+        - "./config/prod"
+        - "update-all-build-cluster-deployments"
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: "true"
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+      volumes:
+      - name: docker-graph
+        emptyDir: {}
+      - name: test-account
         secret:
-          secretName: prow-robot-github-token
-      - name: prow-updater-robot-github-token
+          secretName: test-account
+  - name: post-knative-boskos-resource-updater
+    agent: kubernetes
+    decorate: true
+    path_alias: knative.dev/test-infra
+    max_concurrency: 1
+    cluster: "prow-trusted"
+    run_if_changed: "^config/prod/build-cluster/boskos/.*.yaml$"
+    branches:
+    - "master"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go114:stable
+        imagePullPolicy: Always
+        command:
+        - "make"
+        args:
+        - "-C"
+        - "./config/prod"
+        - "update-boskos-resource"
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: "true"
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+      volumes:
+      - name: docker-graph
+        emptyDir: {}
+      - name: test-account
         secret:
-          secretName: prow-updater-robot-github-token
-      - name: prow-robot-ssh-key
+          secretName: test-account
+  - name: post-knative-testgrid-config-updater
+    agent: kubernetes
+    decorate: true
+    path_alias: knative.dev/test-infra
+    max_concurrency: 1
+    cluster: "prow-trusted"
+    run_if_changed: "^config/prod/prow/testgrid/testgrid.yaml$"
+    branches:
+    - "master"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests-go114:stable
+        imagePullPolicy: Always
+        command:
+        - "make"
+        args:
+        - "-C"
+        - "./config/prod"
+        - "update-testgrid-config"
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: "true"
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+      volumes:
+      - name: docker-graph
+        emptyDir: {}
+      - name: test-account
         secret:
-          secretName: prow-robot-ssh-key
-          defaultMode: 0400
+          secretName: test-account

--- a/config/prow_common.mk
+++ b/config/prow_common.mk
@@ -100,9 +100,13 @@ update-almost-all-cluster-deployments:: confirm-master
 	$(SET_CONTEXT)
 	@for f in $(filter-out $(wildcard $(PROW_DEPLOYS)/*boskos*.yaml),$(wildcard $(PROW_DEPLOYS)/*.yaml)); do kubectl apply -f $${f}; done
 	$(UNSET_CONTEXT)
+
+update-almost-all-build-cluster-deployments:: confirm-master
 	$(SET_BUILD_CLUSTER_CONTEXT)
 	@for f in $(filter-out $(wildcard $(BUILD_CLUSTER_PROW_DEPLOYS)/*boskos*.yaml),$(wildcard $(BUILD_CLUSTER_PROW_DEPLOYS)/*.yaml)); do kubectl apply -f $${f}; done
 	$(UNSET_CONTEXT)
+
+update-all-build-cluster-deployments:: update-almost-all-build-cluster-deployments update-all-boskos-deployments
 
 # Update single deployment of cluster, expect passing in ${NAME} like `make update-single-cluster-deployment NAME=crier_deployment`
 update-single-cluster-deployment: confirm-master
@@ -114,7 +118,7 @@ update-single-cluster-deployment: confirm-master
 	$(UNSET_CONTEXT)
 
 # Update all resources on Prow cluster
-update-prow-cluster: update-almost-all-cluster-deployments update-all-boskos-deployments update-boskos-resource update-prow-config
+update-prow-cluster: update-almost-all-cluster-deployments update-almost-all-build-cluster-deployments update-all-boskos-deployments update-boskos-resource update-prow-config
 
 # Update TestGrid config.
 # Application Default Credentials must be set, otherwise the upload will fail.


### PR DESCRIPTION
This change moves from updating prow cluster with auto-config-updater to directly using make rules in postsubmit jobs. Key updates:

- Stop auto-config-updater
- Stop checking for changes against prod prow cluster config
- Use direct make rules in postsubmit jobs, separated as:
  - prow cluster deployments
  - build cluster deployments
  - boskos resources
  - testgrid update

The implicit impact is knative staging prow will not be tracked any more

/assign chizhg

/hold
Better be merged after #2144 