### PR TITLE
Use go version defined in go.mod to run Prow jobs

### DIFF
--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -75,8 +75,6 @@ RUN GO111MODULE=on go get -u github.com/google/go-licenses
 RUN bazel version > /bazel_version
 RUN ko version > /ko_version
 
-# Set default Go version
-ENV GO_VERSION go1.13
 # Note, it's pointless to run `source-gvm-and-run.sh use go1.13` in this Dockerfile because the PATH changes it makes won't stay in effect
 # We wrap the runner with our own which will run `gvm use $GO_VERSION` for us.
 RUN mv "$(which runner.sh)" "$(dirname "$(which runner.sh)")/kubekins-runner.sh"

--- a/images/prow-tests/runner.sh
+++ b/images/prow-tests/runner.sh
@@ -18,8 +18,23 @@ ORIGINAL_GOPATH="${GOPATH}"
 
 source "${HOME}/.gvm/scripts/gvm"
 
+# By default using Go version 1.13.
+version="go1.13"
+# Extract the go version if the project is using go mod.
+if [[ -f "go.mod" ]]; then
+  version="go$(sed -n 's/^go //p' go.mod | tr -d '[:space:]')"
+  echo "Found go.mod file, using Go version '${version}' specified by it."
+fi
+# If GO_VERSION is defined, use it as the version.
+# It has a higher priority than go.mod as it's specified more explicitly.
 if [[ -v GO_VERSION ]]; then
-  gvm use "${GO_VERSION}"
+  echo "GO_VERSION is defined, overwriting Go version to '${GO_VERSION}'"
+  version="${GO_VERSION}"
+fi
+
+if [[ -n ${version} ]]; then
+  echo "Switching Go version to '${version}'"
+  gvm use "${version}"
   # Get our original Go directory back into GOPATH
   pushd "${ORIGINAL_GOPATH}" || exit 2
   gvm pkgset create --local || echo


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Now that all Knative projects have been switched to go mod, we can parse `go.mod` file to dynamically determine the go version to use in the CI/CD flows. In this way, whenever a project wants to a new Go version, they can just update the `go.mod` file, no changes will be needed for Prow jobs as long as that version of Go has been installed in the `prow-tests` image.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #2118 

/cc @chaodaiG @albertomilan @peterfeifanchen 
