### PR TITLE
Remove the logic to set go version via Prow jobs

### DIFF
--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -20,11 +20,6 @@ presubmits:
   knative/serving:
     - repo-settings:
       performance: true
-      go113-branches:
-      - "release-0.11"
-      - "release-0.12"
-      - "release-0.13"
-      - "release-0.14"
     - build-tests: true
       dot-dev: true
       resources:
@@ -139,12 +134,6 @@ presubmits:
       - "./test/e2e-auto-tls-tests.sh --https"
 
   knative/client:
-    - repo-settings:
-      go113-branches:
-      - "release-0.11"
-      - "release-0.12"
-      - "release-0.13"
-      - "release-0.14"
     - build-tests: true
       dot-dev: true
     - unit-tests: true
@@ -170,11 +159,6 @@ presubmits:
   knative/eventing:
     - repo-settings:
       performance: true
-      go113-branches:
-      - "release-0.11"
-      - "release-0.12"
-      - "release-0.13"
-      - "release-0.14"
     - build-tests: true
       dot-dev: true
       resources:
@@ -190,12 +174,6 @@ presubmits:
       dot-dev: true
 
   knative/eventing-contrib:
-    - repo-settings:
-      go113-branches:
-      - "release-0.11"
-      - "release-0.12"
-      - "release-0.13"
-      - "release-0.14"
     - build-tests: true
       dot-dev: true
       resources:
@@ -223,12 +201,6 @@ presubmits:
         - "./test/presubmit-link-check.sh"
 
   knative/pkg:
-    - repo-settings:
-      go113-branches:
-      - "release-0.11"
-      - "release-0.12"
-      - "release-0.13"
-      - "release-0.14"
     - build-tests: true
       dot-dev: true
     - unit-tests: true
@@ -239,12 +211,6 @@ presubmits:
       dot-dev: true
 
   knative/test-infra:
-    - repo-settings:
-      go113-branches:
-      - "release-0.11"
-      - "release-0.12"
-      - "release-0.13"
-      - "release-0.14"
     - build-tests: true
       dot-dev: true
     - unit-tests: true
@@ -279,11 +245,6 @@ presubmits:
   google/knative-gcp:
     - repo-settings:
       performance: true
-      go113-branches:
-      - "release-0.11"
-      - "release-0.12"
-      - "release-0.13"
-      - "release-0.14"
     - build-tests: true
       resources:
         requests:
@@ -304,12 +265,6 @@ presubmits:
     - go-coverage: true
 
   knative/net-certmanager:
-    - repo-settings:
-      go113-branches:
-      - "release-0.11"
-      - "release-0.12"
-      - "release-0.13"
-      - "release-0.14"
     - build-tests: true
       dot-dev: true
     - unit-tests: true
@@ -320,12 +275,6 @@ presubmits:
       dot-dev: true
 
   knative/net-contour:
-    - repo-settings:
-      go113-branches:
-      - "release-0.11"
-      - "release-0.12"
-      - "release-0.13"
-      - "release-0.14"
     - build-tests: true
       dot-dev: true
     - unit-tests: true
@@ -336,12 +285,6 @@ presubmits:
       dot-dev: true
 
   knative/net-http01:
-    - repo-settings:
-      go113-branches:
-      - "release-0.11"
-      - "release-0.12"
-      - "release-0.13"
-      - "release-0.14"
     - build-tests: true
       dot-dev: true
     - unit-tests: true
@@ -352,12 +295,6 @@ presubmits:
       dot-dev: true
 
   knative/net-istio:
-    - repo-settings:
-      go113-branches:
-      - "release-0.11"
-      - "release-0.12"
-      - "release-0.13"
-      - "release-0.14"
     - build-tests: true
       dot-dev: true
     - unit-tests: true
@@ -374,12 +311,6 @@ presubmits:
       - "./test/e2e-tests.sh --istio-version latest"
 
   knative/net-kourier:
-    - repo-settings:
-      go113-branches:
-      - "release-0.11"
-      - "release-0.12"
-      - "release-0.13"
-      - "release-0.14"
     - build-tests: true
       dot-dev: true
     - unit-tests: true
@@ -390,12 +321,6 @@ presubmits:
       dot-dev: true
 
   knative/serving-operator:
-    - repo-settings:
-      go113-branches:
-      - "release-0.11"
-      - "release-0.12"
-      - "release-0.13"
-      - "release-0.14"
     - build-tests: true
       dot-dev: true
     - unit-tests: true
@@ -411,12 +336,6 @@ presubmits:
         - "./test/e2e-upgrade-tests.sh"
 
   knative/eventing-operator:
-    - repo-settings:
-      go113-branches:
-      - "release-0.11"
-      - "release-0.12"
-      - "release-0.13"
-      - "release-0.14"
     - build-tests: true
       dot-dev: true
     - unit-tests: true
@@ -487,7 +406,6 @@ periodics:
     - continuous: true
       timeout: 100
       dot-dev: true
-      go114: true
       resources:
         requests:
           memory: 12Gi
@@ -514,7 +432,6 @@ periodics:
       - "--run-test"
       - "./test/e2e-auto-tls-tests.sh --istio-version 1.5-latest --mesh"
       dot-dev: true
-      go114: true
     - custom-job: istio-1.5-no-mesh
       command:
       - "./test/presubmit-tests.sh"
@@ -524,7 +441,6 @@ periodics:
       - "--run-test"
       - "./test/e2e-auto-tls-tests.sh --istio-version 1.5-latest --no-mesh"
       dot-dev: true
-      go114: true
     - custom-job: istio-1.4-mesh
       command:
       - "./test/presubmit-tests.sh"
@@ -534,7 +450,6 @@ periodics:
       - "--run-test"
       - "./test/e2e-auto-tls-tests.sh --istio-version 1.4-latest --mesh"
       dot-dev: true
-      go114: true
     - custom-job: istio-1.4-no-mesh
       command:
       - "./test/presubmit-tests.sh"
@@ -544,7 +459,6 @@ periodics:
       - "--run-test"
       - "./test/e2e-auto-tls-tests.sh --istio-version 1.4-latest --no-mesh"
       dot-dev: true
-      go114: true
     - custom-job: gloo-0.17.1
       command:
       - "./test/presubmit-tests.sh"
@@ -554,7 +468,6 @@ periodics:
       - "--run-test"
       - "./test/e2e-auto-tls-tests.sh --gloo-version 0.17.1"
       dot-dev: true
-      go114: true
     - custom-job: kourier-stable
       command:
       - "./test/presubmit-tests.sh"
@@ -564,7 +477,6 @@ periodics:
       - "--run-test"
       - "./test/e2e-auto-tls-tests.sh --kourier-version stable"
       dot-dev: true
-      go114: true
     - custom-job: contour-latest
       command:
       - "./test/presubmit-tests.sh"
@@ -574,7 +486,6 @@ periodics:
       - "--run-test"
       - "./test/e2e-auto-tls-tests.sh --contour-version latest"
       dot-dev: true
-      go114: true
     - custom-job: ambassador-latest
       command:
       - "./test/presubmit-tests.sh"
@@ -584,7 +495,6 @@ periodics:
       - "--run-test"
       - "./test/e2e-auto-tls-tests.sh --ambassador-version latest"
       dot-dev: true
-      go114: true
     - custom-job: https
       command:
       - "./test/presubmit-tests.sh"
@@ -594,10 +504,8 @@ periodics:
       - "--run-test"
       - "./test/e2e-auto-tls-tests.sh --https"
       dot-dev: true
-      go114: true
     - nightly: true
       dot-dev: true
-      go114: true
       resources:
         requests:
           memory: 12Gi
@@ -637,7 +545,6 @@ periodics:
           memory: 16Gi
 #    - dot-release: true
 #      dot-dev: true
-#      go114: true
 #      resources:
 #        requests:
 #          memory: 12Gi
@@ -645,7 +552,6 @@ periodics:
 #          memory: 16Gi
     - auto-release: true
       dot-dev: true
-      go114: true
       resources:
         requests:
           memory: 12Gi
@@ -653,12 +559,10 @@ periodics:
           memory: 16Gi
     - webhook-apicoverage: true
       dot-dev: true
-      go114: true
 
   knative/client:
     - continuous: true
       dot-dev: true
-      go114: true
     - branch-ci: true
       release: "0.11"
       dot-dev: true
@@ -673,7 +577,6 @@ periodics:
       dot-dev: true
     - nightly: true
       dot-dev: true
-      go114: true
     - custom-job: tekton
       # This job must run after the nightly job so it uses the latest nightly.
       # Nightly jobs run between 1AM and 3AM PST.
@@ -681,7 +584,6 @@ periodics:
       cron: "0 13 * * *"
       command: "./test/tekton-tests.sh"
       dot-dev: true
-      go114: true
     - dot-release: true
       dot-dev: true
       release: "0.11"
@@ -696,15 +598,12 @@ periodics:
       release: "0.14"
 #    - dot-release: true
 #      dot-dev: true
-#      go114: true
     - auto-release: true
       dot-dev: true
-      go114: true
 
   knative/client-contrib:
     - continuous: true
       dot-dev: true
-      go114: true
 
   knative/docs:
     - continuous: true
@@ -719,7 +618,6 @@ periodics:
           memory: 12Gi
         limits:
           memory: 16Gi
-      go114: true
     - branch-ci: true
       release: "0.11"
       dot-dev: true
@@ -734,7 +632,6 @@ periodics:
       dot-dev: true
     - nightly: true
       dot-dev: true
-      go114: true
       resources:
         requests:
           memory: 12Gi
@@ -774,7 +671,6 @@ periodics:
           memory: 16Gi
 #    - dot-release: true
 #      dot-dev: true
-#      go114: true
 #      resources:
 #        requests:
 #          memory: 12Gi
@@ -782,7 +678,6 @@ periodics:
 #          memory: 16Gi
     - auto-release: true
       dot-dev: true
-      go114: true
       resources:
         requests:
           memory: 12Gi
@@ -792,7 +687,6 @@ periodics:
   knative/eventing-contrib:
     - continuous: true
       dot-dev: true
-      go114: true
       resources:
         requests:
           memory: 12Gi
@@ -812,7 +706,6 @@ periodics:
       dot-dev: true
     - nightly: true
       dot-dev: true
-      go114: true
       resources:
         requests:
           memory: 12Gi
@@ -852,7 +745,6 @@ periodics:
           memory: 16Gi
 #    - dot-release: true
 #      dot-dev: true
-#      go114: true
 #      resources:
 #        requests:
 #          memory: 12Gi
@@ -860,7 +752,6 @@ periodics:
 #          memory: 16Gi
     - auto-release: true
       dot-dev: true
-      go114: true
       resources:
         requests:
           memory: 12Gi
@@ -870,32 +761,26 @@ periodics:
   knative/pkg:
     - continuous: true
       dot-dev: true
-      go114: true
 
   knative/caching:
     - continuous: true
       dot-dev: true
-      go114: true
 
   knative/sample-controller:
     - continuous: true
       dot-dev: true
-      go114: true
 
   knative/sample-source:
     - continuous: true
       dot-dev: true
-      go114: true
 
   knative/test-infra:
     - continuous: true
       dot-dev: true
-      go114: true
 
   knative/serving-operator:
     - continuous: true
       dot-dev: true
-      go114: true
     - branch-ci: true
       release: "0.11"
       dot-dev: true
@@ -910,7 +795,6 @@ periodics:
       dot-dev: true
     - nightly: true
       dot-dev: true
-      go114: true
     - dot-release: true
       dot-dev: true
       release: "0.11"
@@ -925,15 +809,12 @@ periodics:
       release: "0.14"
 #    - dot-release: true
 #      dot-dev: true
-#      go114: true
     - auto-release: true
       dot-dev: true
-      go114: true
 
   knative/eventing-operator:
     - continuous: true
       dot-dev: true
-      go114: true
     - branch-ci: true
       release: "0.11"
       dot-dev: true
@@ -948,7 +829,6 @@ periodics:
       dot-dev: true
     - nightly: true
       dot-dev: true
-      go114: true
     - dot-release: true
       dot-dev: true
       release: "0.11"
@@ -963,14 +843,11 @@ periodics:
       release: "0.14"
 #    - dot-release: true
 #      dot-dev: true
-#      go114: true
     - auto-release: true
       dot-dev: true
-      go114: true
 
   google/knative-gcp:
     - continuous: true
-      go114: true
       resources:
         requests:
           memory: 12Gi
@@ -998,7 +875,6 @@ periodics:
         limits:
           memory: 16Gi
     - nightly: true
-      go114: true
       resources:
         requests:
           memory: 12Gi
@@ -1032,11 +908,9 @@ periodics:
       env-vars:
       - ORG_NAME=google
 #    - dot-release: true
-#      go114: true
 #      env-vars:
 #      - ORG_NAME=google
     - auto-release: true
-      go114: true
       resources:
         requests:
           memory: 12Gi
@@ -1048,109 +922,81 @@ periodics:
   knative/net-certmanager:
     - continuous: true
       dot-dev: true
-      go114: true
     - nightly: true
       dot-dev: true
-      go114: true
     - dot-release: true
       dot-dev: true
-      go114: true
     - auto-release: true
       dot-dev: true
-      go114: true
 
   knative/net-contour:
     - continuous: true
       dot-dev: true
-      go114: true
     - nightly: true
       dot-dev: true
-      go114: true
     - dot-release: true
       dot-dev: true
-      go114: true
     - auto-release: true
       dot-dev: true
-      go114: true
 
   knative/net-http01:
     - continuous: true
       dot-dev: true
-      go114: true
     - nightly: true
       dot-dev: true
-      go114: true
     - dot-release: true
       dot-dev: true
-      go114: true
     - auto-release: true
       dot-dev: true
-      go114: true
 
   knative/net-istio:
     - continuous: true
       dot-dev: true
-      go114: true
     - nightly: true
       dot-dev: true
-      go114: true
     - dot-release: true
       dot-dev: true
-      go114: true
     - auto-release: true
       dot-dev: true
-      go114: true
 
   knative/net-kourier:
     - continuous: true
       dot-dev: true
-      go114: true
     - nightly: true
       dot-dev: true
-      go114: true
     - dot-release: true
       dot-dev: true
-      go114: true
     - auto-release: true
       dot-dev: true
-      go114: true
 
   knative/operator:
     - continuous: true
       dot-dev: true
-      go114: true
     - nightly: true
       dot-dev: true
-      go114: true
     - dot-release: true
       dot-dev: true
-      go114: true
       env-vars:
       - ORG_NAME=knative-sandbox
     - auto-release: true
       dot-dev: true
-      go114: true
       env-vars:
       - ORG_NAME=knative-sandbox
 
   knative-sandbox/eventing-kafka:
     - continuous: true
       dot-dev: true
-      go114: true
       needs-dind: true
     - nightly: true
       dot-dev: true
-      go114: true
       needs-dind: true
     - dot-release: true
       dot-dev: true
-      go114: true
       needs-dind: true
       env-vars:
       - ORG_NAME=knative-sandbox
     - auto-release: true
       dot-dev: true
-      go114: true
       needs-dind: true
       env-vars:
       - ORG_NAME=knative-sandbox

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -28,11 +28,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/serving
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -66,55 +61,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-serving-build-tests
-    agent: kubernetes
-    context: pull-knative-serving-build-tests
-    always_run: true
-    rerun_command: "/test pull-knative-serving-build-tests"
-    trigger: "(?m)^/test (all|pull-knative-serving-build-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/serving
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--build-tests"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
-        resources:
-          requests:
-            memory: 12Gi
-          limits:
-            memory: 16Gi
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: test-account
-        secret:
-          secretName: test-account
   - name: pull-knative-serving-unit-tests
     agent: kubernetes
     labels:
@@ -128,11 +74,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/serving
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -142,101 +83,6 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--unit-tests"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: test-account
-        secret:
-          secretName: test-account
-  - name: pull-knative-serving-unit-tests
-    agent: kubernetes
-    labels:
-      prow.k8s.io/pubsub.project: knative-tests
-      prow.k8s.io/pubsub.topic: knative-monitoring
-      prow.k8s.io/pubsub.runID: pull-knative-serving-unit-tests
-    context: pull-knative-serving-unit-tests
-    always_run: true
-    rerun_command: "/test pull-knative-serving-unit-tests"
-    trigger: "(?m)^/test (all|pull-knative-serving-unit-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/serving
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--unit-tests"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: test-account
-        secret:
-          secretName: test-account
-  - name: pull-knative-serving-integration-tests
-    agent: kubernetes
-    labels:
-      prow.k8s.io/pubsub.project: knative-tests
-      prow.k8s.io/pubsub.topic: knative-monitoring
-      prow.k8s.io/pubsub.runID: pull-knative-serving-integration-tests
-    context: pull-knative-serving-integration-tests
-    always_run: true
-    rerun_command: "/test pull-knative-serving-integration-tests"
-    trigger: "(?m)^/test (all|pull-knative-serving-integration-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/serving
-    cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--run-test"
-        - "./test/e2e-tests.sh"
         volumeMounts:
         - name: repoview-token
           mountPath: /etc/repoview-token
@@ -269,11 +115,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/serving
     cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -296,8 +137,6 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-central1
-        - name: GO_VERSION
-          value: go1.14
       volumes:
       - name: repoview-token
         secret:
@@ -318,11 +157,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/serving
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -333,90 +167,6 @@ presubmits:
         - "./test/presubmit-tests.sh"
         - "--run-test"
         - "./test/e2e-upgrade-tests.sh"
-        volumeMounts:
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-      volumes:
-      - name: test-account
-        secret:
-          secretName: test-account
-  - name: pull-knative-serving-upgrade-tests
-    agent: kubernetes
-    labels:
-      prow.k8s.io/pubsub.project: knative-tests
-      prow.k8s.io/pubsub.topic: knative-monitoring
-      prow.k8s.io/pubsub.runID: pull-knative-serving-upgrade-tests
-    context: pull-knative-serving-upgrade-tests
-    always_run: true
-    rerun_command: "/test pull-knative-serving-upgrade-tests"
-    trigger: "(?m)^/test (all|pull-knative-serving-upgrade-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/serving
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--run-test"
-        - "./test/e2e-upgrade-tests.sh"
-        volumeMounts:
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
-      volumes:
-      - name: test-account
-        secret:
-          secretName: test-account
-  - name: pull-knative-serving-autotls-tests
-    agent: kubernetes
-    labels:
-      prow.k8s.io/pubsub.project: knative-tests
-      prow.k8s.io/pubsub.topic: knative-monitoring
-      prow.k8s.io/pubsub.runID: pull-knative-serving-autotls-tests
-    context: pull-knative-serving-autotls-tests
-    always_run: true
-    rerun_command: "/test pull-knative-serving-autotls-tests"
-    trigger: "(?m)^/test (all|pull-knative-serving-autotls-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/serving
-    cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--run-test"
-        - "./test/e2e-auto-tls-tests.sh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -443,11 +193,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/serving
     cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -467,8 +212,6 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-central1
-        - name: GO_VERSION
-          value: go1.14
       volumes:
       - name: test-account
         secret:
@@ -483,11 +226,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/serving
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -504,44 +242,6 @@ presubmits:
         - name: covbot-token
           mountPath: /etc/covbot-token
           readOnly: true
-      volumes:
-      - name: covbot-token
-        secret:
-          secretName: covbot-token
-  - name: pull-knative-serving-go-coverage
-    agent: kubernetes
-    context: pull-knative-serving-go-coverage
-    always_run: true
-    rerun_command: "/test pull-knative-serving-go-coverage"
-    trigger: "(?m)^/test (all|pull-knative-serving-go-coverage),?(\\s+|$)"
-    optional: true
-    decorate: true
-    path_alias: knative.dev/serving
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "coverage"
-        - "--postsubmit-job-name=post-knative-serving-go-coverage"
-        - "--artifacts=$(ARTIFACTS)"
-        - "--cov-threshold-percentage=80"
-        - "--github-token=/etc/covbot-token/token"
-        volumeMounts:
-        - name: covbot-token
-          mountPath: /etc/covbot-token
-          readOnly: true
-        env:
-        - name: GO_VERSION
-          value: go1.14
       volumes:
       - name: covbot-token
         secret:
@@ -556,11 +256,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/serving
     cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:coverage-dev
@@ -577,9 +272,6 @@ presubmits:
         - name: covbot-token
           mountPath: /etc/covbot-token
           readOnly: true
-        env:
-        - name: GO_VERSION
-          value: go1.14
       volumes:
       - name: covbot-token
         secret:
@@ -594,11 +286,6 @@ presubmits:
     optional: true
     path_alias: knative.dev/serving
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -624,48 +311,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-serving-istio-1.5-mesh
-    agent: kubernetes
-    context: pull-knative-serving-istio-1.5-mesh
-    always_run: false
-    rerun_command: "/test pull-knative-serving-istio-1.5-mesh"
-    trigger: "(?m)^/test (all|pull-knative-serving-istio-1.5-mesh),?(\\s+|$)"
-    decorate: true
-    optional: true
-    path_alias: knative.dev/serving
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.5-latest --mesh"
-        - "--run-test"
-        - "./test/e2e-auto-tls-tests.sh --istio-version 1.5-latest --mesh"
-        volumeMounts:
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
-      volumes:
-      - name: test-account
-        secret:
-          secretName: test-account
   - name: pull-knative-serving-istio-1.5-no-mesh
     agent: kubernetes
     context: pull-knative-serving-istio-1.5-no-mesh
@@ -676,11 +321,6 @@ presubmits:
     optional: true
     path_alias: knative.dev/serving
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -706,48 +346,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-serving-istio-1.5-no-mesh
-    agent: kubernetes
-    context: pull-knative-serving-istio-1.5-no-mesh
-    always_run: false
-    rerun_command: "/test pull-knative-serving-istio-1.5-no-mesh"
-    trigger: "(?m)^/test (all|pull-knative-serving-istio-1.5-no-mesh),?(\\s+|$)"
-    decorate: true
-    optional: true
-    path_alias: knative.dev/serving
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.5-latest --no-mesh"
-        - "--run-test"
-        - "./test/e2e-auto-tls-tests.sh --istio-version 1.5-latest --no-mesh"
-        volumeMounts:
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
-      volumes:
-      - name: test-account
-        secret:
-          secretName: test-account
   - name: pull-knative-serving-istio-1.4-mesh
     agent: kubernetes
     context: pull-knative-serving-istio-1.4-mesh
@@ -758,11 +356,6 @@ presubmits:
     optional: true
     path_alias: knative.dev/serving
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -788,48 +381,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-serving-istio-1.4-mesh
-    agent: kubernetes
-    context: pull-knative-serving-istio-1.4-mesh
-    always_run: false
-    rerun_command: "/test pull-knative-serving-istio-1.4-mesh"
-    trigger: "(?m)^/test (all|pull-knative-serving-istio-1.4-mesh),?(\\s+|$)"
-    decorate: true
-    optional: true
-    path_alias: knative.dev/serving
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.4-latest --mesh"
-        - "--run-test"
-        - "./test/e2e-auto-tls-tests.sh --istio-version 1.4-latest --mesh"
-        volumeMounts:
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
-      volumes:
-      - name: test-account
-        secret:
-          secretName: test-account
   - name: pull-knative-serving-istio-1.4-no-mesh
     agent: kubernetes
     context: pull-knative-serving-istio-1.4-no-mesh
@@ -840,11 +391,6 @@ presubmits:
     optional: true
     path_alias: knative.dev/serving
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -870,48 +416,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-serving-istio-1.4-no-mesh
-    agent: kubernetes
-    context: pull-knative-serving-istio-1.4-no-mesh
-    always_run: false
-    rerun_command: "/test pull-knative-serving-istio-1.4-no-mesh"
-    trigger: "(?m)^/test (all|pull-knative-serving-istio-1.4-no-mesh),?(\\s+|$)"
-    decorate: true
-    optional: true
-    path_alias: knative.dev/serving
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.4-latest --no-mesh"
-        - "--run-test"
-        - "./test/e2e-auto-tls-tests.sh --istio-version 1.4-latest --no-mesh"
-        volumeMounts:
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
-      volumes:
-      - name: test-account
-        secret:
-          secretName: test-account
   - name: pull-knative-serving-gloo-0.17.1
     agent: kubernetes
     context: pull-knative-serving-gloo-0.17.1
@@ -922,11 +426,6 @@ presubmits:
     optional: true
     path_alias: knative.dev/serving
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -952,48 +451,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-serving-gloo-0.17.1
-    agent: kubernetes
-    context: pull-knative-serving-gloo-0.17.1
-    always_run: false
-    rerun_command: "/test pull-knative-serving-gloo-0.17.1"
-    trigger: "(?m)^/test (all|pull-knative-serving-gloo-0.17.1),?(\\s+|$)"
-    decorate: true
-    optional: true
-    path_alias: knative.dev/serving
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--run-test"
-        - "./test/e2e-tests.sh --gloo-version 0.17.1"
-        - "--run-test"
-        - "./test/e2e-auto-tls-tests.sh --gloo-version 0.17.1"
-        volumeMounts:
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
-      volumes:
-      - name: test-account
-        secret:
-          secretName: test-account
   - name: pull-knative-serving-kourier-stable
     agent: kubernetes
     context: pull-knative-serving-kourier-stable
@@ -1004,11 +461,6 @@ presubmits:
     optional: true
     path_alias: knative.dev/serving
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1034,48 +486,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-serving-kourier-stable
-    agent: kubernetes
-    context: pull-knative-serving-kourier-stable
-    always_run: false
-    rerun_command: "/test pull-knative-serving-kourier-stable"
-    trigger: "(?m)^/test (all|pull-knative-serving-kourier-stable),?(\\s+|$)"
-    decorate: true
-    optional: true
-    path_alias: knative.dev/serving
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--run-test"
-        - "./test/e2e-tests.sh --kourier-version stable"
-        - "--run-test"
-        - "./test/e2e-auto-tls-tests.sh --kourier-version stable"
-        volumeMounts:
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
-      volumes:
-      - name: test-account
-        secret:
-          secretName: test-account
   - name: pull-knative-serving-contour-latest
     agent: kubernetes
     context: pull-knative-serving-contour-latest
@@ -1086,11 +496,6 @@ presubmits:
     optional: true
     path_alias: knative.dev/serving
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1116,48 +521,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-serving-contour-latest
-    agent: kubernetes
-    context: pull-knative-serving-contour-latest
-    always_run: false
-    rerun_command: "/test pull-knative-serving-contour-latest"
-    trigger: "(?m)^/test (all|pull-knative-serving-contour-latest),?(\\s+|$)"
-    decorate: true
-    optional: true
-    path_alias: knative.dev/serving
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--run-test"
-        - "./test/e2e-tests.sh --contour-version latest"
-        - "--run-test"
-        - "./test/e2e-auto-tls-tests.sh --contour-version latest"
-        volumeMounts:
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
-      volumes:
-      - name: test-account
-        secret:
-          secretName: test-account
   - name: pull-knative-serving-ambassador-latest
     agent: kubernetes
     context: pull-knative-serving-ambassador-latest
@@ -1168,11 +531,6 @@ presubmits:
     optional: true
     path_alias: knative.dev/serving
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1198,48 +556,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-serving-ambassador-latest
-    agent: kubernetes
-    context: pull-knative-serving-ambassador-latest
-    always_run: false
-    rerun_command: "/test pull-knative-serving-ambassador-latest"
-    trigger: "(?m)^/test (all|pull-knative-serving-ambassador-latest),?(\\s+|$)"
-    decorate: true
-    optional: true
-    path_alias: knative.dev/serving
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--run-test"
-        - "./test/e2e-tests.sh --ambassador-version latest"
-        - "--run-test"
-        - "./test/e2e-auto-tls-tests.sh --ambassador-version latest"
-        volumeMounts:
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
-      volumes:
-      - name: test-account
-        secret:
-          secretName: test-account
   - name: pull-knative-serving-https
     agent: kubernetes
     context: pull-knative-serving-https
@@ -1250,11 +566,6 @@ presubmits:
     optional: true
     path_alias: knative.dev/serving
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1276,48 +587,6 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-central1
-      volumes:
-      - name: test-account
-        secret:
-          secretName: test-account
-  - name: pull-knative-serving-https
-    agent: kubernetes
-    context: pull-knative-serving-https
-    always_run: false
-    rerun_command: "/test pull-knative-serving-https"
-    trigger: "(?m)^/test (all|pull-knative-serving-https),?(\\s+|$)"
-    decorate: true
-    optional: true
-    path_alias: knative.dev/serving
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--run-test"
-        - "./test/e2e-tests.sh --https"
-        - "--run-test"
-        - "./test/e2e-auto-tls-tests.sh --https"
-        volumeMounts:
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
       volumes:
       - name: test-account
         secret:
@@ -1332,11 +601,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/client
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1365,50 +629,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-client-build-tests
-    agent: kubernetes
-    context: pull-knative-client-build-tests
-    always_run: true
-    rerun_command: "/test pull-knative-client-build-tests"
-    trigger: "(?m)^/test (all|pull-knative-client-build-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/client
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--build-tests"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: test-account
-        secret:
-          secretName: test-account
   - name: pull-knative-client-unit-tests
     agent: kubernetes
     context: pull-knative-client-unit-tests
@@ -1418,11 +638,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/client
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1451,50 +666,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-client-unit-tests
-    agent: kubernetes
-    context: pull-knative-client-unit-tests
-    always_run: true
-    rerun_command: "/test pull-knative-client-unit-tests"
-    trigger: "(?m)^/test (all|pull-knative-client-unit-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/client
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--unit-tests"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: test-account
-        secret:
-          secretName: test-account
   - name: pull-knative-client-integration-tests
     agent: kubernetes
     context: pull-knative-client-integration-tests
@@ -1504,11 +675,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/client
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1537,50 +703,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-client-integration-tests
-    agent: kubernetes
-    context: pull-knative-client-integration-tests
-    always_run: true
-    rerun_command: "/test pull-knative-client-integration-tests"
-    trigger: "(?m)^/test (all|pull-knative-client-integration-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/client
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--integration-tests"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: test-account
-        secret:
-          secretName: test-account
   - name: pull-knative-client-go-coverage
     agent: kubernetes
     context: pull-knative-client-go-coverage
@@ -1591,11 +713,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/client
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1616,44 +733,6 @@ presubmits:
       - name: covbot-token
         secret:
           secretName: covbot-token
-  - name: pull-knative-client-go-coverage
-    agent: kubernetes
-    context: pull-knative-client-go-coverage
-    always_run: true
-    rerun_command: "/test pull-knative-client-go-coverage"
-    trigger: "(?m)^/test (all|pull-knative-client-go-coverage),?(\\s+|$)"
-    optional: true
-    decorate: true
-    path_alias: knative.dev/client
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "coverage"
-        - "--postsubmit-job-name=post-knative-client-go-coverage"
-        - "--artifacts=$(ARTIFACTS)"
-        - "--cov-threshold-percentage=50"
-        - "--github-token=/etc/covbot-token/token"
-        volumeMounts:
-        - name: covbot-token
-          mountPath: /etc/covbot-token
-          readOnly: true
-        env:
-        - name: GO_VERSION
-          value: go1.14
-      volumes:
-      - name: covbot-token
-        secret:
-          secretName: covbot-token
   - name: pull-knative-client-integration-tests-latest-release
     agent: kubernetes
     context: pull-knative-client-integration-tests-latest-release
@@ -1663,11 +742,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/client
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1685,43 +759,6 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-central1
-      volumes:
-      - name: test-account
-        secret:
-          secretName: test-account
-  - name: pull-knative-client-integration-tests-latest-release
-    agent: kubernetes
-    context: pull-knative-client-integration-tests-latest-release
-    always_run: true
-    rerun_command: "/test pull-knative-client-integration-tests-latest-release"
-    trigger: "(?m)^/test (all|pull-knative-client-integration-tests-latest-release),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/client
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-integration-tests-latest-release.sh"
-        volumeMounts:
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
       volumes:
       - name: test-account
         secret:
@@ -1848,11 +885,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/eventing
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1886,55 +918,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-eventing-build-tests
-    agent: kubernetes
-    context: pull-knative-eventing-build-tests
-    always_run: true
-    rerun_command: "/test pull-knative-eventing-build-tests"
-    trigger: "(?m)^/test (all|pull-knative-eventing-build-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/eventing
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--build-tests"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
-        resources:
-          requests:
-            memory: 12Gi
-          limits:
-            memory: 16Gi
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: test-account
-        secret:
-          secretName: test-account
   - name: pull-knative-eventing-unit-tests
     agent: kubernetes
     context: pull-knative-eventing-unit-tests
@@ -1944,11 +927,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/eventing
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -1977,50 +955,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-eventing-unit-tests
-    agent: kubernetes
-    context: pull-knative-eventing-unit-tests
-    always_run: true
-    rerun_command: "/test pull-knative-eventing-unit-tests"
-    trigger: "(?m)^/test (all|pull-knative-eventing-unit-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/eventing
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--unit-tests"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: test-account
-        secret:
-          secretName: test-account
   - name: pull-knative-eventing-integration-tests
     agent: kubernetes
     context: pull-knative-eventing-integration-tests
@@ -2030,11 +964,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/eventing
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -2063,50 +992,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-eventing-integration-tests
-    agent: kubernetes
-    context: pull-knative-eventing-integration-tests
-    always_run: true
-    rerun_command: "/test pull-knative-eventing-integration-tests"
-    trigger: "(?m)^/test (all|pull-knative-eventing-integration-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/eventing
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--integration-tests"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: test-account
-        secret:
-          secretName: test-account
   - name: pull-knative-eventing-go-coverage
     agent: kubernetes
     context: pull-knative-eventing-go-coverage
@@ -2117,11 +1002,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/eventing
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -2138,44 +1018,6 @@ presubmits:
         - name: covbot-token
           mountPath: /etc/covbot-token
           readOnly: true
-      volumes:
-      - name: covbot-token
-        secret:
-          secretName: covbot-token
-  - name: pull-knative-eventing-go-coverage
-    agent: kubernetes
-    context: pull-knative-eventing-go-coverage
-    always_run: true
-    rerun_command: "/test pull-knative-eventing-go-coverage"
-    trigger: "(?m)^/test (all|pull-knative-eventing-go-coverage),?(\\s+|$)"
-    optional: true
-    decorate: true
-    path_alias: knative.dev/eventing
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "coverage"
-        - "--postsubmit-job-name=post-knative-eventing-go-coverage"
-        - "--artifacts=$(ARTIFACTS)"
-        - "--cov-threshold-percentage=50"
-        - "--github-token=/etc/covbot-token/token"
-        volumeMounts:
-        - name: covbot-token
-          mountPath: /etc/covbot-token
-          readOnly: true
-        env:
-        - name: GO_VERSION
-          value: go1.14
       volumes:
       - name: covbot-token
         secret:
@@ -2190,11 +1032,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/eventing-contrib
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -2228,55 +1065,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-eventing-contrib-build-tests
-    agent: kubernetes
-    context: pull-knative-eventing-contrib-build-tests
-    always_run: true
-    rerun_command: "/test pull-knative-eventing-contrib-build-tests"
-    trigger: "(?m)^/test (all|pull-knative-eventing-contrib-build-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/eventing-contrib
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--build-tests"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
-        resources:
-          requests:
-            memory: 12Gi
-          limits:
-            memory: 16Gi
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: test-account
-        secret:
-          secretName: test-account
   - name: pull-knative-eventing-contrib-unit-tests
     agent: kubernetes
     context: pull-knative-eventing-contrib-unit-tests
@@ -2286,11 +1074,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/eventing-contrib
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -2319,50 +1102,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-eventing-contrib-unit-tests
-    agent: kubernetes
-    context: pull-knative-eventing-contrib-unit-tests
-    always_run: true
-    rerun_command: "/test pull-knative-eventing-contrib-unit-tests"
-    trigger: "(?m)^/test (all|pull-knative-eventing-contrib-unit-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/eventing-contrib
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--unit-tests"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: test-account
-        secret:
-          secretName: test-account
   - name: pull-knative-eventing-contrib-integration-tests
     agent: kubernetes
     context: pull-knative-eventing-contrib-integration-tests
@@ -2372,11 +1111,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/eventing-contrib
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -2405,50 +1139,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-eventing-contrib-integration-tests
-    agent: kubernetes
-    context: pull-knative-eventing-contrib-integration-tests
-    always_run: true
-    rerun_command: "/test pull-knative-eventing-contrib-integration-tests"
-    trigger: "(?m)^/test (all|pull-knative-eventing-contrib-integration-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/eventing-contrib
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--integration-tests"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: test-account
-        secret:
-          secretName: test-account
   - name: pull-knative-eventing-contrib-go-coverage
     agent: kubernetes
     context: pull-knative-eventing-contrib-go-coverage
@@ -2459,11 +1149,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/eventing-contrib
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -2480,44 +1165,6 @@ presubmits:
         - name: covbot-token
           mountPath: /etc/covbot-token
           readOnly: true
-      volumes:
-      - name: covbot-token
-        secret:
-          secretName: covbot-token
-  - name: pull-knative-eventing-contrib-go-coverage
-    agent: kubernetes
-    context: pull-knative-eventing-contrib-go-coverage
-    always_run: true
-    rerun_command: "/test pull-knative-eventing-contrib-go-coverage"
-    trigger: "(?m)^/test (all|pull-knative-eventing-contrib-go-coverage),?(\\s+|$)"
-    optional: true
-    decorate: true
-    path_alias: knative.dev/eventing-contrib
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "coverage"
-        - "--postsubmit-job-name=post-knative-eventing-contrib-go-coverage"
-        - "--artifacts=$(ARTIFACTS)"
-        - "--cov-threshold-percentage=50"
-        - "--github-token=/etc/covbot-token/token"
-        volumeMounts:
-        - name: covbot-token
-          mountPath: /etc/covbot-token
-          readOnly: true
-        env:
-        - name: GO_VERSION
-          value: go1.14
       volumes:
       - name: covbot-token
         secret:
@@ -2708,11 +1355,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/pkg
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -2741,50 +1383,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-pkg-build-tests
-    agent: kubernetes
-    context: pull-knative-pkg-build-tests
-    always_run: true
-    rerun_command: "/test pull-knative-pkg-build-tests"
-    trigger: "(?m)^/test (all|pull-knative-pkg-build-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/pkg
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--build-tests"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: test-account
-        secret:
-          secretName: test-account
   - name: pull-knative-pkg-unit-tests
     agent: kubernetes
     context: pull-knative-pkg-unit-tests
@@ -2794,11 +1392,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/pkg
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -2827,50 +1420,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-pkg-unit-tests
-    agent: kubernetes
-    context: pull-knative-pkg-unit-tests
-    always_run: true
-    rerun_command: "/test pull-knative-pkg-unit-tests"
-    trigger: "(?m)^/test (all|pull-knative-pkg-unit-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/pkg
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--unit-tests"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: test-account
-        secret:
-          secretName: test-account
   - name: pull-knative-pkg-integration-tests
     agent: kubernetes
     context: pull-knative-pkg-integration-tests
@@ -2880,11 +1429,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/pkg
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -2913,50 +1457,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-pkg-integration-tests
-    agent: kubernetes
-    context: pull-knative-pkg-integration-tests
-    always_run: true
-    rerun_command: "/test pull-knative-pkg-integration-tests"
-    trigger: "(?m)^/test (all|pull-knative-pkg-integration-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/pkg
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--integration-tests"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: test-account
-        secret:
-          secretName: test-account
   - name: pull-knative-pkg-go-coverage
     agent: kubernetes
     context: pull-knative-pkg-go-coverage
@@ -2967,11 +1467,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/pkg
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -2988,44 +1483,6 @@ presubmits:
         - name: covbot-token
           mountPath: /etc/covbot-token
           readOnly: true
-      volumes:
-      - name: covbot-token
-        secret:
-          secretName: covbot-token
-  - name: pull-knative-pkg-go-coverage
-    agent: kubernetes
-    context: pull-knative-pkg-go-coverage
-    always_run: true
-    rerun_command: "/test pull-knative-pkg-go-coverage"
-    trigger: "(?m)^/test (all|pull-knative-pkg-go-coverage),?(\\s+|$)"
-    optional: true
-    decorate: true
-    path_alias: knative.dev/pkg
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "coverage"
-        - "--postsubmit-job-name=post-knative-pkg-go-coverage"
-        - "--artifacts=$(ARTIFACTS)"
-        - "--cov-threshold-percentage=50"
-        - "--github-token=/etc/covbot-token/token"
-        volumeMounts:
-        - name: covbot-token
-          mountPath: /etc/covbot-token
-          readOnly: true
-        env:
-        - name: GO_VERSION
-          value: go1.14
       volumes:
       - name: covbot-token
         secret:
@@ -3040,11 +1497,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/test-infra
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -3073,50 +1525,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-test-infra-build-tests
-    agent: kubernetes
-    context: pull-knative-test-infra-build-tests
-    always_run: true
-    rerun_command: "/test pull-knative-test-infra-build-tests"
-    trigger: "(?m)^/test (all|pull-knative-test-infra-build-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/test-infra
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--build-tests"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: test-account
-        secret:
-          secretName: test-account
   - name: pull-knative-test-infra-unit-tests
     agent: kubernetes
     context: pull-knative-test-infra-unit-tests
@@ -3126,11 +1534,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/test-infra
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -3159,50 +1562,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-test-infra-unit-tests
-    agent: kubernetes
-    context: pull-knative-test-infra-unit-tests
-    always_run: true
-    rerun_command: "/test pull-knative-test-infra-unit-tests"
-    trigger: "(?m)^/test (all|pull-knative-test-infra-unit-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/test-infra
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--unit-tests"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: test-account
-        secret:
-          secretName: test-account
   - name: pull-knative-test-infra-integration-tests
     agent: kubernetes
     context: pull-knative-test-infra-integration-tests
@@ -3212,11 +1571,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/test-infra
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -3245,50 +1599,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-test-infra-integration-tests
-    agent: kubernetes
-    context: pull-knative-test-infra-integration-tests
-    always_run: true
-    rerun_command: "/test pull-knative-test-infra-integration-tests"
-    trigger: "(?m)^/test (all|pull-knative-test-infra-integration-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/test-infra
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--integration-tests"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: test-account
-        secret:
-          secretName: test-account
   - name: pull-knative-test-infra-go-coverage
     agent: kubernetes
     context: pull-knative-test-infra-go-coverage
@@ -3299,11 +1609,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/test-infra
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -3320,44 +1625,6 @@ presubmits:
         - name: covbot-token
           mountPath: /etc/covbot-token
           readOnly: true
-      volumes:
-      - name: covbot-token
-        secret:
-          secretName: covbot-token
-  - name: pull-knative-test-infra-go-coverage
-    agent: kubernetes
-    context: pull-knative-test-infra-go-coverage
-    always_run: true
-    rerun_command: "/test pull-knative-test-infra-go-coverage"
-    trigger: "(?m)^/test (all|pull-knative-test-infra-go-coverage),?(\\s+|$)"
-    optional: true
-    decorate: true
-    path_alias: knative.dev/test-infra
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "coverage"
-        - "--postsubmit-job-name=post-knative-test-infra-go-coverage"
-        - "--artifacts=$(ARTIFACTS)"
-        - "--cov-threshold-percentage=50"
-        - "--github-token=/etc/covbot-token/token"
-        volumeMounts:
-        - name: covbot-token
-          mountPath: /etc/covbot-token
-          readOnly: true
-        env:
-        - name: GO_VERSION
-          value: go1.14
       volumes:
       - name: covbot-token
         secret:
@@ -3663,11 +1930,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-google-knative-gcp-build-tests),?(\\s+|$)"
     decorate: true
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -3701,54 +1963,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-google-knative-gcp-build-tests
-    agent: kubernetes
-    context: pull-google-knative-gcp-build-tests
-    always_run: true
-    rerun_command: "/test pull-google-knative-gcp-build-tests"
-    trigger: "(?m)^/test (all|pull-google-knative-gcp-build-tests),?(\\s+|$)"
-    decorate: true
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--build-tests"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
-        resources:
-          requests:
-            memory: 12Gi
-          limits:
-            memory: 16Gi
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: test-account
-        secret:
-          secretName: test-account
   - name: pull-google-knative-gcp-unit-tests
     agent: kubernetes
     context: pull-google-knative-gcp-unit-tests
@@ -3757,11 +1971,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-google-knative-gcp-unit-tests),?(\\s+|$)"
     decorate: true
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -3771,95 +1980,6 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--unit-tests"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: test-account
-        secret:
-          secretName: test-account
-  - name: pull-google-knative-gcp-unit-tests
-    agent: kubernetes
-    context: pull-google-knative-gcp-unit-tests
-    always_run: true
-    rerun_command: "/test pull-google-knative-gcp-unit-tests"
-    trigger: "(?m)^/test (all|pull-google-knative-gcp-unit-tests),?(\\s+|$)"
-    decorate: true
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--unit-tests"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: test-account
-        secret:
-          secretName: test-account
-  - name: pull-google-knative-gcp-integration-tests
-    agent: kubernetes
-    labels:
-      prow.k8s.io/pubsub.project: knative-tests
-      prow.k8s.io/pubsub.topic: knative-monitoring
-      prow.k8s.io/pubsub.runID: pull-google-knative-gcp-integration-tests
-    context: pull-google-knative-gcp-integration-tests
-    always_run: true
-    rerun_command: "/test pull-google-knative-gcp-integration-tests"
-    trigger: "(?m)^/test (all|pull-google-knative-gcp-integration-tests),?(\\s+|$)"
-    decorate: true
-    cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--run-test"
-        - "./test/e2e-tests.sh"
         volumeMounts:
         - name: repoview-token
           mountPath: /etc/repoview-token
@@ -3891,11 +2011,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-google-knative-gcp-integration-tests),?(\\s+|$)"
     decorate: true
     cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -3918,8 +2033,6 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-central1
-        - name: GO_VERSION
-          value: go1.14
       volumes:
       - name: repoview-token
         secret:
@@ -3939,11 +2052,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-google-knative-gcp-wi-tests),?(\\s+|$)"
     decorate: true
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -3967,48 +2075,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-google-knative-gcp-wi-tests
-    agent: kubernetes
-    labels:
-      prow.k8s.io/pubsub.project: knative-tests
-      prow.k8s.io/pubsub.topic: knative-monitoring
-      prow.k8s.io/pubsub.runID: pull-google-knative-gcp-wi-tests
-    context: pull-google-knative-gcp-wi-tests
-    always_run: true
-    rerun_command: "/test pull-google-knative-gcp-wi-tests"
-    trigger: "(?m)^/test (all|pull-google-knative-gcp-wi-tests),?(\\s+|$)"
-    decorate: true
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--run-test"
-        - "./test/e2e-wi-tests.sh"
-        volumeMounts:
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
-      volumes:
-      - name: test-account
-        secret:
-          secretName: test-account
   - name: pull-google-knative-gcp-go-coverage
     agent: kubernetes
     context: pull-google-knative-gcp-go-coverage
@@ -4018,11 +2084,6 @@ presubmits:
     optional: true
     decorate: true
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -4039,43 +2100,6 @@ presubmits:
         - name: covbot-token
           mountPath: /etc/covbot-token
           readOnly: true
-      volumes:
-      - name: covbot-token
-        secret:
-          secretName: covbot-token
-  - name: pull-google-knative-gcp-go-coverage
-    agent: kubernetes
-    context: pull-google-knative-gcp-go-coverage
-    always_run: true
-    rerun_command: "/test pull-google-knative-gcp-go-coverage"
-    trigger: "(?m)^/test (all|pull-google-knative-gcp-go-coverage),?(\\s+|$)"
-    optional: true
-    decorate: true
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "coverage"
-        - "--postsubmit-job-name=post-google-knative-gcp-go-coverage"
-        - "--artifacts=$(ARTIFACTS)"
-        - "--cov-threshold-percentage=50"
-        - "--github-token=/etc/covbot-token/token"
-        volumeMounts:
-        - name: covbot-token
-          mountPath: /etc/covbot-token
-          readOnly: true
-        env:
-        - name: GO_VERSION
-          value: go1.14
       volumes:
       - name: covbot-token
         secret:
@@ -4090,11 +2114,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/net-certmanager
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -4123,50 +2142,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-net-certmanager-build-tests
-    agent: kubernetes
-    context: pull-knative-net-certmanager-build-tests
-    always_run: true
-    rerun_command: "/test pull-knative-net-certmanager-build-tests"
-    trigger: "(?m)^/test (all|pull-knative-net-certmanager-build-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/net-certmanager
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--build-tests"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: test-account
-        secret:
-          secretName: test-account
   - name: pull-knative-net-certmanager-unit-tests
     agent: kubernetes
     context: pull-knative-net-certmanager-unit-tests
@@ -4176,11 +2151,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/net-certmanager
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -4209,50 +2179,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-net-certmanager-unit-tests
-    agent: kubernetes
-    context: pull-knative-net-certmanager-unit-tests
-    always_run: true
-    rerun_command: "/test pull-knative-net-certmanager-unit-tests"
-    trigger: "(?m)^/test (all|pull-knative-net-certmanager-unit-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/net-certmanager
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--unit-tests"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: test-account
-        secret:
-          secretName: test-account
   - name: pull-knative-net-certmanager-integration-tests
     agent: kubernetes
     context: pull-knative-net-certmanager-integration-tests
@@ -4262,11 +2188,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/net-certmanager
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -4295,50 +2216,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-net-certmanager-integration-tests
-    agent: kubernetes
-    context: pull-knative-net-certmanager-integration-tests
-    always_run: true
-    rerun_command: "/test pull-knative-net-certmanager-integration-tests"
-    trigger: "(?m)^/test (all|pull-knative-net-certmanager-integration-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/net-certmanager
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--integration-tests"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: test-account
-        secret:
-          secretName: test-account
   - name: pull-knative-net-certmanager-go-coverage
     agent: kubernetes
     context: pull-knative-net-certmanager-go-coverage
@@ -4349,11 +2226,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/net-certmanager
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -4370,44 +2242,6 @@ presubmits:
         - name: covbot-token
           mountPath: /etc/covbot-token
           readOnly: true
-      volumes:
-      - name: covbot-token
-        secret:
-          secretName: covbot-token
-  - name: pull-knative-net-certmanager-go-coverage
-    agent: kubernetes
-    context: pull-knative-net-certmanager-go-coverage
-    always_run: true
-    rerun_command: "/test pull-knative-net-certmanager-go-coverage"
-    trigger: "(?m)^/test (all|pull-knative-net-certmanager-go-coverage),?(\\s+|$)"
-    optional: true
-    decorate: true
-    path_alias: knative.dev/net-certmanager
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "coverage"
-        - "--postsubmit-job-name=post-knative-net-certmanager-go-coverage"
-        - "--artifacts=$(ARTIFACTS)"
-        - "--cov-threshold-percentage=50"
-        - "--github-token=/etc/covbot-token/token"
-        volumeMounts:
-        - name: covbot-token
-          mountPath: /etc/covbot-token
-          readOnly: true
-        env:
-        - name: GO_VERSION
-          value: go1.14
       volumes:
       - name: covbot-token
         secret:
@@ -4422,11 +2256,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/net-contour
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -4455,50 +2284,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-net-contour-build-tests
-    agent: kubernetes
-    context: pull-knative-net-contour-build-tests
-    always_run: true
-    rerun_command: "/test pull-knative-net-contour-build-tests"
-    trigger: "(?m)^/test (all|pull-knative-net-contour-build-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/net-contour
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--build-tests"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: test-account
-        secret:
-          secretName: test-account
   - name: pull-knative-net-contour-unit-tests
     agent: kubernetes
     context: pull-knative-net-contour-unit-tests
@@ -4508,11 +2293,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/net-contour
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -4541,50 +2321,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-net-contour-unit-tests
-    agent: kubernetes
-    context: pull-knative-net-contour-unit-tests
-    always_run: true
-    rerun_command: "/test pull-knative-net-contour-unit-tests"
-    trigger: "(?m)^/test (all|pull-knative-net-contour-unit-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/net-contour
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--unit-tests"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: test-account
-        secret:
-          secretName: test-account
   - name: pull-knative-net-contour-integration-tests
     agent: kubernetes
     context: pull-knative-net-contour-integration-tests
@@ -4594,11 +2330,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/net-contour
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -4627,50 +2358,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-net-contour-integration-tests
-    agent: kubernetes
-    context: pull-knative-net-contour-integration-tests
-    always_run: true
-    rerun_command: "/test pull-knative-net-contour-integration-tests"
-    trigger: "(?m)^/test (all|pull-knative-net-contour-integration-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/net-contour
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--integration-tests"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: test-account
-        secret:
-          secretName: test-account
   - name: pull-knative-net-contour-go-coverage
     agent: kubernetes
     context: pull-knative-net-contour-go-coverage
@@ -4681,11 +2368,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/net-contour
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -4702,44 +2384,6 @@ presubmits:
         - name: covbot-token
           mountPath: /etc/covbot-token
           readOnly: true
-      volumes:
-      - name: covbot-token
-        secret:
-          secretName: covbot-token
-  - name: pull-knative-net-contour-go-coverage
-    agent: kubernetes
-    context: pull-knative-net-contour-go-coverage
-    always_run: true
-    rerun_command: "/test pull-knative-net-contour-go-coverage"
-    trigger: "(?m)^/test (all|pull-knative-net-contour-go-coverage),?(\\s+|$)"
-    optional: true
-    decorate: true
-    path_alias: knative.dev/net-contour
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "coverage"
-        - "--postsubmit-job-name=post-knative-net-contour-go-coverage"
-        - "--artifacts=$(ARTIFACTS)"
-        - "--cov-threshold-percentage=50"
-        - "--github-token=/etc/covbot-token/token"
-        volumeMounts:
-        - name: covbot-token
-          mountPath: /etc/covbot-token
-          readOnly: true
-        env:
-        - name: GO_VERSION
-          value: go1.14
       volumes:
       - name: covbot-token
         secret:
@@ -4754,11 +2398,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/net-http01
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -4787,50 +2426,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-net-http01-build-tests
-    agent: kubernetes
-    context: pull-knative-net-http01-build-tests
-    always_run: true
-    rerun_command: "/test pull-knative-net-http01-build-tests"
-    trigger: "(?m)^/test (all|pull-knative-net-http01-build-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/net-http01
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--build-tests"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: test-account
-        secret:
-          secretName: test-account
   - name: pull-knative-net-http01-unit-tests
     agent: kubernetes
     context: pull-knative-net-http01-unit-tests
@@ -4840,11 +2435,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/net-http01
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -4873,50 +2463,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-net-http01-unit-tests
-    agent: kubernetes
-    context: pull-knative-net-http01-unit-tests
-    always_run: true
-    rerun_command: "/test pull-knative-net-http01-unit-tests"
-    trigger: "(?m)^/test (all|pull-knative-net-http01-unit-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/net-http01
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--unit-tests"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: test-account
-        secret:
-          secretName: test-account
   - name: pull-knative-net-http01-integration-tests
     agent: kubernetes
     context: pull-knative-net-http01-integration-tests
@@ -4926,11 +2472,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/net-http01
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -4959,50 +2500,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-net-http01-integration-tests
-    agent: kubernetes
-    context: pull-knative-net-http01-integration-tests
-    always_run: true
-    rerun_command: "/test pull-knative-net-http01-integration-tests"
-    trigger: "(?m)^/test (all|pull-knative-net-http01-integration-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/net-http01
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--integration-tests"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: test-account
-        secret:
-          secretName: test-account
   - name: pull-knative-net-http01-go-coverage
     agent: kubernetes
     context: pull-knative-net-http01-go-coverage
@@ -5013,11 +2510,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/net-http01
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -5034,44 +2526,6 @@ presubmits:
         - name: covbot-token
           mountPath: /etc/covbot-token
           readOnly: true
-      volumes:
-      - name: covbot-token
-        secret:
-          secretName: covbot-token
-  - name: pull-knative-net-http01-go-coverage
-    agent: kubernetes
-    context: pull-knative-net-http01-go-coverage
-    always_run: true
-    rerun_command: "/test pull-knative-net-http01-go-coverage"
-    trigger: "(?m)^/test (all|pull-knative-net-http01-go-coverage),?(\\s+|$)"
-    optional: true
-    decorate: true
-    path_alias: knative.dev/net-http01
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "coverage"
-        - "--postsubmit-job-name=post-knative-net-http01-go-coverage"
-        - "--artifacts=$(ARTIFACTS)"
-        - "--cov-threshold-percentage=50"
-        - "--github-token=/etc/covbot-token/token"
-        volumeMounts:
-        - name: covbot-token
-          mountPath: /etc/covbot-token
-          readOnly: true
-        env:
-        - name: GO_VERSION
-          value: go1.14
       volumes:
       - name: covbot-token
         secret:
@@ -5086,11 +2540,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/net-istio
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -5119,50 +2568,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-net-istio-build-tests
-    agent: kubernetes
-    context: pull-knative-net-istio-build-tests
-    always_run: true
-    rerun_command: "/test pull-knative-net-istio-build-tests"
-    trigger: "(?m)^/test (all|pull-knative-net-istio-build-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/net-istio
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--build-tests"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: test-account
-        secret:
-          secretName: test-account
   - name: pull-knative-net-istio-unit-tests
     agent: kubernetes
     context: pull-knative-net-istio-unit-tests
@@ -5172,11 +2577,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/net-istio
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -5205,50 +2605,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-net-istio-unit-tests
-    agent: kubernetes
-    context: pull-knative-net-istio-unit-tests
-    always_run: true
-    rerun_command: "/test pull-knative-net-istio-unit-tests"
-    trigger: "(?m)^/test (all|pull-knative-net-istio-unit-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/net-istio
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--unit-tests"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: test-account
-        secret:
-          secretName: test-account
   - name: pull-knative-net-istio-integration-tests
     agent: kubernetes
     context: pull-knative-net-istio-integration-tests
@@ -5258,11 +2614,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/net-istio
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -5291,50 +2642,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-net-istio-integration-tests
-    agent: kubernetes
-    context: pull-knative-net-istio-integration-tests
-    always_run: true
-    rerun_command: "/test pull-knative-net-istio-integration-tests"
-    trigger: "(?m)^/test (all|pull-knative-net-istio-integration-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/net-istio
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--integration-tests"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: test-account
-        secret:
-          secretName: test-account
   - name: pull-knative-net-istio-go-coverage
     agent: kubernetes
     context: pull-knative-net-istio-go-coverage
@@ -5345,11 +2652,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/net-istio
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -5370,44 +2672,6 @@ presubmits:
       - name: covbot-token
         secret:
           secretName: covbot-token
-  - name: pull-knative-net-istio-go-coverage
-    agent: kubernetes
-    context: pull-knative-net-istio-go-coverage
-    always_run: true
-    rerun_command: "/test pull-knative-net-istio-go-coverage"
-    trigger: "(?m)^/test (all|pull-knative-net-istio-go-coverage),?(\\s+|$)"
-    optional: true
-    decorate: true
-    path_alias: knative.dev/net-istio
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "coverage"
-        - "--postsubmit-job-name=post-knative-net-istio-go-coverage"
-        - "--artifacts=$(ARTIFACTS)"
-        - "--cov-threshold-percentage=50"
-        - "--github-token=/etc/covbot-token/token"
-        volumeMounts:
-        - name: covbot-token
-          mountPath: /etc/covbot-token
-          readOnly: true
-        env:
-        - name: GO_VERSION
-          value: go1.14
-      volumes:
-      - name: covbot-token
-        secret:
-          secretName: covbot-token
   - name: pull-knative-net-istio-latest
     agent: kubernetes
     context: pull-knative-net-istio-latest
@@ -5418,11 +2682,6 @@ presubmits:
     optional: true
     path_alias: knative.dev/net-istio
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -5442,46 +2701,6 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-central1
-      volumes:
-      - name: test-account
-        secret:
-          secretName: test-account
-  - name: pull-knative-net-istio-latest
-    agent: kubernetes
-    context: pull-knative-net-istio-latest
-    always_run: true
-    rerun_command: "/test pull-knative-net-istio-latest"
-    trigger: "(?m)^/test (all|pull-knative-net-istio-latest),?(\\s+|$)"
-    decorate: true
-    optional: true
-    path_alias: knative.dev/net-istio
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--run-test"
-        - "./test/e2e-tests.sh --istio-version latest"
-        volumeMounts:
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
       volumes:
       - name: test-account
         secret:
@@ -5496,11 +2715,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/net-kourier
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -5529,50 +2743,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-net-kourier-build-tests
-    agent: kubernetes
-    context: pull-knative-net-kourier-build-tests
-    always_run: true
-    rerun_command: "/test pull-knative-net-kourier-build-tests"
-    trigger: "(?m)^/test (all|pull-knative-net-kourier-build-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/net-kourier
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--build-tests"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: test-account
-        secret:
-          secretName: test-account
   - name: pull-knative-net-kourier-unit-tests
     agent: kubernetes
     context: pull-knative-net-kourier-unit-tests
@@ -5582,11 +2752,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/net-kourier
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -5615,50 +2780,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-net-kourier-unit-tests
-    agent: kubernetes
-    context: pull-knative-net-kourier-unit-tests
-    always_run: true
-    rerun_command: "/test pull-knative-net-kourier-unit-tests"
-    trigger: "(?m)^/test (all|pull-knative-net-kourier-unit-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/net-kourier
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--unit-tests"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: test-account
-        secret:
-          secretName: test-account
   - name: pull-knative-net-kourier-integration-tests
     agent: kubernetes
     context: pull-knative-net-kourier-integration-tests
@@ -5668,11 +2789,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/net-kourier
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -5701,50 +2817,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-net-kourier-integration-tests
-    agent: kubernetes
-    context: pull-knative-net-kourier-integration-tests
-    always_run: true
-    rerun_command: "/test pull-knative-net-kourier-integration-tests"
-    trigger: "(?m)^/test (all|pull-knative-net-kourier-integration-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/net-kourier
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--integration-tests"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: test-account
-        secret:
-          secretName: test-account
   - name: pull-knative-net-kourier-go-coverage
     agent: kubernetes
     context: pull-knative-net-kourier-go-coverage
@@ -5755,11 +2827,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/net-kourier
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -5776,44 +2843,6 @@ presubmits:
         - name: covbot-token
           mountPath: /etc/covbot-token
           readOnly: true
-      volumes:
-      - name: covbot-token
-        secret:
-          secretName: covbot-token
-  - name: pull-knative-net-kourier-go-coverage
-    agent: kubernetes
-    context: pull-knative-net-kourier-go-coverage
-    always_run: true
-    rerun_command: "/test pull-knative-net-kourier-go-coverage"
-    trigger: "(?m)^/test (all|pull-knative-net-kourier-go-coverage),?(\\s+|$)"
-    optional: true
-    decorate: true
-    path_alias: knative.dev/net-kourier
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "coverage"
-        - "--postsubmit-job-name=post-knative-net-kourier-go-coverage"
-        - "--artifacts=$(ARTIFACTS)"
-        - "--cov-threshold-percentage=50"
-        - "--github-token=/etc/covbot-token/token"
-        volumeMounts:
-        - name: covbot-token
-          mountPath: /etc/covbot-token
-          readOnly: true
-        env:
-        - name: GO_VERSION
-          value: go1.14
       volumes:
       - name: covbot-token
         secret:
@@ -5828,11 +2857,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/serving-operator
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -5861,50 +2885,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-serving-operator-build-tests
-    agent: kubernetes
-    context: pull-knative-serving-operator-build-tests
-    always_run: true
-    rerun_command: "/test pull-knative-serving-operator-build-tests"
-    trigger: "(?m)^/test (all|pull-knative-serving-operator-build-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/serving-operator
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--build-tests"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: test-account
-        secret:
-          secretName: test-account
   - name: pull-knative-serving-operator-unit-tests
     agent: kubernetes
     context: pull-knative-serving-operator-unit-tests
@@ -5914,11 +2894,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/serving-operator
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -5947,50 +2922,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-serving-operator-unit-tests
-    agent: kubernetes
-    context: pull-knative-serving-operator-unit-tests
-    always_run: true
-    rerun_command: "/test pull-knative-serving-operator-unit-tests"
-    trigger: "(?m)^/test (all|pull-knative-serving-operator-unit-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/serving-operator
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--unit-tests"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: test-account
-        secret:
-          secretName: test-account
   - name: pull-knative-serving-operator-integration-tests
     agent: kubernetes
     context: pull-knative-serving-operator-integration-tests
@@ -6000,11 +2931,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/serving-operator
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -6033,50 +2959,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-serving-operator-integration-tests
-    agent: kubernetes
-    context: pull-knative-serving-operator-integration-tests
-    always_run: true
-    rerun_command: "/test pull-knative-serving-operator-integration-tests"
-    trigger: "(?m)^/test (all|pull-knative-serving-operator-integration-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/serving-operator
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--integration-tests"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: test-account
-        secret:
-          secretName: test-account
   - name: pull-knative-serving-operator-go-coverage
     agent: kubernetes
     context: pull-knative-serving-operator-go-coverage
@@ -6087,11 +2969,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/serving-operator
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -6112,44 +2989,6 @@ presubmits:
       - name: covbot-token
         secret:
           secretName: covbot-token
-  - name: pull-knative-serving-operator-go-coverage
-    agent: kubernetes
-    context: pull-knative-serving-operator-go-coverage
-    always_run: true
-    rerun_command: "/test pull-knative-serving-operator-go-coverage"
-    trigger: "(?m)^/test (all|pull-knative-serving-operator-go-coverage),?(\\s+|$)"
-    optional: true
-    decorate: true
-    path_alias: knative.dev/serving-operator
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "coverage"
-        - "--postsubmit-job-name=post-knative-serving-operator-go-coverage"
-        - "--artifacts=$(ARTIFACTS)"
-        - "--cov-threshold-percentage=50"
-        - "--github-token=/etc/covbot-token/token"
-        volumeMounts:
-        - name: covbot-token
-          mountPath: /etc/covbot-token
-          readOnly: true
-        env:
-        - name: GO_VERSION
-          value: go1.14
-      volumes:
-      - name: covbot-token
-        secret:
-          secretName: covbot-token
   - name: pull-knative-serving-operator-upgrade-tests
     agent: kubernetes
     context: pull-knative-serving-operator-upgrade-tests
@@ -6159,11 +2998,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/serving-operator
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -6183,45 +3017,6 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-central1
-      volumes:
-      - name: test-account
-        secret:
-          secretName: test-account
-  - name: pull-knative-serving-operator-upgrade-tests
-    agent: kubernetes
-    context: pull-knative-serving-operator-upgrade-tests
-    always_run: true
-    rerun_command: "/test pull-knative-serving-operator-upgrade-tests"
-    trigger: "(?m)^/test (all|pull-knative-serving-operator-upgrade-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/serving-operator
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--run-test"
-        - "./test/e2e-upgrade-tests.sh"
-        volumeMounts:
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
       volumes:
       - name: test-account
         secret:
@@ -6236,11 +3031,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/eventing-operator
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -6269,50 +3059,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-eventing-operator-build-tests
-    agent: kubernetes
-    context: pull-knative-eventing-operator-build-tests
-    always_run: true
-    rerun_command: "/test pull-knative-eventing-operator-build-tests"
-    trigger: "(?m)^/test (all|pull-knative-eventing-operator-build-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/eventing-operator
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--build-tests"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: test-account
-        secret:
-          secretName: test-account
   - name: pull-knative-eventing-operator-unit-tests
     agent: kubernetes
     context: pull-knative-eventing-operator-unit-tests
@@ -6322,11 +3068,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/eventing-operator
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -6355,50 +3096,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-eventing-operator-unit-tests
-    agent: kubernetes
-    context: pull-knative-eventing-operator-unit-tests
-    always_run: true
-    rerun_command: "/test pull-knative-eventing-operator-unit-tests"
-    trigger: "(?m)^/test (all|pull-knative-eventing-operator-unit-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/eventing-operator
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--unit-tests"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: test-account
-        secret:
-          secretName: test-account
   - name: pull-knative-eventing-operator-integration-tests
     agent: kubernetes
     context: pull-knative-eventing-operator-integration-tests
@@ -6408,11 +3105,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/eventing-operator
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -6441,50 +3133,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-eventing-operator-integration-tests
-    agent: kubernetes
-    context: pull-knative-eventing-operator-integration-tests
-    always_run: true
-    rerun_command: "/test pull-knative-eventing-operator-integration-tests"
-    trigger: "(?m)^/test (all|pull-knative-eventing-operator-integration-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/eventing-operator
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--integration-tests"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: test-account
-        secret:
-          secretName: test-account
   - name: pull-knative-eventing-operator-go-coverage
     agent: kubernetes
     context: pull-knative-eventing-operator-go-coverage
@@ -6495,11 +3143,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/eventing-operator
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -6520,44 +3163,6 @@ presubmits:
       - name: covbot-token
         secret:
           secretName: covbot-token
-  - name: pull-knative-eventing-operator-go-coverage
-    agent: kubernetes
-    context: pull-knative-eventing-operator-go-coverage
-    always_run: true
-    rerun_command: "/test pull-knative-eventing-operator-go-coverage"
-    trigger: "(?m)^/test (all|pull-knative-eventing-operator-go-coverage),?(\\s+|$)"
-    optional: true
-    decorate: true
-    path_alias: knative.dev/eventing-operator
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "coverage"
-        - "--postsubmit-job-name=post-knative-eventing-operator-go-coverage"
-        - "--artifacts=$(ARTIFACTS)"
-        - "--cov-threshold-percentage=50"
-        - "--github-token=/etc/covbot-token/token"
-        volumeMounts:
-        - name: covbot-token
-          mountPath: /etc/covbot-token
-          readOnly: true
-        env:
-        - name: GO_VERSION
-          value: go1.14
-      volumes:
-      - name: covbot-token
-        secret:
-          secretName: covbot-token
   - name: pull-knative-eventing-operator-upgrade-tests
     agent: kubernetes
     context: pull-knative-eventing-operator-upgrade-tests
@@ -6567,11 +3172,6 @@ presubmits:
     decorate: true
     path_alias: knative.dev/eventing-operator
     cluster: "build-knative"
-    branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -6591,45 +3191,6 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-central1
-      volumes:
-      - name: test-account
-        secret:
-          secretName: test-account
-  - name: pull-knative-eventing-operator-upgrade-tests
-    agent: kubernetes
-    context: pull-knative-eventing-operator-upgrade-tests
-    always_run: true
-    rerun_command: "/test pull-knative-eventing-operator-upgrade-tests"
-    trigger: "(?m)^/test (all|pull-knative-eventing-operator-upgrade-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/eventing-operator
-    cluster: "build-knative"
-    skip_branches:
-    - "release-0.11"
-    - "release-0.12"
-    - "release-0.13"
-    - "release-0.14"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--run-test"
-        - "./test/e2e-upgrade-tests.sh"
-        volumeMounts:
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        - name: GO_VERSION
-          value: go1.14
       volumes:
       - name: test-account
         secret:
@@ -7122,8 +3683,6 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -7165,8 +3724,6 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -7583,8 +4140,6 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -7620,8 +4175,6 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -7657,8 +4210,6 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -7694,8 +4245,6 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -7731,8 +4280,6 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -7768,8 +4315,6 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -7805,8 +4350,6 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -7842,8 +4385,6 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -7879,8 +4420,6 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -7918,8 +4457,6 @@ periodics:
         mountPath: /etc/nightly-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -8179,8 +4716,6 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -8222,8 +4757,6 @@ periodics:
       env:
       - name: SYSTEM_NAMESPACE
         value: knative-serving
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -8256,9 +4789,6 @@ periodics:
       - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=80"
-      env:
-      - name: GO_VERSION
-        value: go1.14
 - cron: "44 7 * * *"
   name: ci-knative-serving-go-coverage-beta-prow-tests
   labels:
@@ -8283,9 +4813,6 @@ periodics:
       - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=80"
-      env:
-      - name: GO_VERSION
-        value: go1.14
 - cron: "53 * * * *"
   name: ci-knative-client-continuous
   agent: kubernetes
@@ -8314,8 +4841,6 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -8352,8 +4877,6 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -8767,8 +5290,6 @@ periodics:
         mountPath: /etc/nightly-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -8800,8 +5321,6 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -9036,8 +5555,6 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -9073,9 +5590,6 @@ periodics:
       - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
-      env:
-      - name: GO_VERSION
-        value: go1.14
 - cron: "35 7 * * *"
   name: ci-knative-client-go-coverage-beta-prow-tests
   labels:
@@ -9100,9 +5614,6 @@ periodics:
       - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
-      env:
-      - name: GO_VERSION
-        value: go1.14
 - cron: "49 * * * *"
   name: ci-knative-client-contrib-continuous
   agent: kubernetes
@@ -9131,8 +5642,6 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -9169,8 +5678,6 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -9339,8 +5846,6 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -9382,8 +5887,6 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -9802,8 +6305,6 @@ periodics:
         mountPath: /etc/nightly-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -10063,8 +6564,6 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -10105,9 +6604,6 @@ periodics:
       - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
-      env:
-      - name: GO_VERSION
-        value: go1.14
 - cron: "56 7 * * *"
   name: ci-knative-eventing-go-coverage-beta-prow-tests
   labels:
@@ -10132,9 +6628,6 @@ periodics:
       - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
-      env:
-      - name: GO_VERSION
-        value: go1.14
 - cron: "36 * * * *"
   name: ci-knative-eventing-contrib-continuous
   agent: kubernetes
@@ -10163,8 +6656,6 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -10206,8 +6697,6 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -10626,8 +7115,6 @@ periodics:
         mountPath: /etc/nightly-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -10887,8 +7374,6 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -10929,9 +7414,6 @@ periodics:
       - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
-      env:
-      - name: GO_VERSION
-        value: go1.14
 - cron: "56 7 * * *"
   name: ci-knative-eventing-contrib-go-coverage-beta-prow-tests
   labels:
@@ -10956,9 +7438,6 @@ periodics:
       - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
-      env:
-      - name: GO_VERSION
-        value: go1.14
 - cron: "2 * * * *"
   name: ci-knative-pkg-continuous
   agent: kubernetes
@@ -10987,8 +7466,6 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -11025,8 +7502,6 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -11059,9 +7534,6 @@ periodics:
       - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
-      env:
-      - name: GO_VERSION
-        value: go1.14
 - cron: "38 7 * * *"
   name: ci-knative-pkg-go-coverage-beta-prow-tests
   labels:
@@ -11086,9 +7558,6 @@ periodics:
       - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
-      env:
-      - name: GO_VERSION
-        value: go1.14
 - cron: "47 * * * *"
   name: ci-knative-caching-continuous
   agent: kubernetes
@@ -11117,8 +7586,6 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -11155,8 +7622,6 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -11189,9 +7654,6 @@ periodics:
       - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
-      env:
-      - name: GO_VERSION
-        value: go1.14
 - cron: "45 7 * * *"
   name: ci-knative-caching-go-coverage-beta-prow-tests
   labels:
@@ -11216,9 +7678,6 @@ periodics:
       - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
-      env:
-      - name: GO_VERSION
-        value: go1.14
 - cron: "43 * * * *"
   name: ci-knative-sample-controller-continuous
   agent: kubernetes
@@ -11247,8 +7706,6 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -11285,8 +7742,6 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -11323,8 +7778,6 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -11361,8 +7814,6 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -11399,8 +7850,6 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -11437,8 +7886,6 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -11471,9 +7918,6 @@ periodics:
       - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
-      env:
-      - name: GO_VERSION
-        value: go1.14
 - cron: "43 7 * * *"
   name: ci-knative-test-infra-go-coverage-beta-prow-tests
   labels:
@@ -11498,9 +7942,6 @@ periodics:
       - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
-      env:
-      - name: GO_VERSION
-        value: go1.14
 - cron: "33 * * * *"
   name: ci-knative-serving-operator-continuous
   agent: kubernetes
@@ -11529,8 +7970,6 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -11567,8 +8006,6 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -11982,8 +8419,6 @@ periodics:
         mountPath: /etc/nightly-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -12218,8 +8653,6 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -12255,9 +8688,6 @@ periodics:
       - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
-      env:
-      - name: GO_VERSION
-        value: go1.14
 - cron: "31 7 * * *"
   name: ci-knative-serving-operator-go-coverage-beta-prow-tests
   labels:
@@ -12282,9 +8712,6 @@ periodics:
       - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
-      env:
-      - name: GO_VERSION
-        value: go1.14
 - cron: "25 * * * *"
   name: ci-knative-eventing-operator-continuous
   agent: kubernetes
@@ -12313,8 +8740,6 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -12351,8 +8776,6 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -12766,8 +9189,6 @@ periodics:
         mountPath: /etc/nightly-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -13002,8 +9423,6 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -13039,9 +9458,6 @@ periodics:
       - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
-      env:
-      - name: GO_VERSION
-        value: go1.14
 - cron: "23 7 * * *"
   name: ci-knative-eventing-operator-go-coverage-beta-prow-tests
   labels:
@@ -13066,9 +9482,6 @@ periodics:
       - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
-      env:
-      - name: GO_VERSION
-        value: go1.14
 - cron: "18 * * * *"
   name: ci-google-knative-gcp-continuous
   agent: kubernetes
@@ -13096,8 +9509,6 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -13138,8 +9549,6 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -13487,8 +9896,6 @@ periodics:
         mountPath: /etc/nightly-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -13699,8 +10106,6 @@ periodics:
       env:
       - name: ORG_NAME
         value: google
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -13740,9 +10145,6 @@ periodics:
       - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
-      env:
-      - name: GO_VERSION
-        value: go1.14
 - cron: "18 7 * * *"
   name: ci-google-knative-gcp-go-coverage-beta-prow-tests
   labels:
@@ -13766,9 +10168,6 @@ periodics:
       - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
-      env:
-      - name: GO_VERSION
-        value: go1.14
 - cron: "17 * * * *"
   name: ci-knative-net-certmanager-continuous
   agent: kubernetes
@@ -13797,8 +10196,6 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -13835,8 +10232,6 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -13874,8 +10269,6 @@ periodics:
         mountPath: /etc/nightly-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -13918,8 +10311,6 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -13965,8 +10356,6 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -14002,9 +10391,6 @@ periodics:
       - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
-      env:
-      - name: GO_VERSION
-        value: go1.14
 - cron: "31 7 * * *"
   name: ci-knative-net-certmanager-go-coverage-beta-prow-tests
   labels:
@@ -14029,9 +10415,6 @@ periodics:
       - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
-      env:
-      - name: GO_VERSION
-        value: go1.14
 - cron: "8 * * * *"
   name: ci-knative-net-contour-continuous
   agent: kubernetes
@@ -14060,8 +10443,6 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -14098,8 +10479,6 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -14137,8 +10516,6 @@ periodics:
         mountPath: /etc/nightly-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -14181,8 +10558,6 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -14228,8 +10603,6 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -14265,9 +10638,6 @@ periodics:
       - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
-      env:
-      - name: GO_VERSION
-        value: go1.14
 - cron: "40 7 * * *"
   name: ci-knative-net-contour-go-coverage-beta-prow-tests
   labels:
@@ -14292,9 +10662,6 @@ periodics:
       - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
-      env:
-      - name: GO_VERSION
-        value: go1.14
 - cron: "31 * * * *"
   name: ci-knative-net-http01-continuous
   agent: kubernetes
@@ -14323,8 +10690,6 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -14361,8 +10726,6 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -14400,8 +10763,6 @@ periodics:
         mountPath: /etc/nightly-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -14444,8 +10805,6 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -14491,8 +10850,6 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -14528,9 +10885,6 @@ periodics:
       - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
-      env:
-      - name: GO_VERSION
-        value: go1.14
 - cron: "45 7 * * *"
   name: ci-knative-net-http01-go-coverage-beta-prow-tests
   labels:
@@ -14555,9 +10909,6 @@ periodics:
       - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
-      env:
-      - name: GO_VERSION
-        value: go1.14
 - cron: "18 * * * *"
   name: ci-knative-net-istio-continuous
   agent: kubernetes
@@ -14586,8 +10937,6 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -14624,8 +10973,6 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -14663,8 +11010,6 @@ periodics:
         mountPath: /etc/nightly-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -14707,8 +11052,6 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -14754,8 +11097,6 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -14791,9 +11132,6 @@ periodics:
       - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
-      env:
-      - name: GO_VERSION
-        value: go1.14
 - cron: "22 7 * * *"
   name: ci-knative-net-istio-go-coverage-beta-prow-tests
   labels:
@@ -14818,9 +11156,6 @@ periodics:
       - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
-      env:
-      - name: GO_VERSION
-        value: go1.14
 - cron: "3 * * * *"
   name: ci-knative-net-kourier-continuous
   agent: kubernetes
@@ -14849,8 +11184,6 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -14887,8 +11220,6 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -14926,8 +11257,6 @@ periodics:
         mountPath: /etc/nightly-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -14970,8 +11299,6 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -15017,8 +11344,6 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -15054,9 +11379,6 @@ periodics:
       - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
-      env:
-      - name: GO_VERSION
-        value: go1.14
 - cron: "5 7 * * *"
   name: ci-knative-net-kourier-go-coverage-beta-prow-tests
   labels:
@@ -15081,9 +11403,6 @@ periodics:
       - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
-      env:
-      - name: GO_VERSION
-        value: go1.14
 - cron: "0 * * * *"
   name: ci-knative-operator-continuous
   agent: kubernetes
@@ -15112,8 +11431,6 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -15150,8 +11467,6 @@ periodics:
         mountPath: /etc/test-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -15189,8 +11504,6 @@ periodics:
         mountPath: /etc/nightly-account
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -15235,8 +11548,6 @@ periodics:
       env:
       - name: ORG_NAME
         value: knative-sandbox
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -15284,8 +11595,6 @@ periodics:
       env:
       - name: ORG_NAME
         value: knative-sandbox
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -15321,9 +11630,6 @@ periodics:
       - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
-      env:
-      - name: GO_VERSION
-        value: go1.14
 - cron: "40 7 * * *"
   name: ci-knative-operator-go-coverage-beta-prow-tests
   labels:
@@ -15348,9 +11654,6 @@ periodics:
       - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
-      env:
-      - name: GO_VERSION
-        value: go1.14
 - cron: "31 * * * *"
   name: ci-knative-sandbox-eventing-kafka-continuous
   agent: kubernetes
@@ -15385,8 +11688,6 @@ periodics:
       env:
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -15431,8 +11732,6 @@ periodics:
       env:
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -15478,8 +11777,6 @@ periodics:
       env:
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -15532,8 +11829,6 @@ periodics:
         value: "true"
       - name: ORG_NAME
         value: knative-sandbox
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -15589,8 +11884,6 @@ periodics:
         value: "true"
       - name: ORG_NAME
         value: knative-sandbox
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -15628,9 +11921,6 @@ periodics:
       - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
-      env:
-      - name: GO_VERSION
-        value: go1.14
 - cron: "25 7 * * *"
   name: ci-knative-sandbox-eventing-kafka-go-coverage-beta-prow-tests
   labels:
@@ -15655,9 +11945,6 @@ periodics:
       - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
-      env:
-      - name: GO_VERSION
-        value: go1.14
 - cron: "30 07 * * *"
   name: ci-knative-serving-recreate-clusters
   agent: kubernetes
@@ -15686,8 +11973,6 @@ periodics:
         mountPath: /etc/performance-test
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/performance-test/service-account.json
       - name: GITHUB_TOKEN
@@ -15728,8 +12013,6 @@ periodics:
         mountPath: /etc/performance-test
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/performance-test/service-account.json
       - name: GITHUB_TOKEN
@@ -15770,8 +12053,6 @@ periodics:
         mountPath: /etc/performance-test
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/performance-test/service-account.json
       - name: GITHUB_TOKEN
@@ -15812,8 +12093,6 @@ periodics:
         mountPath: /etc/performance-test
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/performance-test/service-account.json
       - name: GITHUB_TOKEN
@@ -15853,8 +12132,6 @@ periodics:
         mountPath: /etc/performance-test
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/performance-test/service-account.json
       - name: GITHUB_TOKEN
@@ -15894,8 +12171,6 @@ periodics:
         mountPath: /etc/performance-test
         readOnly: true
       env:
-      - name: GO_VERSION
-        value: go1.14
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/performance-test/service-account.json
       - name: GITHUB_TOKEN
@@ -16251,8 +12526,6 @@ postsubmits:
           mountPath: /etc/performance-test
           readOnly: true
         env:
-        - name: GO_VERSION
-          value: go1.14
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/performance-test/service-account.json
         - name: GITHUB_TOKEN
@@ -16282,9 +12555,6 @@ postsubmits:
         - "coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=0"
-        env:
-        - name: GO_VERSION
-          value: go1.14
   - name: post-knative-serving-go-coverage-dev
     branches:
     - master
@@ -16302,9 +12572,6 @@ postsubmits:
         - "coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=0"
-        env:
-        - name: GO_VERSION
-          value: go1.14
   knative/client:
   - name: post-knative-client-go-coverage
     branches:
@@ -16323,9 +12590,6 @@ postsubmits:
         - "coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=0"
-        env:
-        - name: GO_VERSION
-          value: go1.14
   knative/eventing:
   - name: post-knative-eventing-reconcile-clusters
     branches:
@@ -16353,8 +12617,6 @@ postsubmits:
           mountPath: /etc/performance-test
           readOnly: true
         env:
-        - name: GO_VERSION
-          value: go1.14
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/performance-test/service-account.json
         - name: GITHUB_TOKEN
@@ -16384,9 +12646,6 @@ postsubmits:
         - "coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=0"
-        env:
-        - name: GO_VERSION
-          value: go1.14
   knative/eventing-contrib:
   - name: post-knative-eventing-contrib-go-coverage
     branches:
@@ -16405,9 +12664,6 @@ postsubmits:
         - "coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=0"
-        env:
-        - name: GO_VERSION
-          value: go1.14
   knative/docs:
   - name: post-knative-docs-go-coverage
     branches:
@@ -16443,9 +12699,6 @@ postsubmits:
         - "coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=0"
-        env:
-        - name: GO_VERSION
-          value: go1.14
   knative/test-infra:
   - name: post-knative-test-infra-go-coverage
     branches:
@@ -16464,9 +12717,6 @@ postsubmits:
         - "coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=0"
-        env:
-        - name: GO_VERSION
-          value: go1.14
   knative/caching:
   - name: post-knative-caching-go-coverage
     branches:
@@ -16485,9 +12735,6 @@ postsubmits:
         - "coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=0"
-        env:
-        - name: GO_VERSION
-          value: go1.14
   google/knative-gcp:
   - name: post-google-knative-gcp-reconcile-clusters
     branches:
@@ -16514,8 +12761,6 @@ postsubmits:
           mountPath: /etc/performance-test
           readOnly: true
         env:
-        - name: GO_VERSION
-          value: go1.14
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/performance-test/service-account.json
         - name: GITHUB_TOKEN
@@ -16544,9 +12789,6 @@ postsubmits:
         - "coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=0"
-        env:
-        - name: GO_VERSION
-          value: go1.14
   knative/net-certmanager:
   - name: post-knative-net-certmanager-go-coverage
     branches:
@@ -16565,9 +12807,6 @@ postsubmits:
         - "coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=0"
-        env:
-        - name: GO_VERSION
-          value: go1.14
   knative/net-contour:
   - name: post-knative-net-contour-go-coverage
     branches:
@@ -16586,9 +12825,6 @@ postsubmits:
         - "coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=0"
-        env:
-        - name: GO_VERSION
-          value: go1.14
   knative/net-http01:
   - name: post-knative-net-http01-go-coverage
     branches:
@@ -16607,9 +12843,6 @@ postsubmits:
         - "coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=0"
-        env:
-        - name: GO_VERSION
-          value: go1.14
   knative/net-istio:
   - name: post-knative-net-istio-go-coverage
     branches:
@@ -16628,9 +12861,6 @@ postsubmits:
         - "coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=0"
-        env:
-        - name: GO_VERSION
-          value: go1.14
   knative/net-kourier:
   - name: post-knative-net-kourier-go-coverage
     branches:
@@ -16649,9 +12879,6 @@ postsubmits:
         - "coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=0"
-        env:
-        - name: GO_VERSION
-          value: go1.14
   knative/serving-operator:
   - name: post-knative-serving-operator-go-coverage
     branches:
@@ -16670,9 +12897,6 @@ postsubmits:
         - "coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=0"
-        env:
-        - name: GO_VERSION
-          value: go1.14
   knative/eventing-operator:
   - name: post-knative-eventing-operator-go-coverage
     branches:
@@ -16691,9 +12915,6 @@ postsubmits:
         - "coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=0"
-        env:
-        - name: GO_VERSION
-          value: go1.14
   knative/operator:
   - name: post-knative-operator-go-coverage
     branches:
@@ -16712,9 +12933,6 @@ postsubmits:
         - "coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=0"
-        env:
-        - name: GO_VERSION
-          value: go1.14
   knative-sandbox/eventing-kafka:
   - name: post-knative-sandbox-eventing-kafka-go-coverage
     branches:
@@ -16733,6 +12951,3 @@ postsubmits:
         - "coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=0"
-        env:
-        - name: GO_VERSION
-          value: go1.14

--- a/config/staging/prow/config_staging.yaml
+++ b/config/staging/prow/config_staging.yaml
@@ -16,32 +16,24 @@ presubmits:
   knative-prow-robot/serving:
   - build-tests: true
     dot-dev: true
-    go114: true
   - unit-tests: true
     dot-dev: true
-    go114: true
   - integration-tests: true
     dot-dev: true
-    go114: true
 
   knative-prow-robot/test-infra:
   - build-tests: true
     dot-dev: true
-    go114: true
   - unit-tests: true
     dot-dev: true
-    go114: true
   - integration-tests: true
     dot-dev: true
-    go114: true
 
 periodics:
   knative-prow-robot/serving:
   - continuous: false
     dot-dev: true
-    go114: true
 
   knative-prow-robot/test-infra:
   - continuous: false
     dot-dev: true
-    go114: true

--- a/config/staging/prow/jobs/config.yaml
+++ b/config/staging/prow/jobs/config.yaml
@@ -45,8 +45,6 @@ presubmits:
           mountPath: /etc/test-account
           readOnly: true
         env:
-        - name: GO_VERSION
-          value: go1.14
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
@@ -84,8 +82,6 @@ presubmits:
           mountPath: /etc/test-account
           readOnly: true
         env:
-        - name: GO_VERSION
-          value: go1.14
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
@@ -123,8 +119,6 @@ presubmits:
           mountPath: /etc/test-account
           readOnly: true
         env:
-        - name: GO_VERSION
-          value: go1.14
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
@@ -163,8 +157,6 @@ presubmits:
           mountPath: /etc/test-account
           readOnly: true
         env:
-        - name: GO_VERSION
-          value: go1.14
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
@@ -202,8 +194,6 @@ presubmits:
           mountPath: /etc/test-account
           readOnly: true
         env:
-        - name: GO_VERSION
-          value: go1.14
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
@@ -241,8 +231,6 @@ presubmits:
           mountPath: /etc/test-account
           readOnly: true
         env:
-        - name: GO_VERSION
-          value: go1.14
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION

--- a/tools/config-generator/main.go
+++ b/tools/config-generator/main.go
@@ -67,8 +67,6 @@ type repositoryData struct {
 	GoCoverageThreshold    int
 	Processed              bool
 	DotDev                 bool
-	Go114                  bool
-	Go113Branches          []string
 }
 
 // prowConfigTemplateData contains basic data about Prow.
@@ -308,33 +306,6 @@ func exclusiveSlices(a1, a2 []string) []string {
 	return res
 }
 
-// strip out all suffixes from the image name
-func stripSuffixFromImageName(name string, suffixes []string) string {
-	parts := strings.SplitN(name, ":", 2)
-	if len(parts) != 2 {
-		log.Fatalf("image name should contain ':': %q", name)
-	}
-	for _, s := range suffixes {
-		if strings.HasSuffix(parts[0], s) {
-			parts[0] = strings.TrimSuffix(parts[0], s)
-		}
-	}
-	return strings.Join(parts, ":")
-}
-
-// add suffix to the image name
-// e.g. if suffix = "-go112", then [IMAGE]:[DIGEST]-> [IMAGE]-go112:[DIGEST]
-func addSuffixToImageName(name string, suffix string) string {
-	parts := strings.SplitN(name, ":", 2)
-	if len(parts) != 2 {
-		log.Fatalf("image name should contain ':': %q", name)
-	}
-	if !strings.HasSuffix(parts[0], suffix) {
-		parts[0] = fmt.Sprintf("%s%s", parts[0], suffix)
-	}
-	return strings.Join(parts, ":")
-}
-
 // Consolidate whitelisted and skipped branches with newly added
 // whitelisted/skipped. To make the logic easier to maintain, this function
 // makes the assumption that the outcome follows these rules:
@@ -462,17 +433,6 @@ func (data *baseProwJobTemplateData) addEnvToJob(key, value string) {
 	data.Env = append(data.Env, envNameToKey(key), envValueToValue(value))
 }
 
-func (data *baseProwJobTemplateData) SetGoVersion(version GoVersion) {
-	envKey := envNameToKey("GO_VERSION")
-	for i, key := range data.Env {
-		if key == envKey {
-			data.Env[i+1] = envValueToValue(version.String())
-			return
-		}
-	}
-	data.addEnvToJob("GO_VERSION", version.String())
-}
-
 // addLabelToJob adds extra labels to a job
 func addLabelToJob(data *baseProwJobTemplateData, key, value string) {
 	(*data).Labels = append((*data).Labels, []string{key + ": " + value}...)
@@ -551,7 +511,7 @@ func setResourcesReqForJob(res yaml.MapSlice, data *baseProwJobTemplateData) {
 // parseBasicJobConfigOverrides updates the given baseProwJobTemplateData with any base option present in the given config.
 func parseBasicJobConfigOverrides(data *baseProwJobTemplateData, config yaml.MapSlice) {
 	(*data).ExtraRefs = append((*data).ExtraRefs, "  base_ref: "+(*data).RepoBranch)
-	var needDotdev, needGo114 bool
+	var needDotdev bool
 	for i, item := range config {
 		switch item.Key {
 		case "skip_branches":
@@ -579,24 +539,10 @@ func parseBasicJobConfigOverrides(data *baseProwJobTemplateData, config yaml.Map
 					repositories[i].DotDev = true
 				}
 			}
-		case "go114":
-			needGo114 = true
-			for i, repo := range repositories {
-				if path.Base(repo.Name) == (*data).RepoName {
-					repositories[i].Go114 = true
-					data.RepoNameForJob = fmt.Sprintf("%s-%s", (*data).OrgName, (*data).RepoName)
-				}
-			}
 		case "performance":
 			for i, repo := range repositories {
 				if path.Base(repo.Name) == (*data).RepoName {
 					repositories[i].EnablePerformanceTests = true
-				}
-			}
-		case "go113-branches":
-			for i, repo := range repositories {
-				if path.Base(repo.Name) == (*data).RepoName {
-					repositories[i].Go113Branches = getStringArray(item.Value)
 				}
 			}
 		case "env-vars":
@@ -618,9 +564,6 @@ func parseBasicJobConfigOverrides(data *baseProwJobTemplateData, config yaml.Map
 	if needDotdev {
 		(*data).PathAlias = "path_alias: knative.dev/" + (*data).RepoName
 		(*data).ExtraRefs = append((*data).ExtraRefs, "  "+(*data).PathAlias)
-	}
-	if needGo114 {
-		data.SetGoVersion(GoVersion{1, 14})
 	}
 	// Override any values if provided by command-line flags.
 	if timeoutOverride > 0 {
@@ -853,8 +796,6 @@ func recursiveSBL(repoName string, data interface{}, generateOneJob func(data in
 // executeJobTemplateWrapper takes in consideration of repo settings, decides how many variants of the
 // same job needs to be generated and generates them.
 func executeJobTemplateWrapper(repoName string, data interface{}, generateOneJob func(data interface{})) {
-	var sbs []specialBranchLogic
-
 	switch data.(type) {
 	case *postsubmitJobTemplateData:
 		if strings.HasSuffix(data.(*postsubmitJobTemplateData).PostsubmitJobName, "go-coverage") {
@@ -862,32 +803,7 @@ func executeJobTemplateWrapper(repoName string, data interface{}, generateOneJob
 			return
 		}
 	}
-
-	var go113Branches []string
-	// Find out if Go113Branches is set in repo settings
-	for _, repo := range repositories {
-		if repo.Name == repoName {
-			if len(repo.Go113Branches) > 0 {
-				go113Branches = repo.Go113Branches
-			}
-		}
-	}
-	if len(go113Branches) > 0 {
-		sbs = append(sbs, specialBranchLogic{
-			branches: go113Branches,
-			opsNew: func(base *baseProwJobTemplateData) {
-				base.SetGoVersion(GoVersion{1, 14})
-			},
-			restore: func(base *baseProwJobTemplateData) {
-			},
-		})
-	}
-
-	if len(sbs) == 0 { // Generate single job if there is no special branch logic
-		generateOneJob(data)
-	} else {
-		recursiveSBL(repoName, data, generateOneJob, sbs, 0)
-	}
+	generateOneJob(data)
 }
 
 // executeTemplate outputs the given job template with the given data, respecting any filtering.

--- a/tools/config-generator/perf_config.go
+++ b/tools/config-generator/perf_config.go
@@ -95,13 +95,6 @@ func perfClusterReconcilePostsubmitJob(jobNamePostFix, command string, args []st
 
 func perfClusterBaseProwJob(command string, args []string, fullRepoName, sa string) baseProwJobTemplateData {
 	base := newbaseProwJobTemplateData(fullRepoName)
-	for _, repo := range repositories {
-		if fullRepoName == repo.Name && repo.Go114 {
-			base.SetGoVersion(GoVersion{1, 14})
-			break
-		}
-	}
-
 	base.Command = command
 	base.Args = args
 	addVolumeToJob(&base, "/etc/performance-test", sa, true, "")

--- a/tools/config-generator/periodic_config.go
+++ b/tools/config-generator/periodic_config.go
@@ -331,9 +331,6 @@ func generateGoCoveragePeriodic(title string, repoName string, _ yaml.MapSlice) 
 		if repo.DotDev {
 			data.Base.ExtraRefs = append(data.Base.ExtraRefs, "  path_alias: knative.dev/"+path.Base(repoName))
 		}
-		if repo.Go114 {
-			data.Base.SetGoVersion(GoVersion{1, 14})
-		}
 		addExtraEnvVarsToJob(extraEnvVars, &data.Base)
 		addMonitoringPubsubLabelsToJob(&data.Base, data.PeriodicJobName)
 		configureServiceAccountForJob(&data.Base)

--- a/tools/config-generator/postsubmit_config.go
+++ b/tools/config-generator/postsubmit_config.go
@@ -49,9 +49,6 @@ func generateGoCoveragePostsubmit(title, repoName string, _ yaml.MapSlice) {
 		if repo.Name == repoName && repo.DotDev {
 			data.Base.PathAlias = "path_alias: knative.dev/" + path.Base(repoName)
 		}
-		if repo.Name == repoName && repo.Go114 {
-			data.Base.SetGoVersion(GoVersion{1, 14})
-		}
 	}
 	addExtraEnvVarsToJob(extraEnvVars, &data.Base)
 	configureServiceAccountForJob(&data.Base)

--- a/tools/config-generator/presubmit_config.go
+++ b/tools/config-generator/presubmit_config.go
@@ -107,9 +107,7 @@ func generatePresubmit(title string, repoName string, presubmitConfig yaml.MapSl
 	jobName := data.PresubmitPullJobName
 
 	// This is where the data actually gets written out
-	executeJobTemplateWrapper(repoName, &data, func(data interface{}) {
-		executeJobTemplate("presubmit", jobTemplate, title, repoName, jobName, true, data)
-	})
+	executeJobTemplate("presubmit", jobTemplate, title, repoName, jobName, true, data)
 
 	// Generate config for pull-knative-serving-go-coverage-dev right after pull-knative-serving-go-coverage,
 	// this job is mainly for debugging purpose.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
After https://github.com/knative/test-infra/pull/2147 is merged and we have a new image, we can simplify the Prow config generator to remove the logic that sets go version via Prow jobs. This change also significantly simplifies the generated Prow job config file, as we don't need to differentiate the release branches for presubmit/postsubmit jobs. 

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @chaodaiG @albertomilan @peterfeifanchen 
/hold
