### PR TITLE
Separate Knative Eventing upgrade tests from regular e2e tests

### DIFF
--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -1,4 +1,4 @@
-# Copyright 2018 The Knative Authors
+# Copyright 2020 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -186,6 +186,16 @@ presubmits:
       dot-dev: true
     - integration-tests: true
       dot-dev: true
+      needs-monitor: true
+      args:
+        - "--run-test"
+        - "./test/e2e-tests.sh"
+    - custom-test: upgrade-tests
+      dot-dev: true
+      needs-monitor: true
+      args:
+        - "--run-test"
+        - "./test/e2e-upgrade-tests.sh"
     - go-coverage: true
       dot-dev: true
 

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -2023,6 +2023,10 @@ presubmits:
           secretName: test-account
   - name: pull-knative-eventing-integration-tests
     agent: kubernetes
+    labels:
+      prow.k8s.io/pubsub.project: knative-tests
+      prow.k8s.io/pubsub.topic: knative-monitoring
+      prow.k8s.io/pubsub.runID: pull-knative-eventing-integration-tests
     context: pull-knative-eventing-integration-tests
     always_run: true
     rerun_command: "/test pull-knative-eventing-integration-tests"
@@ -2043,7 +2047,8 @@ presubmits:
         - runner.sh
         args:
         - "./test/presubmit-tests.sh"
-        - "--integration-tests"
+        - "--run-test"
+        - "./test/e2e-tests.sh"
         volumeMounts:
         - name: repoview-token
           mountPath: /etc/repoview-token
@@ -2065,6 +2070,10 @@ presubmits:
           secretName: test-account
   - name: pull-knative-eventing-integration-tests
     agent: kubernetes
+    labels:
+      prow.k8s.io/pubsub.project: knative-tests
+      prow.k8s.io/pubsub.topic: knative-monitoring
+      prow.k8s.io/pubsub.runID: pull-knative-eventing-integration-tests
     context: pull-knative-eventing-integration-tests
     always_run: true
     rerun_command: "/test pull-knative-eventing-integration-tests"
@@ -2085,7 +2094,8 @@ presubmits:
         - runner.sh
         args:
         - "./test/presubmit-tests.sh"
-        - "--integration-tests"
+        - "--run-test"
+        - "./test/e2e-tests.sh"
         volumeMounts:
         - name: repoview-token
           mountPath: /etc/repoview-token
@@ -2104,6 +2114,90 @@ presubmits:
       - name: repoview-token
         secret:
           secretName: repoview-token
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-eventing-upgrade-tests
+    agent: kubernetes
+    labels:
+      prow.k8s.io/pubsub.project: knative-tests
+      prow.k8s.io/pubsub.topic: knative-monitoring
+      prow.k8s.io/pubsub.runID: pull-knative-eventing-upgrade-tests
+    context: pull-knative-eventing-upgrade-tests
+    always_run: true
+    rerun_command: "/test pull-knative-eventing-upgrade-tests"
+    trigger: "(?m)^/test (all|pull-knative-eventing-upgrade-tests),?(\\s+|$)"
+    decorate: true
+    path_alias: knative.dev/eventing
+    cluster: "build-knative"
+    branches:
+    - "release-0.11"
+    - "release-0.12"
+    - "release-0.13"
+    - "release-0.14"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-upgrade-tests.sh"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-eventing-upgrade-tests
+    agent: kubernetes
+    labels:
+      prow.k8s.io/pubsub.project: knative-tests
+      prow.k8s.io/pubsub.topic: knative-monitoring
+      prow.k8s.io/pubsub.runID: pull-knative-eventing-upgrade-tests
+    context: pull-knative-eventing-upgrade-tests
+    always_run: true
+    rerun_command: "/test pull-knative-eventing-upgrade-tests"
+    trigger: "(?m)^/test (all|pull-knative-eventing-upgrade-tests),?(\\s+|$)"
+    decorate: true
+    path_alias: knative.dev/eventing
+    cluster: "build-knative"
+    skip_branches:
+    - "release-0.11"
+    - "release-0.12"
+    - "release-0.13"
+    - "release-0.14"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-upgrade-tests.sh"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+        - name: GO_VERSION
+          value: go1.14
+      volumes:
       - name: test-account
         secret:
           secretName: test-account


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:

Defining Knative Eventing integration tests to have separate runs for regular e2e tests and for upgrade tests.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:

Fixes knative/eventing#3173

**Special notes to reviewers**:

Requested originally by @chizhg & @houshengbo here https://github.com/knative/eventing/pull/2388#issuecomment-592099119 and https://github.com/knative/eventing/pull/2388#issuecomment-592108828

**User-visible changes in this PR**:

None.
