### PR TITLE
Stop using serving.yaml

### DIFF
--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -449,14 +449,15 @@ function report_go_test() {
 }
 
 # Install Knative Serving in the current cluster.
-# Parameters: $1 - Knative Serving manifest.
+# Parameters: $1 - Knative Serving crds manifest.
+#             $2 - Knative Serving core manifest.
 function start_knative_serving() {
   header "Starting Knative Serving"
   subheader "Installing Knative Serving"
   echo "Installing Serving CRDs from $1"
-  kubectl apply --selector knative.dev/crd-install=true -f "$1"
-  echo "Installing the rest of serving components from $1"
   kubectl apply -f "$1"
+  echo "Installing Serving core components from $2"
+  kubectl apply -f "$2"
   wait_until_pods_running knative-serving || return 1
 }
 
@@ -478,12 +479,13 @@ function start_knative_monitoring() {
 # Install the stable release Knative/serving in the current cluster.
 # Parameters: $1 - Knative Serving version number, e.g. 0.6.0.
 function start_release_knative_serving() {
-  start_knative_serving "https://storage.googleapis.com/knative-releases/serving/previous/v$1/serving.yaml"
+  start_knative_serving "https://storage.googleapis.com/knative-releases/serving/previous/v$1/serving-crds.yaml" \
+    "https://storage.googleapis.com/knative-releases/serving/previous/v$1/serving-core.yaml"
 }
 
 # Install the latest stable Knative Serving in the current cluster.
 function start_latest_knative_serving() {
-  start_knative_serving "${KNATIVE_SERVING_RELEASE}"
+  start_knative_serving "${KNATIVE_SERVING_RELEASE_CRDS}" "${KNATIVE_SERVING_RELEASE_CORE}"
 }
 
 # Install Knative Eventing in the current cluster.
@@ -742,6 +744,7 @@ readonly _TEST_INFRA_SCRIPTS_DIR="$(dirname $(get_canonical_path ${BASH_SOURCE[0
 readonly REPO_NAME_FORMATTED="Knative $(capitalize ${REPO_NAME//-/ })"
 
 # Public latest nightly or release yaml files.
-readonly KNATIVE_SERVING_RELEASE="$(get_latest_knative_yaml_source "serving" "serving")"
+readonly KNATIVE_SERVING_RELEASE_CRDS="$(get_latest_knative_yaml_source "serving" "serving-crds")"
+readonly KNATIVE_SERVING_RELEASE_CORE="$(get_latest_knative_yaml_source "serving" "serving-core")"
 readonly KNATIVE_EVENTING_RELEASE="$(get_latest_knative_yaml_source "eventing" "eventing")"
 readonly KNATIVE_MONITORING_RELEASE="$(get_latest_knative_yaml_source "serving" "monitoring")"


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Stop using serving.yaml to prepare for the changes in https://github.com/knative/serving/pull/8194.
We need to replicate this change to a few repos before the change in serving takes into effect.

/cc @chaodaiG 
