### PR TITLE
Add missing rbac for hook, this should fix updateconfig plugin

### DIFF
--- a/config/prod/prow/cluster/301-rbac.yaml
+++ b/config/prod/prow/cluster/301-rbac.yaml
@@ -347,6 +347,8 @@ rules:
     resources:
       - configmaps
     verbs:
+      - create
+      - get
       - update
 ---
 kind: RoleBinding

--- a/config/prod/prow/core/plugins.yaml
+++ b/config/prod/prow/core/plugins.yaml
@@ -70,7 +70,7 @@ label:
   - source/github
   - source/kafka
   - source/prometheus
-# Settings for the "config-updater" plugin
+# Settings for the "config-updater" plugin.
 config_updater:
   maps:
     config/prod/prow/jobs/*.yaml:

--- a/tools/config-generator/templates/prow/prow_plugins.yaml
+++ b/tools/config-generator/templates/prow/prow_plugins.yaml
@@ -80,7 +80,7 @@ label:
   - source/kafka
   - source/prometheus
 
-# Settings for the "config-updater" plugin
+# Settings for the "config-updater" plugin.
 config_updater:
   maps:
     [[.JobConfigPath]]:


### PR DESCRIPTION
Updateconfig plugin spits out this error:
```
{"author":"chaodaiG","component":"hook","error":"failed to fetch current state of configmap: configmaps \"plugins\" is forbidden: User \"system:serviceaccount:default:hook\" cannot get resource \"configmaps\" in API group \"\" in the namespace \"default\"","event-GUID":"e1c0f780-a6b6-11ea-997b-a5f794441f6e","event-type":"pull_request","file":"prow/hook/events.go:198","func":"k8s.io/test-infra/prow/hook.(*Server).handlePullRequestEvent.func1","level":"error","msg":"Error handling PullRequestEvent.","org":"knative","plugin":"config-updater","pr":2169,"repo":"test-infra","time":"2020-06-04T22:58:23Z","url":"https://github.com/knative/test-infra/pull/2169"}
```

Add missing rbac should fix it

/assign chizhg albertomilan 