### PR TITLE
Use runner.sh for the config-updater job

### DIFF
--- a/config/prod/prow/jobs/custom-jobs.yaml
+++ b/config/prod/prow/jobs/custom-jobs.yaml
@@ -282,8 +282,9 @@ postsubmits:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         imagePullPolicy: Always
         command:
-        - "make"
+        - runner.sh
         args:
+        - "make"
         - "-C"
         - "./config/prod"
         - "update-all"


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
The logic to enable DIND is in `runner.sh`, so we need to use it as the test driver for the config-updater job.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @chaodaiG 
