### PR TITLE
Update deck image to fix spamming errors, restore updateconfig plugin

### DIFF
--- a/config/prod/prow/cluster/400-deck.yaml
+++ b/config/prod/prow/cluster/400-deck.yaml
@@ -37,7 +37,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20200602-f3683752b8
+        image: gcr.io/k8s-prow/deck:v20200608-fa017f09c2
         args:
         - --hook-url=http://hook:8888/plugin-help
         - --tide-url=http://tide/

--- a/config/prod/prow/cluster/400-hook.yaml
+++ b/config/prod/prow/cluster/400-hook.yaml
@@ -38,7 +38,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20200602-f3683752b8
+        image: gcr.io/k8s-prow/hook:v20200604-d7c8ec5bfb
         imagePullPolicy: Always
         args:
         - --dry-run=false


### PR DESCRIPTION
Fixes: #2089 

This should be fixed by https://github.com/kubernetes/test-infra/pull/17873

Also, restore image regression caused by auto image bumper PR #2180 

/assign chizhg
