### PR TITLE
Revert "Define scripts/ as a submodule"

### DIFF
--- a/scripts/dummy.go
+++ b/scripts/dummy.go
@@ -1,14 +1,9 @@
-// +build tools
-
 /*
 Copyright 2018 The Knative Authors
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-
     https://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,3 +12,12 @@ limitations under the License.
 */
 
 package scripts
+
+import (
+	"fmt"
+)
+
+func main() {
+	fmt.Println("This is a dummy go file so `go dep` can be used with knative/test-infra/scripts")
+	fmt.Println("This file can be safely removed if one day this directory contains real, useful go code")
+}

--- a/scripts/go.mod
+++ b/scripts/go.mod
@@ -1,3 +1,0 @@
-module knative.dev/test-infra/scripts
-
-go 1.14

--- a/scripts/presubmit-tests.sh
+++ b/scripts/presubmit-tests.sh
@@ -171,13 +171,12 @@ function default_build_test_runner() {
     # Consider an error message everything that's not a package name.
     errors_go1="$(grep -v '^\(github\.com\|knative\.dev\)/' "${report}" | sort | uniq)"
   fi
-  # Get all packages that have build tags in go code (ignore /vendor, /hack, /scripts and /third_party)
-  # TODO(chizhg): currently it assumes all these packages are test packages, support building normal go packages when we need to.
+  # Get all build tags in go code (ignore /vendor, /hack and /third_party)
   local tags="$(grep -r '// +build' . \
-    | grep -v '^./vendor/' | grep -v '^./hack/' | grep -v '^./third_party' | grep -v '^./scripts' \
+    | grep -v '^./vendor/' | grep -v '^./hack/' | grep -v '^./third_party' \
     | cut -f3 -d' ' | sort | uniq | tr '\n' ' ')"
   local tagged_pkgs="$(grep -r '// +build' . \
-    | grep -v '^./vendor/' | grep -v '^./hack/' | grep -v '^./third_party' | grep -v '^./scripts' \
+    | grep -v '^./vendor/' | grep -v '^./hack/' | grep -v '^./third_party' \
     | grep ":// +build " | cut -f1 -d: | xargs dirname \
     | sort | uniq | tr '\n' ' ')"
   for pkg in ${tagged_pkgs}; do


### PR DESCRIPTION
Reverts knative/test-infra#2141

This does not work as intended - it's causing `knative.dev/test-infra/scripts: ambiguous import: found package knative.dev/test-infra/scripts in multiple modules` error in some repos, but not in `pkg`, which is very confusing...

There is a solution for it - https://github.com/Azure/go-autorest/pull/455, but definitely is not what we want. 

/cc @nachocano @capri-xiyue 