### PR TITLE
updateConcernedFiles returns the stored value, not always true.

### DIFF
--- a/tools/coverage/calc/base.go
+++ b/tools/coverage/calc/base.go
@@ -59,7 +59,7 @@ func updateConcernedFiles(concernedFiles map[string]bool, filePath string, isPre
 	// If true => needs to be skipped for coverage.
 	isConcerned, ok := concernedFiles[filePath]
 	if ok {
-		return true
+		return isConcerned
 	}
 
 	// presubmit already have concerned files defined.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:

`updateConcernedFiles` returns the stored value, not always true. Before this change, I could see the following in Prow coverage outputs:

```
2020/06/11 19:10:50 Skipping as file is coverage-excluded:  pkg/apis/foo/v1alpha1/zz_generated.deepcopy.go
2020/06/11 19:10:50 concerned line: stuff/pkg/apis/foo/v1alpha1/zz_generated.deepcopy.go:38.48,39.15 1 0
2020/06/11 19:10:50 concerned line: stuff/pkg/apis/foo/v1alpha1/zz_generated.deepcopy.go:42.2,44.12 3 0
2020/06/11 19:10:50 concerned line: stuff/pkg/apis/foo/v1alpha1/zz_generated.deepcopy.go:39.15,41.3 1 0
```

I believe that was caused by the old code, which would correctly exclude the file the first time, but would then only check to see if the file was in the `concernedFiles` map, without bothering to see if it was concerned or not. Essentially, on the first check of a file, it went through lines 71-73, which would correctly figure out if this file is concerned or not. But on subsequent checks of that file, it would find that `concernedFiles[filePath] == false`, but because it was present in the map, it assumed the file is concerned.

**Special notes to reviewers**:

**User-visible changes in this PR**:

