### PR TITLE
Use the latest kubectl in prow-tests image

### DIFF
--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -29,13 +29,6 @@ RUN gcloud components update
 RUN gcloud components install docker-credential-gcr
 RUN docker-credential-gcr configure-docker
 
-# Replace kubectl with a working version
-# TODO(chizhg): remove once https://github.com/knative/test-infra/issues/1858 is fixed
-ARG KUBECTL_VERSION=v1.17.4
-RUN rm -f "$(which kubectl)" && \
-    wget "https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" -O /usr/local/bin/kubectl && \
-    chmod +x /usr/local/bin/kubectl
-
 # Extra tools through apt-get
 RUN apt-get install -y uuid-runtime  # for uuidgen
 RUN apt-get install -y rubygems      # for mdl


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
We have changed the logic to install serving after https://github.com/knative/serving/issues/7755 is fixed, which works for the latest kubectl.

Remove the logic to pin the kubectl version in Dockerfile to use the `kubectl` installed with `gcloud`.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #1858 

/cc @chaodaiG 
