### PR TITLE
Update crier and prow-staging

### DIFF
--- a/config/prod/prow/cluster/400-crier.yaml
+++ b/config/prod/prow/cluster/400-crier.yaml
@@ -32,9 +32,10 @@ spec:
         image: gcr.io/k8s-prow/crier:v20200602-f3683752b8
         args:
         - --pubsub-workers=5 # Arbitrary number of multiplier
-        - --gcs-workers=1
+        - --blob-storage-workers=1
         - --gcs-credentials-file=/etc/service-account/service-account.json # TODO(chizhg): use workload identity
-        - --kubernetes-gcs-workers=1
+        - --kubernetes-blob-storage-workers=1
+        - --kubeconfig=/etc/kubeconfig/config
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --github-token-path=/etc/github/oauth
@@ -42,6 +43,9 @@ spec:
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
         volumeMounts:
+        - mountPath: /etc/kubeconfig
+          name: kubeconfig
+          readOnly: true
         - name: config
           mountPath: /etc/config
           readOnly: true
@@ -67,3 +71,7 @@ spec:
       - name: service-account
         secret:
           secretName: service-account
+      - name: kubeconfig
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig

--- a/config/staging/prow/cluster/400-crier.yaml
+++ b/config/staging/prow/cluster/400-crier.yaml
@@ -32,9 +32,10 @@ spec:
         image: gcr.io/k8s-prow/crier:v20200527-0949d40a35
         args:
         - --pubsub-workers=5 # Arbitrary number of multiplier
-        - --gcs-workers=1
+        - --blob-storage-workers=1
         - --gcs-credentials-file=/etc/service-account/service-account.json # TODO(chizhg): use workload identity
-        - --kubernetes-gcs-workers=1
+        - --kubernetes-blob-storage-workers=1
+        - --kubeconfig=/etc/kubeconfig/config
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --github-token-path=/etc/github/oauth
@@ -42,6 +43,9 @@ spec:
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
         volumeMounts:
+        - mountPath: /etc/kubeconfig
+          name: kubeconfig
+          readOnly: true
         - name: config
           mountPath: /etc/config
           readOnly: true
@@ -67,3 +71,7 @@ spec:
       - name: service-account
         secret:
           secretName: service-account
+      - name: kubeconfig
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig

--- a/config/staging/prow/cluster/400-deck.yaml
+++ b/config/staging/prow/cluster/400-deck.yaml
@@ -37,7 +37,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20200527-0949d40a35
+        image: gcr.io/k8s-prow/deck:v20200609-4cc6c6139b
         args:
         - --hook-url=http://hook:8888/plugin-help
         - --tide-url=http://tide/

--- a/config/staging/prow/cluster/400-ghproxy.yaml
+++ b/config/staging/prow/cluster/400-ghproxy.yaml
@@ -53,7 +53,7 @@ spec:
     spec:
       containers:
         - name: ghproxy
-          image: gcr.io/k8s-prow/ghproxy:v20200527-0949d40a35
+          image: gcr.io/k8s-prow/ghproxy:v20200602-f3683752b8
           args:
             - --cache-dir=/cache
             - --cache-sizeGB=99

--- a/config/staging/prow/cluster/400-hook.yaml
+++ b/config/staging/prow/cluster/400-hook.yaml
@@ -38,7 +38,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20200527-0949d40a35
+        image: gcr.io/k8s-prow/hook:v20200602-f3683752b8
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/config/staging/prow/cluster/400-horologium.yaml
+++ b/config/staging/prow/cluster/400-horologium.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20200527-0949d40a35
+        image: gcr.io/k8s-prow/horologium:v20200602-f3683752b8
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/config/staging/prow/cluster/400-plank.yaml
+++ b/config/staging/prow/cluster/400-plank.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
       - name: plank
         # Update plank utility_images versions in config.yaml when updating this version
-        image: gcr.io/k8s-prow/plank:v20200527-0949d40a35
+        image: gcr.io/k8s-prow/plank:v20200602-f3683752b8
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/config/staging/prow/cluster/400-sinker.yaml
+++ b/config/staging/prow/cluster/400-sinker.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: "sinker"
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:v20200527-0949d40a35
+        image: gcr.io/k8s-prow/sinker:v20200602-f3683752b8
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/config/staging/prow/cluster/400-tide.yaml
+++ b/config/staging/prow/cluster/400-tide.yaml
@@ -41,7 +41,7 @@ spec:
       serviceAccountName: "tide"
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20200527-0949d40a35
+        image: gcr.io/k8s-prow/tide:v20200602-f3683752b8
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/config/staging/prow/cluster/500-needs-rebase.yaml
+++ b/config/staging/prow/cluster/500-needs-rebase.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: needs-rebase
-        image: gcr.io/k8s-prow/needs-rebase:v20200527-0949d40a35
+        image: gcr.io/k8s-prow/needs-rebase:v20200602-f3683752b8
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/config/staging/prow/core/config.yaml
+++ b/config/staging/prow/core/config.yaml
@@ -30,10 +30,10 @@ plank:
       grace_period: 15s
       utility_images:
         # Update these versions when updating plank version in cluster.yaml
-        clonerefs: "gcr.io/k8s-prow/clonerefs:v20200527-0949d40a35"
-        initupload: "gcr.io/k8s-prow/initupload:v20200527-0949d40a35"
-        entrypoint: "gcr.io/k8s-prow/entrypoint:v20200527-0949d40a35"
-        sidecar: "gcr.io/k8s-prow/sidecar:v20200527-0949d40a35"
+        clonerefs: "gcr.io/k8s-prow/clonerefs:v20200602-f3683752b8"
+        initupload: "gcr.io/k8s-prow/initupload:v20200602-f3683752b8"
+        entrypoint: "gcr.io/k8s-prow/entrypoint:v20200602-f3683752b8"
+        sidecar: "gcr.io/k8s-prow/sidecar:v20200602-f3683752b8"
       gcs_configuration:
         bucket: "knative-prow-staging"
         path_strategy: "explicit"

--- a/tools/config-generator/templates/prow-staging/prow_config.yaml
+++ b/tools/config-generator/templates/prow-staging/prow_config.yaml
@@ -11,10 +11,10 @@ plank:
       grace_period: 15s
       utility_images:
         # Update these versions when updating plank version in cluster.yaml
-        clonerefs: "gcr.io/k8s-prow/clonerefs:v20200527-0949d40a35"
-        initupload: "gcr.io/k8s-prow/initupload:v20200527-0949d40a35"
-        entrypoint: "gcr.io/k8s-prow/entrypoint:v20200527-0949d40a35"
-        sidecar: "gcr.io/k8s-prow/sidecar:v20200527-0949d40a35"
+        clonerefs: "gcr.io/k8s-prow/clonerefs:v20200602-f3683752b8"
+        initupload: "gcr.io/k8s-prow/initupload:v20200602-f3683752b8"
+        entrypoint: "gcr.io/k8s-prow/entrypoint:v20200602-f3683752b8"
+        sidecar: "gcr.io/k8s-prow/sidecar:v20200602-f3683752b8"
       gcs_configuration:
         bucket: "[[.GcsBucket]]"
         path_strategy: "explicit"


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
1. Update `crier` deployment by adding the `kubeconfig`, this is the reason we are not seeing the pod info tabs on the spyglass pages
2. Also update `crier` deployment by switching to the flags `blob-storage-workers` and `kubernetes-blob-storage-workers`, as per the deprecation notice.
3. Update prow-staging image versions.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @albertomilan @chaodaiG 
