### PR TITLE
Skip collecting event log with -o yaml

### DIFF
--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -108,6 +108,8 @@ function dump_cluster_state() {
       echo ">>> Details" >> ${output}
       if [[ "${crd}" == "secrets" ]]; then
         echo "Secrets are ignored for security reasons" >> ${output}
+      elif [[ "${crd}" == "events" ]]; then
+        echo "events are ignored as making a lot of noise" >> ${output}
       else
         kubectl get ${crd} --all-namespaces -o yaml >> ${output}
       fi


### PR DESCRIPTION
When dump the cluster state, all objects are collected with -o yaml
after `kubectl get <obj>`. 
`-o yaml` is useful but `kubectl get events -o yaml` makes a lot of
noise and so it makes difficult to find useful log.

So this patch skips collecting the log.
