### PR TITLE
Increase frequency and concurrency count for the cleanup job

### DIFF
--- a/config/prod/prow/jobs/custom-jobs.yaml
+++ b/config/prod/prow/jobs/custom-jobs.yaml
@@ -100,7 +100,7 @@ periodics:
     - name: backup-account
       secret:
         secretName: backup-account
-- cron: "0 19 * * 1,3,5"
+- cron: "0 19 * * *"
   name: ci-knative-cleanup
   labels:
     prow.k8s.io/pubsub.project: knative-tests
@@ -121,13 +121,15 @@ periodics:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
       command:
-      - "go"
+      - "runner.sh"
       args:
+      - "go"
       - "run"
       - "./tools/cleanup/cleanup.go"
       - "--project-resource-yaml=config/prod/build-cluster/boskos/boskos_resources.yaml"
       - "--days-to-keep-images=30"
       - "--hours-to-keep-clusters=24"
+      - "--concurrent-operations=50"
       - "--service-account=/etc/test-account/service-account.json"
       volumeMounts:
       - name: test-account
@@ -158,8 +160,9 @@ periodics:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
       command:
-      - "go"
+      - "runner.sh"
       args:
+      - "go"
       - "run"
       - "./tools/cleanup/cleanup.go"
       - "--project=knative-performance"
@@ -267,8 +270,9 @@ periodics:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
       command:
-      - "go"
+      - "runner.sh"
       args:
+      - "go"
       - "run"
       - "./tools/prow-auto-bumper/."
       - "--github-account=/etc/prow-auto-bumper-github-token/token"
@@ -311,8 +315,9 @@ periodics:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       imagePullPolicy: Always
       command:
-      - "go"
+      - "runner.sh"
       args:
+      - "go"
       - "run"
       - "./tools/prow-jobs-syncer"
       - "--github-account=/etc/prow-auto-bumper-github-token/token"


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
1. Increase frequency to `once per day` and concurrency count to `50` for the cleanup job. I'm running one job in https://prow.knative.dev/view/gcs/knative-prow/logs/ci-knative-cleanup/1273298252417994752 and don't see any quota issues.
2. Use `runner.sh` as the test driver instead of `go run` to automatically set Go version for the jobs.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @chaodaiG @peterfeifanchen 

