### PR TITLE
Add postupdate deployment job for prow

### DIFF
--- a/config/prod/prow/core/plugins.yaml
+++ b/config/prod/prow/core/plugins.yaml
@@ -157,6 +157,8 @@ plugins:
   - welcome
   - wip
   - yuks
+  GoogleCloudPlatform/oss-test-infra:
+  - trigger
   knative/test-infra:
   - config-updater
 external_plugins:

--- a/config/prod/prow/jobs/custom-jobs.yaml
+++ b/config/prod/prow/jobs/custom-jobs.yaml
@@ -449,3 +449,35 @@ postsubmits:
       - name: oauth
         secret:
           secretName: oauth-token
+  GoogleCloudPlatform/oss-test-infra:
+  - name: post-knative-prow-cluster-deployment-updater
+    agent: kubernetes
+    decorate: true
+    max_concurrency: 1
+    cluster: "prow-trusted"
+    run_if_changed: "^prow/knative/cluster/"
+    branches:
+    - "master"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "make"
+        - "-C"
+        - "prow/knative"
+        - "deploy"
+        - "deploy-build"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account

--- a/tools/config-generator/templates/prow/prow_plugins.yaml
+++ b/tools/config-generator/templates/prow/prow_plugins.yaml
@@ -152,6 +152,8 @@ plugins:
   - yuks
 [[end]]
 [[end]]
+  GoogleCloudPlatform/oss-test-infra:
+  - trigger
   [[.TestInfraRepo]]:
   - config-updater
 


### PR DESCRIPTION
Now that prow deployment configs are in oss-test-infra, add a postsubmit job updating prow deployment. 

/assign chizhg albertomilan
/cc @cjwagner @fejta 

/hold
This job needs to make prow knative robot an admin of oss-test-infra repo and webhook set up