### PR TITLE
Add needs-dind to eventing-kafka-broker

### DIFF
--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -354,12 +354,16 @@ presubmits:
   knative-sandbox/eventing-kafka-broker:
   - build-tests: true
     dot-dev: true
+    needs-dind: true
   - unit-tests: true
     dot-dev: true
+    needs-dind: true
   - integration-tests: true
     dot-dev: true
+    needs-dind: true
   - go-coverage: true
     dot-dev: true
+    needs-dind: true
   knative-sandbox/eventing-rabbitmq:
   - build-tests: true
     dot-dev: true
@@ -881,13 +885,17 @@ periodics:
   knative-sandbox/eventing-kafka-broker:
   - continuous: true
     dot-dev: true
+    needs-dind: true
   - nightly: true
     dot-dev: true
+    needs-dind: true
   - dot-release: true
     dot-dev: true
+    needs-dind: true
     env-vars:
     - ORG_NAME=knative-sandbox
   - auto-release: true
     dot-dev: true
+    needs-dind: true
     env-vars:
     - ORG_NAME=knative-sandbox

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -3406,14 +3406,20 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--build-tests"
+        securityContext:
+          privileged: true
         volumeMounts:
         - name: repoview-token
           mountPath: /etc/repoview-token
           readOnly: true
+        - name: docker-graph
+          mountPath: /docker-graph
         - name: test-account
           mountPath: /etc/test-account
           readOnly: true
         env:
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: "true"
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
@@ -3422,6 +3428,8 @@ presubmits:
       - name: repoview-token
         secret:
           secretName: repoview-token
+      - name: docker-graph
+        emptyDir: {}
       - name: test-account
         secret:
           secretName: test-account
@@ -3443,14 +3451,20 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--unit-tests"
+        securityContext:
+          privileged: true
         volumeMounts:
         - name: repoview-token
           mountPath: /etc/repoview-token
           readOnly: true
+        - name: docker-graph
+          mountPath: /docker-graph
         - name: test-account
           mountPath: /etc/test-account
           readOnly: true
         env:
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: "true"
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
@@ -3459,6 +3473,8 @@ presubmits:
       - name: repoview-token
         secret:
           secretName: repoview-token
+      - name: docker-graph
+        emptyDir: {}
       - name: test-account
         secret:
           secretName: test-account
@@ -3480,14 +3496,20 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--integration-tests"
+        securityContext:
+          privileged: true
         volumeMounts:
         - name: repoview-token
           mountPath: /etc/repoview-token
           readOnly: true
+        - name: docker-graph
+          mountPath: /docker-graph
         - name: test-account
           mountPath: /etc/test-account
           readOnly: true
         env:
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: "true"
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
@@ -3496,6 +3518,8 @@ presubmits:
       - name: repoview-token
         secret:
           secretName: repoview-token
+      - name: docker-graph
+        emptyDir: {}
       - name: test-account
         secret:
           secretName: test-account
@@ -3525,10 +3549,17 @@ presubmits:
         - name: covbot-token
           mountPath: /etc/covbot-token
           readOnly: true
+        - name: docker-graph
+          mountPath: /docker-graph
+        env:
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: "true"
       volumes:
       - name: covbot-token
         secret:
           secretName: covbot-token
+      - name: docker-graph
+        emptyDir: {}
   knative-sandbox/eventing-rabbitmq:
   - name: pull-knative-sandbox-eventing-rabbitmq-build-tests
     agent: kubernetes
@@ -10724,16 +10755,24 @@ periodics:
       args:
       - "./test/presubmit-tests.sh"
       - "--all-tests"
+      securityContext:
+        privileged: true
       volumeMounts:
+      - name: docker-graph
+        mountPath: /docker-graph
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
       env:
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
     volumes:
+    - name: docker-graph
+      emptyDir: {}
     - name: test-account
       secret:
         secretName: test-account
@@ -10760,16 +10799,24 @@ periodics:
       args:
       - "./test/presubmit-tests.sh"
       - "--all-tests"
+      securityContext:
+        privileged: true
       volumeMounts:
+      - name: docker-graph
+        mountPath: /docker-graph
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
       env:
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
     volumes:
+    - name: docker-graph
+      emptyDir: {}
     - name: test-account
       secret:
         secretName: test-account
@@ -10797,16 +10844,24 @@ periodics:
       - "./hack/release.sh"
       - "--publish"
       - "--tag-release"
+      securityContext:
+        privileged: true
       volumeMounts:
+      - name: docker-graph
+        mountPath: /docker-graph
       - name: nightly-account
         mountPath: /etc/nightly-account
         readOnly: true
       env:
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
     volumes:
+    - name: docker-graph
+      emptyDir: {}
     - name: nightly-account
       secret:
         secretName: nightly-account
@@ -10836,14 +10891,20 @@ periodics:
       - "--release-gcs knative-releases/eventing-kafka-broker"
       - "--release-gcr gcr.io/knative-releases"
       - "--github-token /etc/hub-token/token"
+      securityContext:
+        privileged: true
       volumeMounts:
       - name: hub-token
         mountPath: /etc/hub-token
         readOnly: true
+      - name: docker-graph
+        mountPath: /docker-graph
       - name: release-account
         mountPath: /etc/release-account
         readOnly: true
       env:
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
       - name: ORG_NAME
         value: knative-sandbox
       - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -10854,6 +10915,8 @@ periodics:
     - name: hub-token
       secret:
         secretName: hub-token
+    - name: docker-graph
+      emptyDir: {}
     - name: release-account
       secret:
         secretName: release-account
@@ -10883,14 +10946,20 @@ periodics:
       - "--release-gcs knative-releases/eventing-kafka-broker"
       - "--release-gcr gcr.io/knative-releases"
       - "--github-token /etc/hub-token/token"
+      securityContext:
+        privileged: true
       volumeMounts:
       - name: hub-token
         mountPath: /etc/hub-token
         readOnly: true
+      - name: docker-graph
+        mountPath: /docker-graph
       - name: release-account
         mountPath: /etc/release-account
         readOnly: true
       env:
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
       - name: ORG_NAME
         value: knative-sandbox
       - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -10901,6 +10970,8 @@ periodics:
     - name: hub-token
       secret:
         secretName: hub-token
+    - name: docker-graph
+      emptyDir: {}
     - name: release-account
       secret:
         secretName: release-account


### PR DESCRIPTION
Signed-off-by: Pierangelo Di Pilato <pierangelodipilato@gmail.com>

**What this PR does, why we need it**: `knative-sandbox/eventing-kafka-broker` needs to use docker for running tests.

/assign @chizhg @chaodaiG 

Related: https://github.com/knative-sandbox/eventing-kafka-broker/pull/4, https://github.com/knative/test-infra/pull/2222#issuecomment-646541438