### PR TITLE
Add tooling to generate protobufs to test Dockerfile.

### DIFF
--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -71,6 +71,14 @@ RUN go get -u github.com/jstemmer/go-junit-report
 RUN GO111MODULE=on go get -u github.com/raviqqe/liche@v0.0.0-20200229003944-f57a5d1c5be4  # stable liche version for checking md links
 RUN GO111MODULE=on go get -u github.com/google/go-licenses
 
+# protoc and required golang tooling
+ARG PROTOC_VERSION=3.12.3
+RUN wget "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip" -O protoc.zip \
+    && unzip -p protoc.zip bin/protoc > /usr/local/bin/protoc \
+    && chmod +x /usr/local/bin/protoc \
+    && rm protoc.zip
+RUN GO111MODULE=on go get github.com/gogo/protobuf/protoc-gen-gogofaster@v1.3.1
+
 # Extract versions
 RUN bazel version > /bazel_version
 RUN ko version > /ko_version


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:

We're in the process of generating protobuf APIs in https://github.com/knative/serving/pull/8396 for example, thus need a bit more tooling available to run update-codegen.

**Special notes to reviewers**:

**User-visible changes in this PR**:

