### PR TITLE
Increase image push job memory limit to 16Gb

### DIFF
--- a/config/prod/prow/jobs/custom/test-infra.yaml
+++ b/config/prod/prow/jobs/custom/test-infra.yaml
@@ -426,6 +426,11 @@ postsubmits:
           value: "true"
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
+        resources:
+          requests:
+            memory: 12Gi
+          limits:
+            memory: 16Gi
       volumes:
       - name: docker-graph
         emptyDir: {}


### PR DESCRIPTION
Latest image push job failed OOM: https://prow.knative.dev/view/gcs/knative-prow/logs/post-knative-test-infra-image-push/1275500135224184833
https://pantheon.corp.google.com/kubernetes/pod/us-central1-f/knative-prow-build-cluster/test-pods/9292e70e-b581-11ea-b6d5-664f51b6f877/details?project=knative-tests

Increase memory limit from 8Gb to 16Gb

/assign chizhg