### PR TITLE
Increase image push job memory limit to 32 Gb

### DIFF
--- a/config/prod/prow/jobs/custom/test-infra.yaml
+++ b/config/prod/prow/jobs/custom/test-infra.yaml
@@ -428,9 +428,9 @@ postsubmits:
           value: /etc/test-account/service-account.json
         resources:
           requests:
-            memory: 12Gi
+            memory: 28Gi
           limits:
-            memory: 16Gi
+            memory: 32Gi
       volumes:
       - name: docker-graph
         emptyDir: {}


### PR DESCRIPTION
Image push job still failed: https://prow.k8s.io/view/gcs/oss-prow/logs/ci-oss-test-infra-autobump-prow/1275565582695010304
And it peaked 16Gb of memory: https://pantheon.corp.google.com/kubernetes/pod/us-central1-f/knative-prow-build-cluster/test-pods/46bbbd9d-b5ae-11ea-87bb-0242c0a8090b/details?project=knative-tests

/assign chizhg