### PR TITLE
Update peribolos image to the latest

### DIFF
--- a/config/prod/prow/jobs/custom/label-sync.yaml
+++ b/config/prod/prow/jobs/custom/label-sync.yaml
@@ -18,7 +18,7 @@
 periodics:
 # Run at 8AM PST.
 - cron: "0 15 * * *"
-  name: post-knative-test-infra-label-sync
+  name: ci-knative-test-infra-label-sync
   agent: kubernetes
   decorate: true
   extra_refs:

--- a/config/prod/prow/jobs/custom/peribolos.yaml
+++ b/config/prod/prow/jobs/custom/peribolos.yaml
@@ -28,7 +28,7 @@ postsubmits:
     - "master"
     spec:
       containers:
-      - image: gcr.io/k8s-prow/peribolos:v20200512-5bf6c1ac3
+      - image: gcr.io/k8s-prow/peribolos:v20200624-6fad05ae06
         command:
         - "/peribolos"
         args:
@@ -66,7 +66,7 @@ periodics:
     path_alias: knative.dev/community
   spec:
     containers:
-    - image: gcr.io/k8s-prow/peribolos:v20200512-5bf6c1ac3
+    - image: gcr.io/k8s-prow/peribolos:v20200624-6fad05ae06
       command:
       - "/peribolos"
       args:


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Update the peribolos image to the latest to pick up fixes in https://github.com/kubernetes/test-infra/pull/18068.
Also BTW fixed the job name I mistakenly added in https://github.com/knative/test-infra/pull/2238

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @chaodaiG 
