### PR TITLE
Add stdout option to exec.Command

### DIFF
--- a/pkg/cmd/command.go
+++ b/pkg/cmd/command.go
@@ -69,6 +69,7 @@ func WithStdout() Option {
 
 // RunCommand will run the command and return the standard output, plus error if there is one.
 func runCommand(cmdLine string, options ...Option) (string, error) {
+	var err error
 	cmdSplit, err := shell.Split(cmdLine)
 	if len(cmdSplit) == 0 || err != nil {
 		return "", &CommandLineError{
@@ -88,7 +89,12 @@ func runCommand(cmdLine string, options ...Option) (string, error) {
 	var eb bytes.Buffer
 	cmd.Stderr = &eb
 
-	out, err := cmd.Output()
+	var out []byte
+	if cmd.Stdout != nil {
+		err = cmd.Run()
+	} else {
+		out, err = cmd.Output()
+	}
 	if err != nil {
 		return string(out), &CommandLineError{
 			Command:     cmdLine,

--- a/pkg/cmd/command.go
+++ b/pkg/cmd/command.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"bytes"
+	"os"
 	"os/exec"
 	"strings"
 	"sync"
@@ -54,6 +55,15 @@ func WithEnvs(envs []string) Option {
 func WithDir(dir string) Option {
 	return func(c *exec.Cmd) {
 		c.Dir = dir
+	}
+}
+
+// WithStdout returns an option that sets the cmd output to stdout.
+// This redirects output to stdout, should not use this option if you
+// need the return value of the command.
+func WithStdout() Option {
+	return func(c *exec.Cmd) {
+		c.Stdout = os.Stdout
 	}
 }
 


### PR DESCRIPTION
This redirects the output of the command running to stdout, bypassing
the buffer it is returned to (commands requiring output of a command
should not set this)

/cc @chizhg 

