### PR TITLE
Stop updating core and plugins config from knative prow

### DIFF
--- a/config/prod/prow/core/plugins.yaml
+++ b/config/prod/prow/core/plugins.yaml
@@ -76,10 +76,6 @@ config_updater:
     config/prod/prow/jobs/**/*.yaml:
       name: job-config
       gzip: true
-    config/prod/prow/core/config.yaml:
-      name: config
-    config/prod/prow/core/plugins.yaml:
-      name: plugins
 # Plugins enabled for each repo.
 plugins:
   knative:


### PR DESCRIPTION
The core and plugins configs already live in oss-test-infra, stop updating them from here

/assign chizhg

Unfortunately this change will need to be mirrored in oss-test-infra repo to avoid surprises
/cc cjwagner