### PR TITLE
Fix git command in job syncer

### DIFF
--- a/pkg/git/commit.go
+++ b/pkg/git/commit.go
@@ -60,7 +60,7 @@ func MakeCommit(gi Info, message string, dryrun bool) (bool, error) {
 
 	if gi.UserName != "" && gi.Email != "" {
 		commitCmd = fmt.Sprintf("%s --author '%s <%s>'",
-			commitCmd, gi.UserName, gi.Email)
+			commitCmd, strings.Trim(gi.UserName, "'"), gi.Email)
 	}
 
 	cmds := []string{addCmd, commitCmd, pushCmd}


### PR DESCRIPTION
jobs syncer still failed:

```
Running "git add -A; git commit -m \"[Auto] Update prow jobs for release branches\" --author ''Knative Prow Updater Robot' <knative-prow-updater-robot@google.com>'; git push -f git@github.com:knative-prow-updater-robot/test-infra.git HEAD:releasebranch"
2020/07/07 22:57:20 failed creating pullrequest: 'failed git commit: 'Failed running "git add -A; git commit -m \"[Auto] Update prow jobs for release branches\" --author ''Knative Prow Updater Robot' <knative-prow-updater-robot@google.com>'; git push -f git@github.com:knative-prow-updater-robot/test-infra.git HEAD:releasebranch":
Output: "\n"
Error: error: pathspec 'Prow' did not match any file(s) known to git
error: pathspec 'Updater' did not match any file(s) known to git
error: pathspec 'Robot <knative-prow-updater-robot@google.com>' did not match any file(s) known to git
```

https://prow.knative.dev/view/gcs/knative-prow/logs/ci-knative-prow-jobs-syncer/1280636984045342720

/cc @chizhg 