### PR TITLE
Add sugar-controller extension setup

### DIFF
--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -504,20 +504,18 @@ function start_knative_eventing_extension() {
   header "Starting Knative Eventing Extension"
   echo "Installing Extension CRDs from $1"
   kubectl apply -f "$1"
-  # do the wait for running pods in specific extension function as the namespace could differ
+  wait_until_pods_running "$2" || return 1
 }
 
 # Install the stable release of eventing extension sugar controller in the current cluster.
 # Parameters: $1 - Knative Eventing release version, e.g. 0.16.0
 function start_release_eventing_sugar_controller() {
-    start_knative_eventing_extension "https://storage.googleapis.com/knative-releases/eventing/previous/v$1/eventing-sugar-controller.yaml"
-  wait_until_pods_running knative-eventing || return 1
+  start_knative_eventing_extension "https://storage.googleapis.com/knative-releases/eventing/previous/v$1/eventing-sugar-controller.yaml" "knative-eventing"
 }
 
 # Install the sugar cotroller eventing extension
 function start_latest_eventing_sugar_controller() {
-  start_knative_eventing_extension "${KNATIVE_EVENTING_SUGAR_CONTROLLER_RELEASE}"
-  wait_until_pods_running knative-eventing || return 1
+  start_knative_eventing_extension "${KNATIVE_EVENTING_SUGAR_CONTROLLER_RELEASE}" "knative-eventing"
 }
 
 # Run a go tool, installing it first if necessary.

--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -498,6 +498,28 @@ function start_latest_knative_eventing() {
   start_knative_eventing "${KNATIVE_EVENTING_RELEASE}"
 }
 
+# Install Knative Eventing extension in the current cluster.
+# Parameters: $1 - Knative Eventing extension manifest.
+function start_knative_eventing_extension() {
+  header "Starting Knative Eventing Extension"
+  echo "Installing Extension CRDs from $1"
+  kubectl apply -f "$1"
+  # do the wait for running pods in specific extension function as the namespace could differ
+}
+
+# Install the stable release of eventing extension sugar controller in the current cluster.
+# Parameters: $1 - Knative Eventing release version, e.g. 0.16.0
+function start_release_eventing_sugar_controller() {
+    start_knative_eventing_extension "https://storage.googleapis.com/knative-releases/eventing/previous/v$1/eventing-sugar-controller.yaml"
+  wait_until_pods_running knative-eventing || return 1
+}
+
+# Install the sugar cotroller eventing extension
+function start_latest_eventing_sugar_controller() {
+  start_knative_eventing_extension "${KNATIVE_EVENTING_SUGAR_CONTROLLER_RELEASE}"
+  wait_until_pods_running knative-eventing || return 1
+}
+
 # Run a go tool, installing it first if necessary.
 # Parameters: $1 - tool package/dir for go get/install.
 #             $2 - tool to run.
@@ -754,3 +776,4 @@ readonly KNATIVE_SERVING_RELEASE_CORE="$(get_latest_knative_yaml_source "serving
 readonly KNATIVE_NET_ISTIO_RELEASE="$(get_latest_knative_yaml_source "net-istio" "net-istio")"
 readonly KNATIVE_EVENTING_RELEASE="$(get_latest_knative_yaml_source "eventing" "eventing")"
 readonly KNATIVE_MONITORING_RELEASE="$(get_latest_knative_yaml_source "serving" "monitoring")"
+readonly KNATIVE_EVENTING_SUGAR_CONTROLLER_RELEASE="$(get_latest_knative_yaml_source "eventing" "eventing-sugar-controller")"

--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -500,6 +500,7 @@ function start_latest_knative_eventing() {
 
 # Install Knative Eventing extension in the current cluster.
 # Parameters: $1 - Knative Eventing extension manifest.
+#             $2 - Namespace to look for ready pods into
 function start_knative_eventing_extension() {
   header "Starting Knative Eventing Extension"
   echo "Installing Extension CRDs from $1"


### PR DESCRIPTION

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
 - Add setup utils for nightly and release version of eventing sugar controller
   extension
 - The wait for pod running check is deferred to specific extension function so
   they could watch in respective namespace

**Special notes to reviewers**:

**User-visible changes in this PR**:
- Provide `start_release_eventing_sugar_controller` and `start_latest_eventing_sugar_controller` utils for installing sugar controller extension.
