### PR TITLE
Some improvements to the kntest cluster gke related commands.

### DIFF
--- a/kntest/pkg/cluster/gke/README.md
+++ b/kntest/pkg/cluster/gke/README.md
@@ -3,20 +3,20 @@
 `kntest cluster gke` command is used for creating, deleting or getting a GKE
 cluster
 
-## Prerequisite
-
-- `GOOGLE_APPLICATION_CREDENTIALS` set
-
 ## Usage
 
 This tool can be invoked from command line. The following parameters are common
 for all subcommands:
 
+- `--gcp-credential-file`: the GCP credential file that will be used in the cluster operations \
+  Will fall back to `GOOGLE_APPLICATION_CREDENTIALS` if it's not set.
 - `--project`: GCP project, default empty
 - `--name`: cluster name, default empty
 - `--region`: GKE region, default "us-central1". \
   Can be more than one to set as backup regions.
 - `--resource-type`: Boskos resource type, default "gke-project"
+- `--save-meta-data`: whether or not save the meta data for the current cluster into `metadata.json`,
+  default to be false.
 
 ## Subcommands
 

--- a/kntest/pkg/cluster/gke/README.md
+++ b/kntest/pkg/cluster/gke/README.md
@@ -16,8 +16,8 @@ for all subcommands:
 - `--region`: GKE region, default "us-central1". \
   Can be more than one to set as backup regions.
 - `--resource-type`: Boskos resource type, default "gke-project"
-- `--save-meta-data`: whether or not save the meta data for the current cluster into `metadata.json`,
-  default to be false.
+- `--save-meta-data`: whether or not save the meta data for the current cluster
+  into `metadata.json`, default to be false.
 
 ## Subcommands
 

--- a/kntest/pkg/cluster/gke/README.md
+++ b/kntest/pkg/cluster/gke/README.md
@@ -8,7 +8,8 @@ cluster
 This tool can be invoked from command line. The following parameters are common
 for all subcommands:
 
-- `--gcp-credential-file`: the GCP credential file that will be used in the cluster operations \
+- `--gcp-credential-file`: the GCP credential file that will be used in the
+  cluster operations \
   Will fall back to `GOOGLE_APPLICATION_CREDENTIALS` if it's not set.
 - `--project`: GCP project, default empty
 - `--name`: cluster name, default empty

--- a/kntest/pkg/cluster/gke/options.go
+++ b/kntest/pkg/cluster/gke/options.go
@@ -28,10 +28,12 @@ func addCommonOptions(clusterCmd *cobra.Command, rw *clm.RequestWrapper) {
 	// The default values set here are not used in the final operations,
 	// they will further be defaulted in
 	// https://github.com/knative/pkg/blob/7727cb37e05d6c6dd2abadbc3ab01ab748f12561/testutils/clustermanager/e2e-tests/gke.go#L73-L114
+	pf.StringVar(&req.GCPCredentialFile, "gcp-credential-file", "", "the GCP credential file that will be used in the cluster operations")
 	pf.StringVar(&req.Project, "project", "", "GCP project")
 	pf.StringVar(&req.ClusterName, "name", "", "cluster name")
 	pf.StringSliceVar(&rw.Regions, "region", []string{}, "GCP regions, separated by comma or multiple args")
 	pf.StringVar(&req.ResourceType, "resource-type", "", "Boskos Resource Type")
+	pf.BoolVar(&req.SaveMetaData, "save-meta-data", false, "save meta data for the created cluster into a file")
 }
 
 func addCreateOptions(clusterCmd *cobra.Command, rw *clm.RequestWrapper) {

--- a/pkg/clustermanager/e2e-tests/create.go
+++ b/pkg/clustermanager/e2e-tests/create.go
@@ -47,10 +47,12 @@ func Create(rw *RequestWrapper) (*clm.GKECluster, error) {
 		return nil, err
 	}
 
-	// At this point we should have a cluster ready to run test. Need to save
-	// metadata so that following flow can understand the context of cluster, as
-	// well as for Prow usage later
-	writeMetaData(gkeOps.Cluster, gkeOps.Project)
+	if rw.Request.SaveMetaData {
+		// At this point we should have a cluster ready to run test. Need to save
+		// metadata so that following flow can understand the context of cluster, as
+		// well as for Prow usage later
+		writeMetaData(gkeOps.Cluster, gkeOps.Project)
+	}
 
 	// set up kube config points to cluster
 	clusterAuthCmd := fmt.Sprintf(
@@ -60,7 +62,7 @@ func Create(rw *RequestWrapper) (*clm.GKECluster, error) {
 		return nil, fmt.Errorf("failed connecting to cluster: %q, %w", out, err)
 	}
 	if out, err := cmd.RunCommand("gcloud config set project " + gkeOps.Project); err != nil {
-		return nil, fmt.Errorf("failed setting gcloud: %q, %w", out, err)
+		return nil, fmt.Errorf("failed setting project: %q, %w", out, err)
 	}
 
 	return gkeOps, nil

--- a/pkg/clustermanager/e2e-tests/gke/setup.go
+++ b/pkg/clustermanager/e2e-tests/gke/setup.go
@@ -45,6 +45,9 @@ type GKERequest struct {
 
 	// ResourceType: the boskos resource type to acquire to hold the cluster in create
 	ResourceType string
+
+	// SaveMetaData: save the meta data for the created cluster into a file
+	SaveMetaData bool
 }
 
 // GKECluster implements ClusterOperations

--- a/pkg/gke/request.go
+++ b/pkg/gke/request.go
@@ -26,6 +26,9 @@ const defaultGKEVersion = "latest"
 
 // Request contains all settings collected for cluster creation
 type Request struct {
+	// GCPCredentialFile: the GCP credential file to use for the cluster operations
+	GCPCredentialFile string
+
 	// Project: name of the gcloud project for the cluster
 	Project string
 
@@ -142,11 +145,11 @@ func NewCreateClusterRequest(request *Request) (*container.CreateClusterRequest,
 		},
 	}
 	if request.EnableWorkloadIdentity {
-		// Equivalent to --identity-namespace=[PROJECT_ID].svc.id.goog, then
+		// Equivalent to --workload-pool=[PROJECT_ID].svc.id.goog, then
 		// we can configure a Kubernetes service account to act as a Google
 		// service account.
 		ccr.Cluster.WorkloadIdentityConfig = &container.WorkloadIdentityConfig{
-			IdentityNamespace: request.Project + ".svc.id.goog",
+			WorkloadPool: request.Project + ".svc.id.goog",
 		}
 	}
 	if request.ServiceAccount != "" {

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -68,7 +68,7 @@ function create_test_cluster() {
 
   header "Creating test cluster"
 
-  local creation_args=""
+  local creation_args="--save-meta-data"
   (( SKIP_ISTIO_ADDON )) || creation_args+=" --addons istio"
   [[ -n "${GCP_PROJECT}" ]] && creation_args+=" --project ${GCP_PROJECT}"
   echo "Creating cluster with args ${creation_args}"
@@ -95,14 +95,10 @@ function setup_test_cluster() {
   set -o errexit
   set -o pipefail
 
-  header "Test cluster setup"
-  kubectl get nodes
-
   header "Setting up test cluster"
-
   # Run cluster-creator for acquiring existing test cluster, will fail if
   # kubeconfig isn't set or cluster doesn't exist
-  run_kntest cluster gke get || fail_test "failed getting test cluster" # NA
+  run_kntest cluster gke get --save-meta-data || fail_test "failed getting test cluster" # NA
   # The step above collects cluster metadata and writes to
   # ${ARTIFACTS}/metadata.json file, use this information
   echo "Cluster used for running tests: $(cat "${ARTIFACTS}"/metadata.json)"
@@ -137,9 +133,6 @@ function setup_test_cluster() {
   echo "- gcloud user is ${k8s_user}"
   echo "- Cluster is ${k8s_cluster}"
   echo "- Docker repository is ${KO_DOCKER_REPO}"
-
-  # Use default namespace for all subsequent kubectl commands in this context
-  kubectl config set-context "${k8s_cluster}" --namespace=default
 
   export KO_DATA_PATH="${REPO_ROOT_DIR}/.git"
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
1. Allow passing the credential file via `--gcp-credential-file` flag for the `kntest cluster gke` command
2. Add a switch flag `--save-meta-data` to control if we want to save the cluster config into `metadata.json`.
3. The field name for setting Workload Identity has become `WorkloadPool`

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @chaodaiG 

