### PR TITLE
Auto deploy tools

### DIFF
--- a/config/prod/prow/jobs/custom/test-infra.yaml
+++ b/config/prod/prow/jobs/custom/test-infra.yaml
@@ -426,3 +426,34 @@ postsubmits:
       - name: test-account
         secret:
           secretName: test-account
+  - name: post-knative-test-infra-deploy-tools
+    agent: kubernetes
+    decorate: true
+    path_alias: knative.dev/test-infra
+    max_concurrency: 1
+    cluster: "prow-trusted"
+    run_if_changed: "^tools/flaky-test-retryer/gke_deployment/retryer_service.yaml$"
+    branches:
+    - "master"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "make"
+        - "-C"
+        - "./tools/flaky-test-retryer/gke_deployment"
+        - "deploy"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account

--- a/config/prod/prow/testgrid/testgrid.yaml
+++ b/config/prod/prow/testgrid/testgrid.yaml
@@ -821,6 +821,11 @@ test_groups:
   alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
   num_failures_to_alert: 1
+- name: post-knative-test-infra-deploy-tools
+  gcs_prefix: knative-prow/logs/post-knative-test-infra-deploy-tools
+  alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+  num_failures_to_alert: 1
 dashboards:
 - name: serving
   dashboard_tab:
@@ -1791,6 +1796,9 @@ dashboards:
     base_options: ""
   - name: post-knative-sandbox-peribolos
     test_group_name: post-knative-sandbox-peribolos
+    base_options: ""
+  - name: post-knative-test-infra-deploy-tools
+    test_group_name: post-knative-test-infra-deploy-tools
     base_options: ""
 dashboard_groups:
 - name: knative

--- a/tools/config-generator/customjobs.go
+++ b/tools/config-generator/customjobs.go
@@ -31,6 +31,7 @@ var (
 		"post-knative-prow-cluster-config-updater",
 		"post-knative-test-infra-image-push",
 		"post-knative-sandbox-peribolos",
+		"post-knative-test-infra-deploy-tools",
 	}
 )
 

--- a/tools/flaky-test-retryer/gke_deployment/Makefile
+++ b/tools/flaky-test-retryer/gke_deployment/Makefile
@@ -1,0 +1,31 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SELF_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+include $(SELF_DIR)../../../common.mk
+
+CLUSTER := monitoring
+PROJECT := knative-tests
+ZONE := us-central1-a
+
+DEPLOYMENT_YAML := retryer_service.yaml
+
+.PHONY: deploy
+deploy: confirm-master
+ifdef GOOGLE_APPLICATION_CREDENTIALS
+	gcloud auth activate-service-account --key-file="$(GOOGLE_APPLICATION_CREDENTIALS)"
+endif
+	gcloud container clusters get-credentials "$(CLUSTER)" --project="$(PROJECT)" --zone="$(ZONE)"
+	kubectl apply -f "$(DEPLOYMENT_YAML)"
+	kubectl config unset current-context

--- a/tools/flaky-test-retryer/gke_deployment/Makefile
+++ b/tools/flaky-test-retryer/gke_deployment/Makefile
@@ -15,6 +15,9 @@
 SELF_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 include $(SELF_DIR)../../../common.mk
 
+# Hardcode the cluster information instead of making them parameter, as there
+# can only be a single instance of this tool, otherwise there will be N times
+# comments left on PRs
 CLUSTER := monitoring
 PROJECT := knative-tests
 ZONE := us-central1-a


### PR DESCRIPTION
Add a Makefile and prowjob for automatically deploy kubernetes apps, so far it's only flaky-test-retryer.

Context: flaky-test-retryer is a k8s service, which updates based on the deployment yaml. Currently whenever there is an update in the source code, the following events happens:

1. PR updating flaky-test-retryer source code merges
1. [Automatic] A postsubmit job creates a new version of image
1. [Manual] Create a PR using image tag from step above
1. [Manual] When PR merged, run `kubectl apply` update the service

This PR automates the last step

/cc @chizhg @albertomilan 
Also cc @Yizong98 