### PR TITLE
Fix run_job.sh by exporting the Prow config file to a mountable path

### DIFF
--- a/config/prod/prow/pj-on-kind.sh
+++ b/config/prod/prow/pj-on-kind.sh
@@ -30,7 +30,7 @@ PROW_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 if (( IS_OSX )); then
   # On OS X, the file has to be under /private other it cannot be mounted by the container.
   # See https://stackoverflow.com/questions/45122459/docker-mounts-denied-the-paths-are-not-shared-from-os-x-and-are-not-known/45123074
-  CONFIG_YAML="/private"$(mktemp)
+  CONFIG_YAML="/private$(mktemp)"
 else
   CONFIG_YAML=$(mktemp)
 fi

--- a/config/prod/prow/pj-on-kind.sh
+++ b/config/prod/prow/pj-on-kind.sh
@@ -27,7 +27,7 @@ set -o pipefail
 PROW_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 
 # Download prow core config from prow
-if [[ $IS_OSX ]]; then
+if (( IS_OSX )); then
   # On OS X, the file has to be under /private other it cannot be mounted by the container.
   # See https://stackoverflow.com/questions/45122459/docker-mounts-denied-the-paths-are-not-shared-from-os-x-and-are-not-known/45123074
   CONFIG_YAML="/private"$(mktemp)

--- a/config/prod/prow/pj-on-kind.sh
+++ b/config/prod/prow/pj-on-kind.sh
@@ -27,7 +27,13 @@ set -o pipefail
 PROW_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 
 # Download prow core config from prow
-CONFIG_YAML="$(mktemp)"
+if [[ $IS_OSX ]]; then
+  # On OS X, the file has to be under /private other it cannot be mounted by the container.
+  # See https://stackoverflow.com/questions/45122459/docker-mounts-denied-the-paths-are-not-shared-from-os-x-and-are-not-known/45123074
+  CONFIG_YAML="/private"$(mktemp)
+else
+  CONFIG_YAML=$(mktemp)
+fi
 make -C "${PROW_DIR}/.." get-cluster-credentials
 trap "make -C '${PROW_DIR}/..' unset-cluster-credentials" EXIT
 kubectl get configmaps config -o "jsonpath={.data['config\.yaml']}" >"${CONFIG_YAML}"

--- a/config/prod/prow/run_job.sh
+++ b/config/prod/prow/run_job.sh
@@ -31,7 +31,13 @@ GITHUB_TOKEN_PATH="$2"
 set -e
 
 # Download prow core config from prow
-CONFIG_YAML="$(mktemp)"
+if [[ $IS_OSX ]]; then
+  # On OS X, the file has to be under /private other it cannot be mounted by the container.
+  # See https://stackoverflow.com/questions/45122459/docker-mounts-denied-the-paths-are-not-shared-from-os-x-and-are-not-known/45123074
+  CONFIG_YAML="/private"$(mktemp)
+else
+  CONFIG_YAML=$(mktemp)
+fi
 make -C "${REPO_ROOT_DIR}/config/prod" get-cluster-credentials
 trap "make -C '${REPO_ROOT_DIR}/config/prod' unset-cluster-credentials" EXIT
 kubectl get configmaps config -o "jsonpath={.data['config\.yaml']}" >"${CONFIG_YAML}"

--- a/config/prod/prow/run_job.sh
+++ b/config/prod/prow/run_job.sh
@@ -31,7 +31,7 @@ GITHUB_TOKEN_PATH="$2"
 set -e
 
 # Download prow core config from prow
-if [[ $IS_OSX ]]; then
+if (( IS_OSX )); then
   # On OS X, the file has to be under /private other it cannot be mounted by the container.
   # See https://stackoverflow.com/questions/45122459/docker-mounts-denied-the-paths-are-not-shared-from-os-x-and-are-not-known/45123074
   CONFIG_YAML="/private"$(mktemp)

--- a/config/prod/prow/run_job.sh
+++ b/config/prod/prow/run_job.sh
@@ -34,7 +34,7 @@ set -e
 if (( IS_OSX )); then
   # On OS X, the file has to be under /private other it cannot be mounted by the container.
   # See https://stackoverflow.com/questions/45122459/docker-mounts-denied-the-paths-are-not-shared-from-os-x-and-are-not-known/45123074
-  CONFIG_YAML="/private"$(mktemp)
+  CONFIG_YAML="/private$(mktemp)"
 else
   CONFIG_YAML=$(mktemp)
 fi


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
`run_job.sh` will get an error when running on OS X, and the error message is below:
```
docker: Error response from daemon: Mounts denied: 
The path /var/folders/n1/3yzf5ppx0_9c0vnsmf8k6k2c00lvhy/T/tmp.M2gtJXP3
is not shared from OS X and is not known to Docker.
You can configure shared paths from Docker -> Preferences... -> File Sharing.
See https://docs.docker.com/docker-for-mac/osxfs/#namespaces for more info.
.
ERRO[0000] error waiting for container: context canceled
```

The reason is `/var` cannot be mounted by the container based on the default setting for docker on OS X, see https://stackoverflow.com/questions/45122459/docker-mounts-denied-the-paths-are-not-shared-from-os-x-and-are-not-known/45123074.

Fix it by providing a mountable path when the script is run on OS X.

/cc @chaodaiG 
