### PR TITLE
Fix peribolos Prow jobs by disabling --fix-team-repos and setting --tokens as a larger value

### DIFF
--- a/config/prod/prow/jobs/custom/peribolos.yaml
+++ b/config/prod/prow/jobs/custom/peribolos.yaml
@@ -41,8 +41,10 @@ postsubmits:
         - "--fix-org-members=true"
         - "--fix-teams=true"
         - "--fix-team-members=true"
-        - "--fix-team-repos=true"
+#      TODO(chizhg): reenable it after https://github.com/knative/test-infra/issues/2289 is fixed.
+#      - "--fix-team-repos=true"
         - "--fix-repos=true"
+        - "--tokens=1200"
         - "--confirm=true"
         volumeMounts:
         - name: oauth
@@ -76,8 +78,10 @@ postsubmits:
         - "--fix-org-members=true"
         - "--fix-teams=true"
         - "--fix-team-members=true"
-        - "--fix-team-repos=true"
+#      TODO(chizhg): reenable it after https://github.com/knative/test-infra/issues/2289 is fixed.
+#      - "--fix-team-repos=true"
         - "--fix-repos=true"
+        - "--tokens=1200"
         - "--confirm=true"
         volumeMounts:
         - name: oauth
@@ -114,8 +118,10 @@ periodics:
       - "--fix-org-members=true"
       - "--fix-teams=true"
       - "--fix-team-members=true"
-      - "--fix-team-repos=true"
+#      TODO(chizhg): reenable it after https://github.com/knative/test-infra/issues/2289 is fixed.
+#      - "--fix-team-repos=true"
       - "--fix-repos=true"
+      - "--tokens=1200"
       - "--confirm=true"
       volumeMounts:
       - name: oauth
@@ -150,8 +156,10 @@ periodics:
       - "--fix-org-members=true"
       - "--fix-teams=true"
       - "--fix-team-members=true"
-      - "--fix-team-repos=true"
+#      TODO(chizhg): reenable it after https://github.com/knative/test-infra/issues/2289 is fixed.
+#      - "--fix-team-repos=true"
       - "--fix-repos=true"
+      - "--tokens=1200"
       - "--confirm=true"
       volumeMounts:
       - name: oauth


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
1. The Peribolos Prow jobs are failing when `--fix-team-repos` is set to true, see https://github.com/knative/test-infra/issues/2289, disable it for now until the issue is fixed.
2. Setting `--tokens` as 1200 to allow the Prow jobs using the token more times as we sometimes see `sleep time for token reset exceeds max sleep time (21m25.009135767s \u003e 2m0s)` error in the logs. This is the current setting for the Prow jobs used by k8s.

/cc @chaodaiG @evankanderson 

