### PR TITLE
Improvements to the peribolos and label_sync Prow jobs

### DIFF
--- a/config/prod/prow/jobs/custom/label-sync.yaml
+++ b/config/prod/prow/jobs/custom/label-sync.yaml
@@ -15,6 +15,39 @@
 # label-sync is a tool implemented by k8s sig-testing.
 # It can update or migrate github labels on repos in a github org based on a YAML file.
 
+presubmits:
+  knative/test-infra:
+  - name: pull-knative-test-infra-label-sync
+    agent: kubernetes
+    decorate: true
+    path_alias: knative.dev/test-infra
+    run_if_changed: "^label_sync/labels.yaml$"
+    branches:
+    - "master"
+    spec:
+      containers:
+      - name: label-sync
+        image: gcr.io/k8s-prow/label_sync:v20200708-1254fdd37f
+        command:
+        - /app/label_sync/app.binary
+        args:
+        - --config=label_sync/labels.yaml
+        # Set --confirm=false to only validate the configuration file.
+        - --confirm=false
+        - --orgs=knative-sandbox,knative
+        - --token=/etc/github/oauth
+        - --endpoint=http://ghproxy.default.svc.cluster.local
+        - --endpoint=https://api.github.com
+        - --debug
+        volumeMounts:
+        - name: oauth
+          mountPath: /etc/github
+          readOnly: true
+      volumes:
+      - name: oauth
+        secret:
+          secretName: oauth-token
+
 periodics:
 # Run at 8AM PST.
 - cron: "0 15 * * *"

--- a/config/prod/prow/jobs/custom/peribolos.yaml
+++ b/config/prod/prow/jobs/custom/peribolos.yaml
@@ -15,6 +15,67 @@
 # Peribolos is a tool implemented by k8s sig-testing.
 # It allows the org settings, teams and memberships to be declared in a yaml file, and get GitHub updated to match the declared configuration.
 
+presubmits:
+  knative/community:
+  # Run on the Prow deployment cluster as it needs access to the github oauth token.
+  - name: pull-knative-peribolos
+    agent: kubernetes
+    decorate: true
+    path_alias: knative.dev/community
+    run_if_changed: "^peribolos/knative.yaml$"
+    branches:
+    - "master"
+    spec:
+      containers:
+      - image: gcr.io/k8s-prow/peribolos:v20200708-1254fdd37f
+        command:
+        - "/peribolos"
+        args:
+        - "--config-path=peribolos/knative.yaml"
+        - "--github-endpoint=http://ghproxy.default.svc.cluster.local"
+        - "--github-endpoint=https://api.github.com"
+        - "--github-token-path=/etc/github/oauth"
+        - "--min-admins=5"
+        # Set --confirm=false to only validate the configuration file.
+        - "--confirm=false"
+        volumeMounts:
+        - name: oauth
+          mountPath: /etc/github
+          readOnly: true
+      volumes:
+      - name: oauth
+        secret:
+          secretName: oauth-token
+  # Run on the Prow deployment cluster as it needs access to the github oauth token.
+  - name: pull-knative-sandbox-peribolos
+    agent: kubernetes
+    decorate: true
+    path_alias: knative.dev/community
+    run_if_changed: "^peribolos/knative-sandbox.yaml$"
+    branches:
+    - "master"
+    spec:
+      containers:
+      - image: gcr.io/k8s-prow/peribolos:v20200708-1254fdd37f
+        command:
+        - "/peribolos"
+        args:
+        - "--config-path=peribolos/knative-sandbox.yaml"
+        - "--github-endpoint=http://ghproxy.default.svc.cluster.local"
+        - "--github-endpoint=https://api.github.com"
+        - "--github-token-path=/etc/github/oauth"
+        - "--min-admins=5"
+        # Set --confirm=false to only validate the configuration file.
+        - "--confirm=false"
+        volumeMounts:
+        - name: oauth
+          mountPath: /etc/github
+          readOnly: true
+      volumes:
+      - name: oauth
+        secret:
+          secretName: oauth-token
+
 postsubmits:
   knative/community:
   # Run on the Prow deployment cluster as it needs access to the github oauth token.

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -22,19 +22,56 @@
 ---
 default:
   labels:
-    # Signals to other contributors
+    # Common labels for triaging
+    - color: c5def5
+      description: Parked issue that required triaging/revisit in a near future
+      name: kind/TBD
+      target: issues
+      addedBy: humans
     - color: 7057ff
       description: Denotes an issue ready for a new contributor, according to the "help wanted" guidelines.
-      name: 'good first issue'
+      name: kind/good-first-issue
       target: issues
       prowPlugin: help
       addedBy: anyone
-    - color: "008672"
+    - color: 008672
       description: Denotes an issue that needs help from a contributor. Must meet "help wanted" guidelines.
-      name: 'help wanted'
+      name: kind/help-wanted
       target: issues
       prowPlugin: help
       addedBy: anyone
+    - color: ff0000
+      name: kind/bug
+      target: issues
+      addedBy: humans
+    - color: f9d3c4
+      name: kind/proposal
+      target: issues
+      addedBy: humans
+    - color: 030ba0
+      name: kind/cleanup
+      target: issues
+      addedBy: humans
+    - color: f9d7c4
+      name: kind/feature-request
+      target: issues
+      addedBy: humans
+    - color: f9d0c4
+      name: kind/documentation
+      target: issues
+      addedBy: humans
+    - color: a2eeef
+      name: kind/enhancement
+      target: issues
+      addedBy: humans
+    - color: bfd4f2
+      name: kind/performance
+      target: issues
+      addedBy: humans
+    - color: 1d76db
+      name: kind/refactoring
+      target: issues
+      addedBy: humans
 
     #############################################################################
     # These labels are important for automation so normally should not be changed
@@ -174,85 +211,21 @@ default:
 repos:
   knative/test-infra:
     labels:
-    - color: c5def5
-      description: Parked issue that required triaging/revisit in a near future
-      name: TBD
-      target: issues
-      addedBy: humans
-    - color: 030ba0
-      name: kind/cleanup
-      target: issues
-      addedBy: humans
-    - color: f9d0c4
-      name: kind/documentation
-      target: issues
-      addedBy: humans
-    - color: a2eeef
-      description: New feature or request
-      name: kind/enhancement
-      target: issues
-      addedBy: humans
-    - color: 7057ff
-      description: Good for newcomers
-      name: kind/good-first-issue
-      target: issues
-      addedBy: humans
-    - color: bfd4f2
-      name: kind/performance
-      target: issues
-      addedBy: humans
     - color: f9d0c4
       name: kind/project-support
       target: issues
       addedBy: humans
-    - color: 1d76db
-      name: kind/refactoring
-      target: issues
-      addedBy: humans
   knative-sandbox/eventing-kafka-broker:
     labels:
-      - color: ff0000
-        name: kind/bug
-        target: issues
-        addedBy: humans
-      - color: 030ba0
-        name: kind/cleanup
-        target: issues
-        addedBy: humans
-      - color: f9d0c4
-        name: kind/documentation
-        target: issues
-        addedBy: humans
-      - color: f9d7c4
-        name: kind/feature-request
-        target: issues
-        addedBy: humans
-      - color: f9d3c4
-        name: kind/proposal
-        target: issues
-        addedBy: humans
-      - color: a2eeef
-        description: New feature or request
-        name: kind/enhancement
-        target: issues
-        addedBy: humans
-      - color: bfd4f2
-        name: kind/performance
-        target: issues
-        addedBy: humans
-      - color: 1d76db
-        name: kind/refactoring
-        target: issues
-        addedBy: humans
-      - color: 782b90
-        name: area/data-plane
-        target: issues
-        addedBy: humans
-      - color: 7fd5ea
-        name: area/control-plane
-        target: issues
-        addedBy: humans
-      - color: 72d5e0
-        name: area/api
-        target: issues
-        addedBy: humans
+    - color: 782b90
+      name: area/data-plane
+      target: issues
+      addedBy: humans
+    - color: 7fd5ea
+      name: area/control-plane
+      target: issues
+      addedBy: humans
+    - color: 72d5e0
+      name: area/api
+      target: issues
+      addedBy: humans


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
1. Run presubmit Prow jobs for peribolos and label_sync with `--confirm=false`, to prevent the configuration files to be broken like https://github.com/knative/community/pull/181
2. Move some labels in the `label_sync` config file to be common triaging labels

/cc @chaodaiG @albertomilan 
