### PR TITLE
Productivity oncalls owns custom jobs configs

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -11,4 +11,3 @@ aliases:
   - steuhs
   - peterfeifanchen
   - efiturri
-  - nbarthwal

--- a/config/prod/prow/jobs/custom/OWNERS
+++ b/config/prod/prow/jobs/custom/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+- chaodaiG
+- coryrc
+- chizhg
+- steuhs
+- peterfeifanchen
+- efiturri
+- albertomilan


### PR DESCRIPTION
So that oncall can approve auto bump PRs like https://github.com/knative/test-infra/pull/2287

/cc chizhg albertomilan