### PR TITLE
Replace issue tracker job for test-infra with github action

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,29 @@
+name: 'Close stale'
+on:
+  schedule:
+  - cron: '* * * * *' # Runs everyday
+
+jobs:
+  stale:
+    runs-on: 'ubuntu-latest'
+    steps:
+    - uses: 'actions/stale@v3'
+      with:
+        repo-token: '${{ secrets.GITHUB_TOKEN }}' # No need to setup
+
+        stale-issue-message: |-
+          This issue is stale because it has been open for 90 days with no
+          activity. It will automatically close after 30 more days of
+          inactivity. \nReopen the issue with `/reopen`.\nMark the issue as
+          fresh by adding the comment `/remove-lifecycle stale`.
+        stale-issue-label: 'lifecycle/stale'
+
+        stale-pr-message: |-
+          This Pull Request is stale because it has been open for 90 days with
+          no activity. It will automatically close after 30 more days of
+          inactivity. \nReopen with `/reopen`.\nMark as fresh by adding the
+          comment `/remove-lifecycle stale`.
+        stale-pr-label: 'lifecycle/stale'
+
+        days-before-stale: 90
+        days-before-close: 30

--- a/config/prod/prow/jobs/custom/issue-tracker.yaml
+++ b/config/prod/prow/jobs/custom/issue-tracker.yaml
@@ -32,8 +32,7 @@ periodics:
       command:
       - "/app/robots/commenter/app.binary"
       args:
-      - "--query=repo:knative/test-infra
-      repo:knative/serving
+      - "--query=repo:knative/serving
       repo:knative/docs
       is:open
       -label:lifecycle/frozen
@@ -69,8 +68,7 @@ periodics:
       command:
       - "/app/robots/commenter/app.binary"
       args:
-      - "--query=repo:knative/test-infra
-      repo:knative/serving
+      - "--query=repo:knative/serving
       repo:knative/docs
       is:open
       -label:lifecycle/frozen
@@ -105,8 +103,7 @@ periodics:
       command:
       - "/app/robots/commenter/app.binary"
       args:
-      - "--query=repo:knative/test-infra
-      repo:knative/serving
+      - "--query=repo:repo:knative/serving
       repo:knative/docs
       is:open
       -label:lifecycle/frozen


### PR DESCRIPTION
Github actions support stale https://github.com/actions/stale, which uses default github token for management, using it can avoid us managing another github token

Use label `lifecycle/stale` so that it can works with prow lifecycle plugin.

/cc @chizhg @mattmoor 