### PR TITLE
Ignore 'Terminating' pods when waiting for all pods running.

### DIFF
--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -134,7 +134,9 @@ function wait_until_pods_running() {
   echo -n "Waiting until all pods in namespace $1 are up"
   local failed_pod=""
   for i in {1..150}; do  # timeout after 5 minutes
-    local pods="$(kubectl get pods --no-headers -n $1 2>/dev/null)"
+    # List all pods. Ignore Terminating pods as those have either been replaced through
+    # a deployment or terminated on purpose (through chaosduck for example).
+    local pods="$(kubectl get pods --no-headers -n $1 2>/dev/null | grep -v Terminating)"
     # All pods must be running (ignore ImagePull error to allow the pod to retry)
     local not_running_pods=$(echo "${pods}" | grep -v Running | grep -v Completed | grep -v ErrImagePull | grep -v ImagePullBackOff)
     if [[ -n "${pods}" ]] && [[ -z "${not_running_pods}" ]]; then


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:

Pods that are in a Terminating state don't need to be accounted for when waiting for all pods in a namespace to be up and running as the termination is something that needs to be triggered by an outside signal (i.e. a Deployment update or an explicit deletion of the pod). Those signals should be benign to the system's health.

To allow builds like these to be happy: https://prow.knative.dev/view/gcs/knative-prow/logs/ci-knative-serving-continuous/1283884364689575939

