### PR TITLE
dump metrics to artifacts directory

### DIFF
--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -85,6 +85,19 @@ function go_test_e2e() {
   report_go_test -v -race -count=1 ${go_options} $@ "${test_options}"
 }
 
+# Dumps the k8s api server metrics. Spins up a proxy, waits a little bit and
+# dumps the metrics to ${ARTIFACTS}/k8s.metrics.txt
+function dump_metrics() {
+    header ">> Starting kube proxy"
+    kubectl proxy --port=8080 &
+    local proxy_pid=$!
+    sleep 5
+    header ">> Grabbing k8s metrics"
+    curl -s http://localhost:8080/metrics ${ARTIFACTS}/k8s.metrics.txt
+    # Clean up proxy so it doesn't interfere with job shutting down
+    kill $proxy_pid || true
+}
+
 # Dump info about the test cluster. If dump_extra_cluster_info() is defined, calls it too.
 # This is intended to be called when a test fails to provide debugging information.
 function dump_cluster_state() {
@@ -410,6 +423,7 @@ function success() {
   echo "**************************************"
   echo "***        E2E TESTS PASSED        ***"
   echo "**************************************"
+  dump_metrics
   exit 0
 }
 
@@ -419,6 +433,7 @@ function fail_test() {
   set_test_return_code 1
   [[ -n $1 ]] && echo "ERROR: $1"
   dump_cluster_state
+  dump_metrics
   exit 1
 }
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Add a dump_metrics function and call it from fail/success. This creates
a new file in artifacts called k8s.metrics.txt which contains all the metrics
exposed from the k8s api server. Handy for figuring out all the details about what was created, if it failed, how long it took, etc.
Here's sample lines from the output:

```
apiserver_request_total{client="",code="201",component="apiserver",contentType="application/json",dry_run="",group="eventing.knative.dev",resource="brokers",scope="namespace",subresource="",verb="CREATE",version="v1beta1"} 89
apiserver_request_total{client="",code="201",component="apiserver",contentType="application/json",dry_run="",group="eventing.knative.dev",resource="triggers",scope="namespace",subresource="",verb="CREATE",version="v1beta1"} 16
```

Tried locally here:
https://github.com/knative/eventing/pull/3599/files#diff-bd936cfe1323838e9372afd0ae4135a3R254

And you can see an example (in this case I was just dumping to build-log.txt, but changed it to dump to the artifacts directory instead.
https://prow.knative.dev/view/gs/knative-prow/pr-logs/pull/knative_eventing/3599/pull-knative-eventing-integration-tests/1284189750948794373

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #

**Special notes to reviewers**:

**User-visible changes in this PR**:
Another log gets created in artifacts directory, called k8s.metrics.txt
