### PR TITLE
Redirect the metrics to the actual file. zomg. sorry

### DIFF
--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -93,7 +93,7 @@ function dump_metrics() {
     local proxy_pid=$!
     sleep 5
     header ">> Grabbing k8s metrics"
-    curl -s http://localhost:8080/metrics ${ARTIFACTS}/k8s.metrics.txt
+    curl -s http://localhost:8080/metrics > ${ARTIFACTS}/k8s.metrics.txt
     # Clean up proxy so it doesn't interfere with job shutting down
     kill $proxy_pid || true
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
Good news, we're getting metrics. Bad news, they are showing up build build-log.txt. Why?

Well, there was a tiny bit missing in:
https://github.com/knative/test-infra/pull/2304
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #

**Special notes to reviewers**:

**User-visible changes in this PR**:

