### PR TITLE
Remove a few labels in the label-sync.yaml file for now to get the job pass

### DIFF
--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -24,21 +24,14 @@ default:
   labels:
     # Common labels for triaging
     - color: c5def5
-      description: Parked issue that required triaging/revisit in a near future
+      description: Parked issue that required triaging/revisit in a near future.
       name: kind/TBD
       target: issues
       addedBy: humans
     - color: 7057ff
-      description: Denotes an issue ready for a new contributor, according to the "help wanted" guidelines.
+      description: Denotes an issue ready for a new contributor.
       name: kind/good-first-issue
       target: issues
-      prowPlugin: help
-      addedBy: anyone
-    - color: 008672
-      description: Denotes an issue that needs help from a contributor. Must meet "help wanted" guidelines.
-      name: kind/help-wanted
-      target: issues
-      prowPlugin: help
       addedBy: anyone
     - color: ff0000
       name: kind/bug
@@ -66,10 +59,6 @@ default:
       addedBy: humans
     - color: bfd4f2
       name: kind/performance
-      target: issues
-      addedBy: humans
-    - color: 1d76db
-      name: kind/refactoring
       target: issues
       addedBy: humans
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
The label-sync Prow job is now failing, see https://prow.knative.dev/view/gcs/knative-prow/logs/ci-knative-test-infra-label-sync/1283416279327182849.
Removing a few labels will get the job pass. I haven't figured out the reason for it, but let's remove the labels for now. I have created https://github.com/knative/test-infra/issues/2306 for tracking.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @chaodaiG 