### PR TITLE
Auto generated config header uses fixed copyright year.

### DIFF
--- a/tools/config-generator/templates/common_header.yaml
+++ b/tools/config-generator/templates/common_header.yaml
@@ -1,4 +1,4 @@
-# Copyright [[.Year]] The Knative Authors
+# Copyright 2020 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
/cc chaodaig
fixes #1833 