### PR TITLE
Run eventing conformance tests in a separate Prow job

### DIFF
--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -168,6 +168,12 @@ presubmits:
     args:
     - --run-test
     - ./test/e2e-tests.sh
+  - custom-test: conformance-tests
+    dot-dev: true
+    needs-monitor: true
+    args:
+    - --run-test
+    - ./test/e2e-conformance-tests.sh
   - custom-test: upgrade-tests
     dot-dev: true
     needs-monitor: true

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -1012,6 +1012,42 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
+  - name: pull-knative-eventing-conformance-tests
+    agent: kubernetes
+    labels:
+      prow.k8s.io/pubsub.project: knative-tests
+      prow.k8s.io/pubsub.topic: knative-monitoring
+      prow.k8s.io/pubsub.runID: pull-knative-eventing-conformance-tests
+    context: pull-knative-eventing-conformance-tests
+    always_run: true
+    rerun_command: "/test pull-knative-eventing-conformance-tests"
+    trigger: "(?m)^/test (all|pull-knative-eventing-conformance-tests),?(\\s+|$)"
+    decorate: true
+    path_alias: knative.dev/eventing
+    cluster: "build-knative"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-conformance-tests.sh"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
   - name: pull-knative-eventing-upgrade-tests
     agent: kubernetes
     labels:


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Add a separate Prow job to run eventing conformance tests.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


