### PR TITLE
Fix test-infra continuous tests

### DIFF
--- a/test/unit/presubmit-tests.sh
+++ b/test/unit/presubmit-tests.sh
@@ -15,9 +15,11 @@
 # limitations under the License.
 
 # Fake we're in a Prow job, if running locally.
-[[ ! -v PROW_JOB_ID ]] && PROW_JOB_ID=123
-[[ ! -v JOB_TYPE ]] && JOB_TYPE="presubmit"
-[[ ! -v ARTIFACTS ]] && ARTIFACTS=/tmp
+# Only overwrite the env vars within the scope of this script.
+# shellcheck disable=SC2034
+PROW_JOB_ID=123
+JOB_TYPE="presubmit"
+ARTIFACTS=/tmp
 
 source $(dirname $0)/test-helper.sh
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
The CI flow for test-infra is consistently failing, see https://testgrid.knative.dev/test-infra#continuous

The reason is one of the unit tests rely on the value of `JOB_TYPE`, which is `periodic` instead of `presubmit` in CI flows. This PR overwrite it to `presubmit` to get the tests pass on CI.