### PR TITLE
Replace go-junit-report with gotestsum

### DIFF
--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -67,7 +67,9 @@ RUN source-gvm-and-run.sh install go1.14.6 --prefer-binary
 RUN GO111MODULE=on go get github.com/google/ko/cmd/ko@v0.5.1
 RUN GO111MODULE=on go get github.com/boz/kail/cmd/kail
 RUN go get -u github.com/golang/dep/cmd/dep
+# TODO(chizhg): remove once all repos have been updated to use gotestsum.
 RUN go get -u github.com/jstemmer/go-junit-report
+RUN GO111MODULE=on go get -u gotest.tools/gotestsum
 RUN GO111MODULE=on go get -u github.com/raviqqe/liche@v0.0.0-20200229003944-f57a5d1c5be4  # stable liche version for checking md links
 RUN GO111MODULE=on go get -u github.com/google/go-licenses
 RUN GO111MODULE=on go get -u sigs.k8s.io/kubetest2

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -79,10 +79,13 @@ function teardown_test_resources() {
 # Run the given E2E tests. Assume tests are tagged e2e, unless `-tags=XXX` is passed.
 # Parameters: $1..$n - any go test flags, then directories containing the tests to run.
 function go_test_e2e() {
-  local test_options=""
-  local go_options=""
-  [[ ! " $@" == *" -tags="* ]] && go_options="-tags=e2e"
-  report_go_test -v -race -count=1 ${go_options} $@ "${test_options}"
+  local go_test_args=()
+  # Remove empty args as `go test` will consider it as running tests for the current directory, which is not expected.
+  for arg in "$@"; do
+    [[ -n "$arg" ]] && go_test_args+=("$arg")
+  done
+  [[ ! " $*" == *" -tags="* ]] && go_test_args+=("-tags=e2e")
+  report_go_test -race -count=1 "${go_test_args[@]}"
 }
 
 # Dumps the k8s api server metrics. Spins up a proxy, waits a little bit and
@@ -93,7 +96,7 @@ function dump_metrics() {
     local proxy_pid=$!
     sleep 5
     header ">> Grabbing k8s metrics"
-    curl -s http://localhost:8080/metrics > ${ARTIFACTS}/k8s.metrics.txt
+    curl -s http://localhost:8080/metrics > "${ARTIFACTS}"/k8s.metrics.txt
     # Clean up proxy so it doesn't interfere with job shutting down
     kill $proxy_pid || true
 }

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -28,7 +28,7 @@ source $(dirname "${BASH_SOURCE[0]}")/../scripts/e2e-tests.sh
 # Read metadata.json and get value for key
 # Parameters: $1 - Key for metadata
 function get_meta_value() {
-  run_kntest metadata get --key "$1"
+  run_kntest metadata get --key="$1"
 }
 
 function knative_setup() {
@@ -68,12 +68,12 @@ function create_test_cluster() {
 
   header "Creating test cluster"
 
-  local creation_args="--save-meta-data"
-  (( SKIP_ISTIO_ADDON )) || creation_args+=" --addons istio"
-  [[ -n "${GCP_PROJECT}" ]] && creation_args+=" --project ${GCP_PROJECT}"
-  echo "Creating cluster with args ${creation_args}"
+  local creation_args=("--save-meta-data")
+  (( SKIP_ISTIO_ADDON )) || creation_args+=("--addons=istio")
+  [[ -n "${GCP_PROJECT}" ]] && creation_args+=("--project=${GCP_PROJECT}")
+  echo "Creating cluster with args ${creation_args[*]}"
   # TODO(chizhg): support parameterizing "gke" so that we can create other types of clusters
-  run_kntest cluster gke create "${creation_args}" || fail_test "failed creating test cluster"
+  run_kntest cluster gke create "${creation_args[@]}" || fail_test "failed creating test cluster"
   # Should have kubeconfig set already
   local k8s_cluster
   k8s_cluster=$(get_e2e_test_cluster)

--- a/tools/coverage/presubmit_test.go
+++ b/tools/coverage/presubmit_test.go
@@ -18,6 +18,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"log"
 	"testing"
 
 	"knative.dev/test-infra/tools/coverage/artifacts/artsTest"
@@ -140,5 +141,5 @@ func TestK8sGcsAddress(t *testing.T) {
 	if got != want {
 		t.Fatal(test.StrFailure("", want, got))
 	}
-	fmt.Printf("line cov link=%s", got)
+	log.Printf("line cov link=%s", got)
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
1. Use `gotestsum` to generate XML result, in place of `go-junit-report`
2. Fix a bug that `create_junit_xml` cannot generate the XML files correctly if the error message contains space. The reason is we are using `$@` which will automatically split the string with spaces which will convert the error message into multiple arguments. This is a serious issue as most of the error messages are long.

I have tested the changes in https://github.com/knative/serving/pull/8884 (the failing jobs are due to flaky tests)

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #2319 