### PR TITLE
Omit property in testcase if empty

### DIFF
--- a/pkg/junit/junit.go
+++ b/pkg/junit/junit.go
@@ -56,14 +56,14 @@ type TestSuite struct {
 
 // TestCase holds <testcase/> results
 type TestCase struct {
-	Name       string         `xml:"name,attr"`
-	Time       float64        `xml:"time,attr"` // Seconds
-	ClassName  string         `xml:"classname,attr"`
-	Failure    *string        `xml:"failure,omitempty"`
-	Output     *string        `xml:"system-out,omitempty"`
-	Error      *string        `xml:"system-err,omitempty"`
-	Skipped    *string        `xml:"skipped,omitempty"`
-	Properties TestProperties `xml:"properties,omitempty"`
+	Name       string          `xml:"name,attr"`
+	Time       float64         `xml:"time,attr"` // Seconds
+	ClassName  string          `xml:"classname,attr"`
+	Failure    *string         `xml:"failure,omitempty"`
+	Output     *string         `xml:"system-out,omitempty"`
+	Error      *string         `xml:"system-err,omitempty"`
+	Skipped    *string         `xml:"skipped,omitempty"`
+	Properties *TestProperties `xml:"properties,omitempty"`
 }
 
 // TestProperties is an array of test properties

--- a/pkg/junit/junit.go
+++ b/pkg/junit/junit.go
@@ -63,7 +63,7 @@ type TestCase struct {
 	Output     *string        `xml:"system-out,omitempty"`
 	Error      *string        `xml:"system-err,omitempty"`
 	Skipped    *string        `xml:"skipped,omitempty"`
-	Properties TestProperties `xml:"properties"`
+	Properties TestProperties `xml:"properties,omitempty"`
 }
 
 // TestProperties is an array of test properties

--- a/pkg/junit/junit.go
+++ b/pkg/junit/junit.go
@@ -91,6 +91,9 @@ func (testCase *TestCase) GetTestStatus() TestStatusEnum {
 
 // AddProperty adds property to testcase
 func (testCase *TestCase) AddProperty(name, val string) {
+	if testCase.Properties == nil {
+		testCase.Properties = &TestProperties{}
+	}
 	property := TestProperty{Name: name, Value: val}
 	testCase.Properties.Properties = append(testCase.Properties.Properties, property)
 }

--- a/pkg/junit/junit_test.go
+++ b/pkg/junit/junit_test.go
@@ -161,7 +161,7 @@ func TestCreateXMLErrorMsg(t *testing.T) {
 	defer os.RemoveAll(testDir) // clean up
 	dest := path.Join(testDir, "TestCreateXMLErrorTestFile")
 	CreateXMLErrorMsg("dummySuite", "dummyTest", "dummyError has occurred", dest)
-	expected := `<testsuites><testsuite name="dummySuite" time="0" failures="1" tests="1"><testcase name="dummyTest" time="0" classname=""><failure>dummyError has occurred</failure><properties></properties></testcase><properties></properties></testsuite></testsuites>`
+	expected := `<testsuites><testsuite name="dummySuite" time="0" failures="1" tests="1"><testcase name="dummyTest" time="0" classname=""><failure>dummyError has occurred</failure></testcase><properties></properties></testsuite></testsuites>`
 
 	got, err := ioutil.ReadFile(dest)
 	if err != nil {


### PR DESCRIPTION
To make it more compatible with gotestsum. Omit properties if it is empty.
