### PR TITLE
Replace Istio versions by stable/latest channels

### DIFF
--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -48,57 +48,57 @@ presubmits:
   - go-coverage: true
     go-coverage-threshold: 80
     dot-dev: true
-  - custom-test: istio-1.5-mesh
+  - custom-test: istio-latest-mesh
     dot-dev: true
     always-run: false
     optional: true
     args:
     - --run-test
-    - ./test/e2e-tests.sh --istio-version 1.5-latest --mesh
+    - ./test/e2e-tests.sh --istio-version latest --mesh
     - --run-test
-    - ./test/e2e-auto-tls-tests.sh --istio-version 1.5-latest --mesh
+    - ./test/e2e-auto-tls-tests.sh --istio-version latest --mesh
     resources:
       requests:
         memory: 12Gi
       limits:
         memory: 16Gi
-  - custom-test: istio-1.5-no-mesh
+  - custom-test: istio-latest-no-mesh
     dot-dev: true
     always-run: false
     optional: true
     args:
     - --run-test
-    - ./test/e2e-tests.sh --istio-version 1.5-latest --no-mesh
+    - ./test/e2e-tests.sh --istio-version latest --no-mesh
     - --run-test
-    - ./test/e2e-auto-tls-tests.sh --istio-version 1.5-latest --no-mesh
+    - ./test/e2e-auto-tls-tests.sh --istio-version latest --no-mesh
     resources:
       requests:
         memory: 12Gi
       limits:
         memory: 16Gi
-  - custom-test: istio-1.4-mesh
+  - custom-test: istio-stable-mesh
     dot-dev: true
     always-run: false
     optional: true
     args:
     - --run-test
-    - ./test/e2e-tests.sh --istio-version 1.4-latest --mesh
+    - ./test/e2e-tests.sh --istio-version stable --mesh
     - --run-test
-    - ./test/e2e-auto-tls-tests.sh --istio-version 1.4-latest --mesh
+    - ./test/e2e-auto-tls-tests.sh --istio-version stable --mesh
     resources:
       requests:
         memory: 12Gi
       limits:
         memory: 16Gi
-  - custom-test: istio-1.4-no-mesh
+  - custom-test: istio-stable-no-mesh
     dot-dev: true
     always-run: false
     optional: true
     args:
     - --run-test
-    - ./test/e2e-tests.sh --istio-version 1.4-latest --no-mesh
+    - ./test/e2e-tests.sh --istio-version stable --no-mesh
     - --run-test
-    - ./test/e2e-auto-tls-tests.sh --istio-version 1.4-latest --no-mesh
+    - ./test/e2e-auto-tls-tests.sh --istio-version stable --no-mesh
     resources:
       requests:
         memory: 12Gi
@@ -476,41 +476,41 @@ periodics:
   - branch-ci: true
     release: "0.16"
     dot-dev: true
-  - custom-job: istio-1.5-mesh
+  - custom-job: istio-latest-mesh
     command:
     - ./test/presubmit-tests.sh
     args:
     - --run-test
-    - ./test/e2e-tests.sh --istio-version 1.5-latest --mesh
+    - ./test/e2e-tests.sh --istio-version latest --mesh
     - --run-test
-    - ./test/e2e-auto-tls-tests.sh --istio-version 1.5-latest --mesh
+    - ./test/e2e-auto-tls-tests.sh --istio-version latest --mesh
     dot-dev: true
-  - custom-job: istio-1.5-no-mesh
+  - custom-job: istio-latest-no-mesh
     command:
     - ./test/presubmit-tests.sh
     args:
     - --run-test
-    - ./test/e2e-tests.sh --istio-version 1.5-latest --no-mesh
+    - ./test/e2e-tests.sh --istio-version latest --no-mesh
     - --run-test
-    - ./test/e2e-auto-tls-tests.sh --istio-version 1.5-latest --no-mesh
+    - ./test/e2e-auto-tls-tests.sh --istio-version latest --no-mesh
     dot-dev: true
-  - custom-job: istio-1.4-mesh
+  - custom-job: istio-stable-mesh
     command:
     - ./test/presubmit-tests.sh
     args:
     - --run-test
-    - ./test/e2e-tests.sh --istio-version 1.4-latest --mesh
+    - ./test/e2e-tests.sh --istio-version stable --mesh
     - --run-test
-    - ./test/e2e-auto-tls-tests.sh --istio-version 1.4-latest --mesh
+    - ./test/e2e-auto-tls-tests.sh --istio-version stable --mesh
     dot-dev: true
-  - custom-job: istio-1.4-no-mesh
+  - custom-job: istio-stable-no-mesh
     command:
     - ./test/presubmit-tests.sh
     args:
     - --run-test
-    - ./test/e2e-tests.sh --istio-version 1.4-latest --no-mesh
+    - ./test/e2e-tests.sh --istio-version stable --no-mesh
     - --run-test
-    - ./test/e2e-auto-tls-tests.sh --istio-version 1.4-latest --no-mesh
+    - ./test/e2e-auto-tls-tests.sh --istio-version stable --no-mesh
     dot-dev: true
   - custom-job: gloo-0.17.1
     command:

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -291,12 +291,12 @@ presubmits:
       - name: covbot-token
         secret:
           secretName: covbot-token
-  - name: pull-knative-serving-istio-1.5-mesh
+  - name: pull-knative-serving-istio-latest-mesh
     agent: kubernetes
-    context: pull-knative-serving-istio-1.5-mesh
+    context: pull-knative-serving-istio-latest-mesh
     always_run: false
-    rerun_command: "/test pull-knative-serving-istio-1.5-mesh"
-    trigger: "(?m)^/test (all|pull-knative-serving-istio-1.5-mesh),?(\\s+|$)"
+    rerun_command: "/test pull-knative-serving-istio-latest-mesh"
+    trigger: "(?m)^/test (all|pull-knative-serving-istio-latest-mesh),?(\\s+|$)"
     decorate: true
     optional: true
     path_alias: knative.dev/serving
@@ -310,9 +310,9 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.5-latest --mesh"
+        - "./test/e2e-tests.sh --istio-version latest --mesh"
         - "--run-test"
-        - "./test/e2e-auto-tls-tests.sh --istio-version 1.5-latest --mesh"
+        - "./test/e2e-auto-tls-tests.sh --istio-version latest --mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -331,12 +331,12 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-serving-istio-1.5-no-mesh
+  - name: pull-knative-serving-istio-latest-no-mesh
     agent: kubernetes
-    context: pull-knative-serving-istio-1.5-no-mesh
+    context: pull-knative-serving-istio-latest-no-mesh
     always_run: false
-    rerun_command: "/test pull-knative-serving-istio-1.5-no-mesh"
-    trigger: "(?m)^/test (all|pull-knative-serving-istio-1.5-no-mesh),?(\\s+|$)"
+    rerun_command: "/test pull-knative-serving-istio-latest-no-mesh"
+    trigger: "(?m)^/test (all|pull-knative-serving-istio-latest-no-mesh),?(\\s+|$)"
     decorate: true
     optional: true
     path_alias: knative.dev/serving
@@ -350,9 +350,9 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.5-latest --no-mesh"
+        - "./test/e2e-tests.sh --istio-version latest --no-mesh"
         - "--run-test"
-        - "./test/e2e-auto-tls-tests.sh --istio-version 1.5-latest --no-mesh"
+        - "./test/e2e-auto-tls-tests.sh --istio-version latest --no-mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -371,12 +371,12 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-serving-istio-1.4-mesh
+  - name: pull-knative-serving-istio-stable-mesh
     agent: kubernetes
-    context: pull-knative-serving-istio-1.4-mesh
+    context: pull-knative-serving-istio-stable-mesh
     always_run: false
-    rerun_command: "/test pull-knative-serving-istio-1.4-mesh"
-    trigger: "(?m)^/test (all|pull-knative-serving-istio-1.4-mesh),?(\\s+|$)"
+    rerun_command: "/test pull-knative-serving-istio-stable-mesh"
+    trigger: "(?m)^/test (all|pull-knative-serving-istio-stable-mesh),?(\\s+|$)"
     decorate: true
     optional: true
     path_alias: knative.dev/serving
@@ -390,9 +390,9 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.4-latest --mesh"
+        - "./test/e2e-tests.sh --istio-version stable --mesh"
         - "--run-test"
-        - "./test/e2e-auto-tls-tests.sh --istio-version 1.4-latest --mesh"
+        - "./test/e2e-auto-tls-tests.sh --istio-version stable --mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -411,12 +411,12 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-serving-istio-1.4-no-mesh
+  - name: pull-knative-serving-istio-stable-no-mesh
     agent: kubernetes
-    context: pull-knative-serving-istio-1.4-no-mesh
+    context: pull-knative-serving-istio-stable-no-mesh
     always_run: false
-    rerun_command: "/test pull-knative-serving-istio-1.4-no-mesh"
-    trigger: "(?m)^/test (all|pull-knative-serving-istio-1.4-no-mesh),?(\\s+|$)"
+    rerun_command: "/test pull-knative-serving-istio-stable-no-mesh"
+    trigger: "(?m)^/test (all|pull-knative-serving-istio-stable-no-mesh),?(\\s+|$)"
     decorate: true
     optional: true
     path_alias: knative.dev/serving
@@ -430,9 +430,9 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-tests.sh --istio-version 1.4-latest --no-mesh"
+        - "./test/e2e-tests.sh --istio-version stable --no-mesh"
         - "--run-test"
-        - "./test/e2e-auto-tls-tests.sh --istio-version 1.4-latest --no-mesh"
+        - "./test/e2e-auto-tls-tests.sh --istio-version stable --no-mesh"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
@@ -4335,8 +4335,8 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "38 */2 * * *"
-  name: ci-knative-serving-istio-1.5-mesh
+- cron: "5 */2 * * *"
+  name: ci-knative-serving-istio-latest-mesh
   agent: kubernetes
   decorate: true
   cluster: "build-knative"
@@ -4354,9 +4354,9 @@ periodics:
       args:
       - "./test/presubmit-tests.sh"
       - "--run-test"
-      - "./test/e2e-tests.sh --istio-version 1.5-latest --mesh"
+      - "./test/e2e-tests.sh --istio-version latest --mesh"
       - "--run-test"
-      - "./test/e2e-auto-tls-tests.sh --istio-version 1.5-latest --mesh"
+      - "./test/e2e-auto-tls-tests.sh --istio-version latest --mesh"
       volumeMounts:
       - name: test-account
         mountPath: /etc/test-account
@@ -4370,8 +4370,8 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "54 */2 * * *"
-  name: ci-knative-serving-istio-1.5-no-mesh
+- cron: "31 */2 * * *"
+  name: ci-knative-serving-istio-latest-no-mesh
   agent: kubernetes
   decorate: true
   cluster: "build-knative"
@@ -4389,9 +4389,9 @@ periodics:
       args:
       - "./test/presubmit-tests.sh"
       - "--run-test"
-      - "./test/e2e-tests.sh --istio-version 1.5-latest --no-mesh"
+      - "./test/e2e-tests.sh --istio-version latest --no-mesh"
       - "--run-test"
-      - "./test/e2e-auto-tls-tests.sh --istio-version 1.5-latest --no-mesh"
+      - "./test/e2e-auto-tls-tests.sh --istio-version latest --no-mesh"
       volumeMounts:
       - name: test-account
         mountPath: /etc/test-account
@@ -4405,8 +4405,8 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "23 */2 * * *"
-  name: ci-knative-serving-istio-1.4-mesh
+- cron: "57 */2 * * *"
+  name: ci-knative-serving-istio-stable-mesh
   agent: kubernetes
   decorate: true
   cluster: "build-knative"
@@ -4424,9 +4424,9 @@ periodics:
       args:
       - "./test/presubmit-tests.sh"
       - "--run-test"
-      - "./test/e2e-tests.sh --istio-version 1.4-latest --mesh"
+      - "./test/e2e-tests.sh --istio-version stable --mesh"
       - "--run-test"
-      - "./test/e2e-auto-tls-tests.sh --istio-version 1.4-latest --mesh"
+      - "./test/e2e-auto-tls-tests.sh --istio-version stable --mesh"
       volumeMounts:
       - name: test-account
         mountPath: /etc/test-account
@@ -4440,8 +4440,8 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "53 */2 * * *"
-  name: ci-knative-serving-istio-1.4-no-mesh
+- cron: "47 */2 * * *"
+  name: ci-knative-serving-istio-stable-no-mesh
   agent: kubernetes
   decorate: true
   cluster: "build-knative"
@@ -4459,9 +4459,9 @@ periodics:
       args:
       - "./test/presubmit-tests.sh"
       - "--run-test"
-      - "./test/e2e-tests.sh --istio-version 1.4-latest --no-mesh"
+      - "./test/e2e-tests.sh --istio-version stable --no-mesh"
       - "--run-test"
-      - "./test/e2e-auto-tls-tests.sh --istio-version 1.4-latest --no-mesh"
+      - "./test/e2e-auto-tls-tests.sh --istio-version stable --no-mesh"
       volumeMounts:
       - name: test-account
         mountPath: /etc/test-account

--- a/config/prod/prow/testgrid/testgrid.yaml
+++ b/config/prod/prow/testgrid/testgrid.yaml
@@ -58,17 +58,17 @@ test_groups:
 - name: ci-knative-serving-continuous
   gcs_prefix: knative-prow/logs/ci-knative-serving-continuous
   alert_stale_results_hours: 3
-- name: ci-knative-serving-istio-1.5-mesh
-  gcs_prefix: knative-prow/logs/ci-knative-serving-istio-1.5-mesh
+- name: ci-knative-serving-istio-latest-mesh
+  gcs_prefix: knative-prow/logs/ci-knative-serving-istio-latest-mesh
   alert_stale_results_hours: 3
-- name: ci-knative-serving-istio-1.5-no-mesh
-  gcs_prefix: knative-prow/logs/ci-knative-serving-istio-1.5-no-mesh
+- name: ci-knative-serving-istio-latest-no-mesh
+  gcs_prefix: knative-prow/logs/ci-knative-serving-istio-latest-no-mesh
   alert_stale_results_hours: 3
-- name: ci-knative-serving-istio-1.4-mesh
-  gcs_prefix: knative-prow/logs/ci-knative-serving-istio-1.4-mesh
+- name: ci-knative-serving-istio-stable-mesh
+  gcs_prefix: knative-prow/logs/ci-knative-serving-istio-stable-mesh
   alert_stale_results_hours: 3
-- name: ci-knative-serving-istio-1.4-no-mesh
-  gcs_prefix: knative-prow/logs/ci-knative-serving-istio-1.4-no-mesh
+- name: ci-knative-serving-istio-stable-no-mesh
+  gcs_prefix: knative-prow/logs/ci-knative-serving-istio-stable-no-mesh
   alert_stale_results_hours: 3
 - name: ci-knative-serving-gloo-0.17.1
   gcs_prefix: knative-prow/logs/ci-knative-serving-gloo-0.17.1
@@ -851,17 +851,17 @@ dashboards:
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
     num_failures_to_alert: 3
-  - name: istio-1.5-mesh
-    test_group_name: ci-knative-serving-istio-1.5-mesh
+  - name: istio-latest-mesh
+    test_group_name: ci-knative-serving-istio-latest-mesh
     base_options: "sort-by-name="
-  - name: istio-1.5-no-mesh
-    test_group_name: ci-knative-serving-istio-1.5-no-mesh
+  - name: istio-latest-no-mesh
+    test_group_name: ci-knative-serving-istio-latest-no-mesh
     base_options: "sort-by-name="
-  - name: istio-1.4-mesh
-    test_group_name: ci-knative-serving-istio-1.4-mesh
+  - name: istio-stable-mesh
+    test_group_name: ci-knative-serving-istio-stable-mesh
     base_options: "sort-by-name="
-  - name: istio-1.4-no-mesh
-    test_group_name: ci-knative-serving-istio-1.4-no-mesh
+  - name: istio-stable-no-mesh
+    test_group_name: ci-knative-serving-istio-stable-no-mesh
     base_options: "sort-by-name="
   - name: gloo-0.17.1
     test_group_name: ci-knative-serving-gloo-0.17.1

--- a/pkg/testgrid/testgrid.go
+++ b/pkg/testgrid/testgrid.go
@@ -27,16 +27,15 @@ const (
 
 // jobNameTestgridURLMap contains harded coded mapping of job name: Testgrid tab URL relative to base URL
 var jobNameTestgridURLMap = map[string]string{
-	"ci-knative-serving-continuous":        "serving#continuous",
-	"ci-knative-serving-istio-1.5-mesh":    "serving#istio-1.5-mesh",
-	"ci-knative-serving-istio-1.5-no-mesh": "serving#istio-1.5-no-mesh",
-	"ci-knative-serving-istio-1.4-mesh":    "serving#istio-1.4-mesh",
-	"ci-knative-serving-istio-1.4-no-mesh": "serving#istio-1.4-no-mesh",
-	"ci-knative-serving-gloo-0.17.1":       "serving#gloo-0.17.1",
-	"ci-knative-serving-kourier-stable":    "serving#kourier-stable",
-	"ci-knative-serving-contour-latest":    "serving#contour-latest",
-	"ci-knative-serving-ambassador-latest": "serving#ambassador-latest",
-	"ci-knative-serving-kong-latest":       "serving#kong-latest",
+	"ci-knative-serving-continuous":           "serving#continuous",
+	"ci-knative-serving-istio-latest-mesh":    "serving#istio-latest-mesh",
+	"ci-knative-serving-istio-latest-no-mesh": "serving#istio-latest-no-mesh",
+	"ci-knative-serving-istio-stable-mesh":    "serving#istio-stable-mesh",
+	"ci-knative-serving-istio-stable-no-mesh": "serving#istio-stable-no-mesh",
+	"ci-knative-serving-gloo-0.17.1":          "serving#gloo-0.17.1",
+	"ci-knative-serving-kourier-stable":       "serving#kourier-stable",
+	"ci-knative-serving-contour-latest":       "serving#contour-latest",
+	"ci-knative-serving-ambassador-latest":    "serving#ambassador-latest",
 }
 
 // GetTestgridTabURL gets Testgrid URL for giving job and filters for Testgrid

--- a/tools/flaky-test-reporter/config/config.yaml
+++ b/tools/flaky-test-reporter/config/config.yaml
@@ -21,28 +21,28 @@ jobConfigs:
     slackChannels:
       - name: serving-api
         identity: CA4DNJ9A4
-  - name: ci-knative-serving-istio-1.5-mesh
+  - name: ci-knative-serving-istio-latest-mesh
     org: knative
     repo: serving
     type: postsubmit
     slackChannels:
       - name: net-istio
         identity: C012AK2FPK7
-  - name: ci-knative-serving-istio-1.5-no-mesh
+  - name: ci-knative-serving-istio-latest-no-mesh
     org: knative
     repo: serving
     type: postsubmit
     slackChannels:
       - name: net-istio
         identity: C012AK2FPK7
-  - name: ci-knative-serving-istio-1.4-mesh
+  - name: ci-knative-serving-istio-stable-mesh
     org: knative
     repo: serving
     type: postsubmit
     slackChannels:
       - name: net-istio
         identity: C012AK2FPK7
-  - name: ci-knative-serving-istio-1.4-no-mesh
+  - name: ci-knative-serving-istio-stable-no-mesh
     org: knative
     repo: serving
     type: postsubmit


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

In conjunction with https://github.com/knative/serving/pull/8945.

**What this PR does, why we need it**:
Today, changing the Istio major version used by Knative is a huge process. On the `test-infra` side, it requires changes in multiple files (YAML, Go) for TestGrid, Prow, tools, etc...

Instead of having the version sprinkled everywhere, let's just use channels (`stable` and `latest`).
This way, to change Istio version only one file needs to be updated in `net-istio` and `test-infra` and `serving` (and others) automatically pick it up.

