### PR TITLE
Config generator supports run_if_changed config

### DIFF
--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -50,7 +50,7 @@ presubmits:
     dot-dev: true
   - custom-test: istio-1.5-mesh
     dot-dev: true
-    always_run: false
+    always-run: false
     optional: true
     args:
     - --run-test
@@ -64,7 +64,7 @@ presubmits:
         memory: 16Gi
   - custom-test: istio-1.5-no-mesh
     dot-dev: true
-    always_run: false
+    always-run: false
     optional: true
     args:
     - --run-test
@@ -78,7 +78,7 @@ presubmits:
         memory: 16Gi
   - custom-test: istio-1.4-mesh
     dot-dev: true
-    always_run: false
+    always-run: false
     optional: true
     args:
     - --run-test
@@ -92,7 +92,7 @@ presubmits:
         memory: 16Gi
   - custom-test: istio-1.4-no-mesh
     dot-dev: true
-    always_run: false
+    always-run: false
     optional: true
     args:
     - --run-test
@@ -106,7 +106,7 @@ presubmits:
         memory: 16Gi
   - custom-test: gloo-0.17.1
     dot-dev: true
-    always_run: false
+    always-run: false
     optional: true
     args:
     - --run-test
@@ -120,7 +120,7 @@ presubmits:
         memory: 16Gi
   - custom-test: kourier-stable
     dot-dev: true
-    always_run: false
+    always-run: false
     optional: true
     args:
     - --run-test
@@ -134,7 +134,8 @@ presubmits:
         memory: 16Gi
   - custom-test: contour-latest
     dot-dev: true
-    always_run: false
+    always-run: false
+    run-if-changed: "^third_party/contour-latest/*"
     optional: true
     args:
     - --run-test
@@ -148,7 +149,7 @@ presubmits:
         memory: 16Gi
   - custom-test: ambassador-latest
     dot-dev: true
-    always_run: false
+    always-run: false
     optional: true
     args:
     - --run-test
@@ -162,7 +163,7 @@ presubmits:
         memory: 16Gi
   - custom-test: https
     dot-dev: true
-    always_run: false
+    always-run: false
     optional: true
     args:
     - --run-test
@@ -179,7 +180,7 @@ presubmits:
   - go-coverage: true
     dot-dev: true
   - custom-test: integration-tests-latest-release
-    always_run: true
+    always-run: true
     command:
     - ./test/presubmit-integration-tests-latest-release.sh
     dot-dev: true
@@ -243,7 +244,7 @@ presubmits:
     needs-dind: true
   - go-coverage: true
   - custom-test: markdown-link-check
-    always_run: true
+    always-run: true
     optional: true
     command:
     - ./test/presubmit-link-check.sh

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -535,6 +535,7 @@ presubmits:
     agent: kubernetes
     context: pull-knative-serving-contour-latest
     always_run: false
+    run_if_changed: "^third_party/contour-latest/*"
     rerun_command: "/test pull-knative-serving-contour-latest"
     trigger: "(?m)^/test (all|pull-knative-serving-contour-latest),?(\\s+|$)"
     decorate: true

--- a/tools/config-generator/main.go
+++ b/tools/config-generator/main.go
@@ -115,7 +115,6 @@ type baseProwJobTemplateData struct {
 	Image               string
 	Labels              []string
 	PathAlias           string
-	RunIfChanged        string
 	Cluster             string
 	Optional            string
 	NeedsMonitor        bool
@@ -371,7 +370,7 @@ func parseBasicJobConfigOverrides(data *baseProwJobTemplateData, config yaml.Map
 			if getBool(item.Value) {
 				setupDockerInDockerForJob(data)
 			}
-		case "always_run":
+		case "always-run":
 			(*data).AlwaysRun = getBool(item.Value)
 		case "dot-dev":
 			needDotdev = true

--- a/tools/config-generator/presubmit_config.go
+++ b/tools/config-generator/presubmit_config.go
@@ -37,6 +37,7 @@ type presubmitJobTemplateData struct {
 	PresubmitPullJobName string
 	PresubmitPostJobName string
 	PresubmitCommand     []string
+	RunIfChanged         string
 }
 
 // generatePresubmit generates all presubmit job configs for the given repo and configuration.
@@ -81,6 +82,8 @@ func generatePresubmit(title string, repoName string, presubmitConfig yaml.MapSl
 			repoData.GoCoverageThreshold = data.Base.GoCoverageThreshold
 		case "repo-settings":
 			generateJob = false
+		case "run-if-changed":
+			data.RunIfChanged = "run_if_changed: \"" + getString(item.Value) + "\""
 		default:
 			continue
 		}

--- a/tools/config-generator/templates/prow_presubmit_job.yaml
+++ b/tools/config-generator/templates/prow_presubmit_job.yaml
@@ -3,6 +3,7 @@
     [[indent_section 6 "labels" .Base.Labels]]
     context: [[.PresubmitPullJobName]]
     always_run: [[.Base.AlwaysRun]]
+    [[.RunIfChanged]]
     rerun_command: "/test [[.PresubmitPullJobName]]"
     trigger: "(?m)^/test (all|[[.PresubmitPullJobName]]),?(\\s+|$)"
     decorate: true


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
1. Config generator supports run_if_changed config
2. Also by the way change `always_run` to `always-run` in the meta config file since it's the only exception (other fields are all using `-` as the name separator.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #2343 

/cc @chaodaiG @mattmoor 

