### PR TITLE
gotestsum outputs a json file, for debugging an error

### DIFF
--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -408,10 +408,13 @@ function report_go_test() {
   report="$(mktemp)"
   local xml
   xml="$(mktemp_with_extension "${ARTIFACTS}"/junit_XXXXXXXX xml)"
+  local json
+  json="$(mktemp_with_extension "${ARTIFACTS}"/json_XXXXXXXX json)"
   echo "Running go test with args: ${go_test_args[*]}"
   # TODO(chizhg): change to `--format testname`?
   capture_output "${report}" gotestsum --format standard-verbose \
     --junitfile "${xml}" --junitfile-testsuite-name relative --junitfile-testcase-classname relative \
+    --jsonfile "${json}" \
     -- "${go_test_args[@]}"
   local failed=$?
   echo "Finished run, return code is ${failed}"


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
`gotestsum` outputs a json file for debugging an error

/cc @mattmoor @chaodaiG 

