### PR TITLE
Post nightly failures to respective channels.

### DIFF
--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -544,6 +544,12 @@ periodics:
     dot-dev: true
   - nightly: true
     dot-dev: true
+    reporter_config:
+      slack:
+        channel: serving-api
+        job_states_to_report:
+        - failure
+        report_template: '"The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"'
     resources:
       requests:
         memory: 12Gi
@@ -875,6 +881,12 @@ periodics:
     dot-dev: true
   - nightly: true
     dot-dev: true
+    reporter_config:
+      slack:
+        channel: net-certmanager
+        job_states_to_report:
+        - failure
+        report_template: '"The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"'
   - dot-release: true
     dot-dev: true
   - auto-release: true
@@ -884,6 +896,12 @@ periodics:
     dot-dev: true
   - nightly: true
     dot-dev: true
+    reporter_config:
+      slack:
+        channel: net-contour
+        job_states_to_report:
+        - failure
+        report_template: '"The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"'
   - dot-release: true
     dot-dev: true
   - auto-release: true
@@ -893,6 +911,12 @@ periodics:
     dot-dev: true
   - nightly: true
     dot-dev: true
+    reporter_config:
+      slack:
+        channel: net-http01
+        job_states_to_report:
+        - failure
+        report_template: '"The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"'
   - dot-release: true
     dot-dev: true
   - auto-release: true
@@ -902,6 +926,12 @@ periodics:
     dot-dev: true
   - nightly: true
     dot-dev: true
+    reporter_config:
+      slack:
+        channel: net-istio
+        job_states_to_report:
+        - failure
+        report_template: '"The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"'
   - dot-release: true
     dot-dev: true
     release: "0.14"
@@ -918,6 +948,12 @@ periodics:
     dot-dev: true
   - nightly: true
     dot-dev: true
+    reporter_config:
+      slack:
+        channel: net-kourier
+        job_states_to_report:
+        - failure
+        report_template: '"The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"'
   - dot-release: true
     dot-dev: true
   - auto-release: true

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -4613,6 +4613,12 @@ periodics:
   name: ci-knative-serving-nightly-release
   agent: kubernetes
   decorate: true
+  reporter_config:
+    slack:
+      channel: serving-api
+      report_template: "The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"
+      job_states_to_report:
+      - "failure"
   cluster: "build-knative"
   extra_refs:
   - org: knative
@@ -8703,6 +8709,12 @@ periodics:
   name: ci-knative-sandbox-net-certmanager-nightly-release
   agent: kubernetes
   decorate: true
+  reporter_config:
+    slack:
+      channel: net-certmanager
+      report_template: "The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"
+      job_states_to_report:
+      - "failure"
   cluster: "build-knative"
   extra_refs:
   - org: knative-sandbox
@@ -8930,6 +8942,12 @@ periodics:
   name: ci-knative-sandbox-net-contour-nightly-release
   agent: kubernetes
   decorate: true
+  reporter_config:
+    slack:
+      channel: net-contour
+      report_template: "The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"
+      job_states_to_report:
+      - "failure"
   cluster: "build-knative"
   extra_refs:
   - org: knative-sandbox
@@ -9157,6 +9175,12 @@ periodics:
   name: ci-knative-sandbox-net-http01-nightly-release
   agent: kubernetes
   decorate: true
+  reporter_config:
+    slack:
+      channel: net-http01
+      report_template: "The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"
+      job_states_to_report:
+      - "failure"
   cluster: "build-knative"
   extra_refs:
   - org: knative-sandbox
@@ -9384,6 +9408,12 @@ periodics:
   name: ci-knative-sandbox-net-istio-nightly-release
   agent: kubernetes
   decorate: true
+  reporter_config:
+    slack:
+      channel: net-istio
+      report_template: "The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"
+      job_states_to_report:
+      - "failure"
   cluster: "build-knative"
   extra_refs:
   - org: knative-sandbox
@@ -9702,6 +9732,12 @@ periodics:
   name: ci-knative-sandbox-net-kourier-nightly-release
   agent: kubernetes
   decorate: true
+  reporter_config:
+    slack:
+      channel: net-kourier
+      report_template: "The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"
+      job_states_to_report:
+      - "failure"
   cluster: "build-knative"
   extra_refs:
   - org: knative-sandbox


### PR DESCRIPTION
Eventing does this and I'm jealous, proactively enabling for others in Serving since it is only on failures.
