### PR TITLE
Change time schema from float64 to string to preserve precision

### DIFF
--- a/pkg/junit/junit.go
+++ b/pkg/junit/junit.go
@@ -47,7 +47,7 @@ type TestSuites struct {
 type TestSuite struct {
 	XMLName    xml.Name       `xml:"testsuite"`
 	Name       string         `xml:"name,attr"`
-	Time       float64        `xml:"time,attr"` // Seconds
+	Time       string         `xml:"time,attr"` // Seconds
 	Failures   int            `xml:"failures,attr"`
 	Tests      int            `xml:"tests,attr"`
 	TestCases  []TestCase     `xml:"testcase"`
@@ -57,7 +57,7 @@ type TestSuite struct {
 // TestCase holds <testcase/> results
 type TestCase struct {
 	Name       string          `xml:"name,attr"`
-	Time       float64         `xml:"time,attr"` // Seconds
+	Time       string          `xml:"time,attr"` // Seconds
 	ClassName  string          `xml:"classname,attr"`
 	Failure    *string         `xml:"failure,omitempty"`
 	Output     *string         `xml:"system-out,omitempty"`

--- a/pkg/junit/junit_test.go
+++ b/pkg/junit/junit_test.go
@@ -161,7 +161,7 @@ func TestCreateXMLErrorMsg(t *testing.T) {
 	defer os.RemoveAll(testDir) // clean up
 	dest := path.Join(testDir, "TestCreateXMLErrorTestFile")
 	CreateXMLErrorMsg("dummySuite", "dummyTest", "dummyError has occurred", dest)
-	expected := `<testsuites><testsuite name="dummySuite" time="0" failures="1" tests="1"><testcase name="dummyTest" time="0" classname=""><failure>dummyError has occurred</failure></testcase><properties></properties></testsuite></testsuites>`
+	expected := `<testsuites><testsuite name="dummySuite" time="" failures="1" tests="1"><testcase name="dummyTest" time="" classname=""><failure>dummyError has occurred</failure></testcase><properties></properties></testsuite></testsuites>`
 
 	got, err := ioutil.ReadFile(dest)
 	if err != nil {


### PR DESCRIPTION
Change time schema to string from float64 to enable precision preservation from outputs and align with gotestsum and go-junit-reporter.

