### PR TITLE
Add Kong test jobs

### DIFF
--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -161,6 +161,20 @@ presubmits:
         memory: 12Gi
       limits:
         memory: 16Gi
+  - custom-test: kong-latest
+    dot-dev: true
+    always-run: false
+    optional: true
+    args:
+    - --run-test
+    - ./test/e2e-tests.sh --kong-version latest
+    - --run-test
+    - ./test/e2e-auto-tls-tests.sh --kong-version latest
+    resources:
+      requests:
+        memory: 12Gi
+      limits:
+        memory: 16Gi
   - custom-test: https
     dot-dev: true
     always-run: false
@@ -533,6 +547,15 @@ periodics:
     - ./test/e2e-tests.sh --ambassador-version latest
     - --run-test
     - ./test/e2e-auto-tls-tests.sh --ambassador-version latest
+    dot-dev: true
+  - custom-job: kong-latest
+    command:
+    - ./test/presubmit-tests.sh
+    args:
+    - --run-test
+    - ./test/e2e-tests.sh --kong-version latest
+    - --run-test
+    - ./test/e2e-auto-tls-tests.sh --kong-version latest
     dot-dev: true
   - custom-job: https
     command:

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -612,6 +612,46 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
+  - name: pull-knative-serving-kong-latest
+    agent: kubernetes
+    context: pull-knative-serving-kong-latest
+    always_run: false
+    rerun_command: "/test pull-knative-serving-kong-latest"
+    trigger: "(?m)^/test (all|pull-knative-serving-kong-latest),?(\\s+|$)"
+    decorate: true
+    optional: true
+    path_alias: knative.dev/serving
+    cluster: "build-knative"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-tests.sh --kong-version latest"
+        - "--run-test"
+        - "./test/e2e-auto-tls-tests.sh --kong-version latest"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+        resources:
+          requests:
+            memory: 12Gi
+          limits:
+            memory: 16Gi
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
   - name: pull-knative-serving-https
     agent: kubernetes
     context: pull-knative-serving-https
@@ -4562,6 +4602,41 @@ periodics:
       - "./test/e2e-tests.sh --ambassador-version latest"
       - "--run-test"
       - "./test/e2e-auto-tls-tests.sh --ambassador-version latest"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "44 */2 * * *"
+  name: ci-knative-serving-kong-latest
+  agent: kubernetes
+  decorate: true
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: master
+    path_alias: knative.dev/serving
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./test/presubmit-tests.sh"
+      - "--run-test"
+      - "./test/e2e-tests.sh --kong-version latest"
+      - "--run-test"
+      - "./test/e2e-auto-tls-tests.sh --kong-version latest"
       volumeMounts:
       - name: test-account
         mountPath: /etc/test-account

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -4615,7 +4615,7 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "44 */2 * * *"
+- cron: "20 */2 * * *"
   name: ci-knative-serving-kong-latest
   agent: kubernetes
   decorate: true

--- a/config/prod/prow/testgrid/testgrid.yaml
+++ b/config/prod/prow/testgrid/testgrid.yaml
@@ -82,6 +82,9 @@ test_groups:
 - name: ci-knative-serving-ambassador-latest
   gcs_prefix: knative-prow/logs/ci-knative-serving-ambassador-latest
   alert_stale_results_hours: 3
+- name: ci-knative-serving-kong-latest
+  gcs_prefix: knative-prow/logs/ci-knative-serving-kong-latest
+  alert_stale_results_hours: 3
 - name: ci-knative-serving-https
   gcs_prefix: knative-prow/logs/ci-knative-serving-https
   alert_stale_results_hours: 3
@@ -871,6 +874,9 @@ dashboards:
     base_options: "sort-by-name="
   - name: ambassador-latest
     test_group_name: ci-knative-serving-ambassador-latest
+    base_options: "sort-by-name="
+  - name: kong-latest
+    test_group_name: ci-knative-serving-kong-latest
     base_options: "sort-by-name="
   - name: https
     test_group_name: ci-knative-serving-https

--- a/pkg/testgrid/testgrid.go
+++ b/pkg/testgrid/testgrid.go
@@ -36,6 +36,7 @@ var jobNameTestgridURLMap = map[string]string{
 	"ci-knative-serving-kourier-stable":    "serving#kourier-stable",
 	"ci-knative-serving-contour-latest":    "serving#contour-latest",
 	"ci-knative-serving-ambassador-latest": "serving#ambassador-latest",
+	"ci-knative-serving-kong-latest":       "serving#kong-latest",
 }
 
 // GetTestgridTabURL gets Testgrid URL for giving job and filters for Testgrid

--- a/tools/flaky-test-reporter/config/config.yaml
+++ b/tools/flaky-test-reporter/config/config.yaml
@@ -77,6 +77,13 @@ jobConfigs:
     slackChannels:
       - name: net-ambassador
         identity: C011X8SPF8X
+  - name: ci-knative-serving-kong-latest
+    org: knative
+    repo: serving
+    type: postsubmit
+    slackChannels:
+      - name: net-kong
+        identity: C01258TE58W
   - name: ci-knative-eventing-continuous
     org: knative
     repo: eventing


### PR DESCRIPTION
This patch adds Kong to test grid, test jobs.

Although Kong was added in the [installation
doc](https://knative.dev/docs/install/any-kubernetes-cluster/), it is
not tested so we don't know how it is stable.
This patch starts testing Kong and see the test results.

/lint

/cc @tcnghia @chaodaiG 

