### PR TITLE
GKE cluster creation creates network plus firewall rules

### DIFF
--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -185,6 +185,7 @@ function create_test_cluster() {
     "--cluster-name=${E2E_CLUSTER_NAME}"
     "--num-nodes=${E2E_MIN_CLUSTER_NODES}"
     "--machine-type=${E2E_CLUSTER_MACHINE}"
+    "--network=${E2E_NETWORK_NAME}"
     --up
   )
   if (( ! IS_BOSKOS )); then


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
The eventing-upgrade-tests needs the firewall rules to be created for the cluster, which won't be created if we are using the `default` network. Adding `--network=${E2E_NETWORK_NAME}` which will create a new network for the cluster and also create required firewall rules for that network.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @chaodaiG @albertomilan 

