### PR TITLE
Keep in-gvm-env.sh to use different Go version to install tools

### DIFF
--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -137,4 +137,3 @@ RUN cd /go/src/knative.dev/test-infra && git reset --hard upstream/release-0.14 
 # Cleanup
 RUN rm -fr /go/src/knative.dev/test-infra
 RUN rm -f /usr/local/bin/source-gvm-and-run.sh
-RUN rm -f /usr/local/bin/in-gvm-env.sh


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
We need it to install some internal tools implemented in different Go versions.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @peterfeifanchen @coryrc 

