### PR TITLE
Support passing kubetest2-flag for the e2e-tests.sh

### DIFF
--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -220,7 +220,7 @@ function create_test_cluster() {
 
   # Create cluster and run the tests
   create_test_cluster_with_retries "${E2E_SCRIPT} ${test_cmd_args}" \
-    "${CLUSTER_CREATION_ARGS[@]}" "${extra_flags[@]}"
+    "${CLUSTER_CREATION_ARGS[@]}" "${extra_flags[@]}" "${EXTRA_KUBETEST2_FLAGS[@]}"
   local result="$?"
   # Ignore any errors below, this is a best-effort cleanup and shouldn't affect the test result.
   set +o errexit
@@ -377,6 +377,7 @@ E2E_SCRIPT=""
 E2E_CLUSTER_VERSION="latest"
 GKE_ADDONS=""
 EXTRA_CLUSTER_CREATION_FLAGS=()
+EXTRA_KUBETEST2_FLAGS=()
 E2E_SCRIPT_CUSTOM_FLAGS=()
 
 # Parse flags and initialize the test cluster.
@@ -413,6 +414,7 @@ function initialize() {
           --gcp-project) GCP_PROJECT=$1 ;;
           --cluster-version) E2E_CLUSTER_VERSION=$1 ;;
           --cluster-creation-flag) EXTRA_CLUSTER_CREATION_FLAGS+=("$1") ;;
+          --kubetest2-flag) EXTRA_KUBETEST2_FLAGS+=("$1") ;;
           *) abort "unknown option ${parameter}" ;;
         esac
     esac
@@ -436,6 +438,7 @@ function initialize() {
   readonly GCP_PROJECT
   readonly IS_BOSKOS
   readonly EXTRA_CLUSTER_CREATION_FLAGS
+  readonly EXTRA_KUBETEST2_FLAGS
   readonly SKIP_KNATIVE_SETUP
   readonly SKIP_TEARDOWNS
   readonly GKE_ADDONS


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
This is the same as https://github.com/knative/test-infra/pull/2357 but for release-0.17 branch.

/cc @chaodaiG 
