### PR TITLE
Enable NodeLocalDNS GKE addon in test setup.

### DIFF
--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -433,7 +433,11 @@ function initialize() {
 
   (( IS_PROW )) && [[ -z "${GCP_PROJECT}" ]] && IS_BOSKOS=1
 
-  (( SKIP_ISTIO_ADDON )) || GKE_ADDONS="--addons=Istio"
+  if (( SKIP_ISTIO_ADDON )); then
+    GKE_ADDONS="--addons=NodeLocalDNS"
+  else
+    GKE_ADDONS="--addons=Istio,NodeLocalDNS"
+  fi
 
   readonly RUN_TESTS
   readonly GCP_PROJECT


### PR DESCRIPTION

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Enabling NodeLocalDNS on GKE test cluster to help with some intermittent issues due to `kube-dns` being overloaded. In the future we should replace this usage by https://kubernetes.io/docs/tasks/administer-cluster/nodelocaldns/ .

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes https://github.com/knative/networking/issues/87

**Special notes to reviewers**:

**User-visible changes in this PR**:

