### PR TITLE
Fix release jobs for a few knative-sandbox repos

### DIFF
--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -912,8 +912,12 @@ periodics:
         report_template: '"The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"'
   - dot-release: true
     dot-dev: true
+    env-vars:
+    - ORG_NAME=knative-sandbox
   - auto-release: true
     dot-dev: true
+    env-vars:
+    - ORG_NAME=knative-sandbox
   knative-sandbox/net-contour:
   - continuous: true
     dot-dev: true
@@ -927,8 +931,12 @@ periodics:
         report_template: '"The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"'
   - dot-release: true
     dot-dev: true
+    env-vars:
+    - ORG_NAME=knative-sandbox
   - auto-release: true
     dot-dev: true
+    env-vars:
+    - ORG_NAME=knative-sandbox
   knative-sandbox/net-http01:
   - continuous: true
     dot-dev: true
@@ -942,8 +950,12 @@ periodics:
         report_template: '"The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"'
   - dot-release: true
     dot-dev: true
+    env-vars:
+    - ORG_NAME=knative-sandbox
   - auto-release: true
     dot-dev: true
+    env-vars:
+    - ORG_NAME=knative-sandbox
   knative-sandbox/net-istio:
   - continuous: true
     dot-dev: true
@@ -965,14 +977,22 @@ periodics:
   - dot-release: true
     dot-dev: true
     release: "0.14"
+    env-vars:
+    - ORG_NAME=knative-sandbox
   - dot-release: true
     dot-dev: true
     release: "0.15"
+    env-vars:
+    - ORG_NAME=knative-sandbox
   - dot-release: true
     dot-dev: true
     release: "0.16"
+    env-vars:
+    - ORG_NAME=knative-sandbox
   - auto-release: true
     dot-dev: true
+    env-vars:
+    - ORG_NAME=knative-sandbox
   knative-sandbox/net-kourier:
   - continuous: true
     dot-dev: true
@@ -986,8 +1006,12 @@ periodics:
         report_template: '"The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"'
   - dot-release: true
     dot-dev: true
+    env-vars:
+    - ORG_NAME=knative-sandbox
   - auto-release: true
     dot-dev: true
+    env-vars:
+    - ORG_NAME=knative-sandbox
   knative/operator:
   - continuous: true
     dot-dev: true
@@ -1009,12 +1033,8 @@ periodics:
     dot-dev: true
   - dot-release: true
     dot-dev: true
-    env-vars:
-    - ORG_NAME=knative-sandbox
   - auto-release: true
     dot-dev: true
-    env-vars:
-    - ORG_NAME=knative-sandbox
   knative-sandbox/discovery:
   - continuous: true
     dot-dev: true

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -8849,6 +8849,8 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
+      - name: ORG_NAME
+        value: knative-sandbox
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -8890,6 +8892,8 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
+      - name: ORG_NAME
+        value: knative-sandbox
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -9082,6 +9086,8 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
+      - name: ORG_NAME
+        value: knative-sandbox
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -9123,6 +9129,8 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
+      - name: ORG_NAME
+        value: knative-sandbox
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -9315,6 +9323,8 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
+      - name: ORG_NAME
+        value: knative-sandbox
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -9356,6 +9366,8 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
+      - name: ORG_NAME
+        value: knative-sandbox
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -9582,6 +9594,8 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
+      - name: ORG_NAME
+        value: knative-sandbox
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -9626,6 +9640,8 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
+      - name: ORG_NAME
+        value: knative-sandbox
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -9670,6 +9686,8 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
+      - name: ORG_NAME
+        value: knative-sandbox
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -9713,6 +9731,8 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
+      - name: ORG_NAME
+        value: knative-sandbox
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -9905,6 +9925,8 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
+      - name: ORG_NAME
+        value: knative-sandbox
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -9946,6 +9968,8 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
+      - name: ORG_NAME
+        value: knative-sandbox
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -10320,8 +10344,6 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
-      - name: ORG_NAME
-        value: knative-sandbox
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -10363,8 +10385,6 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
-      - name: ORG_NAME
-        value: knative-sandbox
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Fix the release jobs for some knative-sandbox repos - they need the `ORG_NAME` env var to be set as `knative-sandbox`, otherwise it will default to `knative`.

/cc @chaodaiG @mattmoor @tcnghia 
