### PR TITLE
Restore from revert "[Auto] Update prow jobs for release branches""

### DIFF
--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -465,9 +465,6 @@ periodics:
       limits:
         memory: 16Gi
   - branch-ci: true
-    release: "0.13"
-    dot-dev: true
-  - branch-ci: true
     release: "0.14"
     dot-dev: true
   - branch-ci: true
@@ -475,6 +472,9 @@ periodics:
     dot-dev: true
   - branch-ci: true
     release: "0.16"
+    dot-dev: true
+  - branch-ci: true
+    release: "0.17"
     dot-dev: true
   - custom-job: istio-latest-mesh
     command:
@@ -581,14 +581,6 @@ periodics:
         memory: 16Gi
   - dot-release: true
     dot-dev: true
-    release: "0.13"
-    resources:
-      requests:
-        memory: 12Gi
-      limits:
-        memory: 16Gi
-  - dot-release: true
-    dot-dev: true
     release: "0.14"
     resources:
       requests:
@@ -606,6 +598,14 @@ periodics:
   - dot-release: true
     dot-dev: true
     release: "0.16"
+    resources:
+      requests:
+        memory: 12Gi
+      limits:
+        memory: 16Gi
+  - dot-release: true
+    dot-dev: true
+    release: "0.17"
     resources:
       requests:
         memory: 12Gi
@@ -671,9 +671,6 @@ periodics:
       limits:
         memory: 16Gi
   - branch-ci: true
-    release: "0.13"
-    dot-dev: true
-  - branch-ci: true
     release: "0.14"
     dot-dev: true
   - branch-ci: true
@@ -681,6 +678,9 @@ periodics:
     dot-dev: true
   - branch-ci: true
     release: "0.16"
+    dot-dev: true
+  - branch-ci: true
+    release: "0.17"
     dot-dev: true
   - nightly: true
     dot-dev: true
@@ -697,14 +697,6 @@ periodics:
         memory: 16Gi
   - dot-release: true
     dot-dev: true
-    release: "0.13"
-    resources:
-      requests:
-        memory: 12Gi
-      limits:
-        memory: 16Gi
-  - dot-release: true
-    dot-dev: true
     release: "0.14"
     resources:
       requests:
@@ -722,6 +714,14 @@ periodics:
   - dot-release: true
     dot-dev: true
     release: "0.16"
+    resources:
+      requests:
+        memory: 12Gi
+      limits:
+        memory: 16Gi
+  - dot-release: true
+    dot-dev: true
+    release: "0.17"
     resources:
       requests:
         memory: 12Gi

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -3991,92 +3991,6 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "45 8 * * *"
-  name: ci-knative-serving-0.13-continuous
-  agent: kubernetes
-  decorate: true
-  cluster: "build-knative"
-  extra_refs:
-  - org: knative
-    repo: serving
-    base_ref: release-0.13
-    path_alias: knative.dev/serving
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./hack/release.sh"
-      - "--nopublish"
-      - "--notag-release"
-      securityContext:
-        privileged: true
-      volumeMounts:
-      - name: docker-graph
-        mountPath: /docker-graph
-      - name: test-account
-        mountPath: /etc/test-account
-        readOnly: true
-      env:
-      - name: DOCKER_IN_DOCKER_ENABLED
-        value: "true"
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/test-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-      - name: PULL_BASE_REF
-        value: release-0.13
-    volumes:
-    - name: docker-graph
-      emptyDir: {}
-    - name: test-account
-      secret:
-        secretName: test-account
-- cron: "37 8,11 * * *"
-  name: ci-knative-serving-0.13-continuous-beta-prow-tests
-  agent: kubernetes
-  decorate: true
-  cluster: "build-knative"
-  extra_refs:
-  - org: knative
-    repo: serving
-    base_ref: release-0.13
-    path_alias: knative.dev/serving
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:beta
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./hack/release.sh"
-      - "--nopublish"
-      - "--notag-release"
-      securityContext:
-        privileged: true
-      volumeMounts:
-      - name: docker-graph
-        mountPath: /docker-graph
-      - name: test-account
-        mountPath: /etc/test-account
-        readOnly: true
-      env:
-      - name: DOCKER_IN_DOCKER_ENABLED
-        value: "true"
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/test-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-      - name: PULL_BASE_REF
-        value: release-0.13
-    volumes:
-    - name: docker-graph
-      emptyDir: {}
-    - name: test-account
-      secret:
-        secretName: test-account
 - cron: "42 8 * * *"
   name: ci-knative-serving-0.14-continuous
   agent: kubernetes
@@ -4329,6 +4243,92 @@ periodics:
         value: us-central1
       - name: PULL_BASE_REF
         value: release-0.16
+    volumes:
+    - name: docker-graph
+      emptyDir: {}
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "21 8 * * *"
+  name: ci-knative-serving-0.17-continuous
+  agent: kubernetes
+  decorate: true
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: release-0.17
+    path_alias: knative.dev/serving
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--nopublish"
+      - "--notag-release"
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - name: docker-graph
+        mountPath: /docker-graph
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.17
+    volumes:
+    - name: docker-graph
+      emptyDir: {}
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "9 8,11 * * *"
+  name: ci-knative-serving-0.17-continuous-beta-prow-tests
+  agent: kubernetes
+  decorate: true
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: release-0.17
+    path_alias: knative.dev/serving
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:beta
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--nopublish"
+      - "--notag-release"
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - name: docker-graph
+        mountPath: /docker-graph
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.17
     volumes:
     - name: docker-graph
       emptyDir: {}
@@ -4729,55 +4729,6 @@ periodics:
     - name: nightly-account
       secret:
         secretName: nightly-account
-- cron: "57 9 * * 2"
-  name: ci-knative-serving-0.13-dot-release
-  agent: kubernetes
-  decorate: true
-  cluster: "build-knative"
-  extra_refs:
-  - org: knative
-    repo: serving
-    base_ref: release-0.13
-    path_alias: knative.dev/serving
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./hack/release.sh"
-      - "--dot-release"
-      - "--release-gcs knative-releases/serving"
-      - "--release-gcr gcr.io/knative-releases"
-      - "--github-token /etc/hub-token/token"
-      - "--branch release-0.13"
-      volumeMounts:
-      - name: hub-token
-        mountPath: /etc/hub-token
-        readOnly: true
-      - name: release-account
-        mountPath: /etc/release-account
-        readOnly: true
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/release-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-      - name: PULL_BASE_REF
-        value: release-0.13
-      resources:
-        requests:
-          memory: 12Gi
-        limits:
-          memory: 16Gi
-    volumes:
-    - name: hub-token
-      secret:
-        secretName: hub-token
-    - name: release-account
-      secret:
-        secretName: release-account
 - cron: "32 9 * * 2"
   name: ci-knative-serving-0.14-dot-release
   agent: kubernetes
@@ -4913,6 +4864,55 @@ periodics:
         value: us-central1
       - name: PULL_BASE_REF
         value: release-0.16
+      resources:
+        requests:
+          memory: 12Gi
+        limits:
+          memory: 16Gi
+    volumes:
+    - name: hub-token
+      secret:
+        secretName: hub-token
+    - name: release-account
+      secret:
+        secretName: release-account
+- cron: "13 9 * * 2"
+  name: ci-knative-serving-0.17-dot-release
+  agent: kubernetes
+  decorate: true
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative
+    repo: serving
+    base_ref: release-0.17
+    path_alias: knative.dev/serving
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--dot-release"
+      - "--release-gcs knative-releases/serving"
+      - "--release-gcr gcr.io/knative-releases"
+      - "--github-token /etc/hub-token/token"
+      - "--branch release-0.17"
+      volumeMounts:
+      - name: hub-token
+        mountPath: /etc/hub-token
+        readOnly: true
+      - name: release-account
+        mountPath: /etc/release-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.17
       resources:
         requests:
           memory: 12Gi
@@ -6051,92 +6051,6 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "37 8 * * *"
-  name: ci-knative-eventing-0.13-continuous
-  agent: kubernetes
-  decorate: true
-  cluster: "build-knative"
-  extra_refs:
-  - org: knative
-    repo: eventing
-    base_ref: release-0.13
-    path_alias: knative.dev/eventing
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./hack/release.sh"
-      - "--nopublish"
-      - "--notag-release"
-      securityContext:
-        privileged: true
-      volumeMounts:
-      - name: docker-graph
-        mountPath: /docker-graph
-      - name: test-account
-        mountPath: /etc/test-account
-        readOnly: true
-      env:
-      - name: DOCKER_IN_DOCKER_ENABLED
-        value: "true"
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/test-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-      - name: PULL_BASE_REF
-        value: release-0.13
-    volumes:
-    - name: docker-graph
-      emptyDir: {}
-    - name: test-account
-      secret:
-        secretName: test-account
-- cron: "53 8,11 * * *"
-  name: ci-knative-eventing-0.13-continuous-beta-prow-tests
-  agent: kubernetes
-  decorate: true
-  cluster: "build-knative"
-  extra_refs:
-  - org: knative
-    repo: eventing
-    base_ref: release-0.13
-    path_alias: knative.dev/eventing
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:beta
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./hack/release.sh"
-      - "--nopublish"
-      - "--notag-release"
-      securityContext:
-        privileged: true
-      volumeMounts:
-      - name: docker-graph
-        mountPath: /docker-graph
-      - name: test-account
-        mountPath: /etc/test-account
-        readOnly: true
-      env:
-      - name: DOCKER_IN_DOCKER_ENABLED
-        value: "true"
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/test-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-      - name: PULL_BASE_REF
-        value: release-0.13
-    volumes:
-    - name: docker-graph
-      emptyDir: {}
-    - name: test-account
-      secret:
-        secretName: test-account
 - cron: "14 8 * * *"
   name: ci-knative-eventing-0.14-continuous
   agent: kubernetes
@@ -6395,6 +6309,92 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
+- cron: "37 8 * * *"
+  name: ci-knative-eventing-0.17-continuous
+  agent: kubernetes
+  decorate: true
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative
+    repo: eventing
+    base_ref: release-0.17
+    path_alias: knative.dev/eventing
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--nopublish"
+      - "--notag-release"
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - name: docker-graph
+        mountPath: /docker-graph
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.17
+    volumes:
+    - name: docker-graph
+      emptyDir: {}
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "21 8,11 * * *"
+  name: ci-knative-eventing-0.17-continuous-beta-prow-tests
+  agent: kubernetes
+  decorate: true
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative
+    repo: eventing
+    base_ref: release-0.17
+    path_alias: knative.dev/eventing
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:beta
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--nopublish"
+      - "--notag-release"
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - name: docker-graph
+        mountPath: /docker-graph
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.17
+    volumes:
+    - name: docker-graph
+      emptyDir: {}
+    - name: test-account
+      secret:
+        secretName: test-account
 - cron: "12 9 * * *"
   name: ci-knative-eventing-nightly-release
   agent: kubernetes
@@ -6439,55 +6439,6 @@ periodics:
     - name: nightly-account
       secret:
         secretName: nightly-account
-- cron: "41 9 * * 2"
-  name: ci-knative-eventing-0.13-dot-release
-  agent: kubernetes
-  decorate: true
-  cluster: "build-knative"
-  extra_refs:
-  - org: knative
-    repo: eventing
-    base_ref: release-0.13
-    path_alias: knative.dev/eventing
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./hack/release.sh"
-      - "--dot-release"
-      - "--release-gcs knative-releases/eventing"
-      - "--release-gcr gcr.io/knative-releases"
-      - "--github-token /etc/hub-token/token"
-      - "--branch release-0.13"
-      volumeMounts:
-      - name: hub-token
-        mountPath: /etc/hub-token
-        readOnly: true
-      - name: release-account
-        mountPath: /etc/release-account
-        readOnly: true
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/release-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-      - name: PULL_BASE_REF
-        value: release-0.13
-      resources:
-        requests:
-          memory: 12Gi
-        limits:
-          memory: 16Gi
-    volumes:
-    - name: hub-token
-      secret:
-        secretName: hub-token
-    - name: release-account
-      secret:
-        secretName: release-account
 - cron: "36 9 * * 2"
   name: ci-knative-eventing-0.14-dot-release
   agent: kubernetes
@@ -6623,6 +6574,55 @@ periodics:
         value: us-central1
       - name: PULL_BASE_REF
         value: release-0.16
+      resources:
+        requests:
+          memory: 12Gi
+        limits:
+          memory: 16Gi
+    volumes:
+    - name: hub-token
+      secret:
+        secretName: hub-token
+    - name: release-account
+      secret:
+        secretName: release-account
+- cron: "29 9 * * 2"
+  name: ci-knative-eventing-0.17-dot-release
+  agent: kubernetes
+  decorate: true
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative
+    repo: eventing
+    base_ref: release-0.17
+    path_alias: knative.dev/eventing
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--dot-release"
+      - "--release-gcs knative-releases/eventing"
+      - "--release-gcr gcr.io/knative-releases"
+      - "--github-token /etc/hub-token/token"
+      - "--branch release-0.17"
+      volumeMounts:
+      - name: hub-token
+        mountPath: /etc/hub-token
+        readOnly: true
+      - name: release-account
+        mountPath: /etc/release-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.17
       resources:
         requests:
           memory: 12Gi

--- a/config/prod/prow/testgrid/testgrid.yaml
+++ b/config/prod/prow/testgrid/testgrid.yaml
@@ -204,50 +204,6 @@ test_groups:
 - name: ci-knative-operator-test-coverage
   gcs_prefix: knative-prow/logs/ci-knative-operator-go-coverage
   short_text_metric: "coverage"
-- name: ci-knative-serving-0.13-continuous
-  gcs_prefix: knative-prow/logs/ci-knative-serving-0.13-continuous
-  alert_options:
-    alert_mail_to_addresses: "serverless-engprod-sea@google.com"
-  num_failures_to_alert: 3
-- name: ci-knative-serving-0.13-dot-release
-  gcs_prefix: knative-prow/logs/ci-knative-serving-0.13-dot-release
-  alert_options:
-    alert_mail_to_addresses: "serverless-engprod-sea@google.com"
-  alert_stale_results_hours: 170
-  num_failures_to_alert: 1
-- name: ci-knative-client-0.13-continuous
-  gcs_prefix: knative-prow/logs/ci-knative-client-0.13-continuous
-  alert_options:
-    alert_mail_to_addresses: "serverless-engprod-sea@google.com"
-  num_failures_to_alert: 3
-- name: ci-knative-client-0.13-dot-release
-  gcs_prefix: knative-prow/logs/ci-knative-client-0.13-dot-release
-  alert_options:
-    alert_mail_to_addresses: "serverless-engprod-sea@google.com"
-  alert_stale_results_hours: 170
-  num_failures_to_alert: 1
-- name: ci-knative-eventing-0.13-continuous
-  gcs_prefix: knative-prow/logs/ci-knative-eventing-0.13-continuous
-  alert_options:
-    alert_mail_to_addresses: "serverless-engprod-sea@google.com"
-  num_failures_to_alert: 3
-- name: ci-knative-eventing-0.13-dot-release
-  gcs_prefix: knative-prow/logs/ci-knative-eventing-0.13-dot-release
-  alert_options:
-    alert_mail_to_addresses: "serverless-engprod-sea@google.com"
-  alert_stale_results_hours: 170
-  num_failures_to_alert: 1
-- name: ci-knative-eventing-contrib-0.13-continuous
-  gcs_prefix: knative-prow/logs/ci-knative-eventing-contrib-0.13-continuous
-  alert_options:
-    alert_mail_to_addresses: "serverless-engprod-sea@google.com"
-  num_failures_to_alert: 3
-- name: ci-knative-eventing-contrib-0.13-dot-release
-  gcs_prefix: knative-prow/logs/ci-knative-eventing-contrib-0.13-dot-release
-  alert_options:
-    alert_mail_to_addresses: "serverless-engprod-sea@google.com"
-  alert_stale_results_hours: 170
-  num_failures_to_alert: 1
 - name: ci-knative-serving-0.14-continuous
   gcs_prefix: knative-prow/logs/ci-knative-serving-0.14-continuous
   alert_options:
@@ -390,6 +346,50 @@ test_groups:
   alert_options:
     alert_mail_to_addresses: "serverless-engprod-sea@google.com"
   num_failures_to_alert: 3
+- name: ci-knative-serving-0.17-continuous
+  gcs_prefix: knative-prow/logs/ci-knative-serving-0.17-continuous
+  alert_options:
+    alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+  num_failures_to_alert: 3
+- name: ci-knative-serving-0.17-dot-release
+  gcs_prefix: knative-prow/logs/ci-knative-serving-0.17-dot-release
+  alert_options:
+    alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+  alert_stale_results_hours: 170
+  num_failures_to_alert: 1
+- name: ci-knative-eventing-0.17-continuous
+  gcs_prefix: knative-prow/logs/ci-knative-eventing-0.17-continuous
+  alert_options:
+    alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+  num_failures_to_alert: 3
+- name: ci-knative-eventing-0.17-dot-release
+  gcs_prefix: knative-prow/logs/ci-knative-eventing-0.17-dot-release
+  alert_options:
+    alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+  alert_stale_results_hours: 170
+  num_failures_to_alert: 1
+- name: ci-knative-client-0.13-continuous
+  gcs_prefix: knative-prow/logs/ci-knative-client-0.13-continuous
+  alert_options:
+    alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+  num_failures_to_alert: 3
+- name: ci-knative-client-0.13-dot-release
+  gcs_prefix: knative-prow/logs/ci-knative-client-0.13-dot-release
+  alert_options:
+    alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+  alert_stale_results_hours: 170
+  num_failures_to_alert: 1
+- name: ci-knative-eventing-contrib-0.13-continuous
+  gcs_prefix: knative-prow/logs/ci-knative-eventing-contrib-0.13-continuous
+  alert_options:
+    alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+  num_failures_to_alert: 3
+- name: ci-knative-eventing-contrib-0.13-dot-release
+  gcs_prefix: knative-prow/logs/ci-knative-eventing-contrib-0.13-dot-release
+  alert_options:
+    alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+  alert_stale_results_hours: 170
+  num_failures_to_alert: 1
 - name: ci-knative-sandbox-sample-controller-continuous
   gcs_prefix: knative-prow/logs/ci-knative-sandbox-sample-controller-continuous
   alert_stale_results_hours: 3
@@ -646,14 +646,14 @@ test_groups:
   num_failures_to_alert: 1
 - name: ci-knative-serving-continuous-beta-prow-tests
   gcs_prefix: knative-prow/logs/ci-knative-serving-continuous-beta-prow-tests
-- name: ci-knative-serving-0.13-continuous-beta-prow-tests
-  gcs_prefix: knative-prow/logs/ci-knative-serving-0.13-continuous-beta-prow-tests
 - name: ci-knative-serving-0.14-continuous-beta-prow-tests
   gcs_prefix: knative-prow/logs/ci-knative-serving-0.14-continuous-beta-prow-tests
 - name: ci-knative-serving-0.15-continuous-beta-prow-tests
   gcs_prefix: knative-prow/logs/ci-knative-serving-0.15-continuous-beta-prow-tests
 - name: ci-knative-serving-0.16-continuous-beta-prow-tests
   gcs_prefix: knative-prow/logs/ci-knative-serving-0.16-continuous-beta-prow-tests
+- name: ci-knative-serving-0.17-continuous-beta-prow-tests
+  gcs_prefix: knative-prow/logs/ci-knative-serving-0.17-continuous-beta-prow-tests
 - name: ci-knative-serving-go-coverage-beta-prow-tests
   gcs_prefix: knative-prow/logs/ci-knative-serving-go-coverage-beta-prow-tests
   short_text_metric: "coverage"
@@ -679,14 +679,14 @@ test_groups:
   short_text_metric: "coverage"
 - name: ci-knative-eventing-continuous-beta-prow-tests
   gcs_prefix: knative-prow/logs/ci-knative-eventing-continuous-beta-prow-tests
-- name: ci-knative-eventing-0.13-continuous-beta-prow-tests
-  gcs_prefix: knative-prow/logs/ci-knative-eventing-0.13-continuous-beta-prow-tests
 - name: ci-knative-eventing-0.14-continuous-beta-prow-tests
   gcs_prefix: knative-prow/logs/ci-knative-eventing-0.14-continuous-beta-prow-tests
 - name: ci-knative-eventing-0.15-continuous-beta-prow-tests
   gcs_prefix: knative-prow/logs/ci-knative-eventing-0.15-continuous-beta-prow-tests
 - name: ci-knative-eventing-0.16-continuous-beta-prow-tests
   gcs_prefix: knative-prow/logs/ci-knative-eventing-0.16-continuous-beta-prow-tests
+- name: ci-knative-eventing-0.17-continuous-beta-prow-tests
+  gcs_prefix: knative-prow/logs/ci-knative-eventing-0.17-continuous-beta-prow-tests
 - name: ci-knative-eventing-go-coverage-beta-prow-tests
   gcs_prefix: knative-prow/logs/ci-knative-eventing-go-coverage-beta-prow-tests
   short_text_metric: "coverage"
@@ -1320,56 +1320,6 @@ dashboards:
   - name: coverage
     test_group_name: ci-google-knative-gcp-test-coverage
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
-- name: knative-0.13
-  dashboard_tab:
-  - name: serving-continuous
-    test_group_name: ci-knative-serving-0.13-continuous
-    base_options: "sort-by-name="
-    alert_options:
-      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
-    num_failures_to_alert: 3
-  - name: serving-dot-release
-    test_group_name: ci-knative-serving-0.13-dot-release
-    base_options: "sort-by-name="
-    alert_options:
-      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
-    num_failures_to_alert: 3
-  - name: client-continuous
-    test_group_name: ci-knative-client-0.13-continuous
-    base_options: "sort-by-name="
-    alert_options:
-      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
-    num_failures_to_alert: 3
-  - name: client-dot-release
-    test_group_name: ci-knative-client-0.13-dot-release
-    base_options: "sort-by-name="
-    alert_options:
-      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
-    num_failures_to_alert: 3
-  - name: eventing-continuous
-    test_group_name: ci-knative-eventing-0.13-continuous
-    base_options: "sort-by-name="
-    alert_options:
-      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
-    num_failures_to_alert: 3
-  - name: eventing-dot-release
-    test_group_name: ci-knative-eventing-0.13-dot-release
-    base_options: "sort-by-name="
-    alert_options:
-      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
-    num_failures_to_alert: 3
-  - name: eventing-contrib-continuous
-    test_group_name: ci-knative-eventing-contrib-0.13-continuous
-    base_options: "sort-by-name="
-    alert_options:
-      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
-    num_failures_to_alert: 3
-  - name: eventing-contrib-dot-release
-    test_group_name: ci-knative-eventing-contrib-0.13-dot-release
-    base_options: "sort-by-name="
-    alert_options:
-      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
-    num_failures_to_alert: 3
 - name: knative-0.14
   dashboard_tab:
   - name: serving-continuous
@@ -1532,6 +1482,58 @@ dashboards:
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
     num_failures_to_alert: 3
+- name: knative-0.17
+  dashboard_tab:
+  - name: serving-continuous
+    test_group_name: ci-knative-serving-0.17-continuous
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
+  - name: serving-dot-release
+    test_group_name: ci-knative-serving-0.17-dot-release
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
+  - name: eventing-continuous
+    test_group_name: ci-knative-eventing-0.17-continuous
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
+  - name: eventing-dot-release
+    test_group_name: ci-knative-eventing-0.17-dot-release
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
+- name: knative-0.13
+  dashboard_tab:
+  - name: client-continuous
+    test_group_name: ci-knative-client-0.13-continuous
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
+  - name: client-dot-release
+    test_group_name: ci-knative-client-0.13-dot-release
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
+  - name: eventing-contrib-continuous
+    test_group_name: ci-knative-eventing-contrib-0.13-continuous
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
+  - name: eventing-contrib-dot-release
+    test_group_name: ci-knative-eventing-contrib-0.13-dot-release
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
 - name: google-0.13
   dashboard_tab:
   - name: knative-gcp-continuous
@@ -1617,9 +1619,6 @@ dashboards:
   - name: ci-knative-serving-continuous
     test_group_name: ci-knative-serving-continuous-beta-prow-tests
     base_options: "sort-by-failures="
-  - name: ci-knative-serving-0.13-continuous
-    test_group_name: ci-knative-serving-0.13-continuous-beta-prow-tests
-    base_options: "sort-by-failures="
   - name: ci-knative-serving-0.14-continuous
     test_group_name: ci-knative-serving-0.14-continuous-beta-prow-tests
     base_options: "sort-by-failures="
@@ -1628,6 +1627,9 @@ dashboards:
     base_options: "sort-by-failures="
   - name: ci-knative-serving-0.16-continuous
     test_group_name: ci-knative-serving-0.16-continuous-beta-prow-tests
+    base_options: "sort-by-failures="
+  - name: ci-knative-serving-0.17-continuous
+    test_group_name: ci-knative-serving-0.17-continuous-beta-prow-tests
     base_options: "sort-by-failures="
   - name: ci-knative-serving-go-coverage
     test_group_name: ci-knative-serving-go-coverage-beta-prow-tests
@@ -1662,9 +1664,6 @@ dashboards:
   - name: ci-knative-eventing-continuous
     test_group_name: ci-knative-eventing-continuous-beta-prow-tests
     base_options: "sort-by-failures="
-  - name: ci-knative-eventing-0.13-continuous
-    test_group_name: ci-knative-eventing-0.13-continuous-beta-prow-tests
-    base_options: "sort-by-failures="
   - name: ci-knative-eventing-0.14-continuous
     test_group_name: ci-knative-eventing-0.14-continuous-beta-prow-tests
     base_options: "sort-by-failures="
@@ -1673,6 +1672,9 @@ dashboards:
     base_options: "sort-by-failures="
   - name: ci-knative-eventing-0.16-continuous
     test_group_name: ci-knative-eventing-0.16-continuous-beta-prow-tests
+    base_options: "sort-by-failures="
+  - name: ci-knative-eventing-0.17-continuous
+    test_group_name: ci-knative-eventing-0.17-continuous-beta-prow-tests
     base_options: "sort-by-failures="
   - name: ci-knative-eventing-go-coverage
     test_group_name: ci-knative-eventing-go-coverage-beta-prow-tests


### PR DESCRIPTION
The revert did not restore Testgrid functionality. Restoring the release branches.

Reverts knative/test-infra#2375