### PR TITLE
Remove dot-dev and ORG_NAME env var from meta job config

### DIFF
--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -3,17 +3,14 @@ presubmits:
   - repo-settings: null
     performance: true
   - build-tests: true
-    dot-dev: true
     resources:
       requests:
         memory: 12Gi
       limits:
         memory: 16Gi
   - unit-tests: true
-    dot-dev: true
     needs-monitor: true
   - integration-tests: true
-    dot-dev: true
     needs-monitor: true
     args:
     - --run-test
@@ -24,7 +21,6 @@ presubmits:
       limits:
         memory: 16Gi
   - custom-test: upgrade-tests
-    dot-dev: true
     needs-monitor: true
     args:
     - --run-test
@@ -35,7 +31,6 @@ presubmits:
       limits:
         memory: 16Gi
   - custom-test: autotls-tests
-    dot-dev: true
     needs-monitor: true
     args:
     - --run-test
@@ -47,9 +42,7 @@ presubmits:
         memory: 16Gi
   - go-coverage: true
     go-coverage-threshold: 80
-    dot-dev: true
   - custom-test: istio-latest-mesh
-    dot-dev: true
     always-run: false
     optional: true
     args:
@@ -63,7 +56,6 @@ presubmits:
       limits:
         memory: 16Gi
   - custom-test: istio-latest-no-mesh
-    dot-dev: true
     always-run: false
     optional: true
     args:
@@ -77,7 +69,6 @@ presubmits:
       limits:
         memory: 16Gi
   - custom-test: istio-stable-mesh
-    dot-dev: true
     always-run: false
     optional: true
     run-if-changed: ^third_party/net-istio.yaml
@@ -92,7 +83,6 @@ presubmits:
       limits:
         memory: 16Gi
   - custom-test: istio-stable-no-mesh
-    dot-dev: true
     always-run: false
     optional: true
     args:
@@ -106,7 +96,6 @@ presubmits:
       limits:
         memory: 16Gi
   - custom-test: gloo-0.17.1
-    dot-dev: true
     always-run: false
     optional: true
     args:
@@ -120,7 +109,6 @@ presubmits:
       limits:
         memory: 16Gi
   - custom-test: kourier-stable
-    dot-dev: true
     always-run: false
     optional: true
     args:
@@ -134,7 +122,6 @@ presubmits:
       limits:
         memory: 16Gi
   - custom-test: contour-latest
-    dot-dev: true
     always-run: false
     run-if-changed: ^third_party/contour-latest/*
     args:
@@ -148,7 +135,6 @@ presubmits:
       limits:
         memory: 16Gi
   - custom-test: ambassador-latest
-    dot-dev: true
     always-run: false
     optional: true
     args:
@@ -162,7 +148,6 @@ presubmits:
       limits:
         memory: 16Gi
   - custom-test: kong-latest
-    dot-dev: true
     always-run: false
     optional: true
     args:
@@ -176,7 +161,6 @@ presubmits:
       limits:
         memory: 16Gi
   - custom-test: https
-    dot-dev: true
     always-run: false
     optional: true
     args:
@@ -186,71 +170,53 @@ presubmits:
     - ./test/e2e-auto-tls-tests.sh --https
   knative/client:
   - build-tests: true
-    dot-dev: true
   - unit-tests: true
-    dot-dev: true
   - integration-tests: true
-    dot-dev: true
   - go-coverage: true
-    dot-dev: true
   - custom-test: integration-tests-latest-release
     always-run: true
     command:
     - ./test/presubmit-integration-tests-latest-release.sh
-    dot-dev: true
   knative/client-contrib:
   - build-tests: true
-    dot-dev: true
   - unit-tests: true
-    dot-dev: true
   - integration-tests: true
-    dot-dev: true
   knative/eventing:
   - repo-settings: null
     performance: true
   - build-tests: true
-    dot-dev: true
     resources:
       requests:
         memory: 12Gi
       limits:
         memory: 16Gi
   - unit-tests: true
-    dot-dev: true
   - integration-tests: true
-    dot-dev: true
     needs-monitor: true
     args:
     - --run-test
     - ./test/e2e-tests.sh
   - custom-test: conformance-tests
-    dot-dev: true
     needs-monitor: true
     args:
     - --run-test
     - ./test/e2e-conformance-tests.sh
   - custom-test: upgrade-tests
-    dot-dev: true
     needs-monitor: true
     args:
     - --run-test
     - ./test/e2e-upgrade-tests.sh
   - go-coverage: true
-    dot-dev: true
   knative/eventing-contrib:
   - build-tests: true
-    dot-dev: true
     resources:
       requests:
         memory: 12Gi
       limits:
         memory: 16Gi
   - unit-tests: true
-    dot-dev: true
   - integration-tests: true
-    dot-dev: true
   - go-coverage: true
-    dot-dev: true
   knative/docs:
   - build-tests: true
   - unit-tests: true
@@ -264,41 +230,25 @@ presubmits:
     - ./test/presubmit-link-check.sh
   knative/pkg:
   - build-tests: true
-    dot-dev: true
   - unit-tests: true
-    dot-dev: true
   - integration-tests: true
-    dot-dev: true
   - go-coverage: true
-    dot-dev: true
   knative/test-infra:
   - build-tests: true
-    dot-dev: true
   - unit-tests: true
-    dot-dev: true
   - integration-tests: true
-    dot-dev: true
   - go-coverage: true
-    dot-dev: true
   knative/caching:
   - build-tests: true
-    dot-dev: true
   - unit-tests: true
-    dot-dev: true
   - integration-tests: true
-    dot-dev: true
   - go-coverage: true
-    dot-dev: true
   knative-sandbox/sample-controller:
   - build-tests: true
-    dot-dev: true
   - unit-tests: true
-    dot-dev: true
   knative-sandbox/sample-source:
   - build-tests: true
-    dot-dev: true
   - unit-tests: true
-    dot-dev: true
   google/knative-gcp:
   - repo-settings: null
     performance: true
@@ -332,64 +282,39 @@ presubmits:
   - go-coverage: true
   knative/networking:
   - build-tests: true
-    dot-dev: true
   - unit-tests: true
-    dot-dev: true
   - integration-tests: true
-    dot-dev: true
   - go-coverage: true
-    dot-dev: true
   knative-sandbox/net-certmanager:
   - build-tests: true
-    dot-dev: true
   - unit-tests: true
-    dot-dev: true
   - integration-tests: true
-    dot-dev: true
   - go-coverage: true
-    dot-dev: true
   knative-sandbox/net-contour:
   - build-tests: true
-    dot-dev: true
   - unit-tests: true
-    dot-dev: true
   - integration-tests: true
-    dot-dev: true
   - go-coverage: true
-    dot-dev: true
   knative-sandbox/net-http01:
   - build-tests: true
-    dot-dev: true
   - unit-tests: true
-    dot-dev: true
   - integration-tests: true
-    dot-dev: true
   - go-coverage: true
-    dot-dev: true
   knative-sandbox/net-istio:
   - build-tests: true
-    dot-dev: true
   - unit-tests: true
-    dot-dev: true
   - integration-tests: true
-    dot-dev: true
   - go-coverage: true
-    dot-dev: true
   - custom-test: latest
-    dot-dev: true
     optional: true
     args:
     - --run-test
     - ./test/e2e-tests.sh --istio-version latest
   knative-sandbox/net-kourier:
   - build-tests: true
-    dot-dev: true
   - unit-tests: true
-    dot-dev: true
   - integration-tests: true
-    dot-dev: true
   - go-coverage: true
-    dot-dev: true
   knative/website:
   - build-tests: false
   - unit-tests: false
@@ -402,63 +327,43 @@ presubmits:
   - go-coverage: false
   knative/operator:
   - build-tests: true
-    dot-dev: true
   - unit-tests: true
-    dot-dev: true
   - integration-tests: true
-    dot-dev: true
   - go-coverage: true
-    dot-dev: true
   - custom-test: upgrade-tests
-    dot-dev: true
     args:
     - --run-test
     - ./test/e2e-upgrade-tests.sh
   knative-sandbox/discovery:
   - build-tests: true
-    dot-dev: true
   - unit-tests: true
-    dot-dev: true
   - integration-tests: true
-    dot-dev: true
   knative-sandbox/eventing-kafka:
   - build-tests: true
-    dot-dev: true
     needs-dind: true
   - unit-tests: true
-    dot-dev: true
     needs-dind: true
   - integration-tests: true
-    dot-dev: true
     needs-dind: true
   - go-coverage: true
-    dot-dev: true
     needs-dind: true
   knative-sandbox/eventing-kafka-broker:
   - build-tests: true
-    dot-dev: true
     needs-dind: true
   - unit-tests: true
-    dot-dev: true
     needs-dind: true
   - integration-tests: true
-    dot-dev: true
     needs-dind: true
   - go-coverage: true
-    dot-dev: true
     needs-dind: true
   knative-sandbox/eventing-rabbitmq:
   - build-tests: true
-    dot-dev: true
   - unit-tests: true
-    dot-dev: true
   - integration-tests: true
-    dot-dev: true
 periodics:
   knative/serving:
   - continuous: true
     timeout: 100
-    dot-dev: true
     resources:
       requests:
         memory: 12Gi
@@ -466,16 +371,12 @@ periodics:
         memory: 16Gi
   - branch-ci: true
     release: "0.14"
-    dot-dev: true
   - branch-ci: true
     release: "0.15"
-    dot-dev: true
   - branch-ci: true
     release: "0.16"
-    dot-dev: true
   - branch-ci: true
     release: "0.17"
-    dot-dev: true
   - custom-job: istio-latest-mesh
     command:
     - ./test/presubmit-tests.sh
@@ -484,7 +385,6 @@ periodics:
     - ./test/e2e-tests.sh --istio-version latest --mesh
     - --run-test
     - ./test/e2e-auto-tls-tests.sh --istio-version latest --mesh
-    dot-dev: true
   - custom-job: istio-latest-no-mesh
     command:
     - ./test/presubmit-tests.sh
@@ -493,7 +393,6 @@ periodics:
     - ./test/e2e-tests.sh --istio-version latest --no-mesh
     - --run-test
     - ./test/e2e-auto-tls-tests.sh --istio-version latest --no-mesh
-    dot-dev: true
   - custom-job: istio-stable-mesh
     command:
     - ./test/presubmit-tests.sh
@@ -502,7 +401,6 @@ periodics:
     - ./test/e2e-tests.sh --istio-version stable --mesh
     - --run-test
     - ./test/e2e-auto-tls-tests.sh --istio-version stable --mesh
-    dot-dev: true
   - custom-job: istio-stable-no-mesh
     command:
     - ./test/presubmit-tests.sh
@@ -511,7 +409,6 @@ periodics:
     - ./test/e2e-tests.sh --istio-version stable --no-mesh
     - --run-test
     - ./test/e2e-auto-tls-tests.sh --istio-version stable --no-mesh
-    dot-dev: true
   - custom-job: gloo-0.17.1
     command:
     - ./test/presubmit-tests.sh
@@ -520,7 +417,6 @@ periodics:
     - ./test/e2e-tests.sh --gloo-version 0.17.1
     - --run-test
     - ./test/e2e-auto-tls-tests.sh --gloo-version 0.17.1
-    dot-dev: true
   - custom-job: kourier-stable
     command:
     - ./test/presubmit-tests.sh
@@ -529,7 +425,6 @@ periodics:
     - ./test/e2e-tests.sh --kourier-version stable
     - --run-test
     - ./test/e2e-auto-tls-tests.sh --kourier-version stable
-    dot-dev: true
   - custom-job: contour-latest
     command:
     - ./test/presubmit-tests.sh
@@ -538,7 +433,6 @@ periodics:
     - ./test/e2e-tests.sh --contour-version latest
     - --run-test
     - ./test/e2e-auto-tls-tests.sh --contour-version latest
-    dot-dev: true
   - custom-job: ambassador-latest
     command:
     - ./test/presubmit-tests.sh
@@ -547,7 +441,6 @@ periodics:
     - ./test/e2e-tests.sh --ambassador-version latest
     - --run-test
     - ./test/e2e-auto-tls-tests.sh --ambassador-version latest
-    dot-dev: true
   - custom-job: kong-latest
     command:
     - ./test/presubmit-tests.sh
@@ -556,7 +449,6 @@ periodics:
     - ./test/e2e-tests.sh --kong-version latest
     - --run-test
     - ./test/e2e-auto-tls-tests.sh --kong-version latest
-    dot-dev: true
   - custom-job: https
     command:
     - ./test/presubmit-tests.sh
@@ -565,9 +457,7 @@ periodics:
     - ./test/e2e-tests.sh --https
     - --run-test
     - ./test/e2e-auto-tls-tests.sh --https
-    dot-dev: true
   - nightly: true
-    dot-dev: true
     reporter_config:
       slack:
         channel: serving-api
@@ -580,7 +470,6 @@ periodics:
       limits:
         memory: 16Gi
   - dot-release: true
-    dot-dev: true
     release: "0.14"
     resources:
       requests:
@@ -588,7 +477,6 @@ periodics:
       limits:
         memory: 16Gi
   - dot-release: true
-    dot-dev: true
     release: "0.15"
     resources:
       requests:
@@ -596,7 +484,6 @@ periodics:
       limits:
         memory: 16Gi
   - dot-release: true
-    dot-dev: true
     release: "0.16"
     resources:
       requests:
@@ -604,7 +491,6 @@ periodics:
       limits:
         memory: 16Gi
   - dot-release: true
-    dot-dev: true
     release: "0.17"
     resources:
       requests:
@@ -612,59 +498,43 @@ periodics:
       limits:
         memory: 16Gi
   - auto-release: true
-    dot-dev: true
     resources:
       requests:
         memory: 12Gi
       limits:
         memory: 16Gi
   - webhook-apicoverage: true
-    dot-dev: true
   knative/client:
   - continuous: true
-    dot-dev: true
   - branch-ci: true
     release: "0.13"
-    dot-dev: true
   - branch-ci: true
     release: "0.14"
-    dot-dev: true
   - branch-ci: true
     release: "0.15"
-    dot-dev: true
   - branch-ci: true
     release: "0.16"
-    dot-dev: true
   - nightly: true
-    dot-dev: true
   - custom-job: tekton
     cron: 0 13 * * *
     command: ./test/tekton-tests.sh
-    dot-dev: true
   - dot-release: true
-    dot-dev: true
     release: "0.13"
   - dot-release: true
-    dot-dev: true
     release: "0.14"
   - dot-release: true
-    dot-dev: true
     release: "0.15"
   - dot-release: true
-    dot-dev: true
     release: "0.16"
   - auto-release: true
-    dot-dev: true
   knative/client-contrib:
   - continuous: true
-    dot-dev: true
   knative/docs:
   - continuous: true
     needs-dind: true
   knative/eventing:
   - continuous: true
     timeout: 90
-    dot-dev: true
     resources:
       requests:
         memory: 12Gi
@@ -672,18 +542,13 @@ periodics:
         memory: 16Gi
   - branch-ci: true
     release: "0.14"
-    dot-dev: true
   - branch-ci: true
     release: "0.15"
-    dot-dev: true
   - branch-ci: true
     release: "0.16"
-    dot-dev: true
   - branch-ci: true
     release: "0.17"
-    dot-dev: true
   - nightly: true
-    dot-dev: true
     reporter_config:
       slack:
         channel: eventing
@@ -696,7 +561,6 @@ periodics:
       limits:
         memory: 16Gi
   - dot-release: true
-    dot-dev: true
     release: "0.14"
     resources:
       requests:
@@ -704,7 +568,6 @@ periodics:
       limits:
         memory: 16Gi
   - dot-release: true
-    dot-dev: true
     release: "0.15"
     resources:
       requests:
@@ -712,7 +575,6 @@ periodics:
       limits:
         memory: 16Gi
   - dot-release: true
-    dot-dev: true
     release: "0.16"
     resources:
       requests:
@@ -720,7 +582,6 @@ periodics:
       limits:
         memory: 16Gi
   - dot-release: true
-    dot-dev: true
     release: "0.17"
     resources:
       requests:
@@ -728,7 +589,6 @@ periodics:
       limits:
         memory: 16Gi
   - auto-release: true
-    dot-dev: true
     resources:
       requests:
         memory: 12Gi
@@ -736,7 +596,6 @@ periodics:
         memory: 16Gi
   knative/eventing-contrib:
   - continuous: true
-    dot-dev: true
     resources:
       requests:
         memory: 12Gi
@@ -744,25 +603,19 @@ periodics:
         memory: 16Gi
   - branch-ci: true
     release: "0.13"
-    dot-dev: true
   - branch-ci: true
     release: "0.14"
-    dot-dev: true
   - branch-ci: true
     release: "0.15"
-    dot-dev: true
   - branch-ci: true
     release: "0.16"
-    dot-dev: true
   - nightly: true
-    dot-dev: true
     resources:
       requests:
         memory: 12Gi
       limits:
         memory: 16Gi
   - dot-release: true
-    dot-dev: true
     release: "0.13"
     resources:
       requests:
@@ -770,7 +623,6 @@ periodics:
       limits:
         memory: 16Gi
   - dot-release: true
-    dot-dev: true
     release: "0.14"
     resources:
       requests:
@@ -778,7 +630,6 @@ periodics:
       limits:
         memory: 16Gi
   - dot-release: true
-    dot-dev: true
     release: "0.15"
     resources:
       requests:
@@ -786,7 +637,6 @@ periodics:
       limits:
         memory: 16Gi
   - dot-release: true
-    dot-dev: true
     release: "0.16"
     resources:
       requests:
@@ -794,7 +644,6 @@ periodics:
       limits:
         memory: 16Gi
   - auto-release: true
-    dot-dev: true
     resources:
       requests:
         memory: 12Gi
@@ -802,19 +651,14 @@ periodics:
         memory: 16Gi
   knative/pkg:
   - continuous: true
-    dot-dev: true
   knative/caching:
   - continuous: true
-    dot-dev: true
   knative-sandbox/sample-controller:
   - continuous: true
-    dot-dev: true
   knative-sandbox/sample-source:
   - continuous: true
-    dot-dev: true
   knative/test-infra:
   - continuous: true
-    dot-dev: true
   google/knative-gcp:
   - continuous: true
     resources:
@@ -863,8 +707,6 @@ periodics:
         memory: 12Gi
       limits:
         memory: 16Gi
-    env-vars:
-    - ORG_NAME=google
   - dot-release: true
     release: "0.14"
     resources:
@@ -872,8 +714,6 @@ periodics:
         memory: 12Gi
       limits:
         memory: 16Gi
-    env-vars:
-    - ORG_NAME=google
   - dot-release: true
     release: "0.15"
     resources:
@@ -881,8 +721,6 @@ periodics:
         memory: 12Gi
       limits:
         memory: 16Gi
-    env-vars:
-    - ORG_NAME=google
   - dot-release: true
     release: "0.16"
     resources:
@@ -890,21 +728,15 @@ periodics:
         memory: 12Gi
       limits:
         memory: 16Gi
-    env-vars:
-    - ORG_NAME=google
   - auto-release: true
     resources:
       requests:
         memory: 12Gi
       limits:
         memory: 16Gi
-    env-vars:
-    - ORG_NAME=google
   knative-sandbox/net-certmanager:
   - continuous: true
-    dot-dev: true
   - nightly: true
-    dot-dev: true
     reporter_config:
       slack:
         channel: net-certmanager
@@ -912,18 +744,10 @@ periodics:
         - failure
         report_template: '"The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"'
   - dot-release: true
-    dot-dev: true
-    env-vars:
-    - ORG_NAME=knative-sandbox
   - auto-release: true
-    dot-dev: true
-    env-vars:
-    - ORG_NAME=knative-sandbox
   knative-sandbox/net-contour:
   - continuous: true
-    dot-dev: true
   - nightly: true
-    dot-dev: true
     reporter_config:
       slack:
         channel: net-contour
@@ -931,18 +755,10 @@ periodics:
         - failure
         report_template: '"The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"'
   - dot-release: true
-    dot-dev: true
-    env-vars:
-    - ORG_NAME=knative-sandbox
   - auto-release: true
-    dot-dev: true
-    env-vars:
-    - ORG_NAME=knative-sandbox
   knative-sandbox/net-http01:
   - continuous: true
-    dot-dev: true
   - nightly: true
-    dot-dev: true
     reporter_config:
       slack:
         channel: net-http01
@@ -950,18 +766,10 @@ periodics:
         - failure
         report_template: '"The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"'
   - dot-release: true
-    dot-dev: true
-    env-vars:
-    - ORG_NAME=knative-sandbox
   - auto-release: true
-    dot-dev: true
-    env-vars:
-    - ORG_NAME=knative-sandbox
   knative-sandbox/net-istio:
   - continuous: true
-    dot-dev: true
   - nightly: true
-    dot-dev: true
     reporter_config:
       slack:
         channel: net-istio
@@ -974,31 +782,16 @@ periodics:
     args:
     - --run-test
     - ./test/e2e-tests.sh --istio-version latest
-    dot-dev: true
   - dot-release: true
-    dot-dev: true
     release: "0.14"
-    env-vars:
-    - ORG_NAME=knative-sandbox
   - dot-release: true
-    dot-dev: true
     release: "0.15"
-    env-vars:
-    - ORG_NAME=knative-sandbox
   - dot-release: true
-    dot-dev: true
     release: "0.16"
-    env-vars:
-    - ORG_NAME=knative-sandbox
   - auto-release: true
-    dot-dev: true
-    env-vars:
-    - ORG_NAME=knative-sandbox
   knative-sandbox/net-kourier:
   - continuous: true
-    dot-dev: true
   - nightly: true
-    dot-dev: true
     reporter_config:
       slack:
         channel: net-kourier
@@ -1006,16 +799,9 @@ periodics:
         - failure
         report_template: '"The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"'
   - dot-release: true
-    dot-dev: true
-    env-vars:
-    - ORG_NAME=knative-sandbox
   - auto-release: true
-    dot-dev: true
-    env-vars:
-    - ORG_NAME=knative-sandbox
   knative/operator:
   - continuous: true
-    dot-dev: true
   - branch-ci: true
     release: "0.15"
     resources:
@@ -1031,55 +817,28 @@ periodics:
       limits:
         memory: 16Gi
   - nightly: true
-    dot-dev: true
   - dot-release: true
-    dot-dev: true
   - auto-release: true
-    dot-dev: true
   knative-sandbox/discovery:
   - continuous: true
-    dot-dev: true
   - nightly: true
-    dot-dev: true
   - dot-release: true
-    dot-dev: true
-    env-vars:
-    - ORG_NAME=knative-sandbox
   - auto-release: true
-    dot-dev: true
-    env-vars:
-    - ORG_NAME=knative-sandbox
   knative-sandbox/eventing-kafka:
   - continuous: true
-    dot-dev: true
     needs-dind: true
   - nightly: true
-    dot-dev: true
     needs-dind: true
   - dot-release: true
-    dot-dev: true
     needs-dind: true
-    env-vars:
-    - ORG_NAME=knative-sandbox
   - auto-release: true
-    dot-dev: true
     needs-dind: true
-    env-vars:
-    - ORG_NAME=knative-sandbox
   knative-sandbox/eventing-kafka-broker:
   - continuous: true
-    dot-dev: true
     needs-dind: true
   - nightly: true
-    dot-dev: true
     needs-dind: true
   - dot-release: true
-    dot-dev: true
     needs-dind: true
-    env-vars:
-    - ORG_NAME=knative-sandbox
   - auto-release: true
-    dot-dev: true
     needs-dind: true
-    env-vars:
-    - ORG_NAME=knative-sandbox

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -1350,7 +1350,6 @@ presubmits:
     rerun_command: "/test pull-knative-docs-build-tests"
     trigger: "(?m)^/test (all|pull-knative-docs-build-tests),?(\\s+|$)"
     decorate: true
-    path_alias: knative.dev/docs
     cluster: "build-knative"
     spec:
       containers:
@@ -1387,7 +1386,6 @@ presubmits:
     rerun_command: "/test pull-knative-docs-unit-tests"
     trigger: "(?m)^/test (all|pull-knative-docs-unit-tests),?(\\s+|$)"
     decorate: true
-    path_alias: knative.dev/docs
     cluster: "build-knative"
     spec:
       containers:
@@ -1424,7 +1422,6 @@ presubmits:
     rerun_command: "/test pull-knative-docs-integration-tests"
     trigger: "(?m)^/test (all|pull-knative-docs-integration-tests),?(\\s+|$)"
     decorate: true
-    path_alias: knative.dev/docs
     cluster: "build-knative"
     spec:
       containers:
@@ -1470,7 +1467,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-docs-go-coverage),?(\\s+|$)"
     optional: true
     decorate: true
-    path_alias: knative.dev/docs
     cluster: "build-knative"
     spec:
       containers:
@@ -1500,7 +1496,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-docs-markdown-link-check),?(\\s+|$)"
     decorate: true
     optional: true
-    path_alias: knative.dev/docs
     cluster: "build-knative"
     spec:
       containers:
@@ -5866,7 +5861,6 @@ periodics:
   extra_refs:
   - org: knative
     repo: docs
-    path_alias: knative.dev/docs
     base_ref: master
   spec:
     containers:
@@ -5906,7 +5900,6 @@ periodics:
   extra_refs:
   - org: knative
     repo: docs
-    path_alias: knative.dev/docs
     base_ref: master
   spec:
     containers:
@@ -5950,7 +5943,6 @@ periodics:
   extra_refs:
   - org: knative
     repo: docs
-    path_alias: knative.dev/docs
     base_ref: master
   spec:
     containers:
@@ -5974,7 +5966,6 @@ periodics:
   extra_refs:
   - org: knative
     repo: docs
-    path_alias: knative.dev/docs
     base_ref: master
   spec:
     containers:
@@ -11642,7 +11633,6 @@ postsubmits:
     agent: kubernetes
     decorate: true
     cluster: "build-knative"
-    path_alias: knative.dev/docs
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -1350,6 +1350,7 @@ presubmits:
     rerun_command: "/test pull-knative-docs-build-tests"
     trigger: "(?m)^/test (all|pull-knative-docs-build-tests),?(\\s+|$)"
     decorate: true
+    path_alias: knative.dev/docs
     cluster: "build-knative"
     spec:
       containers:
@@ -1386,6 +1387,7 @@ presubmits:
     rerun_command: "/test pull-knative-docs-unit-tests"
     trigger: "(?m)^/test (all|pull-knative-docs-unit-tests),?(\\s+|$)"
     decorate: true
+    path_alias: knative.dev/docs
     cluster: "build-knative"
     spec:
       containers:
@@ -1422,6 +1424,7 @@ presubmits:
     rerun_command: "/test pull-knative-docs-integration-tests"
     trigger: "(?m)^/test (all|pull-knative-docs-integration-tests),?(\\s+|$)"
     decorate: true
+    path_alias: knative.dev/docs
     cluster: "build-knative"
     spec:
       containers:
@@ -1467,6 +1470,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-docs-go-coverage),?(\\s+|$)"
     optional: true
     decorate: true
+    path_alias: knative.dev/docs
     cluster: "build-knative"
     spec:
       containers:
@@ -1496,6 +1500,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-knative-docs-markdown-link-check),?(\\s+|$)"
     decorate: true
     optional: true
+    path_alias: knative.dev/docs
     cluster: "build-knative"
     spec:
       containers:
@@ -3925,8 +3930,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: serving
-    base_ref: master
     path_alias: knative.dev/serving
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -3962,8 +3967,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: serving
-    base_ref: master
     path_alias: knative.dev/serving
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:beta
@@ -3999,8 +4004,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: serving
-    base_ref: release-0.14
     path_alias: knative.dev/serving
+    base_ref: release-0.14
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -4042,8 +4047,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: serving
-    base_ref: release-0.14
     path_alias: knative.dev/serving
+    base_ref: release-0.14
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:beta
@@ -4085,8 +4090,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: serving
-    base_ref: release-0.15
     path_alias: knative.dev/serving
+    base_ref: release-0.15
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -4128,8 +4133,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: serving
-    base_ref: release-0.15
     path_alias: knative.dev/serving
+    base_ref: release-0.15
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:beta
@@ -4171,8 +4176,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: serving
-    base_ref: release-0.16
     path_alias: knative.dev/serving
+    base_ref: release-0.16
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -4214,8 +4219,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: serving
-    base_ref: release-0.16
     path_alias: knative.dev/serving
+    base_ref: release-0.16
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:beta
@@ -4257,8 +4262,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: serving
-    base_ref: release-0.17
     path_alias: knative.dev/serving
+    base_ref: release-0.17
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -4300,8 +4305,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: serving
-    base_ref: release-0.17
     path_alias: knative.dev/serving
+    base_ref: release-0.17
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:beta
@@ -4343,8 +4348,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: serving
-    base_ref: master
     path_alias: knative.dev/serving
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -4378,8 +4383,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: serving
-    base_ref: master
     path_alias: knative.dev/serving
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -4413,8 +4418,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: serving
-    base_ref: master
     path_alias: knative.dev/serving
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -4448,8 +4453,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: serving
-    base_ref: master
     path_alias: knative.dev/serving
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -4483,8 +4488,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: serving
-    base_ref: master
     path_alias: knative.dev/serving
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -4518,8 +4523,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: serving
-    base_ref: master
     path_alias: knative.dev/serving
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -4553,8 +4558,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: serving
-    base_ref: master
     path_alias: knative.dev/serving
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -4588,8 +4593,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: serving
-    base_ref: master
     path_alias: knative.dev/serving
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -4623,8 +4628,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: serving
-    base_ref: master
     path_alias: knative.dev/serving
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -4658,8 +4663,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: serving
-    base_ref: master
     path_alias: knative.dev/serving
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -4699,8 +4704,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: serving
-    base_ref: master
     path_alias: knative.dev/serving
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -4737,8 +4742,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: serving
-    base_ref: release-0.14
     path_alias: knative.dev/serving
+    base_ref: release-0.14
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -4786,8 +4791,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: serving
-    base_ref: release-0.15
     path_alias: knative.dev/serving
+    base_ref: release-0.15
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -4835,8 +4840,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: serving
-    base_ref: release-0.16
     path_alias: knative.dev/serving
+    base_ref: release-0.16
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -4884,8 +4889,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: serving
-    base_ref: release-0.17
     path_alias: knative.dev/serving
+    base_ref: release-0.17
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -4933,8 +4938,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: serving
-    base_ref: master
     path_alias: knative.dev/serving
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -4979,8 +4984,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: serving
-    base_ref: master
     path_alias: knative.dev/serving
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -5016,8 +5021,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: serving
-    base_ref: master
     path_alias: knative.dev/serving
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -5040,8 +5045,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: serving
-    base_ref: master
     path_alias: knative.dev/serving
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:beta
@@ -5060,8 +5065,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: client
-    base_ref: master
     path_alias: knative.dev/client
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -5092,8 +5097,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: client
-    base_ref: master
     path_alias: knative.dev/client
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:beta
@@ -5124,8 +5129,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: client
-    base_ref: release-0.13
     path_alias: knative.dev/client
+    base_ref: release-0.13
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -5167,8 +5172,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: client
-    base_ref: release-0.13
     path_alias: knative.dev/client
+    base_ref: release-0.13
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:beta
@@ -5210,8 +5215,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: client
-    base_ref: release-0.14
     path_alias: knative.dev/client
+    base_ref: release-0.14
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -5253,8 +5258,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: client
-    base_ref: release-0.14
     path_alias: knative.dev/client
+    base_ref: release-0.14
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:beta
@@ -5296,8 +5301,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: client
-    base_ref: release-0.15
     path_alias: knative.dev/client
+    base_ref: release-0.15
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -5339,8 +5344,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: client
-    base_ref: release-0.15
     path_alias: knative.dev/client
+    base_ref: release-0.15
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:beta
@@ -5382,8 +5387,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: client
-    base_ref: release-0.16
     path_alias: knative.dev/client
+    base_ref: release-0.16
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -5425,8 +5430,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: client
-    base_ref: release-0.16
     path_alias: knative.dev/client
+    base_ref: release-0.16
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:beta
@@ -5468,8 +5473,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: client
-    base_ref: master
     path_alias: knative.dev/client
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -5501,8 +5506,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: client
-    base_ref: master
     path_alias: knative.dev/client
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -5532,8 +5537,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: client
-    base_ref: release-0.13
     path_alias: knative.dev/client
+    base_ref: release-0.13
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -5576,8 +5581,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: client
-    base_ref: release-0.14
     path_alias: knative.dev/client
+    base_ref: release-0.14
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -5620,8 +5625,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: client
-    base_ref: release-0.15
     path_alias: knative.dev/client
+    base_ref: release-0.15
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -5664,8 +5669,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: client
-    base_ref: release-0.16
     path_alias: knative.dev/client
+    base_ref: release-0.16
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -5708,8 +5713,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: client
-    base_ref: master
     path_alias: knative.dev/client
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -5753,8 +5758,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: client
-    base_ref: master
     path_alias: knative.dev/client
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -5777,8 +5782,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: client
-    base_ref: master
     path_alias: knative.dev/client
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:beta
@@ -5797,8 +5802,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: client-contrib
-    base_ref: master
     path_alias: knative.dev/client-contrib
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -5829,8 +5834,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: client-contrib
-    base_ref: master
     path_alias: knative.dev/client-contrib
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:beta
@@ -5861,6 +5866,7 @@ periodics:
   extra_refs:
   - org: knative
     repo: docs
+    path_alias: knative.dev/docs
     base_ref: master
   spec:
     containers:
@@ -5900,6 +5906,7 @@ periodics:
   extra_refs:
   - org: knative
     repo: docs
+    path_alias: knative.dev/docs
     base_ref: master
   spec:
     containers:
@@ -5943,6 +5950,7 @@ periodics:
   extra_refs:
   - org: knative
     repo: docs
+    path_alias: knative.dev/docs
     base_ref: master
   spec:
     containers:
@@ -5966,6 +5974,7 @@ periodics:
   extra_refs:
   - org: knative
     repo: docs
+    path_alias: knative.dev/docs
     base_ref: master
   spec:
     containers:
@@ -5985,8 +5994,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: eventing
-    base_ref: master
     path_alias: knative.dev/eventing
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -6022,8 +6031,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: eventing
-    base_ref: master
     path_alias: knative.dev/eventing
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:beta
@@ -6059,8 +6068,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: eventing
-    base_ref: release-0.14
     path_alias: knative.dev/eventing
+    base_ref: release-0.14
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -6102,8 +6111,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: eventing
-    base_ref: release-0.14
     path_alias: knative.dev/eventing
+    base_ref: release-0.14
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:beta
@@ -6145,8 +6154,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: eventing
-    base_ref: release-0.15
     path_alias: knative.dev/eventing
+    base_ref: release-0.15
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -6188,8 +6197,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: eventing
-    base_ref: release-0.15
     path_alias: knative.dev/eventing
+    base_ref: release-0.15
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:beta
@@ -6231,8 +6240,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: eventing
-    base_ref: release-0.16
     path_alias: knative.dev/eventing
+    base_ref: release-0.16
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -6274,8 +6283,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: eventing
-    base_ref: release-0.16
     path_alias: knative.dev/eventing
+    base_ref: release-0.16
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:beta
@@ -6317,8 +6326,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: eventing
-    base_ref: release-0.17
     path_alias: knative.dev/eventing
+    base_ref: release-0.17
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -6360,8 +6369,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: eventing
-    base_ref: release-0.17
     path_alias: knative.dev/eventing
+    base_ref: release-0.17
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:beta
@@ -6409,8 +6418,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: eventing
-    base_ref: master
     path_alias: knative.dev/eventing
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -6447,8 +6456,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: eventing
-    base_ref: release-0.14
     path_alias: knative.dev/eventing
+    base_ref: release-0.14
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -6496,8 +6505,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: eventing
-    base_ref: release-0.15
     path_alias: knative.dev/eventing
+    base_ref: release-0.15
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -6545,8 +6554,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: eventing
-    base_ref: release-0.16
     path_alias: knative.dev/eventing
+    base_ref: release-0.16
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -6594,8 +6603,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: eventing
-    base_ref: release-0.17
     path_alias: knative.dev/eventing
+    base_ref: release-0.17
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -6643,8 +6652,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: eventing
-    base_ref: master
     path_alias: knative.dev/eventing
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -6693,8 +6702,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: eventing
-    base_ref: master
     path_alias: knative.dev/eventing
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -6717,8 +6726,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: eventing
-    base_ref: master
     path_alias: knative.dev/eventing
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:beta
@@ -6737,8 +6746,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: eventing-contrib
-    base_ref: master
     path_alias: knative.dev/eventing-contrib
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -6774,8 +6783,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: eventing-contrib
-    base_ref: master
     path_alias: knative.dev/eventing-contrib
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:beta
@@ -6811,8 +6820,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: eventing-contrib
-    base_ref: release-0.13
     path_alias: knative.dev/eventing-contrib
+    base_ref: release-0.13
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -6854,8 +6863,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: eventing-contrib
-    base_ref: release-0.13
     path_alias: knative.dev/eventing-contrib
+    base_ref: release-0.13
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:beta
@@ -6897,8 +6906,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: eventing-contrib
-    base_ref: release-0.14
     path_alias: knative.dev/eventing-contrib
+    base_ref: release-0.14
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -6940,8 +6949,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: eventing-contrib
-    base_ref: release-0.14
     path_alias: knative.dev/eventing-contrib
+    base_ref: release-0.14
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:beta
@@ -6983,8 +6992,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: eventing-contrib
-    base_ref: release-0.15
     path_alias: knative.dev/eventing-contrib
+    base_ref: release-0.15
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -7026,8 +7035,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: eventing-contrib
-    base_ref: release-0.15
     path_alias: knative.dev/eventing-contrib
+    base_ref: release-0.15
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:beta
@@ -7069,8 +7078,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: eventing-contrib
-    base_ref: release-0.16
     path_alias: knative.dev/eventing-contrib
+    base_ref: release-0.16
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -7112,8 +7121,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: eventing-contrib
-    base_ref: release-0.16
     path_alias: knative.dev/eventing-contrib
+    base_ref: release-0.16
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:beta
@@ -7155,8 +7164,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: eventing-contrib
-    base_ref: master
     path_alias: knative.dev/eventing-contrib
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -7193,8 +7202,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: eventing-contrib
-    base_ref: release-0.13
     path_alias: knative.dev/eventing-contrib
+    base_ref: release-0.13
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -7242,8 +7251,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: eventing-contrib
-    base_ref: release-0.14
     path_alias: knative.dev/eventing-contrib
+    base_ref: release-0.14
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -7291,8 +7300,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: eventing-contrib
-    base_ref: release-0.15
     path_alias: knative.dev/eventing-contrib
+    base_ref: release-0.15
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -7340,8 +7349,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: eventing-contrib
-    base_ref: release-0.16
     path_alias: knative.dev/eventing-contrib
+    base_ref: release-0.16
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -7389,8 +7398,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: eventing-contrib
-    base_ref: master
     path_alias: knative.dev/eventing-contrib
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -7439,8 +7448,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: eventing-contrib
-    base_ref: master
     path_alias: knative.dev/eventing-contrib
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -7463,8 +7472,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: eventing-contrib
-    base_ref: master
     path_alias: knative.dev/eventing-contrib
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:beta
@@ -7483,8 +7492,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: pkg
-    base_ref: master
     path_alias: knative.dev/pkg
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -7515,8 +7524,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: pkg
-    base_ref: master
     path_alias: knative.dev/pkg
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:beta
@@ -7551,8 +7560,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: pkg
-    base_ref: master
     path_alias: knative.dev/pkg
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -7575,8 +7584,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: pkg
-    base_ref: master
     path_alias: knative.dev/pkg
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:beta
@@ -7595,8 +7604,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: caching
-    base_ref: master
     path_alias: knative.dev/caching
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -7627,8 +7636,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: caching
-    base_ref: master
     path_alias: knative.dev/caching
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:beta
@@ -7663,8 +7672,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: caching
-    base_ref: master
     path_alias: knative.dev/caching
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -7687,8 +7696,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: caching
-    base_ref: master
     path_alias: knative.dev/caching
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:beta
@@ -7707,8 +7716,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: sample-controller
-    base_ref: master
     path_alias: knative.dev/sample-controller
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -7739,8 +7748,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: sample-controller
-    base_ref: master
     path_alias: knative.dev/sample-controller
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:beta
@@ -7771,8 +7780,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: sample-source
-    base_ref: master
     path_alias: knative.dev/sample-source
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -7803,8 +7812,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: sample-source
-    base_ref: master
     path_alias: knative.dev/sample-source
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:beta
@@ -7835,8 +7844,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: test-infra
-    base_ref: master
     path_alias: knative.dev/test-infra
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -7867,8 +7876,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: test-infra
-    base_ref: master
     path_alias: knative.dev/test-infra
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:beta
@@ -7903,8 +7912,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: test-infra
-    base_ref: master
     path_alias: knative.dev/test-infra
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -7927,8 +7936,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: test-infra
-    base_ref: master
     path_alias: knative.dev/test-infra
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:beta
@@ -8725,8 +8734,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: net-certmanager
-    base_ref: master
     path_alias: knative.dev/net-certmanager
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -8757,8 +8766,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: net-certmanager
-    base_ref: master
     path_alias: knative.dev/net-certmanager
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:beta
@@ -8795,8 +8804,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: net-certmanager
-    base_ref: master
     path_alias: knative.dev/net-certmanager
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -8828,8 +8837,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: net-certmanager
-    base_ref: master
     path_alias: knative.dev/net-certmanager
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -8871,8 +8880,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: net-certmanager
-    base_ref: master
     path_alias: knative.dev/net-certmanager
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -8918,8 +8927,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: net-certmanager
-    base_ref: master
     path_alias: knative.dev/net-certmanager
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -8942,8 +8951,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: net-certmanager
-    base_ref: master
     path_alias: knative.dev/net-certmanager
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:beta
@@ -8962,8 +8971,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: net-contour
-    base_ref: master
     path_alias: knative.dev/net-contour
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -8994,8 +9003,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: net-contour
-    base_ref: master
     path_alias: knative.dev/net-contour
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:beta
@@ -9032,8 +9041,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: net-contour
-    base_ref: master
     path_alias: knative.dev/net-contour
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -9065,8 +9074,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: net-contour
-    base_ref: master
     path_alias: knative.dev/net-contour
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -9108,8 +9117,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: net-contour
-    base_ref: master
     path_alias: knative.dev/net-contour
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -9155,8 +9164,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: net-contour
-    base_ref: master
     path_alias: knative.dev/net-contour
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -9179,8 +9188,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: net-contour
-    base_ref: master
     path_alias: knative.dev/net-contour
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:beta
@@ -9199,8 +9208,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: net-http01
-    base_ref: master
     path_alias: knative.dev/net-http01
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -9231,8 +9240,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: net-http01
-    base_ref: master
     path_alias: knative.dev/net-http01
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:beta
@@ -9269,8 +9278,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: net-http01
-    base_ref: master
     path_alias: knative.dev/net-http01
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -9302,8 +9311,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: net-http01
-    base_ref: master
     path_alias: knative.dev/net-http01
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -9345,8 +9354,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: net-http01
-    base_ref: master
     path_alias: knative.dev/net-http01
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -9392,8 +9401,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: net-http01
-    base_ref: master
     path_alias: knative.dev/net-http01
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -9416,8 +9425,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: net-http01
-    base_ref: master
     path_alias: knative.dev/net-http01
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:beta
@@ -9436,8 +9445,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: net-istio
-    base_ref: master
     path_alias: knative.dev/net-istio
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -9468,8 +9477,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: net-istio
-    base_ref: master
     path_alias: knative.dev/net-istio
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:beta
@@ -9506,8 +9515,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: net-istio
-    base_ref: master
     path_alias: knative.dev/net-istio
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -9539,8 +9548,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: net-istio
-    base_ref: master
     path_alias: knative.dev/net-istio
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -9572,8 +9581,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: net-istio
-    base_ref: release-0.14
     path_alias: knative.dev/net-istio
+    base_ref: release-0.14
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -9618,8 +9627,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: net-istio
-    base_ref: release-0.15
     path_alias: knative.dev/net-istio
+    base_ref: release-0.15
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -9664,8 +9673,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: net-istio
-    base_ref: release-0.16
     path_alias: knative.dev/net-istio
+    base_ref: release-0.16
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -9710,8 +9719,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: net-istio
-    base_ref: master
     path_alias: knative.dev/net-istio
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -9757,8 +9766,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: net-istio
-    base_ref: master
     path_alias: knative.dev/net-istio
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -9781,8 +9790,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: net-istio
-    base_ref: master
     path_alias: knative.dev/net-istio
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:beta
@@ -9801,8 +9810,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: net-kourier
-    base_ref: master
     path_alias: knative.dev/net-kourier
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -9833,8 +9842,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: net-kourier
-    base_ref: master
     path_alias: knative.dev/net-kourier
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:beta
@@ -9871,8 +9880,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: net-kourier
-    base_ref: master
     path_alias: knative.dev/net-kourier
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -9904,8 +9913,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: net-kourier
-    base_ref: master
     path_alias: knative.dev/net-kourier
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -9947,8 +9956,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: net-kourier
-    base_ref: master
     path_alias: knative.dev/net-kourier
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -9994,8 +10003,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: net-kourier
-    base_ref: master
     path_alias: knative.dev/net-kourier
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -10018,8 +10027,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: net-kourier
-    base_ref: master
     path_alias: knative.dev/net-kourier
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:beta
@@ -10038,8 +10047,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: operator
-    base_ref: master
     path_alias: knative.dev/operator
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -10070,8 +10079,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: operator
-    base_ref: master
     path_alias: knative.dev/operator
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:beta
@@ -10102,6 +10111,7 @@ periodics:
   extra_refs:
   - org: knative
     repo: operator
+    path_alias: knative.dev/operator
     base_ref: release-0.15
   spec:
     containers:
@@ -10149,6 +10159,7 @@ periodics:
   extra_refs:
   - org: knative
     repo: operator
+    path_alias: knative.dev/operator
     base_ref: release-0.15
   spec:
     containers:
@@ -10196,6 +10207,7 @@ periodics:
   extra_refs:
   - org: knative
     repo: operator
+    path_alias: knative.dev/operator
     base_ref: release-0.16
   spec:
     containers:
@@ -10243,6 +10255,7 @@ periodics:
   extra_refs:
   - org: knative
     repo: operator
+    path_alias: knative.dev/operator
     base_ref: release-0.16
   spec:
     containers:
@@ -10290,8 +10303,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: operator
-    base_ref: master
     path_alias: knative.dev/operator
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -10323,8 +10336,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: operator
-    base_ref: master
     path_alias: knative.dev/operator
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -10364,8 +10377,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: operator
-    base_ref: master
     path_alias: knative.dev/operator
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -10409,8 +10422,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: operator
-    base_ref: master
     path_alias: knative.dev/operator
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -10433,8 +10446,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: operator
-    base_ref: master
     path_alias: knative.dev/operator
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:beta
@@ -10453,8 +10466,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: discovery
-    base_ref: master
     path_alias: knative.dev/discovery
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -10485,8 +10498,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: discovery
-    base_ref: master
     path_alias: knative.dev/discovery
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:beta
@@ -10517,8 +10530,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: discovery
-    base_ref: master
     path_alias: knative.dev/discovery
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -10550,8 +10563,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: discovery
-    base_ref: master
     path_alias: knative.dev/discovery
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -10593,8 +10606,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: discovery
-    base_ref: master
     path_alias: knative.dev/discovery
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -10636,8 +10649,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: eventing-kafka
-    base_ref: master
     path_alias: knative.dev/eventing-kafka
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -10676,8 +10689,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: eventing-kafka
-    base_ref: master
     path_alias: knative.dev/eventing-kafka
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:beta
@@ -10716,8 +10729,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: eventing-kafka
-    base_ref: master
     path_alias: knative.dev/eventing-kafka
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -10757,8 +10770,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: eventing-kafka
-    base_ref: master
     path_alias: knative.dev/eventing-kafka
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -10783,10 +10796,10 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
-      - name: DOCKER_IN_DOCKER_ENABLED
-        value: "true"
       - name: ORG_NAME
         value: knative-sandbox
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -10808,8 +10821,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: eventing-kafka
-    base_ref: master
     path_alias: knative.dev/eventing-kafka
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -10834,10 +10847,10 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
-      - name: DOCKER_IN_DOCKER_ENABLED
-        value: "true"
       - name: ORG_NAME
         value: knative-sandbox
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -10863,8 +10876,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: eventing-kafka
-    base_ref: master
     path_alias: knative.dev/eventing-kafka
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -10887,8 +10900,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: eventing-kafka
-    base_ref: master
     path_alias: knative.dev/eventing-kafka
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:beta
@@ -10907,8 +10920,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: eventing-kafka-broker
-    base_ref: master
     path_alias: knative.dev/eventing-kafka-broker
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -10947,8 +10960,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: eventing-kafka-broker
-    base_ref: master
     path_alias: knative.dev/eventing-kafka-broker
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:beta
@@ -10987,8 +11000,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: eventing-kafka-broker
-    base_ref: master
     path_alias: knative.dev/eventing-kafka-broker
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -11028,8 +11041,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: eventing-kafka-broker
-    base_ref: master
     path_alias: knative.dev/eventing-kafka-broker
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -11054,10 +11067,10 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
-      - name: DOCKER_IN_DOCKER_ENABLED
-        value: "true"
       - name: ORG_NAME
         value: knative-sandbox
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -11079,8 +11092,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: eventing-kafka-broker
-    base_ref: master
     path_alias: knative.dev/eventing-kafka-broker
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -11105,10 +11118,10 @@ periodics:
         mountPath: /etc/release-account
         readOnly: true
       env:
-      - name: DOCKER_IN_DOCKER_ENABLED
-        value: "true"
       - name: ORG_NAME
         value: knative-sandbox
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
@@ -11134,8 +11147,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: eventing-kafka-broker
-    base_ref: master
     path_alias: knative.dev/eventing-kafka-broker
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -11158,8 +11171,8 @@ periodics:
   extra_refs:
   - org: knative-sandbox
     repo: eventing-kafka-broker
-    base_ref: master
     path_alias: knative.dev/eventing-kafka-broker
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:beta
@@ -11182,8 +11195,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: networking
-    base_ref: master
     path_alias: knative.dev/networking
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -11206,8 +11219,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: networking
-    base_ref: master
     path_alias: knative.dev/networking
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:beta
@@ -11230,8 +11243,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: serving
-    base_ref: master
     path_alias: knative.dev/serving
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -11270,8 +11283,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: serving
-    base_ref: master
     path_alias: knative.dev/serving
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -11310,8 +11323,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: eventing
-    base_ref: master
     path_alias: knative.dev/eventing
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -11350,8 +11363,8 @@ periodics:
   extra_refs:
   - org: knative
     repo: eventing
-    base_ref: master
     path_alias: knative.dev/eventing
+    base_ref: master
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -11629,6 +11642,7 @@ postsubmits:
     agent: kubernetes
     decorate: true
     cluster: "build-knative"
+    path_alias: knative.dev/docs
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable

--- a/config/prod/prow/jobs/custom/test-infra.yaml
+++ b/config/prod/prow/jobs/custom/test-infra.yaml
@@ -302,6 +302,7 @@ periodics:
     - name: prow-auto-bumper-github-token
       secret:
         secretName: prow-auto-bumper-github-token
+
 - cron: "0 */2 * * *" # Every other hour
   name: ci-knative-prow-jobs-syncer
   agent: kubernetes

--- a/tools/config-generator/main.go
+++ b/tools/config-generator/main.go
@@ -35,6 +35,8 @@ import (
 	"time"
 
 	"gopkg.in/yaml.v2"
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	"knative.dev/test-infra/pkg/ghutil"
 )
 
@@ -48,9 +50,13 @@ const (
 	// ##########################################################
 	// commonHeaderConfig contains common header definitions.
 	commonHeaderConfig = "common_header.yaml"
+)
 
-	// generalProwConfig contains config-wide definitions.
-	generalProwConfig = "prow_config.yaml"
+var (
+	// GitHub orgs that are using knative.dev path alias.
+	pathAliasOrgs = sets.NewString("knative", "knative-sandbox")
+	// GitHub repos that are not using knative.dev path alias.
+	nonPathAliasRepos = sets.NewString("knative/docs")
 )
 
 // repositoryData contains basic data about each Knative repository.
@@ -205,7 +211,7 @@ func newbaseProwJobTemplateData(repo string) baseProwJobTemplateData {
 	data.OrgName = strings.Split(repo, "/")[0]
 	data.RepoName = strings.Replace(repo, data.OrgName+"/", "", 1)
 	data.ExtraRefs = []string{"- org: " + data.OrgName, "  repo: " + data.RepoName}
-	if data.OrgName == "knative" || data.OrgName == "knative-sandbox" {
+	if pathAliasOrgs.Has(data.OrgName) && !nonPathAliasRepos.Has(repo) {
 		data.PathAlias = "path_alias: knative.dev/" + data.RepoName
 		data.ExtraRefs = append(data.ExtraRefs, "  "+data.PathAlias)
 	}

--- a/tools/config-generator/main.go
+++ b/tools/config-generator/main.go
@@ -60,7 +60,6 @@ type repositoryData struct {
 	EnableGoCoverage       bool
 	GoCoverageThreshold    int
 	Processed              bool
-	DotDev                 bool
 }
 
 // prowConfigTemplateData contains basic data about Prow.
@@ -205,6 +204,11 @@ func newbaseProwJobTemplateData(repo string) baseProwJobTemplateData {
 	data.Timeout = 50
 	data.OrgName = strings.Split(repo, "/")[0]
 	data.RepoName = strings.Replace(repo, data.OrgName+"/", "", 1)
+	data.ExtraRefs = []string{"- org: " + data.OrgName, "  repo: " + data.RepoName}
+	if data.OrgName == "knative" || data.OrgName == "knative-sandbox" {
+		data.PathAlias = "path_alias: knative.dev/" + data.RepoName
+		data.ExtraRefs = append(data.ExtraRefs, "  "+data.PathAlias)
+	}
 	data.RepoNameForJob = strings.ToLower(strings.Replace(repo, "/", "-", -1))
 	data.RepoBranch = "master" // Default to be master, will override later for other branches
 	data.GcsBucket = GCSBucket
@@ -221,7 +225,6 @@ func newbaseProwJobTemplateData(repo string) baseProwJobTemplateData {
 	data.Volumes = make([]string, 0)
 	data.VolumeMounts = make([]string, 0)
 	data.Env = make([]string, 0)
-	data.ExtraRefs = []string{"- org: " + data.OrgName, "  repo: " + data.RepoName}
 	data.Labels = make([]string, 0)
 	data.Optional = ""
 	data.Cluster = "cluster: \"build-knative\""
@@ -351,7 +354,6 @@ func setReporterConfigReqForJob(res yaml.MapSlice, data *baseProwJobTemplateData
 // parseBasicJobConfigOverrides updates the given baseProwJobTemplateData with any base option present in the given config.
 func parseBasicJobConfigOverrides(data *baseProwJobTemplateData, config yaml.MapSlice) {
 	(*data).ExtraRefs = append((*data).ExtraRefs, "  base_ref: "+(*data).RepoBranch)
-	var needDotdev bool
 	for i, item := range config {
 		switch item.Key {
 		case "skip_branches":
@@ -372,13 +374,6 @@ func parseBasicJobConfigOverrides(data *baseProwJobTemplateData, config yaml.Map
 			}
 		case "always-run":
 			(*data).AlwaysRun = getBool(item.Value)
-		case "dot-dev":
-			needDotdev = true
-			for i, repo := range repositories {
-				if path.Base(repo.Name) == (*data).RepoName {
-					repositories[i].DotDev = true
-				}
-			}
 		case "performance":
 			for i, repo := range repositories {
 				if path.Base(repo.Name) == (*data).RepoName {
@@ -397,16 +392,11 @@ func parseBasicJobConfigOverrides(data *baseProwJobTemplateData, config yaml.Map
 			continue
 		default:
 			log.Fatalf("Unknown entry %q for job", item.Key)
-			continue
 		}
 		// Knock-out the item, signalling it was already parsed.
 		config[i] = yaml.MapItem{}
 	}
 
-	if needDotdev {
-		(*data).PathAlias = "path_alias: knative.dev/" + (*data).RepoName
-		(*data).ExtraRefs = append((*data).ExtraRefs, "  "+(*data).PathAlias)
-	}
 	// Override any values if provided by command-line flags.
 	if timeoutOverride > 0 {
 		(*data).Timeout = timeoutOverride

--- a/tools/config-generator/perf_config.go
+++ b/tools/config-generator/perf_config.go
@@ -69,9 +69,6 @@ func perfClusterPeriodicJob(jobNamePostFix, cronString, command string, args []s
 	var data periodicJobTemplateData
 	data.Base = perfClusterBaseProwJob(command, args, repo.Name, sa)
 	data.Base.ExtraRefs = append(data.Base.ExtraRefs, "  base_ref: "+data.Base.RepoBranch)
-	if repo.DotDev {
-		data.Base.ExtraRefs = append(data.Base.ExtraRefs, "  path_alias: knative.dev/"+data.Base.RepoName)
-	}
 	data.PeriodicJobName = fmt.Sprintf("ci-%s-%s", data.Base.RepoNameForJob, jobNamePostFix)
 	data.CronString = cronString
 	data.PeriodicCommand = createCommand(data.Base)
@@ -83,9 +80,6 @@ func perfClusterPeriodicJob(jobNamePostFix, cronString, command string, args []s
 func perfClusterReconcilePostsubmitJob(jobNamePostFix, command string, args []string, repo repositoryData, sa string) {
 	var data postsubmitJobTemplateData
 	data.Base = perfClusterBaseProwJob(command, args, repo.Name, sa)
-	if repo.DotDev {
-		data.Base.PathAlias = "path_alias: knative.dev/" + data.Base.RepoName
-	}
 	data.PostsubmitJobName = fmt.Sprintf("post-%s-%s", data.Base.RepoNameForJob, jobNamePostFix)
 	data.PostsubmitCommand = createCommand(data.Base)
 	addMonitoringPubsubLabelsToJob(&data.Base, data.PostsubmitJobName)

--- a/tools/config-generator/postsubmit_config.go
+++ b/tools/config-generator/postsubmit_config.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"fmt"
-	"path"
 	"strings"
 
 	"gopkg.in/yaml.v2"
@@ -45,11 +44,6 @@ func generateGoCoveragePostsubmit(title, repoName string, _ yaml.MapSlice) {
 	var data postsubmitJobTemplateData
 	data.Base = newbaseProwJobTemplateData(repoName)
 	data.PostsubmitJobName = fmt.Sprintf("post-%s-go-coverage", data.Base.RepoNameForJob)
-	for _, repo := range repositories {
-		if repo.Name == repoName && repo.DotDev {
-			data.Base.PathAlias = "path_alias: knative.dev/" + path.Base(repoName)
-		}
-	}
 	addExtraEnvVarsToJob(extraEnvVars, &data.Base)
 	configureServiceAccountForJob(&data.Base)
 	jobName := data.PostsubmitJobName


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Remove dot-dev and ORG_NAME env var from meta job config. This change deletes 241 lines from the meta config file.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #2373

/cc @chaodaiG 

