### PR TITLE
Fix Peribolos Prow jobs by using a different GitHub token and running it in the build cluster

### DIFF
--- a/config/prod/prow/jobs/custom/peribolos.yaml
+++ b/config/prod/prow/jobs/custom/peribolos.yaml
@@ -23,6 +23,7 @@ presubmits:
     decorate: true
     path_alias: knative.dev/community
     run_if_changed: "^peribolos/knative.yaml$"
+    cluster: "prow-trusted"
     branches:
     - "master"
     spec:
@@ -32,9 +33,7 @@ presubmits:
         - "/peribolos"
         args:
         - "--config-path=peribolos/knative.yaml"
-        - "--github-endpoint=http://ghproxy.default.svc.cluster.local"
-        - "--github-endpoint=https://api.github.com"
-        - "--github-token-path=/etc/github/oauth"
+        - "--github-token-path=/etc/github/token"
         - "--min-admins=5"
         # Set --confirm=false to only validate the configuration file.
         - "--confirm=false"
@@ -45,13 +44,14 @@ presubmits:
       volumes:
       - name: oauth
         secret:
-          secretName: oauth-token
+          secretName: github-token-for-peribolos
   # Run on the Prow deployment cluster as it needs access to the github oauth token.
   - name: pull-knative-sandbox-peribolos
     agent: kubernetes
     decorate: true
     path_alias: knative.dev/community
     run_if_changed: "^peribolos/knative-sandbox.yaml$"
+    cluster: "prow-trusted"
     branches:
     - "master"
     spec:
@@ -61,9 +61,7 @@ presubmits:
         - "/peribolos"
         args:
         - "--config-path=peribolos/knative-sandbox.yaml"
-        - "--github-endpoint=http://ghproxy.default.svc.cluster.local"
-        - "--github-endpoint=https://api.github.com"
-        - "--github-token-path=/etc/github/oauth"
+        - "--github-token-path=/etc/github/token"
         - "--min-admins=5"
         # Set --confirm=false to only validate the configuration file.
         - "--confirm=false"
@@ -74,7 +72,7 @@ presubmits:
       volumes:
       - name: oauth
         secret:
-          secretName: oauth-token
+          secretName: github-token-for-peribolos
 
 postsubmits:
   knative/community:
@@ -85,6 +83,7 @@ postsubmits:
     path_alias: knative.dev/community
     max_concurrency: 1
     run_if_changed: "^peribolos/knative.yaml$"
+    cluster: "prow-trusted"
     branches:
     - "master"
     spec:
@@ -94,16 +93,13 @@ postsubmits:
         - "/peribolos"
         args:
         - "--config-path=peribolos/knative.yaml"
-        - "--github-endpoint=http://ghproxy.default.svc.cluster.local"
-        - "--github-endpoint=https://api.github.com"
-        - "--github-token-path=/etc/github/oauth"
+        - "--github-token-path=/etc/github/token"
         - "--min-admins=5"
         - "--fix-org=true"
         - "--fix-org-members=true"
         - "--fix-teams=true"
         - "--fix-team-members=true"
-#      TODO(chizhg): reenable it after https://github.com/knative/test-infra/issues/2289 is fixed.
-#      - "--fix-team-repos=true"
+        - "--fix-team-repos=true"
         - "--fix-repos=true"
         - "--tokens=1200"
         - "--confirm=true"
@@ -114,7 +110,7 @@ postsubmits:
       volumes:
       - name: oauth
         secret:
-          secretName: oauth-token
+          secretName: github-token-for-peribolos
   # Run on the Prow deployment cluster as it needs access to the github oauth token.
   - name: post-knative-sandbox-peribolos
     agent: kubernetes
@@ -122,6 +118,7 @@ postsubmits:
     path_alias: knative.dev/community
     max_concurrency: 1
     run_if_changed: "^peribolos/knative-sandbox.yaml$"
+    cluster: "prow-trusted"
     branches:
     - "master"
     spec:
@@ -131,16 +128,13 @@ postsubmits:
         - "/peribolos"
         args:
         - "--config-path=peribolos/knative-sandbox.yaml"
-        - "--github-endpoint=http://ghproxy.default.svc.cluster.local"
-        - "--github-endpoint=https://api.github.com"
-        - "--github-token-path=/etc/github/oauth"
+        - "--github-token-path=/etc/github/token"
         - "--min-admins=5"
         - "--fix-org=true"
         - "--fix-org-members=true"
         - "--fix-teams=true"
         - "--fix-team-members=true"
-#      TODO(chizhg): reenable it after https://github.com/knative/test-infra/issues/2289 is fixed.
-#      - "--fix-team-repos=true"
+        - "--fix-team-repos=true"
         - "--fix-repos=true"
         - "--tokens=1200"
         - "--confirm=true"
@@ -151,7 +145,7 @@ postsubmits:
       volumes:
       - name: oauth
         secret:
-          secretName: oauth-token
+          secretName: github-token-for-peribolos
 
 periodics:
 # Run at 9AM PST.
@@ -159,6 +153,7 @@ periodics:
   name: ci-knative-peribolos
   agent: kubernetes
   decorate: true
+  cluster: "prow-trusted"
   extra_refs:
   - org: knative
     repo: community
@@ -171,16 +166,13 @@ periodics:
       - "/peribolos"
       args:
       - "--config-path=peribolos/knative.yaml"
-      - "--github-endpoint=http://ghproxy.default.svc.cluster.local"
-      - "--github-endpoint=https://api.github.com"
-      - "--github-token-path=/etc/github/oauth"
+      - "--github-token-path=/etc/github/token"
       - "--min-admins=5"
       - "--fix-org=true"
       - "--fix-org-members=true"
       - "--fix-teams=true"
       - "--fix-team-members=true"
-#      TODO(chizhg): reenable it after https://github.com/knative/test-infra/issues/2289 is fixed.
-#      - "--fix-team-repos=true"
+      - "--fix-team-repos=true"
       - "--fix-repos=true"
       - "--tokens=1200"
       - "--confirm=true"
@@ -191,12 +183,13 @@ periodics:
     volumes:
     - name: oauth
       secret:
-        secretName: oauth-token
+        secretName: github-token-for-peribolos
 # Run at 10AM PST.
 - cron: "0 17 * * *"
   name: ci-knative-sandbox-peribolos
   agent: kubernetes
   decorate: true
+  cluster: "prow-trusted"
   extra_refs:
   - org: knative
     repo: community
@@ -209,16 +202,13 @@ periodics:
       - "/peribolos"
       args:
       - "--config-path=peribolos/knative-sandbox.yaml"
-      - "--github-endpoint=http://ghproxy.default.svc.cluster.local"
-      - "--github-endpoint=https://api.github.com"
-      - "--github-token-path=/etc/github/oauth"
+      - "--github-token-path=/etc/github/token"
       - "--min-admins=5"
       - "--fix-org=true"
       - "--fix-org-members=true"
       - "--fix-teams=true"
       - "--fix-team-members=true"
-#      TODO(chizhg): reenable it after https://github.com/knative/test-infra/issues/2289 is fixed.
-#      - "--fix-team-repos=true"
+      - "--fix-team-repos=true"
       - "--fix-repos=true"
       - "--tokens=1200"
       - "--confirm=true"
@@ -229,4 +219,4 @@ periodics:
     volumes:
     - name: oauth
       secret:
-        secretName: oauth-token
+        secretName: github-token-for-peribolos


### PR DESCRIPTION

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
1. Run Peribolos Prow jobs with `--fix-team-repos=true` option on the `prow-trusted` build cluster, which seemingly to be able to fix the `Entrypoint received interrupt: terminated` error, see the discussions in https://github.com/kubernetes/test-infra/issues/18930
2. Use a dedicated GitHub oauth token for running Peribolos jobs, which I think is the reason for the `sleep time for token reset exceeds max sleep time` error we received on Slack - https://knative.slack.com/archives/CCSNR4FCH/p1597949495009800. I also updated our oncall playbook.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #2289 

/cc @chaodaiG @mattmoor @albertomilan 

