### PR TITLE
Make E2E_SCRIPT value global

### DIFF
--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -129,15 +129,15 @@ function fail_test() {
 
 SKIP_TEARDOWNS=0
 SKIP_ISTIO_ADDON=0
+E2E_SCRIPT=""
 
 # Parse flags and initialize the test cluster.
 function initialize() {
   local run_tests=0
   local extra_kubetest2_flags=()
   local extra_cluster_creation_flags=()
-  local e2e_script
-  e2e_script="$(get_canonical_path "$0")"
-  local e2e_script_command=( "${e2e_script}" "--run-tests" )
+  E2E_SCRIPT="$(get_canonical_path "$0")"
+  local e2e_script_command=( "${E2E_SCRIPT}" "--run-tests" )
 
   cd "${REPO_ROOT_DIR}"
   while [[ $# -ne 0 ]]; do


### PR DESCRIPTION
Since https://github.com/knative/test-infra/commit/67da4f8de8cd43ec361b0c43950b2ab1a160304d, `E2E_SCRIPT` became local value as `e2e_script`.
But E2E_SCRIPT is used for log file's suffix like
https://github.com/knative/test-infra/blob/master/scripts/infra-library.sh#L72.

Hence this patch makes E2E_SCRIPT value global.

/cc @chizhg @chaodaiG 

