### PR TITLE
Grant container admin role to the Prow tests service account

### DIFF
--- a/config/prod/build-cluster/boskos/set_up_boskos_project.sh
+++ b/config/prod/build-cluster/boskos/set_up_boskos_project.sh
@@ -49,6 +49,11 @@ readonly RESOURCES=(
     "prow-job@knative-nightly.iam.gserviceaccount.com"
     "prow-job@knative-releases.iam.gserviceaccount.com"
 
+    "roles/container.admin"
+    "prow-job@knative-tests.iam.gserviceaccount.com"
+    "prow-job@knative-nightly.iam.gserviceaccount.com"
+    "prow-job@knative-releases.iam.gserviceaccount.com"
+
     "roles/storage.admin"
     "prow-job@knative-tests.iam.gserviceaccount.com"
     "prow-job@knative-nightly.iam.gserviceaccount.com"


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
I was surprised that Prow tests service account does not have `container.admin` role, that's why we have a so complicated `acquire_cluster_admin_role` function in https://github.com/knative/test-infra/blob/master/scripts/library.sh#L330-L366.

Grant this role then we can change the function to one line.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @chaodaiG 

