### PR TITLE
Fix flaky test reporter by removing over cautious check

### DIFF
--- a/tools/flaky-test-reporter/result.go
+++ b/tools/flaky-test-reporter/result.go
@@ -199,6 +199,10 @@ func getCombinedResultsForBuild(build *prow.Build) ([]*junit.TestSuites, error) 
 		if err != nil {
 			return nil, err
 		}
+		// Empty file failed junit unmarshal
+		if len(contents) == 0 || strings.TrimSpace(string(contents)) == "" {
+			continue
+		}
 		if suites, err := junit.UnMarshal(contents); err != nil {
 			return nil, err
 		} else {
@@ -281,11 +285,6 @@ func getLatestFinishedBuilds(job *prow.Job, count int) []prow.Build {
 			}
 			builds = append(builds, *build)
 		}
-	}
-	if !sort.SliceIsSorted(builds, func(i, j int) bool {
-		return *builds[i].StartTime > *builds[j].StartTime
-	}) {
-		log.Fatalf("Error: found build with smaller buildID started later than one with larger buildID")
 	}
 	return builds
 }


### PR DESCRIPTION
Flaky test reporter takes the assumption of larger build ID always started later than smaller build ID, and has a over cautious check in the code to enforce this. Since prow use a global incremental ID for all prow jobs, this assumption could be hold true in majority of cases, and shouldn't required in code check at all

By the way deal with empty junit result file

/assign @chizhg @mattmoor 
/cc @coryrc 