### PR TITLE
adding ci-knative-serving-contour-latest to beta-prow-tests

### DIFF
--- a/config/prod/prow/jobs/custom/experimental.yaml
+++ b/config/prod/prow/jobs/custom/experimental.yaml
@@ -47,6 +47,8 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
+      - name: GO_VERSION
+        value: devel
   volumes:
   - name: test-account
     secret:

--- a/config/prod/prow/jobs/custom/experimental.yaml
+++ b/config/prod/prow/jobs/custom/experimental.yaml
@@ -36,8 +36,6 @@ periodics:
       - "./test/presubmit-tests.sh"
       - "--run-test"
       - "./test/e2e-tests.sh --contour-version latest"
-      - "--run-test"
-      - "./test/e2e-auto-tls-tests.sh --contour-version latest"
       volumeMounts:
       - name: test-account
         mountPath: /etc/test-account

--- a/config/prod/prow/jobs/custom/experimental.yaml
+++ b/config/prod/prow/jobs/custom/experimental.yaml
@@ -1,0 +1,37 @@
+periodics:
+- cron: "43 */2 * * *"
+  name: ci-knative-serving-contour-latest-beta-prow-tests
+  agent: kubernetes
+  decorate: true
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative
+    repo: serving
+    path_alias: knative.dev/serving
+    base_ref: master
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:beta
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./test/presubmit-tests.sh"
+      - "--run-test"
+      - "./test/e2e-tests.sh --contour-version latest"
+      - "--run-test"
+      - "./test/e2e-auto-tls-tests.sh --contour-version latest"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+  volumes:
+  - name: test-account
+    secret:
+      secretName: test-account
+

--- a/config/prod/prow/jobs/custom/experimental.yaml
+++ b/config/prod/prow/jobs/custom/experimental.yaml
@@ -1,3 +1,20 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Miscellaneous prow jobs not worth the effort to edit the config generator
+# to create.
+
 periodics:
 - cron: "43 */2 * * *"
   name: ci-knative-serving-contour-latest-beta-prow-tests


### PR DESCRIPTION
we want to test Go compiler versions without breaking prod

/cc @chizhg @mattmoor 

