### PR TITLE
Make coryrc a member of productivity-approvers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -4,6 +4,7 @@ aliases:
   productivity-approvers:
   - chaodaiG
   - chizhg
+  - coryrc
   productivity-reviewers:
   - chaodaiG
   - coryrc


### PR DESCRIPTION
Cory meets all the requirements for being an approver:

*Reviewer of the codebase for at least 3 months* https://github.com/knative/test-infra/search?q=assignee%3Acoryrc+is%3Amerged&unscoped_q=assignee%3Acoryrc+is%3Amerged&type=Issues (since Sep 2019)

*Primary reviewer for at least 10 substantial PRs to the codebase* #1766 #1780 #1448 #1425 #2040 #1944 #1937 #1883 #1815 #2339 

*Reviewed or merged at least 30 PRs to the codebase* https://github.com/knative/test-infra/search?p=2&q=assignee%3Acoryrc+is%3Amerged&type=Issues&unscoped_q=assignee%3Acoryrc+is%3Amerged (31 so far)

*Nominated by an area lead (with no objections from other leads)* Nominated by chizhg, approved by chaodaig.

FYI @coryrc @albertomilan 