### PR TITLE
Fix the experimental Prow job

### DIFF
--- a/config/prod/prow/check_config.sh
+++ b/config/prod/prow/check_config.sh
@@ -48,7 +48,7 @@ REPO_YAML_PATH_ARG=""
 docker run -i --rm \
     -v "${PWD}:${PWD}" -v "${CONFIG_YAML}:${CONFIG_YAML}" -v "${PLUGINS_YAML}:${PLUGINS_YAML}" -v "${JOB_CONFIG_YAML}:${JOB_CONFIG_YAML}" \
     -w "${PWD}" \
-    gcr.io/k8s-prow/checkconfig:v20200603-4badfd9f37 \
+    gcr.io/k8s-prow/checkconfig:v20200904-8d0a527a58 \
     "--config-path=${CONFIG_YAML}" "--job-config-path=${JOB_CONFIG_YAML}" \
     "--plugin-config=${PLUGINS_YAML}" "--strict" "--exclude-warning=mismatched-tide" \
     "--exclude-warning=long-job-names" \

--- a/config/prod/prow/jobs/custom/experimental.yaml
+++ b/config/prod/prow/jobs/custom/experimental.yaml
@@ -47,8 +47,8 @@ periodics:
         value: us-central1
       - name: GO_VERSION
         value: devel
-  volumes:
-  - name: test-account
-    secret:
-      secretName: test-account
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
`crier` kept crashing with the below error message:
```
{"component":"crier","error":"invalid periodic job ci-knative-serving-contour-latest-beta-prow-tests: volumeMount named \"test-account\" is undefined","file":"prow/cmd/crier/main.go:200","func":"main.main","level":"fatal","msg":"Error starting config agent.","severity":"fatal","time":"2020-09-05T22:26:41Z"}
```

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
