### PR TITLE
Add kubetest2 wrapper command for kntest

### DIFF
--- a/kntest/cmd/kntest/main.go
+++ b/kntest/cmd/kntest/main.go
@@ -41,7 +41,7 @@ func main() {
 	cluster.AddCommands(cmds)
 	junit.AddCommands(cmds)
 	metadata.AddCommands(cmds)
-	kubetest2.AddCommands(cmds)
+	kubetest2.AddCommand(cmds)
 
 	if err := cmds.Execute(); err != nil {
 		log.Fatalf("Error during command execution: %v", err)

--- a/kntest/cmd/kntest/main.go
+++ b/kntest/cmd/kntest/main.go
@@ -23,6 +23,7 @@ import (
 
 	"knative.dev/test-infra/kntest/pkg/cluster"
 	"knative.dev/test-infra/kntest/pkg/junit"
+	"knative.dev/test-infra/kntest/pkg/kubetest2"
 	"knative.dev/test-infra/kntest/pkg/metadata"
 )
 
@@ -40,6 +41,7 @@ func main() {
 	cluster.AddCommands(cmds)
 	junit.AddCommands(cmds)
 	metadata.AddCommands(cmds)
+	kubetest2.AddCommands(cmds)
 
 	if err := cmds.Execute(); err != nil {
 		log.Fatalf("Error during command execution: %v", err)

--- a/kntest/pkg/kubetest2/commands.go
+++ b/kntest/pkg/kubetest2/commands.go
@@ -1,0 +1,22 @@
+package kubetest2
+
+import (
+	"github.com/spf13/cobra"
+
+	"knative.dev/test-infra/kntest/pkg/kubetest2/gke"
+	"knative.dev/test-infra/pkg/clustermanager/kubetest2"
+)
+
+func AddCommands(topLevel *cobra.Command) {
+	var kubetest2Cmd = &cobra.Command{
+		Use:   "kubetest2",
+		Short: "Simple wrapper of kubetest2 commands for Knative testing.",
+	}
+
+	kubetest2Options := &kubetest2.Options{}
+	addOptions(kubetest2Cmd, kubetest2Options)
+
+	gke.AddCommand(kubetest2Cmd, kubetest2Options)
+
+	topLevel.AddCommand(kubetest2Cmd)
+}

--- a/kntest/pkg/kubetest2/commands.go
+++ b/kntest/pkg/kubetest2/commands.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package kubetest2
 
 import (
@@ -7,7 +23,8 @@ import (
 	"knative.dev/test-infra/pkg/clustermanager/kubetest2"
 )
 
-func AddCommands(topLevel *cobra.Command) {
+// AddCommand add the command for running kubetest2.
+func AddCommand(topLevel *cobra.Command) {
 	var kubetest2Cmd = &cobra.Command{
 		Use:   "kubetest2",
 		Short: "Simple wrapper of kubetest2 commands for Knative testing.",

--- a/kntest/pkg/kubetest2/gke/README.md
+++ b/kntest/pkg/kubetest2/gke/README.md
@@ -1,0 +1,9 @@
+## kntest kubetest2 gke
+
+`kntest kubetest2 gke` command is a wrapper of `kubetest2-gke` [deployer](https://github.com/kubernetes-sigs/kubetest2/tree/master/kubetest2-gke) 
+to make it easier to run integration tests for Knative. 
+
+## Usage
+
+This tool can be invoked from command line, and the supported flags could be
+checked from [kubetest2 common flags](../options.go) and [gke specific flags](./options.go).

--- a/kntest/pkg/kubetest2/gke/commands.go
+++ b/kntest/pkg/kubetest2/gke/commands.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package gke
 
 import (

--- a/kntest/pkg/kubetest2/gke/commands.go
+++ b/kntest/pkg/kubetest2/gke/commands.go
@@ -1,0 +1,28 @@
+package gke
+
+import (
+	"log"
+
+	"github.com/spf13/cobra"
+
+	"knative.dev/test-infra/pkg/clustermanager/kubetest2"
+)
+
+// AddCommand adds gke subcommands.
+func AddCommand(kubetest2Cmd *cobra.Command, kubetest2Opts *kubetest2.Options) {
+	clusterConfig := &kubetest2.GKEClusterConfig{}
+
+	var gkeCmd = &cobra.Command{
+		Use:   "gke",
+		Short: "gke related commands for kubetest2.",
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := kubetest2.Run(kubetest2Opts, clusterConfig); err != nil {
+				log.Fatalf("Failed to run tests with kubetest2: %v", err)
+			}
+		},
+	}
+	addOptions(gkeCmd, clusterConfig)
+
+	kubetest2Cmd.AddCommand(gkeCmd)
+}

--- a/kntest/pkg/kubetest2/gke/options.go
+++ b/kntest/pkg/kubetest2/gke/options.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package gke
 
 import (
@@ -8,19 +24,19 @@ import (
 
 func addOptions(gkeCmd *cobra.Command, cfg *kubetest2.GKEClusterConfig) {
 	f := gkeCmd.Flags()
-	f.StringVar(&cfg.Environment, "environment", "prod", "")
-	f.StringVar(&cfg.CommandGroup, "command-group", "beta", "")
+	f.StringVar(&cfg.Environment, "environment", "prod", "The GKE environment, must be one of prod, staging, staging2 and test.")
+	f.StringVar(&cfg.CommandGroup, "command-group", "beta", "The gcloud command group, must be alpha, beta or empty.")
 	f.StringVar(&cfg.GCPProjectID, "gcp-project-id", "", "GCP project ID for creating the cluster")
-	f.StringVar(&cfg.Name, "name", "e2e-cls", "")
-	f.StringVar(&cfg.Region, "region", "us-central1", "")
-	f.StringSliceVar(&cfg.BackupRegions, "backup-regions", []string{"us-west1", "us-east1"}, "")
-	f.StringVar(&cfg.Machine, "machine", "e2-standard-4", "")
-	f.IntVar(&cfg.MinNodes, "min-nodes", 1, "")
-	f.IntVar(&cfg.MaxNodes, "max-nodes", 3, "")
-	f.StringVar(&cfg.Network, "network", "e2e-network", "")
-	f.StringVar(&cfg.Version, "version", "latest", "")
-	f.StringVar(&cfg.Scopes, "scopes", "cloud-platform", "")
-	f.StringVar(&cfg.Addons, "addons", "", "")
-	f.StringVar(&cfg.PrivateClusterAccessLevel, "private-cluster-access-level", "", "")
-	f.StringVar(&cfg.PrivateClusterMasterIPRange, "private-cluster-master-ip-range", "172.16.0.%d/28", "")
+	f.StringVar(&cfg.Name, "name", "e2e-cls", "The GKE cluster name.")
+	f.StringVar(&cfg.Region, "region", "us-central1", "The region to create the GKE cluster.")
+	f.StringSliceVar(&cfg.BackupRegions, "backup-regions", []string{"us-west1", "us-east1"}, "The backup regions if the cluster creation runs into stockout issue in the primary region.")
+	f.StringVar(&cfg.Machine, "machine", "e2-standard-4", "The machine type for the GKE cluster.")
+	f.IntVar(&cfg.MinNodes, "min-nodes", 1, "The minimum number of nodes.")
+	f.IntVar(&cfg.MaxNodes, "max-nodes", 3, "The maximum number of nodes.")
+	f.StringVar(&cfg.Network, "network", "e2e-network", "The network name for the GKE cluster.")
+	f.StringVar(&cfg.Version, "version", "latest", "The version of the GKE cluster.")
+	f.StringVar(&cfg.Scopes, "scopes", "cloud-platform", "Scopes for the GKE cluster, should be comma-separated.")
+	f.StringVar(&cfg.Addons, "addons", "", "Addons for the GKE cluster, should be comma-separated.")
+	f.StringVar(&cfg.PrivateClusterAccessLevel, "private-cluster-access-level", "", "Private cluster access level, if not empty, must be one of 'no', 'limited' or 'unrestricted'")
+	f.StringVar(&cfg.PrivateClusterMasterIPRange, "private-cluster-master-ip-range", "172.16.0.%d/28", "The master IP range for the private cluster. The last digit must be left unformatted to allow retrying.")
 }

--- a/kntest/pkg/kubetest2/gke/options.go
+++ b/kntest/pkg/kubetest2/gke/options.go
@@ -1,0 +1,26 @@
+package gke
+
+import (
+	"github.com/spf13/cobra"
+
+	"knative.dev/test-infra/pkg/clustermanager/kubetest2"
+)
+
+func addOptions(gkeCmd *cobra.Command, cfg *kubetest2.GKEClusterConfig) {
+	f := gkeCmd.Flags()
+	f.StringVar(&cfg.Environment, "environment", "prod", "")
+	f.StringVar(&cfg.CommandGroup, "command-group", "beta", "")
+	f.StringVar(&cfg.GCPProjectID, "gcp-project-id", "", "GCP project ID for creating the cluster")
+	f.StringVar(&cfg.Name, "name", "e2e-cls", "")
+	f.StringVar(&cfg.Region, "region", "us-central1", "")
+	f.StringSliceVar(&cfg.BackupRegions, "backup-regions", []string{"us-west1", "us-east1"}, "")
+	f.StringVar(&cfg.Machine, "machine", "e2-standard-4", "")
+	f.IntVar(&cfg.MinNodes, "min-nodes", 1, "")
+	f.IntVar(&cfg.MaxNodes, "max-nodes", 3, "")
+	f.StringVar(&cfg.Network, "network", "e2e-network", "")
+	f.StringVar(&cfg.Version, "version", "latest", "")
+	f.StringVar(&cfg.Scopes, "scopes", "cloud-platform", "")
+	f.StringVar(&cfg.Addons, "addons", "", "")
+	f.StringVar(&cfg.PrivateClusterAccessLevel, "private-cluster-access-level", "", "")
+	f.StringVar(&cfg.PrivateClusterMasterIPRange, "private-cluster-master-ip-range", "172.16.0.%d/28", "")
+}

--- a/kntest/pkg/kubetest2/gke/options.go
+++ b/kntest/pkg/kubetest2/gke/options.go
@@ -37,6 +37,7 @@ func addOptions(gkeCmd *cobra.Command, cfg *kubetest2.GKEClusterConfig) {
 	f.StringVar(&cfg.Version, "version", "latest", "The version of the GKE cluster.")
 	f.StringVar(&cfg.Scopes, "scopes", "cloud-platform", "Scopes for the GKE cluster, should be comma-separated.")
 	f.StringVar(&cfg.Addons, "addons", "", "Addons for the GKE cluster, should be comma-separated.")
+	f.BoolVar(&cfg.EnableWorkloadIdentity, "enable-workload-identity", false, "Whether to enable workload identity for this cluster or not.")
 	f.StringVar(&cfg.PrivateClusterAccessLevel, "private-cluster-access-level", "", "Private cluster access level, if not empty, must be one of 'no', 'limited' or 'unrestricted'")
 	f.StringVar(&cfg.PrivateClusterMasterIPSubnetRange, "private-cluster-master-ip-subnet-range", "172.16.0", "The master IP subnet range for the private cluster. The last digit must be left empty to allow retrying cluster creation in the backup regions.")
 	f.StringVar(&cfg.PrivateClusterMasterIPSubnetMask, "private-cluster-master-ip-subnet-mask", "28", "The master IP subnet mask for the private cluster.")

--- a/kntest/pkg/kubetest2/gke/options.go
+++ b/kntest/pkg/kubetest2/gke/options.go
@@ -38,5 +38,6 @@ func addOptions(gkeCmd *cobra.Command, cfg *kubetest2.GKEClusterConfig) {
 	f.StringVar(&cfg.Scopes, "scopes", "cloud-platform", "Scopes for the GKE cluster, should be comma-separated.")
 	f.StringVar(&cfg.Addons, "addons", "", "Addons for the GKE cluster, should be comma-separated.")
 	f.StringVar(&cfg.PrivateClusterAccessLevel, "private-cluster-access-level", "", "Private cluster access level, if not empty, must be one of 'no', 'limited' or 'unrestricted'")
-	f.StringVar(&cfg.PrivateClusterMasterIPRange, "private-cluster-master-ip-range", "172.16.0.%d/28", "The master IP range for the private cluster. The last digit must be left unformatted to allow retrying.")
+	f.StringVar(&cfg.PrivateClusterMasterIPSubnetRange, "private-cluster-master-ip-subnet-range", "172.16.0", "The master IP subnet range for the private cluster. The last digit must be left empty to allow retrying cluster creation in the backup regions.")
+	f.StringVar(&cfg.PrivateClusterMasterIPSubnetMask, "private-cluster-master-ip-subnet-mask", "28", "The master IP subnet mask for the private cluster.")
 }

--- a/kntest/pkg/kubetest2/options.go
+++ b/kntest/pkg/kubetest2/options.go
@@ -24,7 +24,6 @@ import (
 
 func addOptions(kubetest2Cmd *cobra.Command, opts *kubetest2.Options) {
 	pf := kubetest2Cmd.PersistentFlags()
-	pf.StringVar(&opts.ExtraKubetest2Flags, "extra-kubetest2-flags", "", "extra flags for kubetest2")
 	pf.StringVar(&opts.TestCommand, "test-command", "", "test command for running the tests")
 	pf.BoolVar(&opts.SaveMetaData, "save-meta-data", true, "whether or not to save cluster info into metadata.json")
 }

--- a/kntest/pkg/kubetest2/options.go
+++ b/kntest/pkg/kubetest2/options.go
@@ -1,0 +1,14 @@
+package kubetest2
+
+import (
+	"github.com/spf13/cobra"
+
+	"knative.dev/test-infra/pkg/clustermanager/kubetest2"
+)
+
+func addOptions(kubetest2Cmd *cobra.Command, opts *kubetest2.Options) {
+	pf := kubetest2Cmd.PersistentFlags()
+	pf.StringVar(&opts.ExtraKubetest2Flags, "extra-kubetest2-flags", "", "extra flags for kubetest2")
+	pf.StringVar(&opts.TestCommand, "test-command", "", "test command for running the tests")
+	pf.BoolVar(&opts.SaveMetaData, "save-meta-data", true, "whether or not to save cluster info into metadata.json")
+}

--- a/kntest/pkg/kubetest2/options.go
+++ b/kntest/pkg/kubetest2/options.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package kubetest2
 
 import (

--- a/pkg/clustermanager/kubetest2/exec.go
+++ b/pkg/clustermanager/kubetest2/exec.go
@@ -1,0 +1,16 @@
+package kubetest2
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"os/exec"
+)
+
+func run(command *exec.Cmd) (string, error) {
+	var buf bytes.Buffer
+	command.Stdout = io.MultiWriter(&buf, os.Stdout)
+	command.Stderr = io.MultiWriter(&buf, os.Stderr)
+	err := command.Run()
+	return buf.String(), err
+}

--- a/pkg/clustermanager/kubetest2/exec.go
+++ b/pkg/clustermanager/kubetest2/exec.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package kubetest2
 
 import (
@@ -7,7 +23,7 @@ import (
 	"os/exec"
 )
 
-func run(command *exec.Cmd) (string, error) {
+func runWithOutput(command *exec.Cmd) (string, error) {
 	var buf bytes.Buffer
 	command.Stdout = io.MultiWriter(&buf, os.Stdout)
 	command.Stderr = io.MultiWriter(&buf, os.Stderr)

--- a/pkg/clustermanager/kubetest2/gke.go
+++ b/pkg/clustermanager/kubetest2/gke.go
@@ -1,0 +1,151 @@
+package kubetest2
+
+import (
+	"fmt"
+	"log"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"knative.dev/test-infra/pkg/cmd"
+	"knative.dev/test-infra/pkg/metautil"
+	"knative.dev/test-infra/pkg/prow"
+)
+
+const (
+	createCommandTmpl = "%s container clusters create --quiet --enable-autoscaling --min-nodes=%d --max-nodes=%d " +
+		"--cluster-version=%s --scopes=%s --no-enable-autoupgrade"
+	boskosAcquireTimeoutSeconds = "1200"
+)
+
+var (
+	baseKubetest2Flags = []string{"gke", "--ignore-gcp-ssh-key=true", "--up"}
+
+	// If one of the error patterns below is matched, it would be recommended to
+	// retry creating the cluster in a different region/zone.
+	// - stockout (https://github.com/knative/test-infra/issues/592)
+	retryableCreationErrors = []*regexp.Regexp{
+		regexp.MustCompile(`.*does not have enough resources available to fulfill.*`),
+		regexp.MustCompile(`.*only \d+ nodes out of \d+ have registered; this is likely due to Nodes failing to start correctly.*`),
+	}
+)
+
+type GKEClusterConfig struct {
+	GCPProjectID                string
+	Name                        string
+	Region                      string
+	BackupRegions               []string
+	Machine                     string
+	MinNodes                    int
+	MaxNodes                    int
+	Network                     string
+	Version                     string
+	Scopes                      string
+	Addons                      string
+	Environment                 string
+	CommandGroup                string
+	PrivateClusterAccessLevel   string
+	PrivateClusterMasterIPRange string
+}
+
+func Run(opts *Options, cc *GKEClusterConfig) error {
+	createCommand := fmt.Sprintf(createCommandTmpl, cc.CommandGroup, cc.MinNodes, cc.MaxNodes, cc.Version, cc.Scopes)
+	if cc.Addons != "" {
+		createCommand += " --addons=" + cc.Addons
+	}
+	kubetest2Flags := append(baseKubetest2Flags, "--create-command="+createCommand)
+
+	kubetest2Flags = append(kubetest2Flags, "--cluster-name="+cc.Name, "--environment="+cc.Environment,
+		"--num-nodes="+strconv.Itoa(cc.MinNodes), "--machine-type="+cc.Machine, "--network="+cc.Network)
+
+	if prow.IsCI() && cc.GCPProjectID == "" {
+		log.Println("Will use boskos to provision the GCP project")
+		kubetest2Flags = append(kubetest2Flags, "--boskos-acquire-timeout-seconds="+boskosAcquireTimeoutSeconds)
+	} else {
+		if cc.GCPProjectID == "" {
+			var err error
+			cc.GCPProjectID, err = cmd.RunCommand("gcloud config get-value project")
+			if err != nil {
+				return fmt.Errorf("error getting the current GCP project: %v", err)
+			}
+		}
+		log.Printf("Will use the GCP project %q for creating the cluster", cc.GCPProjectID)
+		kubetest2Flags = append(kubetest2Flags, "--project="+cc.GCPProjectID)
+	}
+	kubetest2Flags = append(kubetest2Flags, strings.Split(opts.ExtraKubetest2Flags, " ")...)
+
+	return createGKEClusterWithRetries(kubetest2Flags, opts.TestCommand, cc)
+}
+
+func createGKEClusterWithRetries(kubetest2Flags []string, testerCommand string, cc *GKEClusterConfig) error {
+	var err error
+	regions := append([]string{cc.Region}, cc.BackupRegions...)
+	for i, region := range regions {
+		kubetest2Flags = append(kubetest2Flags, "--region="+region)
+		if cc.PrivateClusterAccessLevel != "" {
+			kubetest2Flags = append(kubetest2Flags, "--private-cluster-access-level="+cc.PrivateClusterAccessLevel)
+			kubetest2Flags = append(kubetest2Flags, "--private-cluster-master-ip-range="+fmt.Sprintf(cc.PrivateClusterMasterIPRange, i))
+		}
+
+		if len(testerCommand) != 0 {
+			kubetest2Flags = append(kubetest2Flags, "--test=exec", "--")
+			kubetest2Flags = append(kubetest2Flags, strings.Split(testerCommand, " ")...)
+		}
+
+		log.Printf("Running kubetest2 with flags: %q", kubetest2Flags)
+		command := exec.Command("kubetest2", kubetest2Flags...)
+		var out string
+		out, err = run(command)
+		if err != nil {
+			if isRetryableCreationError(out) {
+				log.Print("Cluster creation fails due to unpredictable reasons, will retry creating with different args")
+				continue
+			} else {
+				return err
+			}
+		} else {
+			saveMetaData(cc, region)
+			break
+		}
+	}
+
+	return err
+}
+
+// isRetryableCreationError determines if cluster creation should be retried based on the error message.
+func isRetryableCreationError(errMsg string) bool {
+	for _, regx := range retryableCreationErrors {
+		if regx.MatchString(errMsg) {
+			return true
+		}
+	}
+	return false
+}
+
+// saveMetaData will save the metadata with best effort.
+func saveMetaData(cc *GKEClusterConfig, region string) {
+	// Only save the metadata if it's in CI environment.
+	if !prow.IsCI() {
+		return
+	}
+
+	cli, err := metautil.NewClient("")
+	if err != nil {
+		log.Printf("error creating the metautil client: %v", err)
+		return
+	}
+	cv, err := cmd.RunCommand("kubectl version --short=true")
+	if err != nil {
+		log.Printf("error getting the cluster version: %v", err)
+		return
+	}
+
+	// Set the metadata with best effort.
+	cli.Set("E2E:Provider", "gke")
+	cli.Set("E2E:Region", region)
+	cli.Set("E2E:Machine", cc.Machine)
+	cli.Set("E2E:Version", cv)
+	cli.Set("E2E:MinNodes", strconv.Itoa(cc.MinNodes))
+	cli.Set("E2E:MaxNodes", strconv.Itoa(cc.MaxNodes))
+}

--- a/pkg/clustermanager/kubetest2/gke.go
+++ b/pkg/clustermanager/kubetest2/gke.go
@@ -49,22 +49,23 @@ var (
 
 // GKEClusterConfig are the supported configurations for creating a GKE cluster.
 type GKEClusterConfig struct {
-	GCPProjectID                string
-	BoskosAcquireTimeoutSeconds int
-	Name                        string
-	Region                      string
-	BackupRegions               []string
-	Machine                     string
-	MinNodes                    int
-	MaxNodes                    int
-	Network                     string
-	Version                     string
-	Scopes                      string
-	Addons                      string
-	Environment                 string
-	CommandGroup                string
-	PrivateClusterAccessLevel   string
-	PrivateClusterMasterIPRange string
+	GCPProjectID                      string
+	BoskosAcquireTimeoutSeconds       int
+	Name                              string
+	Region                            string
+	BackupRegions                     []string
+	Machine                           string
+	MinNodes                          int
+	MaxNodes                          int
+	Network                           string
+	Version                           string
+	Scopes                            string
+	Addons                            string
+	Environment                       string
+	CommandGroup                      string
+	PrivateClusterAccessLevel         string
+	PrivateClusterMasterIPSubnetRange string
+	PrivateClusterMasterIPSubnetMask  string
 }
 
 // Run will run the `kubetest2 gke` command with the provided parameters,
@@ -109,7 +110,8 @@ func createGKEClusterWithRetries(kubetest2Flags []string, opts *Options, cc *GKE
 		kubetest2Flags = append(kubetest2Flags, "--region="+region)
 		if cc.PrivateClusterAccessLevel != "" {
 			kubetest2Flags = append(kubetest2Flags, "--private-cluster-access-level="+cc.PrivateClusterAccessLevel)
-			kubetest2Flags = append(kubetest2Flags, "--private-cluster-master-ip-range="+fmt.Sprintf(cc.PrivateClusterMasterIPRange, i))
+			masterIPRange := fmt.Sprintf("%s.%d/%s", cc.PrivateClusterMasterIPSubnetRange, i, cc.PrivateClusterMasterIPSubnetMask)
+			kubetest2Flags = append(kubetest2Flags, "--private-cluster-master-ip-range="+masterIPRange)
 		}
 
 		if opts.TestCommand != "" {

--- a/pkg/clustermanager/kubetest2/gke.go
+++ b/pkg/clustermanager/kubetest2/gke.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kubetest2
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"os/exec"
@@ -89,11 +90,7 @@ func Run(opts *Options, cc *GKEClusterConfig) error {
 		kubetest2Flags = append(kubetest2Flags, "--boskos-acquire-timeout-seconds="+strconv.Itoa(timeout))
 	} else {
 		if cc.GCPProjectID == "" {
-			var err error
-			cc.GCPProjectID, err = cmd.RunCommand("gcloud config get-value project")
-			if err != nil {
-				return fmt.Errorf("error getting the current GCP project: %v", err)
-			}
+			return errors.New("GCP project must be provided in non-CI environment")
 		}
 		log.Printf("Will use the GCP project %q for creating the cluster", cc.GCPProjectID)
 		kubetest2Flags = append(kubetest2Flags, "--project="+cc.GCPProjectID)

--- a/pkg/clustermanager/kubetest2/gke.go
+++ b/pkg/clustermanager/kubetest2/gke.go
@@ -62,6 +62,7 @@ type GKEClusterConfig struct {
 	Version                           string
 	Scopes                            string
 	Addons                            string
+	EnableWorkloadIdentity            bool
 	Environment                       string
 	CommandGroup                      string
 	PrivateClusterAccessLevel         string
@@ -79,7 +80,8 @@ func Run(opts *Options, cc *GKEClusterConfig) error {
 	kubetest2Flags := append(baseKubetest2Flags, "--create-command="+createCommand)
 
 	kubetest2Flags = append(kubetest2Flags, "--cluster-name="+cc.Name, "--environment="+cc.Environment,
-		"--num-nodes="+strconv.Itoa(cc.MinNodes), "--machine-type="+cc.Machine, "--network="+cc.Network)
+		"--num-nodes="+strconv.Itoa(cc.MinNodes), "--machine-type="+cc.Machine, "--network="+cc.Network,
+		"--enable-workload-identity="+strconv.FormatBool(cc.EnableWorkloadIdentity))
 
 	if prow.IsCI() && cc.GCPProjectID == "" {
 		log.Println("Will use boskos to provision the GCP project")
@@ -95,7 +97,6 @@ func Run(opts *Options, cc *GKEClusterConfig) error {
 		log.Printf("Will use the GCP project %q for creating the cluster", cc.GCPProjectID)
 		kubetest2Flags = append(kubetest2Flags, "--project="+cc.GCPProjectID)
 	}
-	kubetest2Flags = append(kubetest2Flags, strings.Split(opts.ExtraKubetest2Flags, " ")...)
 
 	return createGKEClusterWithRetries(kubetest2Flags, opts, cc)
 }

--- a/pkg/clustermanager/kubetest2/gke.go
+++ b/pkg/clustermanager/kubetest2/gke.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package kubetest2
 
 import (
@@ -16,14 +32,14 @@ import (
 const (
 	createCommandTmpl = "%s container clusters create --quiet --enable-autoscaling --min-nodes=%d --max-nodes=%d " +
 		"--cluster-version=%s --scopes=%s --no-enable-autoupgrade"
-	boskosAcquireTimeoutSeconds = "1200"
+	boskosAcquireDefaultTimeoutSeconds = 1200
 )
 
 var (
 	baseKubetest2Flags = []string{"gke", "--ignore-gcp-ssh-key=true", "--up"}
 
 	// If one of the error patterns below is matched, it would be recommended to
-	// retry creating the cluster in a different region/zone.
+	// retry creating the cluster in a different region.
 	// - stockout (https://github.com/knative/test-infra/issues/592)
 	retryableCreationErrors = []*regexp.Regexp{
 		regexp.MustCompile(`.*does not have enough resources available to fulfill.*`),
@@ -31,8 +47,10 @@ var (
 	}
 )
 
+// GKEClusterConfig are the supported configurations for creating a GKE cluster.
 type GKEClusterConfig struct {
 	GCPProjectID                string
+	BoskosAcquireTimeoutSeconds int
 	Name                        string
 	Region                      string
 	BackupRegions               []string
@@ -49,6 +67,8 @@ type GKEClusterConfig struct {
 	PrivateClusterMasterIPRange string
 }
 
+// Run will run the `kubetest2 gke` command with the provided parameters,
+// it will also handle the logic that is only used for Knative integration testing, like retrying cluster creation.
 func Run(opts *Options, cc *GKEClusterConfig) error {
 	createCommand := fmt.Sprintf(createCommandTmpl, cc.CommandGroup, cc.MinNodes, cc.MaxNodes, cc.Version, cc.Scopes)
 	if cc.Addons != "" {
@@ -61,7 +81,11 @@ func Run(opts *Options, cc *GKEClusterConfig) error {
 
 	if prow.IsCI() && cc.GCPProjectID == "" {
 		log.Println("Will use boskos to provision the GCP project")
-		kubetest2Flags = append(kubetest2Flags, "--boskos-acquire-timeout-seconds="+boskosAcquireTimeoutSeconds)
+		timeout := cc.BoskosAcquireTimeoutSeconds
+		if timeout == 0 {
+			timeout = boskosAcquireDefaultTimeoutSeconds
+		}
+		kubetest2Flags = append(kubetest2Flags, "--boskos-acquire-timeout-seconds="+strconv.Itoa(timeout))
 	} else {
 		if cc.GCPProjectID == "" {
 			var err error
@@ -75,10 +99,10 @@ func Run(opts *Options, cc *GKEClusterConfig) error {
 	}
 	kubetest2Flags = append(kubetest2Flags, strings.Split(opts.ExtraKubetest2Flags, " ")...)
 
-	return createGKEClusterWithRetries(kubetest2Flags, opts.TestCommand, cc)
+	return createGKEClusterWithRetries(kubetest2Flags, opts, cc)
 }
 
-func createGKEClusterWithRetries(kubetest2Flags []string, testerCommand string, cc *GKEClusterConfig) error {
+func createGKEClusterWithRetries(kubetest2Flags []string, opts *Options, cc *GKEClusterConfig) error {
 	var err error
 	regions := append([]string{cc.Region}, cc.BackupRegions...)
 	for i, region := range regions {
@@ -88,15 +112,15 @@ func createGKEClusterWithRetries(kubetest2Flags []string, testerCommand string, 
 			kubetest2Flags = append(kubetest2Flags, "--private-cluster-master-ip-range="+fmt.Sprintf(cc.PrivateClusterMasterIPRange, i))
 		}
 
-		if len(testerCommand) != 0 {
+		if opts.TestCommand != "" {
 			kubetest2Flags = append(kubetest2Flags, "--test=exec", "--")
-			kubetest2Flags = append(kubetest2Flags, strings.Split(testerCommand, " ")...)
+			kubetest2Flags = append(kubetest2Flags, strings.Split(opts.TestCommand, " ")...)
 		}
 
 		log.Printf("Running kubetest2 with flags: %q", kubetest2Flags)
 		command := exec.Command("kubetest2", kubetest2Flags...)
 		var out string
-		out, err = run(command)
+		out, err = runWithOutput(command)
 		if err != nil {
 			if isRetryableCreationError(out) {
 				log.Print("Cluster creation fails due to unpredictable reasons, will retry creating with different args")
@@ -105,7 +129,10 @@ func createGKEClusterWithRetries(kubetest2Flags []string, testerCommand string, 
 				return err
 			}
 		} else {
-			saveMetaData(cc, region)
+			// Only save the metadata if it's in CI environment and meta data is asked to be saved.
+			if prow.IsCI() && opts.SaveMetaData {
+				saveMetaData(cc, region)
+			}
 			break
 		}
 	}
@@ -125,11 +152,6 @@ func isRetryableCreationError(errMsg string) bool {
 
 // saveMetaData will save the metadata with best effort.
 func saveMetaData(cc *GKEClusterConfig, region string) {
-	// Only save the metadata if it's in CI environment.
-	if !prow.IsCI() {
-		return
-	}
-
 	cli, err := metautil.NewClient("")
 	if err != nil {
 		log.Printf("error creating the metautil client: %v", err)

--- a/pkg/clustermanager/kubetest2/options.go
+++ b/pkg/clustermanager/kubetest2/options.go
@@ -1,0 +1,7 @@
+package kubetest2
+
+type Options struct {
+	ExtraKubetest2Flags string
+	TestCommand         string
+	SaveMetaData        bool
+}

--- a/pkg/clustermanager/kubetest2/options.go
+++ b/pkg/clustermanager/kubetest2/options.go
@@ -1,5 +1,22 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package kubetest2
 
+// Options are the common options for running kubetest2 command.
 type Options struct {
 	ExtraKubetest2Flags string
 	TestCommand         string

--- a/pkg/clustermanager/kubetest2/options.go
+++ b/pkg/clustermanager/kubetest2/options.go
@@ -18,7 +18,6 @@ package kubetest2
 
 // Options are the common options for running kubetest2 command.
 type Options struct {
-	ExtraKubetest2Flags string
-	TestCommand         string
-	SaveMetaData        bool
+	TestCommand  string
+	SaveMetaData bool
 }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -110,28 +110,8 @@ main "$@"
 
 This is a helper script for Knative E2E test scripts. To use it:
 
-1. [optional] Customize the test cluster. Set the following environment
-   variables if the default values don't fit your needs:
-
-   - `E2E_GCP_PROJECT_ID`: GCP project ID for creating the clusters, defaults to
-     none.
-   - `E2E_GKE_CLUSTER_REGION`: Cluster region, defaults to `us-central1`.
-   - `E2E_GKE_CLUSTER_BACKUP_REGIONS`: Space-separated list of regions to retry
-     test cluster creation in case of stockout. Defaults to `us-west1 us-east1`.
-   - `E2E_GKE_CLUSTER_ZONE`: Cluster zone (e.g., `a`), defaults to none (i.e.
-     use a regional cluster).
-   - `E2E_GKE_CLUSTER_BACKUP_ZONES`: Space-separated list of zones to retry test
-     cluster creation in case of stockout. If defined,
-     `E2E_GKE_CLUSTER_BACKUP_REGIONS` will be ignored thus it defaults to none.
-   - `E2E_GKE_CLUSTER_MACHINE`: Cluster node machine type, defaults to
-     `e2-standard-4}`.
-   - `E2E_MIN_CLUSTER_NODES`: Minimum number of nodes in the cluster when
-     autoscaling, defaults to 1.
-   - `E2E_MAX_CLUSTER_NODES`: Maximum number of nodes in the cluster when
-     autoscaling, defaults to 3.
-   - `E2E_GKE_SCOPES`: Scopes for the GKE node instances, defaults to
-     `cloud-platform`.
-   - `E2E_CLUSTER_VERSION`: Version for the cluster, defaults to `latest`.
+1. [optional] Customize the test cluster. Pass the flags as described [here](../kntest/pkg/kubetest2/gke/README.md)
+   to the `initialize` function call if the default values don't fit your needs.
 
 1. Source the script.
 
@@ -163,7 +143,7 @@ This is a helper script for Knative E2E test scripts. To use it:
    of items to skip in the command line if the flag was parsed successfully. For
    example, return 1 for a simple flag, and 2 for a flag with a parameter.
 
-1. Call the `initialize()` function passing `$@` (without quotes).
+1. Call the `initialize()` function passing `"$@"`.
 
 1. Write logic for the end-to-end tests. Run all go tests using `go_test_e2e()`
    (or `report_go_test()` if you need a more fine-grained control) and call
@@ -173,8 +153,8 @@ This is a helper script for Knative E2E test scripts. To use it:
 
 **Notes:**
 
-1. Calling your script without arguments will create a new cluster in the GCP
-   project `$E2E_GCP_PROJECT_ID` and run the tests against it.
+1. Calling your script without arguments will create a new cluster in your current
+   GCP project and run the tests against it.
 
 1. Calling your script with `--run-tests` and the variable `KO_DOCKER_REPO` set
    will immediately start the tests against the cluster currently configured for
@@ -195,9 +175,6 @@ test cluster is created in a specific region, `us-west2`.
 
 ```bash
 
-# This test requires a cluster in LA
-E2E_CLUSTER_REGION=us-west2
-
 source vendor/knative.dev/test-infra/scripts/e2e-tests.sh
 
 function knative_setup() {
@@ -217,7 +194,8 @@ function parse_flags() {
 
 WAIT_FOR_KNATIVE=1
 
-initialize $@
+# This test requires a cluster in LA
+initialize $@ --region=us-west2
 
 # TODO: use go_test_e2e to run the tests.
 kubectl get pods || fail_test

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -128,14 +128,15 @@ CLOUD_PROVIDER="gke"
 # Parse flags and initialize the test cluster.
 function initialize() {
   local run_tests=0
+  local custom_flags=()
   local extra_kubetest2_flags=()
-  local extra_cluster_creation_flags=()
   E2E_SCRIPT="$(get_canonical_path "$0")"
   local e2e_script_command=( "${E2E_SCRIPT}" "--run-tests" )
 
   cd "${REPO_ROOT_DIR}"
   while [[ $# -ne 0 ]]; do
     local parameter=$1
+    # TODO(chizhg): remove parse_flags logic if no repos are using it.
     # Try parsing flag as a custom one.
     if function_exists parse_flags; then
       parse_flags "$@"
@@ -157,13 +158,10 @@ function initialize() {
       # TODO(chizhg): remove this flag once the addons is defined as an env var.
       --skip-istio-addon) SKIP_ISTIO_ADDON=1 ;;
       *)
-        [[ $# -ge 2 ]] || abort "missing parameter after $1"
-        shift
         case ${parameter} in
-          --cloud-provider) CLOUD_PROVIDER="$1" ;;
-          --kubetest2-flag) extra_kubetest2_flags+=("$1") ;;
-          --cluster-creation-flag) extra_cluster_creation_flags+=("$1") ;;
-          *) abort "unknown option ${parameter}" ;;
+          --cloud-provider) shift; CLOUD_PROVIDER="$1" ;;
+          --kubetest2-flag) shift; extra_kubetest2_flags+=("$1") ;;
+          *) custom_flags+=("$parameter") ;;
         esac
     esac
     shift
@@ -172,16 +170,16 @@ function initialize() {
   (( IS_PROW )) && [[ -z "${GCP_PROJECT_ID:-}" ]] && IS_BOSKOS=1
 
   if (( SKIP_ISTIO_ADDON )); then
-    extra_cluster_creation_flags+=("--addons=NodeLocalDNS")
+    custom_flags+=("--addons=NodeLocalDNS")
   else
-    extra_cluster_creation_flags+=("--addons=Istio,NodeLocalDNS")
+    custom_flags+=("--addons=Istio,NodeLocalDNS")
   fi
 
   readonly IS_BOSKOS
   readonly SKIP_TEARDOWNS
 
   if (( ! run_tests )); then
-    create_test_cluster "${CLOUD_PROVIDER}" extra_kubetest2_flags extra_cluster_creation_flags e2e_script_command
+    create_test_cluster "${CLOUD_PROVIDER}" custom_flags extra_kubetest2_flags e2e_script_command
   else
     setup_test_cluster
   fi

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -129,7 +129,6 @@ CLOUD_PROVIDER="gke"
 function initialize() {
   local run_tests=0
   local custom_flags=()
-  local extra_kubetest2_flags=()
   E2E_SCRIPT="$(get_canonical_path "$0")"
   local e2e_script_command=( "${E2E_SCRIPT}" "--run-tests" )
 
@@ -160,7 +159,6 @@ function initialize() {
       *)
         case ${parameter} in
           --cloud-provider) shift; CLOUD_PROVIDER="$1" ;;
-          --kubetest2-flag) shift; extra_kubetest2_flags+=("$1") ;;
           *) custom_flags+=("$parameter") ;;
         esac
     esac
@@ -179,7 +177,7 @@ function initialize() {
   readonly SKIP_TEARDOWNS
 
   if (( ! run_tests )); then
-    create_test_cluster "${CLOUD_PROVIDER}" custom_flags extra_kubetest2_flags e2e_script_command
+    create_test_cluster "${CLOUD_PROVIDER}" custom_flags e2e_script_command
   else
     setup_test_cluster
   fi

--- a/scripts/infra-library.sh
+++ b/scripts/infra-library.sh
@@ -19,34 +19,6 @@
 
 source $(dirname "${BASH_SOURCE[0]}")/library.sh
 
-# Test cluster parameters
-
-# Configurable parameters
-export E2E_GCP_PROJECT_ID=${E2E_GCP_PROJECT_ID:-}
-# export E2E_GKE_CLUSTER_REGION and E2E_GKE_CLUSTER_ZONE as they're used in the cluster setup subprocess
-export E2E_GKE_CLUSTER_REGION=${E2E_GKE_CLUSTER_REGION:-us-central1}
-# By default we use regional clusters.
-export E2E_GKE_CLUSTER_ZONE=${E2E_GKE_CLUSTER_ZONE:-}
-
-# Default backup regions in case of stockouts; by default we don't fall back to a different zone in the same region
-readonly E2E_GKE_CLUSTER_BACKUP_REGIONS=${E2E_GKE_CLUSTER_BACKUP_REGIONS:-us-west1 us-east1}
-readonly E2E_GKE_CLUSTER_BACKUP_ZONES=${E2E_GKE_CLUSTER_BACKUP_ZONES:-}
-
-readonly E2E_GKE_ENVIRONMENT=${E2E_GKE_ENVIRONMENT:-prod}
-readonly E2E_GKE_COMMAND_GROUP=${E2E_GKE_COMMAND_GROUP:-beta}
-readonly E2E_GKE_CLUSTER_MACHINE=${E2E_GKE_CLUSTER_MACHINE:-e2-standard-4}
-readonly E2E_GKE_SCOPES=${E2E_GKE_SCOPES:-cloud-platform}
-
-# Each knative repository may have a different cluster size requirement here,
-# so we allow calling code to set these parameters.  If they are not set we
-# use some sane defaults.
-readonly E2E_MIN_CLUSTER_NODES=${E2E_MIN_CLUSTER_NODES:-1}
-readonly E2E_MAX_CLUSTER_NODES=${E2E_MAX_CLUSTER_NODES:-3}
-readonly E2E_CLUSTER_VERSION=${E2E_CLUSTER_VERSION:-latest}
-
-readonly E2E_CLUSTER_NAME=$(build_resource_name e2e-cls)
-readonly E2E_GKE_NETWORK_NAME=$(build_resource_name e2e-net)
-
 # Dumps the k8s api server metrics. Spins up a proxy, waits a little bit and
 # dumps the metrics to ${ARTIFACTS}/k8s.metrics.txt
 function dump_metrics() {
@@ -105,26 +77,6 @@ function dump_cluster_state() {
   echo "***************************************"
 }
 
-# On a Prow job, save some metadata about the test for Testgrid.
-# Parameters: $1 - cluster provider name
-function save_metadata() {
-  (( ! IS_PROW )) && return
-  local geo_key="Region"
-  local geo_value="${E2E_GKE_CLUSTER_REGION}"
-  if [[ -n "${E2E_GKE_CLUSTER_ZONE}" ]]; then
-    geo_key="Zone"
-    geo_value="${E2E_GKE_CLUSTER_REGION}-${E2E_GKE_CLUSTER_ZONE}"
-  fi
-  local cluster_version
-  cluster_version="$(kubectl version --short=true)"
-  run_kntest metadata set --key="E2E:Provider" --value="$1"
-  run_kntest metadata set --key="E2E:${geo_key}" --value="${geo_value}"
-  run_kntest metadata set --key="E2E:Machine" --value="${E2E_GKE_CLUSTER_MACHINE}"
-  run_kntest metadata set --key="E2E:Version" --value="${cluster_version}"
-  run_kntest metadata set --key="E2E:MinNodes" --value="${E2E_MIN_CLUSTER_NODES}"
-  run_kntest metadata set --key="E2E:MaxNodes" --value="${E2E_MAX_CLUSTER_NODES}"
-}
-
 # Sets the current user as cluster admin for the given cluster.
 # Parameters: $1 - cluster context name
 function acquire_cluster_admin_role() {
@@ -141,8 +93,8 @@ function acquire_cluster_admin_role() {
 
 # Create a test cluster and run the tests if provided.
 # Parameters: $1 - cluster provider name, e.g. gke
-#             $2 - extra kubetest2 flags
-#             $3 - extra cluster creation flags
+#             $2 - custom flags supported by kntest kubetest2-wrapper
+#             $3 - extra kubetest2 flags
 #             $4 - test command to run by the kubetest2 tester
 function create_test_cluster() {
   # Fail fast during setup.
@@ -179,102 +131,15 @@ function create_kind_test_cluster() {
 }
 
 # Create a GKE test cluster with kubetest2 and run the test command.
-# Parameters: $1 - extra kubetest2 flags
-#             $2 - extra cluster creation flags
+# Parameters: $1 - custom flags defined in kntest kubetest2-wrapper
+#             $2 - extra kubetest2 flags
 #             $3 - test command to run by the kubetest2 tester after the cluster is created (optional)
 function create_gke_test_cluster() {
-  local -n _extra_kubetest2_flags=$1
-  local -n _extra_cluster_creation_flags=$2
+  local -n _custom_flags=$1
+  local -n _extra_kubetest2_flags=$2
+  local -n _test_command=$3
 
-  echo "Cluster will have a minimum of ${E2E_MIN_CLUSTER_NODES} and a maximum of ${E2E_MAX_CLUSTER_NODES} nodes."
-  local _kubetest2_flags=(
-    "gke"
-    "--create-command=${E2E_GKE_COMMAND_GROUP} container clusters create --quiet --enable-autoscaling
-      --min-nodes=${E2E_MIN_CLUSTER_NODES} --max-nodes=${E2E_MAX_CLUSTER_NODES}
-      --cluster-version=${E2E_CLUSTER_VERSION}
-      --scopes=${E2E_GKE_SCOPES} --no-enable-autoupgrade
-      ${_extra_cluster_creation_flags[@]}"
-    "--environment=${E2E_GKE_ENVIRONMENT}"
-    "--cluster-name=${E2E_CLUSTER_NAME}"
-    "--num-nodes=${E2E_MIN_CLUSTER_NODES}"
-    "--machine-type=${E2E_GKE_CLUSTER_MACHINE}"
-    "--network=${E2E_GKE_NETWORK_NAME}"
-    "--ignore-gcp-ssh-key=true"
-    --up
-  )
-  _kubetest2_flags+=( "${_extra_kubetest2_flags[@]}" )
-  if (( ! IS_BOSKOS )); then
-    local gcloud_project="${E2E_GCP_PROJECT_ID}"
-    [[ -z "${gcloud_project}" ]] && gcloud_project="$(gcloud config get-value project)"
-    _kubetest2_flags+=("--project=${gcloud_project}")
-    echo "gcloud project is ${gcloud_project}"
-  else
-    echo "Using boskos for provisioning the GCP project to create the test cluster"
-  fi
-
-  if (( IS_BOSKOS )); then
-    # Add arbitrary duration, wait for Boskos projects acquisition before error out
-    _kubetest2_flags+=("--boskos-acquire-timeout-seconds=1200")
-  elif (( ! SKIP_TEARDOWNS )); then
-    # Only let kubetest2 tear down the cluster if not using Boskos and teardowns are not expected to be skipped,
-    # it's done by Janitor if using Boskos
-    _kubetest2_flags+=("--down")
-  fi
-
-  # Create cluster and run the tests
-  create_gke_test_cluster_with_retries _kubetest2_flags "$3"
-}
-
-# TODO(chizhg): move this to kubetest2 gke deployer.
-# Retry backup regions/zones if cluster creations failed due to stockout.
-# Parameters: $1 - kubetest2 flags other than geo flag
-#             $2 - test command to run by the kubetest2 tester after the cluster is created (optional)
-function create_gke_test_cluster_with_retries() {
-  local -n kubetest2_flags=$1
-  local -n command=$2
-  if (( ${#command[@]} )); then
-    tester_command=("--test=exec" "--" "${command[@]}")
-  fi
-  local cluster_creation_log=/tmp/${REPO_NAME}-cluster_creation-log
-  # zone_not_provided is a placeholder for e2e_cluster_zone to make for loop below work
-  local zone_not_provided="zone_not_provided"
-
-  local e2e_cluster_regions=("${E2E_GKE_CLUSTER_REGION}")
-  local e2e_cluster_zones=("${E2E_GKE_CLUSTER_ZONE}")
-
-  if [[ -n "${E2E_GKE_CLUSTER_BACKUP_ZONES}" ]]; then
-    e2e_cluster_zones+=("${E2E_GKE_CLUSTER_BACKUP_ZONES}")
-  elif [[ -n "${E2E_GKE_CLUSTER_BACKUP_REGIONS}" ]]; then
-    e2e_cluster_regions+=("${E2E_GKE_CLUSTER_BACKUP_REGIONS}")
-    e2e_cluster_zones=("${zone_not_provided}")
-  else
-    echo "No backup region/zone set, cluster creation will fail in case of stockout"
-  fi
-
-  for e2e_cluster_region in "${e2e_cluster_regions[@]}"; do
-    for e2e_cluster_zone in "${e2e_cluster_zones[@]}"; do
-      E2E_GKE_CLUSTER_REGION=${e2e_cluster_region}
-      E2E_GKE_CLUSTER_ZONE=${e2e_cluster_zone}
-      [[ "${E2E_GKE_CLUSTER_ZONE}" == "${zone_not_provided}" ]] && E2E_GKE_CLUSTER_ZONE=""
-      local cluster_creation_zone="${E2E_GKE_CLUSTER_REGION}"
-      [[ -n "${E2E_GKE_CLUSTER_ZONE}" ]] && cluster_creation_zone="${E2E_GKE_CLUSTER_REGION}-${E2E_GKE_CLUSTER_ZONE}"
-
-      header "Creating test cluster ${E2E_CLUSTER_VERSION} in ${cluster_creation_zone}"
-      if run_go_tool k8s-sigs.io/kubetest2 \
-        kubetest2 "${kubetest2_flags[@]}" --region="${cluster_creation_zone}" "${tester_command[@]}" 2>&1 \
-         | tee "${cluster_creation_log}"; then
-        # Save some metadata about cluster creation for using in prow and testgrid
-        save_metadata "gke"
-        return 0
-      fi
-      # Retry if cluster creation failed because of stockout (https://github.com/knative/test-infra/issues/592)
-      # or Nodes failing to start correctly.
-      # shellcheck disable=SC2143
-      [[ -z "$(grep -Fo 'does not have enough resources available to fulfill' "${cluster_creation_log}")" \
-          && -z "$(grep -Po 'only \d+ nodes out of \d+ have registered; this is likely due to Nodes failing to start correctly' "${cluster_creation_log}")" ]] \
-          && return 1
-    done
-  done
-  echo "No more region/zones to try, quitting"
-  return 1
+  run_kntest kubetest2 gke --extra-kubetest2-flags="${_extra_kubetest2_flags[*]}" \
+    --test-command="${_test_command[*]}" \
+    "${_custom_flags[@]}"
 }

--- a/scripts/infra-library.sh
+++ b/scripts/infra-library.sh
@@ -93,9 +93,8 @@ function acquire_cluster_admin_role() {
 
 # Create a test cluster and run the tests if provided.
 # Parameters: $1 - cluster provider name, e.g. gke
-#             $2 - custom flags supported by kntest kubetest2-wrapper
-#             $3 - extra kubetest2 flags
-#             $4 - test command to run by the kubetest2 tester
+#             $2 - custom flags supported by kntest
+#             $3 - test command to run after cluster is created
 function create_test_cluster() {
   # Fail fast during setup.
   set -o errexit
@@ -122,24 +121,19 @@ function create_test_cluster() {
 }
 
 # Create a KIND test cluster with kubetest2 and run the test command.
-# Parameters: $1 - extra kubetest2 flags
-#             $2 - extra cluster creation flags
-#             $3 - test command to run by the kubetest2 tester
+# Parameters: $1 - extra cluster creation flags
+#             $2 - test command to run by the kubetest2 tester
 function create_kind_test_cluster() {
   # TODO(chizhg): implement with kubetest2
   return 0
 }
 
 # Create a GKE test cluster with kubetest2 and run the test command.
-# Parameters: $1 - custom flags defined in kntest kubetest2-wrapper
-#             $2 - extra kubetest2 flags
-#             $3 - test command to run by the kubetest2 tester after the cluster is created (optional)
+# Parameters: $1 - custom flags defined in kntest
+#             $2 - test command to run after the cluster is created (optional)
 function create_gke_test_cluster() {
   local -n _custom_flags=$1
-  local -n _extra_kubetest2_flags=$2
-  local -n _test_command=$3
+  local -n _test_command=$2
 
-  run_kntest kubetest2 gke --extra-kubetest2-flags="${_extra_kubetest2_flags[*]}" \
-    --test-command="${_test_command[*]}" \
-    "${_custom_flags[@]}"
+  run_kntest kubetest2 gke "${_custom_flags[@]}" --test-command="${_test_command[*]}"
 }

--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -65,22 +65,6 @@ function abort() {
   exit 1
 }
 
-# Build a resource name based on $REPO_NAME, a suffix and $BUILD_NUMBER.
-# Restricts the name length to 40 chars (the limit for resource names in GCP).
-# Name will have the form $REPO_NAME-<PREFIX>$BUILD_NUMBER.
-# Parameters: $1 - name suffix
-function build_resource_name() {
-  local prefix=${REPO_NAME}-$1
-  local suffix=${BUILD_NUMBER}
-  # Restrict suffix length to 20 chars
-  if [[ -n "${suffix}" ]]; then
-    suffix=${suffix:${#suffix}<20?0:-20}
-  fi
-  local name="${prefix:0:20}${suffix}"
-  # Ensure name doesn't end with "-"
-  echo "${name%-}"
-}
-
 # Display a box banner.
 # Parameters: $1 - character to use for the box.
 #             $2 - banner message.

--- a/scripts/presubmit-tests.sh
+++ b/scripts/presubmit-tests.sh
@@ -272,7 +272,7 @@ function run_integration_tests() {
 # Default integration test runner that runs all `test/e2e-*tests.sh`.
 function default_integration_test_runner() {
   local failed=0
-  find test/ ! -name "$(printf "*\n*")" -name "e2e-*tests.sh" > tmp
+  find test/ ! -name "$(printf "*\n*")" -name "e2e-*tests.sh" -maxdepth 1 > tmp
   while IFS= read -r e2e_test
   do
     echo "Running integration test ${e2e_test}"

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -30,7 +30,8 @@ function knative_setup() {
 }
 
 # Script entry point.
-initialize "$@" --kubetest2-flag "--enable-workload-identity=true" --max-nodes=1
+initialize "$@" --kubetest2-flag "--enable-workload-identity=true --gcp-service-account=${GOOGLE_APPLICATION_CREDENTIALS}" \
+  --max-nodes=1 --machine=e2-standard-2
 
 go_test_e2e ./test/e2e || fail_test
 

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -30,7 +30,7 @@ function knative_setup() {
 }
 
 # Script entry point.
-initialize "$@"
+initialize "$@" --kubetest2-flag "--enable-workload-identity=true" --max-nodes=1
 
 go_test_e2e ./test/e2e || fail_test
 

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -30,8 +30,7 @@ function knative_setup() {
 }
 
 # Script entry point.
-initialize "$@" --kubetest2-flag "--enable-workload-identity=true --gcp-service-account=${GOOGLE_APPLICATION_CREDENTIALS}" \
-  --max-nodes=1 --machine=e2-standard-2
+initialize "$@" --max-nodes=1 --machine=e2-standard-2 --enable-workload-identity=true
 
 go_test_e2e ./test/e2e || fail_test
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
1. Implement a `kntest kubetest2` subcommand for ease of running integration tests for Knative.
2. Remove all the cluster creation related env vars from the base bash script, and instead using flags to change the default configuration.
3. Other nit fixes and cleanups.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->