### PR TITLE
kntest kubetest2 supports more flags and bug fix

### DIFF
--- a/kntest/pkg/kubetest2/gke/options.go
+++ b/kntest/pkg/kubetest2/gke/options.go
@@ -35,8 +35,9 @@ func addOptions(gkeCmd *cobra.Command, cfg *kubetest2.GKEClusterConfig) {
 	f.IntVar(&cfg.MinNodes, "min-nodes", 1, "The minimum number of nodes.")
 	f.IntVar(&cfg.MaxNodes, "max-nodes", 3, "The maximum number of nodes.")
 	f.StringVar(&cfg.Network, "network", "e2e-network", "The network name for the GKE cluster.")
-	f.StringVar(&cfg.ReleaseChannel, "release-channel", "", "The release channel of the GKE cluster.")
-	f.StringVar(&cfg.Version, "cluster-version", "latest", "The version of the GKE cluster.")
+	f.StringVar(&cfg.ReleaseChannel, "release-channel", "", "The release channel of the GKE cluster, can be one of (empty, rapid, regular, stable). When it's used, --cluster-version must be empty or a valid version in the channel."+
+		"Reference: https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels")
+	f.StringVar(&cfg.Version, "cluster-version", "latest", "The version of the GKE cluster. If --release-channel is not empty, it must be empty or a valid version in the channel")
 	f.StringVar(&cfg.Scopes, "scopes", "cloud-platform", "Scopes for the GKE cluster, should be comma-separated.")
 	f.StringVar(&cfg.Addons, "addons", "", "Addons for the GKE cluster, should be comma-separated.")
 	f.BoolVar(&cfg.EnableWorkloadIdentity, "enable-workload-identity", false, "Whether to enable workload identity for this cluster or not.")

--- a/kntest/pkg/kubetest2/gke/options.go
+++ b/kntest/pkg/kubetest2/gke/options.go
@@ -24,6 +24,7 @@ import (
 
 func addOptions(gkeCmd *cobra.Command, cfg *kubetest2.GKEClusterConfig) {
 	f := gkeCmd.Flags()
+	f.StringVar(&cfg.GCPServiceAccount, "gcp-service-account", "", "The GCP service account used for creating the cluster.")
 	f.StringVar(&cfg.Environment, "environment", "prod", "The GKE environment, must be one of prod, staging, staging2 and test.")
 	f.StringVar(&cfg.CommandGroup, "command-group", "beta", "The gcloud command group, must be alpha, beta or empty.")
 	f.StringVar(&cfg.GCPProjectID, "gcp-project-id", "", "GCP project ID for creating the cluster")
@@ -34,10 +35,12 @@ func addOptions(gkeCmd *cobra.Command, cfg *kubetest2.GKEClusterConfig) {
 	f.IntVar(&cfg.MinNodes, "min-nodes", 1, "The minimum number of nodes.")
 	f.IntVar(&cfg.MaxNodes, "max-nodes", 3, "The maximum number of nodes.")
 	f.StringVar(&cfg.Network, "network", "e2e-network", "The network name for the GKE cluster.")
-	f.StringVar(&cfg.Version, "version", "latest", "The version of the GKE cluster.")
+	f.StringVar(&cfg.ReleaseChannel, "release-channel", "", "The release channel of the GKE cluster.")
+	f.StringVar(&cfg.Version, "cluster-version", "latest", "The version of the GKE cluster.")
 	f.StringVar(&cfg.Scopes, "scopes", "cloud-platform", "Scopes for the GKE cluster, should be comma-separated.")
 	f.StringVar(&cfg.Addons, "addons", "", "Addons for the GKE cluster, should be comma-separated.")
 	f.BoolVar(&cfg.EnableWorkloadIdentity, "enable-workload-identity", false, "Whether to enable workload identity for this cluster or not.")
+	f.BoolVar(&cfg.EnableStackdriverKubernetes, "enable-stackdriver-kubernetes", false, "Whether to enable Stackdriver Kubernetes monitoring and logging or not.")
 	f.StringVar(&cfg.PrivateClusterAccessLevel, "private-cluster-access-level", "", "Private cluster access level, if not empty, must be one of 'no', 'limited' or 'unrestricted'")
 	f.StringVar(&cfg.PrivateClusterMasterIPSubnetRange, "private-cluster-master-ip-subnet-range", "172.16.0", "The master IP subnet range for the private cluster. The last digit must be left empty to allow retrying cluster creation in the backup regions.")
 	f.StringVar(&cfg.PrivateClusterMasterIPSubnetMask, "private-cluster-master-ip-subnet-mask", "28", "The master IP subnet mask for the private cluster.")

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -30,7 +30,9 @@ function knative_setup() {
 }
 
 # Script entry point.
-initialize "$@" --max-nodes=1 --machine=e2-standard-2 --enable-workload-identity=true
+initialize "$@" --max-nodes=1 --machine=e2-standard-2 \
+  --enable-workload-identity --enable-stackdriver-kubernetes \
+  --cluster-version=latest
 
 go_test_e2e ./test/e2e || fail_test
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
1. Support `--release-channel` and `--enable-stackdriver-kubernetes` flags as they are needed for internal testing
2. Support use `--gcp-service-account` to specify a different service account other than `GOOGLE_APPLICATOIN_CREDENTIALS`
3. Change `--version` to `--cluster-version` to be consistent with the `gcloud` command
4. Fix a bug in the cluster creation retry logic - create a new `flags` array each time it retries, otherwise every time it retries, duplicated flags will be appended to the `kubetest2Flags` array.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc

