### PR TITLE
Prow jobs support running integration tests with kind

### DIFF
--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -246,7 +246,16 @@ presubmits:
   - build-tests: true
   - unit-tests: true
   - integration-tests: true
+    args:
+    - --run-test
+    - ./test/e2e-tests.sh
   - go-coverage: true
+  - custom-test: kind-tests
+    always-run: false
+    needs-dind: true
+    args:
+    - --run-test
+    - ./test/e2e-kind.sh
   knative/caching:
   - build-tests: true
   - unit-tests: true
@@ -673,6 +682,7 @@ periodics:
   - continuous: true
   knative/test-infra:
   - continuous: true
+    needs-dind: true
   google/knative-gcp:
   - continuous: true
     resources:

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -1476,6 +1476,10 @@ presubmits:
           readOnly: true
         - name: docker-graph
           mountPath: /docker-graph
+        - name: modules
+          mountPath: /lib/modules
+        - name: cgroup
+          mountPath: /sys/fs/cgroup
         - name: test-account
           mountPath: /etc/test-account
           readOnly: true
@@ -1492,6 +1496,14 @@ presubmits:
           secretName: repoview-token
       - name: docker-graph
         emptyDir: {}
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
       - name: test-account
         secret:
           secretName: test-account
@@ -1788,7 +1800,8 @@ presubmits:
         - runner.sh
         args:
         - "./test/presubmit-tests.sh"
-        - "--integration-tests"
+        - "--run-test"
+        - "./test/e2e-tests.sh"
         volumeMounts:
         - name: repoview-token
           mountPath: /etc/repoview-token
@@ -1838,6 +1851,58 @@ presubmits:
       - name: covbot-token
         secret:
           secretName: covbot-token
+  - name: pull-knative-test-infra-kind-tests
+    agent: kubernetes
+    context: pull-knative-test-infra-kind-tests
+    always_run: false
+    rerun_command: "/test pull-knative-test-infra-kind-tests"
+    trigger: "(?m)^/test (all|pull-knative-test-infra-kind-tests),?(\\s+|$)"
+    decorate: true
+    path_alias: knative.dev/test-infra
+    cluster: "build-knative"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-kind.sh"
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: docker-graph
+          mountPath: /docker-graph
+        - name: modules
+          mountPath: /lib/modules
+        - name: cgroup
+          mountPath: /sys/fs/cgroup
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: "true"
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: docker-graph
+        emptyDir: {}
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      - name: test-account
+        secret:
+          secretName: test-account
   knative/caching:
   - name: pull-knative-caching-build-tests
     agent: kubernetes
@@ -3663,6 +3728,10 @@ presubmits:
           readOnly: true
         - name: docker-graph
           mountPath: /docker-graph
+        - name: modules
+          mountPath: /lib/modules
+        - name: cgroup
+          mountPath: /sys/fs/cgroup
         - name: test-account
           mountPath: /etc/test-account
           readOnly: true
@@ -3679,6 +3748,14 @@ presubmits:
           secretName: repoview-token
       - name: docker-graph
         emptyDir: {}
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
       - name: test-account
         secret:
           secretName: test-account
@@ -3708,6 +3785,10 @@ presubmits:
           readOnly: true
         - name: docker-graph
           mountPath: /docker-graph
+        - name: modules
+          mountPath: /lib/modules
+        - name: cgroup
+          mountPath: /sys/fs/cgroup
         - name: test-account
           mountPath: /etc/test-account
           readOnly: true
@@ -3724,6 +3805,14 @@ presubmits:
           secretName: repoview-token
       - name: docker-graph
         emptyDir: {}
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
       - name: test-account
         secret:
           secretName: test-account
@@ -3753,6 +3842,10 @@ presubmits:
           readOnly: true
         - name: docker-graph
           mountPath: /docker-graph
+        - name: modules
+          mountPath: /lib/modules
+        - name: cgroup
+          mountPath: /sys/fs/cgroup
         - name: test-account
           mountPath: /etc/test-account
           readOnly: true
@@ -3769,6 +3862,14 @@ presubmits:
           secretName: repoview-token
       - name: docker-graph
         emptyDir: {}
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
       - name: test-account
         secret:
           secretName: test-account
@@ -3800,6 +3901,10 @@ presubmits:
           readOnly: true
         - name: docker-graph
           mountPath: /docker-graph
+        - name: modules
+          mountPath: /lib/modules
+        - name: cgroup
+          mountPath: /sys/fs/cgroup
         env:
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
@@ -3809,6 +3914,14 @@ presubmits:
           secretName: covbot-token
       - name: docker-graph
         emptyDir: {}
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
   knative-sandbox/eventing-kafka-broker:
   - name: pull-knative-sandbox-eventing-kafka-broker-build-tests
     agent: kubernetes
@@ -3836,6 +3949,10 @@ presubmits:
           readOnly: true
         - name: docker-graph
           mountPath: /docker-graph
+        - name: modules
+          mountPath: /lib/modules
+        - name: cgroup
+          mountPath: /sys/fs/cgroup
         - name: test-account
           mountPath: /etc/test-account
           readOnly: true
@@ -3852,6 +3969,14 @@ presubmits:
           secretName: repoview-token
       - name: docker-graph
         emptyDir: {}
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
       - name: test-account
         secret:
           secretName: test-account
@@ -3881,6 +4006,10 @@ presubmits:
           readOnly: true
         - name: docker-graph
           mountPath: /docker-graph
+        - name: modules
+          mountPath: /lib/modules
+        - name: cgroup
+          mountPath: /sys/fs/cgroup
         - name: test-account
           mountPath: /etc/test-account
           readOnly: true
@@ -3897,6 +4026,14 @@ presubmits:
           secretName: repoview-token
       - name: docker-graph
         emptyDir: {}
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
       - name: test-account
         secret:
           secretName: test-account
@@ -3926,6 +4063,10 @@ presubmits:
           readOnly: true
         - name: docker-graph
           mountPath: /docker-graph
+        - name: modules
+          mountPath: /lib/modules
+        - name: cgroup
+          mountPath: /sys/fs/cgroup
         - name: test-account
           mountPath: /etc/test-account
           readOnly: true
@@ -3942,6 +4083,14 @@ presubmits:
           secretName: repoview-token
       - name: docker-graph
         emptyDir: {}
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
       - name: test-account
         secret:
           secretName: test-account
@@ -3973,6 +4122,10 @@ presubmits:
           readOnly: true
         - name: docker-graph
           mountPath: /docker-graph
+        - name: modules
+          mountPath: /lib/modules
+        - name: cgroup
+          mountPath: /sys/fs/cgroup
         env:
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
@@ -3982,6 +4135,14 @@ presubmits:
           secretName: covbot-token
       - name: docker-graph
         emptyDir: {}
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
 periodics:
 - cron: "0 */2 * * *"
   name: ci-knative-serving-continuous
@@ -4082,6 +4243,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -4097,6 +4262,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -4125,6 +4298,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -4140,6 +4317,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -4168,6 +4353,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -4183,6 +4372,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -4211,6 +4408,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -4226,6 +4427,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -4254,6 +4463,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -4269,6 +4482,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -4297,6 +4518,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -4312,6 +4537,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -4340,6 +4573,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -4355,6 +4592,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -4383,6 +4628,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -4398,6 +4647,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -5207,6 +5464,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -5222,6 +5483,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -5250,6 +5519,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -5265,6 +5538,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -5293,6 +5574,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -5308,6 +5593,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -5336,6 +5629,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -5351,6 +5648,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -5379,6 +5684,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -5394,6 +5703,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -5422,6 +5739,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -5437,6 +5758,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -5465,6 +5794,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -5480,6 +5813,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -5508,6 +5849,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -5523,6 +5868,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -5942,6 +6295,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -5955,6 +6312,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -5981,6 +6346,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -5994,6 +6363,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -6142,6 +6519,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -6157,6 +6538,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -6185,6 +6574,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -6200,6 +6593,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -6228,6 +6629,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -6243,6 +6648,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -6271,6 +6684,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -6286,6 +6703,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -6314,6 +6739,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -6329,6 +6758,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -6357,6 +6794,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -6372,6 +6813,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -6400,6 +6849,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -6415,6 +6868,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -6443,6 +6904,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -6458,6 +6923,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -6894,6 +7367,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -6909,6 +7386,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -6937,6 +7422,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -6952,6 +7441,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -6980,6 +7477,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -6995,6 +7496,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -7023,6 +7532,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -7038,6 +7551,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -7066,6 +7587,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -7081,6 +7606,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -7109,6 +7642,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -7124,6 +7661,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -7152,6 +7697,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -7167,6 +7716,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -7195,6 +7752,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -7210,6 +7771,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -7912,16 +8481,36 @@ periodics:
       args:
       - "./test/presubmit-tests.sh"
       - "--all-tests"
+      securityContext:
+        privileged: true
       volumeMounts:
+      - name: docker-graph
+        mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
       env:
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
     volumes:
+    - name: docker-graph
+      emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -7944,16 +8533,36 @@ periodics:
       args:
       - "./test/presubmit-tests.sh"
       - "--all-tests"
+      securityContext:
+        privileged: true
       volumeMounts:
+      - name: docker-graph
+        mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
       env:
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
     volumes:
+    - name: docker-graph
+      emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -8101,6 +8710,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -8121,6 +8734,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -8148,6 +8769,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -8168,6 +8793,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -8195,6 +8828,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -8215,6 +8852,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -8242,6 +8887,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -8262,6 +8911,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -8289,6 +8946,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -8309,6 +8970,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -8336,6 +9005,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -8356,6 +9029,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -8383,6 +9064,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -8403,6 +9088,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -8430,6 +9123,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -8450,6 +9147,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -10231,6 +10936,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -10251,6 +10960,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -10279,6 +10996,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -10299,6 +11020,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -10327,6 +11056,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -10347,6 +11080,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -10375,6 +11116,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -10395,6 +11140,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -10423,6 +11176,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -10443,6 +11200,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -10471,6 +11236,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -10491,6 +11260,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -11095,6 +11872,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -11108,6 +11889,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -11135,6 +11924,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -11148,6 +11941,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -11176,6 +11977,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: nightly-account
         mountPath: /etc/nightly-account
         readOnly: true
@@ -11189,6 +11994,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: nightly-account
       secret:
         secretName: nightly-account
@@ -11222,6 +12035,10 @@ periodics:
         readOnly: true
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: release-account
         mountPath: /etc/release-account
         readOnly: true
@@ -11240,6 +12057,14 @@ periodics:
         secretName: hub-token
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: release-account
       secret:
         secretName: release-account
@@ -11273,6 +12098,10 @@ periodics:
         readOnly: true
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: release-account
         mountPath: /etc/release-account
         readOnly: true
@@ -11291,6 +12120,14 @@ periodics:
         secretName: hub-token
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: release-account
       secret:
         secretName: release-account
@@ -11366,6 +12203,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -11379,6 +12220,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -11406,6 +12255,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: test-account
         mountPath: /etc/test-account
         readOnly: true
@@ -11419,6 +12272,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: test-account
       secret:
         secretName: test-account
@@ -11447,6 +12308,10 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: nightly-account
         mountPath: /etc/nightly-account
         readOnly: true
@@ -11460,6 +12325,14 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: nightly-account
       secret:
         secretName: nightly-account
@@ -11493,6 +12366,10 @@ periodics:
         readOnly: true
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: release-account
         mountPath: /etc/release-account
         readOnly: true
@@ -11511,6 +12388,14 @@ periodics:
         secretName: hub-token
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: release-account
       secret:
         secretName: release-account
@@ -11544,6 +12429,10 @@ periodics:
         readOnly: true
       - name: docker-graph
         mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
       - name: release-account
         mountPath: /etc/release-account
         readOnly: true
@@ -11562,6 +12451,14 @@ periodics:
         secretName: hub-token
     - name: docker-graph
       emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
     - name: release-account
       secret:
         secretName: release-account

--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -68,6 +68,7 @@ RUN go get -u github.com/jstemmer/go-junit-report
 RUN GO111MODULE=on go get -u gotest.tools/gotestsum
 RUN GO111MODULE=on go get -u github.com/raviqqe/liche@v0.0.0-20200229003944-f57a5d1c5be4  # stable liche version for checking md links
 RUN GO111MODULE=on go get -u github.com/google/go-licenses
+RUN GO111MODULE=on go get sigs.k8s.io/kind@v0.9.0
 RUN GO111MODULE=on go get -u sigs.k8s.io/kubetest2
 RUN GO111MODULE=on go get -u sigs.k8s.io/kubetest2/kubetest2-gke
 RUN GO111MODULE=on go get -u sigs.k8s.io/kubetest2/kubetest2-kind

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -167,10 +167,12 @@ function initialize() {
 
   (( IS_PROW )) && [[ -z "${GCP_PROJECT_ID:-}" ]] && IS_BOSKOS=1
 
-  if (( SKIP_ISTIO_ADDON )); then
-    custom_flags+=("--addons=NodeLocalDNS")
-  else
-    custom_flags+=("--addons=Istio,NodeLocalDNS")
+  if [[ "${CLOUD_PROVIDER}" == "gke" ]]; then
+    if (( SKIP_ISTIO_ADDON )); then
+      custom_flags+=("--addons=NodeLocalDNS")
+    else
+      custom_flags+=("--addons=Istio,NodeLocalDNS")
+    fi
   fi
 
   readonly IS_BOSKOS

--- a/scripts/infra-library.sh
+++ b/scripts/infra-library.sh
@@ -124,8 +124,10 @@ function create_test_cluster() {
 # Parameters: $1 - extra cluster creation flags
 #             $2 - test command to run by the kubetest2 tester
 function create_kind_test_cluster() {
-  # TODO(chizhg): implement with kubetest2
-  return 0
+  local -n _custom_flags=$1
+  local -n _test_command=$2
+
+  kubetest2 kind "${_custom_flags[@]}" --up --down --test=exec -- "${_test_command[@]}"
 }
 
 # Create a GKE test cluster with kubetest2 and run the test command.

--- a/test/e2e-kind.sh
+++ b/test/e2e-kind.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source $(dirname "${BASH_SOURCE[0]}")/../scripts/e2e-tests.sh
+
+function knative_setup() {
+  start_latest_knative_serving
+}
+
+# Script entry point.
+initialize "$@" --cloud-provider kind --verbosity 9
+
+go_test_e2e ./test/e2e || fail_test
+
+success

--- a/tools/config-generator/main.go
+++ b/tools/config-generator/main.go
@@ -281,7 +281,7 @@ func addMonitoringPubsubLabelsToJob(data *baseProwJobTemplateData, runID string)
 }
 
 // addVolumeToJob adds the given mount path as volume for the job.
-func addVolumeToJob(data *baseProwJobTemplateData, mountPath, name string, isSecret bool, defaultMode string) {
+func addVolumeToJob(data *baseProwJobTemplateData, mountPath, name string, isSecret bool, content []string) {
 	(*data).VolumeMounts = append((*data).VolumeMounts, []string{"- name: " + name, "  mountPath: " + mountPath}...)
 	if isSecret {
 		(*data).VolumeMounts = append((*data).VolumeMounts, "  readOnly: true")
@@ -289,12 +289,10 @@ func addVolumeToJob(data *baseProwJobTemplateData, mountPath, name string, isSec
 	s := []string{"- name: " + name}
 	if isSecret {
 		arr := []string{"  secret:", "    secretName: " + name}
-		if len(defaultMode) > 0 {
-			arr = append(arr, "    defaultMode: "+defaultMode)
-		}
 		s = append(s, arr...)
-	} else {
-		s = append(s, "  emptyDir: {}")
+	}
+	for _, line := range content {
+		s = append(s, "  "+line)
 	}
 	(*data).Volumes = append((*data).Volumes, s...)
 }
@@ -309,7 +307,7 @@ func configureServiceAccountForJob(data *baseProwJobTemplateData) {
 		log.Fatalf("Service account path %q is expected to be \"/etc/<name>/service-account.json\"", data.ServiceAccount)
 	}
 	name := p[2]
-	addVolumeToJob(data, "/etc/"+name, name, true, "")
+	addVolumeToJob(data, "/etc/"+name, name, true, nil)
 }
 
 // addExtraEnvVarsToJob adds extra environment variables to a job.
@@ -325,7 +323,9 @@ func addExtraEnvVarsToJob(envVars []string, data *baseProwJobTemplateData) {
 
 // setupDockerInDockerForJob enables docker-in-docker for the given job.
 func setupDockerInDockerForJob(data *baseProwJobTemplateData) {
-	addVolumeToJob(data, "/docker-graph", "docker-graph", false, "")
+	addVolumeToJob(data, "/docker-graph", "docker-graph", false, []string{"emptyDir: {}"})
+	addVolumeToJob(data, "/lib/modules", "modules", false, []string{"hostPath:", "  path: /lib/modules", "  type: Directory"})
+	addVolumeToJob(data, "/sys/fs/cgroup", "cgroup", false, []string{"hostPath:", "  path: /sys/fs/cgroup", "  type: Directory"})
 	data.addEnvToJob("DOCKER_IN_DOCKER_ENABLED", "\"true\"")
 	(*data).SecurityContext = []string{"privileged: true"}
 }

--- a/tools/config-generator/main.go
+++ b/tools/config-generator/main.go
@@ -323,6 +323,8 @@ func addExtraEnvVarsToJob(envVars []string, data *baseProwJobTemplateData) {
 
 // setupDockerInDockerForJob enables docker-in-docker for the given job.
 func setupDockerInDockerForJob(data *baseProwJobTemplateData) {
+	// These volumes are required for running docker command and creating kind clusters.
+	// Reference: https://github.com/kubernetes-sigs/kind/issues/303
 	addVolumeToJob(data, "/docker-graph", "docker-graph", false, []string{"emptyDir: {}"})
 	addVolumeToJob(data, "/lib/modules", "modules", false, []string{"hostPath:", "  path: /lib/modules", "  type: Directory"})
 	addVolumeToJob(data, "/sys/fs/cgroup", "cgroup", false, []string{"hostPath:", "  path: /sys/fs/cgroup", "  type: Directory"})

--- a/tools/config-generator/perf_config.go
+++ b/tools/config-generator/perf_config.go
@@ -91,7 +91,7 @@ func perfClusterBaseProwJob(command string, args []string, fullRepoName, sa stri
 	base := newbaseProwJobTemplateData(fullRepoName)
 	base.Command = command
 	base.Args = args
-	addVolumeToJob(&base, "/etc/performance-test", sa, true, "")
+	addVolumeToJob(&base, "/etc/performance-test", sa, true, nil)
 	base.addEnvToJob("GOOGLE_APPLICATION_CREDENTIALS", "/etc/performance-test/service-account.json")
 	base.addEnvToJob("GITHUB_TOKEN", "/etc/performance-test/github-token")
 	base.addEnvToJob("SLACK_READ_TOKEN", "/etc/performance-test/slack-read-token")

--- a/tools/config-generator/periodic_config.go
+++ b/tools/config-generator/periodic_config.go
@@ -186,7 +186,7 @@ func generatePeriodic(title string, repoName string, periodicConfig yaml.MapSlic
 				"--release-gcs " + data.Base.ReleaseGcs,
 				"--release-gcr gcr.io/knative-releases",
 				"--github-token /etc/hub-token/token"}
-			addVolumeToJob(&data.Base, "/etc/hub-token", "hub-token", true, "")
+			addVolumeToJob(&data.Base, "/etc/hub-token", "hub-token", true, nil)
 			// For dot-release and auto-release jobs, set ORG_NAME env var if the org name is not knative, as it's needed by release.sh
 			if data.Base.OrgName != "knative" {
 				data.Base.addEnvToJob("ORG_NAME", data.Base.OrgName)

--- a/tools/config-generator/presubmit_config.go
+++ b/tools/config-generator/presubmit_config.go
@@ -65,7 +65,7 @@ func generatePresubmit(title string, repoName string, presubmitConfig yaml.MapSl
 			if len(data.Base.Args) == 0 {
 				data.Base.Args = []string{"--" + jobName}
 			}
-			addVolumeToJob(&data.Base, "/etc/repoview-token", "repoview-token", true, "")
+			addVolumeToJob(&data.Base, "/etc/repoview-token", "repoview-token", true, nil)
 		case "go-coverage":
 			if !getBool(item.Value) {
 				return
@@ -74,7 +74,7 @@ func generatePresubmit(title string, repoName string, presubmitConfig yaml.MapSl
 			data.PresubmitJobName = data.Base.RepoNameForJob + "-go-coverage"
 			data.Base.ServiceAccount = ""
 			repoData.EnableGoCoverage = true
-			addVolumeToJob(&data.Base, "/etc/covbot-token", "covbot-token", true, "")
+			addVolumeToJob(&data.Base, "/etc/covbot-token", "covbot-token", true, nil)
 		case "custom-test":
 			data.PresubmitJobName = data.Base.RepoNameForJob + "-" + getString(item.Value)
 		case "go-coverage-threshold":


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #

**Special notes to reviewers**:
1. `config-generator` adds configuration to Prow jobs that has `needs-dind: true` to allow creating `kind` clusters in Prow job pods
2. Add a Prow job for test-infra repo to run a smoke integration tests Prow job with `kind`


/cc