### PR TITLE
Add eventing-awssqs sandbox repo for continuous testing/release

### DIFF
--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -676,6 +676,10 @@ periodics:
         memory: 12Gi
       limits:
         memory: 16Gi
+  knative-sandbox/eventing-awssqs:
+  - continuous: true
+  - nightly: true
+  - auto-release: true
   knative-sandbox/eventing-couchdb:
   - continuous: true
   - nightly: true

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -8110,6 +8110,146 @@ periodics:
       - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
+- cron: "21 * * * *"
+  name: ci-knative-sandbox-eventing-awssqs-continuous
+  agent: kubernetes
+  decorate: true
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative-sandbox
+    repo: eventing-awssqs
+    path_alias: knative.dev/eventing-awssqs
+    base_ref: master
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./test/presubmit-tests.sh"
+      - "--all-tests"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "25 8,11,22 * * *"
+  name: ci-knative-sandbox-eventing-awssqs-continuous-beta-prow-tests
+  agent: kubernetes
+  decorate: true
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative-sandbox
+    repo: eventing-awssqs
+    path_alias: knative.dev/eventing-awssqs
+    base_ref: master
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:beta
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./test/presubmit-tests.sh"
+      - "--all-tests"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "51 9 * * *"
+  name: ci-knative-sandbox-eventing-awssqs-nightly-release
+  agent: kubernetes
+  decorate: true
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative-sandbox
+    repo: eventing-awssqs
+    path_alias: knative.dev/eventing-awssqs
+    base_ref: master
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--publish"
+      - "--tag-release"
+      volumeMounts:
+      - name: nightly-account
+        mountPath: /etc/nightly-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/nightly-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: nightly-account
+      secret:
+        secretName: nightly-account
+- cron: "21 */2 * * *"
+  name: ci-knative-sandbox-eventing-awssqs-auto-release
+  agent: kubernetes
+  decorate: true
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative-sandbox
+    repo: eventing-awssqs
+    path_alias: knative.dev/eventing-awssqs
+    base_ref: master
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--auto-release"
+      - "--release-gcs knative-releases/eventing-awssqs"
+      - "--release-gcr gcr.io/knative-releases"
+      - "--github-token /etc/hub-token/token"
+      volumeMounts:
+      - name: hub-token
+        mountPath: /etc/hub-token
+        readOnly: true
+      - name: release-account
+        mountPath: /etc/release-account
+        readOnly: true
+      env:
+      - name: ORG_NAME
+        value: knative-sandbox
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: hub-token
+      secret:
+        secretName: hub-token
+    - name: release-account
+      secret:
+        secretName: release-account
 - cron: "37 * * * *"
   name: ci-knative-sandbox-eventing-couchdb-continuous
   agent: kubernetes

--- a/config/prod/prow/testgrid/testgrid.yaml
+++ b/config/prod/prow/testgrid/testgrid.yaml
@@ -395,6 +395,19 @@ test_groups:
   alert_options:
     alert_mail_to_addresses: "serverless-engprod-sea@google.com"
   num_failures_to_alert: 3
+- name: ci-knative-sandbox-eventing-awssqs-continuous
+  gcs_prefix: knative-prow/logs/ci-knative-sandbox-eventing-awssqs-continuous
+  alert_stale_results_hours: 3
+- name: ci-knative-sandbox-eventing-awssqs-nightly-release
+  gcs_prefix: knative-prow/logs/ci-knative-sandbox-eventing-awssqs-nightly-release
+  alert_options:
+    alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+  num_failures_to_alert: 1
+- name: ci-knative-sandbox-eventing-awssqs-auto-release
+  gcs_prefix: knative-prow/logs/ci-knative-sandbox-eventing-awssqs-auto-release
+  alert_options:
+    alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+  num_failures_to_alert: 1
 - name: ci-knative-sandbox-eventing-couchdb-continuous
   gcs_prefix: knative-prow/logs/ci-knative-sandbox-eventing-couchdb-continuous
   alert_stale_results_hours: 3
@@ -807,6 +820,8 @@ test_groups:
 - name: ci-knative-eventing-contrib-go-coverage-beta-prow-tests
   gcs_prefix: knative-prow/logs/ci-knative-eventing-contrib-go-coverage-beta-prow-tests
   short_text_metric: "coverage"
+- name: ci-knative-sandbox-eventing-awssqs-continuous-beta-prow-tests
+  gcs_prefix: knative-prow/logs/ci-knative-sandbox-eventing-awssqs-continuous-beta-prow-tests
 - name: ci-knative-sandbox-eventing-couchdb-continuous-beta-prow-tests
   gcs_prefix: knative-prow/logs/ci-knative-sandbox-eventing-couchdb-continuous-beta-prow-tests
 - name: ci-knative-sandbox-eventing-github-continuous-beta-prow-tests
@@ -1172,6 +1187,26 @@ dashboards:
   - name: coverage
     test_group_name: ci-knative-operator-test-coverage
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
+- name: eventing-awssqs
+  dashboard_tab:
+  - name: continuous
+    test_group_name: ci-knative-sandbox-eventing-awssqs-continuous
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
+  - name: nightly
+    test_group_name: ci-knative-sandbox-eventing-awssqs-nightly-release
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 1
+  - name: auto-release
+    test_group_name: ci-knative-sandbox-eventing-awssqs-auto-release
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 1
 - name: eventing-couchdb
   dashboard_tab:
   - name: continuous
@@ -1955,6 +1990,9 @@ dashboards:
   - name: ci-knative-eventing-contrib-go-coverage
     test_group_name: ci-knative-eventing-contrib-go-coverage-beta-prow-tests
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
+  - name: ci-knative-sandbox-eventing-awssqs-continuous
+    test_group_name: ci-knative-sandbox-eventing-awssqs-continuous-beta-prow-tests
+    base_options: "sort-by-failures="
   - name: ci-knative-sandbox-eventing-couchdb-continuous
     test_group_name: ci-knative-sandbox-eventing-couchdb-continuous-beta-prow-tests
     base_options: "sort-by-failures="
@@ -2125,6 +2163,7 @@ dashboard_groups:
   - "operator"
 - name: knative-sandbox
   dashboard_names:
+  - "eventing-awssqs"
   - "eventing-couchdb"
   - "eventing-github"
   - "eventing-gitlab"


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
eventing contrib is moving components to sandbox repos, this is to ensure we have nightly releases & continuous tests for eventing-awssqs
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #knative/community#232


