### PR TITLE
Add prometheus & ceph sources

### DIFF
--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -680,6 +680,8 @@ periodics:
   - continuous: true
   - nightly: true
   - auto-release: true
+  knative-sandbox/eventing-ceph:
+  - continuous: true
   knative-sandbox/eventing-couchdb:
   - continuous: true
   - nightly: true
@@ -689,6 +691,10 @@ periodics:
   - nightly: true
   - auto-release: true
   knative-sandbox/eventing-gitlab:
+  - continuous: true
+  - nightly: true
+  - auto-release: true
+  knative-sandbox/eventing-prometheus:
   - continuous: true
   - nightly: true
   - auto-release: true

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -8250,6 +8250,70 @@ periodics:
     - name: release-account
       secret:
         secretName: release-account
+- cron: "27 * * * *"
+  name: ci-knative-sandbox-eventing-ceph-continuous
+  agent: kubernetes
+  decorate: true
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative-sandbox
+    repo: eventing-ceph
+    path_alias: knative.dev/eventing-ceph
+    base_ref: master
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./test/presubmit-tests.sh"
+      - "--all-tests"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "55 8,11,22 * * *"
+  name: ci-knative-sandbox-eventing-ceph-continuous-beta-prow-tests
+  agent: kubernetes
+  decorate: true
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative-sandbox
+    repo: eventing-ceph
+    path_alias: knative.dev/eventing-ceph
+    base_ref: master
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:beta
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./test/presubmit-tests.sh"
+      - "--all-tests"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
 - cron: "37 * * * *"
   name: ci-knative-sandbox-eventing-couchdb-continuous
   agent: kubernetes
@@ -8647,6 +8711,146 @@ periodics:
       - "./hack/release.sh"
       - "--auto-release"
       - "--release-gcs knative-releases/eventing-gitlab"
+      - "--release-gcr gcr.io/knative-releases"
+      - "--github-token /etc/hub-token/token"
+      volumeMounts:
+      - name: hub-token
+        mountPath: /etc/hub-token
+        readOnly: true
+      - name: release-account
+        mountPath: /etc/release-account
+        readOnly: true
+      env:
+      - name: ORG_NAME
+        value: knative-sandbox
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: hub-token
+      secret:
+        secretName: hub-token
+    - name: release-account
+      secret:
+        secretName: release-account
+- cron: "7 * * * *"
+  name: ci-knative-sandbox-eventing-prometheus-continuous
+  agent: kubernetes
+  decorate: true
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative-sandbox
+    repo: eventing-prometheus
+    path_alias: knative.dev/eventing-prometheus
+    base_ref: master
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./test/presubmit-tests.sh"
+      - "--all-tests"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "11 8,11,22 * * *"
+  name: ci-knative-sandbox-eventing-prometheus-continuous-beta-prow-tests
+  agent: kubernetes
+  decorate: true
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative-sandbox
+    repo: eventing-prometheus
+    path_alias: knative.dev/eventing-prometheus
+    base_ref: master
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:beta
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./test/presubmit-tests.sh"
+      - "--all-tests"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "37 9 * * *"
+  name: ci-knative-sandbox-eventing-prometheus-nightly-release
+  agent: kubernetes
+  decorate: true
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative-sandbox
+    repo: eventing-prometheus
+    path_alias: knative.dev/eventing-prometheus
+    base_ref: master
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--publish"
+      - "--tag-release"
+      volumeMounts:
+      - name: nightly-account
+        mountPath: /etc/nightly-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/nightly-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: nightly-account
+      secret:
+        secretName: nightly-account
+- cron: "11 */2 * * *"
+  name: ci-knative-sandbox-eventing-prometheus-auto-release
+  agent: kubernetes
+  decorate: true
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative-sandbox
+    repo: eventing-prometheus
+    path_alias: knative.dev/eventing-prometheus
+    base_ref: master
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--auto-release"
+      - "--release-gcs knative-releases/eventing-prometheus"
       - "--release-gcr gcr.io/knative-releases"
       - "--github-token /etc/hub-token/token"
       volumeMounts:

--- a/config/prod/prow/testgrid/testgrid.yaml
+++ b/config/prod/prow/testgrid/testgrid.yaml
@@ -408,6 +408,9 @@ test_groups:
   alert_options:
     alert_mail_to_addresses: "serverless-engprod-sea@google.com"
   num_failures_to_alert: 1
+- name: ci-knative-sandbox-eventing-ceph-continuous
+  gcs_prefix: knative-prow/logs/ci-knative-sandbox-eventing-ceph-continuous
+  alert_stale_results_hours: 3
 - name: ci-knative-sandbox-eventing-couchdb-continuous
   gcs_prefix: knative-prow/logs/ci-knative-sandbox-eventing-couchdb-continuous
   alert_stale_results_hours: 3
@@ -444,6 +447,19 @@ test_groups:
   num_failures_to_alert: 1
 - name: ci-knative-sandbox-eventing-gitlab-auto-release
   gcs_prefix: knative-prow/logs/ci-knative-sandbox-eventing-gitlab-auto-release
+  alert_options:
+    alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+  num_failures_to_alert: 1
+- name: ci-knative-sandbox-eventing-prometheus-continuous
+  gcs_prefix: knative-prow/logs/ci-knative-sandbox-eventing-prometheus-continuous
+  alert_stale_results_hours: 3
+- name: ci-knative-sandbox-eventing-prometheus-nightly-release
+  gcs_prefix: knative-prow/logs/ci-knative-sandbox-eventing-prometheus-nightly-release
+  alert_options:
+    alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+  num_failures_to_alert: 1
+- name: ci-knative-sandbox-eventing-prometheus-auto-release
+  gcs_prefix: knative-prow/logs/ci-knative-sandbox-eventing-prometheus-auto-release
   alert_options:
     alert_mail_to_addresses: "serverless-engprod-sea@google.com"
   num_failures_to_alert: 1
@@ -822,12 +838,16 @@ test_groups:
   short_text_metric: "coverage"
 - name: ci-knative-sandbox-eventing-awssqs-continuous-beta-prow-tests
   gcs_prefix: knative-prow/logs/ci-knative-sandbox-eventing-awssqs-continuous-beta-prow-tests
+- name: ci-knative-sandbox-eventing-ceph-continuous-beta-prow-tests
+  gcs_prefix: knative-prow/logs/ci-knative-sandbox-eventing-ceph-continuous-beta-prow-tests
 - name: ci-knative-sandbox-eventing-couchdb-continuous-beta-prow-tests
   gcs_prefix: knative-prow/logs/ci-knative-sandbox-eventing-couchdb-continuous-beta-prow-tests
 - name: ci-knative-sandbox-eventing-github-continuous-beta-prow-tests
   gcs_prefix: knative-prow/logs/ci-knative-sandbox-eventing-github-continuous-beta-prow-tests
 - name: ci-knative-sandbox-eventing-gitlab-continuous-beta-prow-tests
   gcs_prefix: knative-prow/logs/ci-knative-sandbox-eventing-gitlab-continuous-beta-prow-tests
+- name: ci-knative-sandbox-eventing-prometheus-continuous-beta-prow-tests
+  gcs_prefix: knative-prow/logs/ci-knative-sandbox-eventing-prometheus-continuous-beta-prow-tests
 - name: ci-knative-pkg-continuous-beta-prow-tests
   gcs_prefix: knative-prow/logs/ci-knative-pkg-continuous-beta-prow-tests
 - name: ci-knative-pkg-go-coverage-beta-prow-tests
@@ -1207,6 +1227,14 @@ dashboards:
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
     num_failures_to_alert: 1
+- name: eventing-ceph
+  dashboard_tab:
+  - name: continuous
+    test_group_name: ci-knative-sandbox-eventing-ceph-continuous
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
 - name: eventing-couchdb
   dashboard_tab:
   - name: continuous
@@ -1263,6 +1291,26 @@ dashboards:
     num_failures_to_alert: 1
   - name: auto-release
     test_group_name: ci-knative-sandbox-eventing-gitlab-auto-release
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 1
+- name: eventing-prometheus
+  dashboard_tab:
+  - name: continuous
+    test_group_name: ci-knative-sandbox-eventing-prometheus-continuous
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
+  - name: nightly
+    test_group_name: ci-knative-sandbox-eventing-prometheus-nightly-release
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 1
+  - name: auto-release
+    test_group_name: ci-knative-sandbox-eventing-prometheus-auto-release
     base_options: "sort-by-name="
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
@@ -1993,6 +2041,9 @@ dashboards:
   - name: ci-knative-sandbox-eventing-awssqs-continuous
     test_group_name: ci-knative-sandbox-eventing-awssqs-continuous-beta-prow-tests
     base_options: "sort-by-failures="
+  - name: ci-knative-sandbox-eventing-ceph-continuous
+    test_group_name: ci-knative-sandbox-eventing-ceph-continuous-beta-prow-tests
+    base_options: "sort-by-failures="
   - name: ci-knative-sandbox-eventing-couchdb-continuous
     test_group_name: ci-knative-sandbox-eventing-couchdb-continuous-beta-prow-tests
     base_options: "sort-by-failures="
@@ -2001,6 +2052,9 @@ dashboards:
     base_options: "sort-by-failures="
   - name: ci-knative-sandbox-eventing-gitlab-continuous
     test_group_name: ci-knative-sandbox-eventing-gitlab-continuous-beta-prow-tests
+    base_options: "sort-by-failures="
+  - name: ci-knative-sandbox-eventing-prometheus-continuous
+    test_group_name: ci-knative-sandbox-eventing-prometheus-continuous-beta-prow-tests
     base_options: "sort-by-failures="
   - name: ci-knative-pkg-continuous
     test_group_name: ci-knative-pkg-continuous-beta-prow-tests
@@ -2164,9 +2218,11 @@ dashboard_groups:
 - name: knative-sandbox
   dashboard_names:
   - "eventing-awssqs"
+  - "eventing-ceph"
   - "eventing-couchdb"
   - "eventing-github"
   - "eventing-gitlab"
+  - "eventing-prometheus"
   - "sample-controller"
   - "sample-source"
   - "net-certmanager"


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
This address the prometheus and ceph sources being broken out from eventing-contrib to their respective eventing-foo repositories in sandbox

**Which issue(s) this PR fixes**:
Fixes: knative/community#234
Fixes: knative/community#237

