### PR TITLE
kntest kubetest2 supports --extra-gcloud-flags

### DIFF
--- a/kntest/pkg/kubetest2/gke/options.go
+++ b/kntest/pkg/kubetest2/gke/options.go
@@ -28,6 +28,7 @@ func addOptions(gkeCmd *cobra.Command, cfg *kubetest2.GKEClusterConfig) {
 	f.StringVar(&cfg.Environment, "environment", "prod", "The GKE environment, must be one of prod, staging, staging2 and test.")
 	f.StringVar(&cfg.CommandGroup, "command-group", "beta", "The gcloud command group, must be alpha, beta or empty.")
 	f.StringVar(&cfg.GCPProjectID, "gcp-project-id", "", "GCP project ID for creating the cluster")
+
 	f.StringVar(&cfg.Name, "name", "e2e-cls", "The GKE cluster name.")
 	f.StringVar(&cfg.Region, "region", "us-central1", "The region to create the GKE cluster.")
 	f.StringSliceVar(&cfg.BackupRegions, "backup-regions", []string{"us-west1", "us-east1"}, "The backup regions if the cluster creation runs into stockout issue in the primary region.")
@@ -41,8 +42,9 @@ func addOptions(gkeCmd *cobra.Command, cfg *kubetest2.GKEClusterConfig) {
 	f.StringVar(&cfg.Scopes, "scopes", "cloud-platform", "Scopes for the GKE cluster, should be comma-separated.")
 	f.StringVar(&cfg.Addons, "addons", "", "Addons for the GKE cluster, should be comma-separated.")
 	f.BoolVar(&cfg.EnableWorkloadIdentity, "enable-workload-identity", false, "Whether to enable workload identity for this cluster or not.")
-	f.BoolVar(&cfg.EnableStackdriverKubernetes, "enable-stackdriver-kubernetes", false, "Whether to enable Stackdriver Kubernetes monitoring and logging or not.")
 	f.StringVar(&cfg.PrivateClusterAccessLevel, "private-cluster-access-level", "", "Private cluster access level, if not empty, must be one of 'no', 'limited' or 'unrestricted'")
 	f.StringVar(&cfg.PrivateClusterMasterIPSubnetRange, "private-cluster-master-ip-subnet-range", "172.16.0", "The master IP subnet range for the private cluster. The last digit must be left empty to allow retrying cluster creation in the backup regions.")
 	f.StringVar(&cfg.PrivateClusterMasterIPSubnetMask, "private-cluster-master-ip-subnet-mask", "28", "The master IP subnet mask for the private cluster.")
+
+	f.StringVar(&cfg.ExtraGcloudFlags, "extra-gcloud-flags", "", "The extra gcloud flags that will be used for cluster creation.")
 }

--- a/pkg/clustermanager/kubetest2/gke.go
+++ b/pkg/clustermanager/kubetest2/gke.go
@@ -50,9 +50,14 @@ var (
 
 // GKEClusterConfig are the supported configurations for creating a GKE cluster.
 type GKEClusterConfig struct {
-	GCPServiceAccount                 string
-	GCPProjectID                      string
-	BoskosAcquireTimeoutSeconds       int
+	GCPServiceAccount string
+	GCPProjectID      string
+
+	BoskosAcquireTimeoutSeconds int
+
+	Environment  string
+	CommandGroup string
+
 	Name                              string
 	Region                            string
 	BackupRegions                     []string
@@ -65,12 +70,11 @@ type GKEClusterConfig struct {
 	Scopes                            string
 	Addons                            string
 	EnableWorkloadIdentity            bool
-	EnableStackdriverKubernetes       bool
-	Environment                       string
-	CommandGroup                      string
 	PrivateClusterAccessLevel         string
 	PrivateClusterMasterIPSubnetRange string
 	PrivateClusterMasterIPSubnetMask  string
+
+	ExtraGcloudFlags string
 }
 
 // Run will run the `kubetest2 gke` command with the provided parameters,
@@ -87,8 +91,8 @@ func Run(opts *Options, cc *GKEClusterConfig) error {
 	if cc.Addons != "" {
 		createCommand += " --addons=" + cc.Addons
 	}
-	if cc.EnableStackdriverKubernetes {
-		createCommand += " --enable-stackdriver-kubernetes"
+	if cc.ExtraGcloudFlags != "" {
+		createCommand += " " + cc.ExtraGcloudFlags
 	}
 	kubetest2Flags := append(baseKubetest2Flags, "--create-command="+createCommand)
 

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -31,8 +31,8 @@ function knative_setup() {
 
 # Script entry point.
 initialize "$@" --max-nodes=1 --machine=e2-standard-2 \
-  --enable-workload-identity --enable-stackdriver-kubernetes \
-  --cluster-version=latest
+  --enable-workload-identity --cluster-version=latest \
+  --extra-gcloud-flags "--enable-stackdriver-kubernetes --no-enable-ip-alias --no-enable-autoupgrade"
 
 go_test_e2e ./test/e2e || fail_test
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #

**Special notes to reviewers**:

**User-visible changes in this PR**:

/cc
/hold