### PR TITLE
Permissions for Eventing's new service account

### DIFF
--- a/config/prod/build-cluster/boskos/set_up_boskos_project.sh
+++ b/config/prod/build-cluster/boskos/set_up_boskos_project.sh
@@ -49,17 +49,15 @@ readonly RESOURCES=(
     "prow-job@knative-nightly.iam.gserviceaccount.com"
     "prow-job@knative-releases.iam.gserviceaccount.com"
 
+    "roles/viewer"
+    "knative-dev@googlegroups.com"
+
+    "roles/cloudscheduler.admin"
+    "prow-job@knative-tests.iam.gserviceaccount.com"
+    "prow-job@knative-nightly.iam.gserviceaccount.com"
+    "prow-job@knative-releases.iam.gserviceaccount.com"
+
     "roles/container.admin"
-    "prow-job@knative-tests.iam.gserviceaccount.com"
-    "prow-job@knative-nightly.iam.gserviceaccount.com"
-    "prow-job@knative-releases.iam.gserviceaccount.com"
-
-    "roles/storage.admin"
-    "prow-job@knative-tests.iam.gserviceaccount.com"
-    "prow-job@knative-nightly.iam.gserviceaccount.com"
-    "prow-job@knative-releases.iam.gserviceaccount.com"
-
-    "roles/pubsub.admin"
     "prow-job@knative-tests.iam.gserviceaccount.com"
     "prow-job@knative-nightly.iam.gserviceaccount.com"
     "prow-job@knative-releases.iam.gserviceaccount.com"
@@ -69,13 +67,15 @@ readonly RESOURCES=(
     "prow-job@knative-nightly.iam.gserviceaccount.com"
     "prow-job@knative-releases.iam.gserviceaccount.com"
 
-    "roles/cloudscheduler.admin"
+    "roles/pubsub.admin"
     "prow-job@knative-tests.iam.gserviceaccount.com"
     "prow-job@knative-nightly.iam.gserviceaccount.com"
     "prow-job@knative-releases.iam.gserviceaccount.com"
 
-    "roles/viewer"
-    "knative-dev@googlegroups.com"
+    "roles/storage.admin"
+    "prow-job@knative-tests.iam.gserviceaccount.com"
+    "prow-job@knative-nightly.iam.gserviceaccount.com"
+    "prow-job@knative-releases.iam.gserviceaccount.com"
 
     # APIs to enable
     "cloudresourcemanager.googleapis.com"

--- a/config/prod/build-cluster/boskos/set_up_boskos_project.sh
+++ b/config/prod/build-cluster/boskos/set_up_boskos_project.sh
@@ -57,6 +57,9 @@ readonly RESOURCES=(
     "prow-job@knative-nightly.iam.gserviceaccount.com"
     "prow-job@knative-releases.iam.gserviceaccount.com"
 
+    "roles/cloudtrace.agent"
+    "cloud-run-events-source@prow-build-crgke.iam.gserviceaccount.com"
+
     "roles/container.admin"
     "prow-job@knative-tests.iam.gserviceaccount.com"
     "prow-job@knative-nightly.iam.gserviceaccount.com"
@@ -67,10 +70,16 @@ readonly RESOURCES=(
     "prow-job@knative-nightly.iam.gserviceaccount.com"
     "prow-job@knative-releases.iam.gserviceaccount.com"
 
+    "roles/monitoring.editor"
+    "cloud-run-events-source@prow-build-crgke.iam.gserviceaccount.com"
+
     "roles/pubsub.admin"
     "prow-job@knative-tests.iam.gserviceaccount.com"
     "prow-job@knative-nightly.iam.gserviceaccount.com"
     "prow-job@knative-releases.iam.gserviceaccount.com"
+
+    "roles/pubsub.editor"
+    "cloud-run-events-source@prow-build-crgke.iam.gserviceaccount.com"
 
     "roles/storage.admin"
     "prow-job@knative-tests.iam.gserviceaccount.com"


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Added permissions to all to cloud-run-events-source@prow-build-crgke.iam.gserviceaccount.com to boskos projects:
roles/pubsub.editor
roles/monitoring.editor 
roles/cloudtrace.agent

Needed for eventing e2e tests

Also more logically ordered the permissions.

/cc @chaodaiG 
/cc @coryrc 