### PR TITLE
Use cloud build to build the prow-tests image

### DIFF
--- a/config/prod/prow/jobs/custom/test-infra.yaml
+++ b/config/prod/prow/jobs/custom/test-infra.yaml
@@ -427,6 +427,37 @@ postsubmits:
       - name: test-account
         secret:
           secretName: test-account
+  - name: post-knative-test-infra-prow-tests-image-push
+    agent: kubernetes
+    decorate: true
+    path_alias: knative.dev/test-infra
+    max_concurrency: 1
+    cluster: "build-knative"
+    run_if_changed: "^(images/prow-tests/.*|kntest/.*|pkg/.*|go.mod)$"
+    branches:
+    - "master"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "make"
+        - "-C"
+        - "images/prow-tests"
+        - "cloud_build"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
   - name: post-knative-test-infra-deploy-tools
     agent: kubernetes
     decorate: true

--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -126,10 +126,6 @@ RUN go install knative.dev/test-infra/kntest/cmd/kntest
 # TODO(chizhg): maybe also move perf-tests tool to be part of kntest?
 RUN go install knative.dev/test-infra/pkg/clustermanager/perf-tests
 
-# reset --hard doesn't care about dirty working copy
-# This must be the last install
-RUN cd /go/src/knative.dev/test-infra && git reset --hard upstream/release-0.14 && go install knative.dev/test-infra/tools/dep-collector
-
 # Cleanup
 RUN rm -fr /go/src/knative.dev/test-infra
 RUN rm -f /usr/local/bin/source-gvm-and-run.sh

--- a/images/prow-tests/Makefile
+++ b/images/prow-tests/Makefile
@@ -17,5 +17,5 @@ include ../simple-image.mk
 
 cloud_build:
 	gcloud builds submit --config=./cloudbuild.yaml --substitutions=_TAG=$(TAG),_IMG=$(IMG) \
-		--machine-type=n1-highcpu-32 \
+		--machine-type=n1-highcpu-8 \
 		--project=$(PROJECT) --timeout=1h ./../..

--- a/images/prow-tests/README.md
+++ b/images/prow-tests/README.md
@@ -29,8 +29,8 @@ something complicated, do some rudimentary exploration in the image by running
 
 With an image you feel comfortable with deploying, create a PR to
 knative/test-infra and get approval. Once merged, pull upstream into your master
-branch and run `make cloud_build`. This will upload your image to the registry at
-http://gcr.io/knative-tests/test-infra/prow-tests with a date-commit_hash,
+branch and run `make cloud_build`. This will upload your image to the registry
+at http://gcr.io/knative-tests/test-infra/prow-tests with a date-commit_hash,
 `latest`, and `beta` tags. Let the image run at least a single overnight and
 ensure the jobs in the https://testgrid.knative.dev/beta-prow-tests testgrid are
 as good as the jobs at https://testgrid.knative.dev/knative for master branch

--- a/images/prow-tests/README.md
+++ b/images/prow-tests/README.md
@@ -14,9 +14,9 @@ See parent README.md
 
 ## Testing and Deploying Images
 
-When `make cloud_build` is run for `prow-tests`, it publishes your image with the
-`:beta` label. At night Pacific time, a set of duplicate jobs are run using this
-new image and viewable at https://testgrid.knative.dev/beta-prow-tests
+When `make cloud_build` is run for `prow-tests`, it publishes your image with
+the `:beta` label. At night Pacific time, a set of duplicate jobs are run using
+this new image and viewable at https://testgrid.knative.dev/beta-prow-tests
 
 A normal release process would involve first editing Dockerfile and/or programs
 it installs from test-infra, then running `make iterative-build` to build a

--- a/images/prow-tests/README.md
+++ b/images/prow-tests/README.md
@@ -14,7 +14,7 @@ See parent README.md
 
 ## Testing and Deploying Images
 
-When `make push` is run for `prow-tests`, it publishes your image with the
+When `make cloud_build` is run for `prow-tests`, it publishes your image with the
 `:beta` label. At night Pacific time, a set of duplicate jobs are run using this
 new image and viewable at https://testgrid.knative.dev/beta-prow-tests
 
@@ -29,7 +29,7 @@ something complicated, do some rudimentary exploration in the image by running
 
 With an image you feel comfortable with deploying, create a PR to
 knative/test-infra and get approval. Once merged, pull upstream into your master
-branch and run `make push`. This will upload your image to the registry at
+branch and run `make cloud_build`. This will upload your image to the registry at
 http://gcr.io/knative-tests/test-infra/prow-tests with a date-commit_hash,
 `latest`, and `beta` tags. Let the image run at least a single overnight and
 ensure the jobs in the https://testgrid.knative.dev/beta-prow-tests testgrid are

--- a/images/prow-tests/cloudbuild.yaml
+++ b/images/prow-tests/cloudbuild.yaml
@@ -1,4 +1,4 @@
-# Copyright 2019 The Knative Authors
+# Copyright 2020 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,10 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-IMAGE_NAME = prow-tests
-include ../simple-image.mk
-
-cloud_build:
-	gcloud builds submit --config=./cloudbuild.yaml --substitutions=_TAG=$(TAG),_IMG=$(IMG) \
-		--machine-type=n1-highcpu-32 \
-		--project=$(PROJECT) --timeout=1h ./../..
+steps:
+- name: gcr.io/cloud-builders/docker
+  args: ['build', '--no-cache', '--pull', '-t',
+         '${_IMG}:${_TAG}',
+         '-f', 'images/prow-tests/Dockerfile', '.']
+- name: gcr.io/cloud-builders/docker
+  args: [ 'tag',
+          '${_IMG}:${_TAG}',
+          '${_IMG}:beta']
+- name: gcr.io/cloud-builders/docker
+  args: [ 'tag',
+          '${_IMG}:${_TAG}',
+          '${_IMG}:latest']
+images:
+- '${_IMG}:${_TAG}'
+- '${_IMG}:beta'
+- '${_IMG}:latest'

--- a/images/prow-tests/cloudbuild.yaml
+++ b/images/prow-tests/cloudbuild.yaml
@@ -14,17 +14,25 @@
 
 steps:
 - name: gcr.io/cloud-builders/docker
-  args: ['build', '--no-cache', '--pull', '-t',
-         '${_IMG}:${_TAG}',
-         '-f', 'images/prow-tests/Dockerfile', '.']
+  args:
+  - 'build'
+  - '--no-cache'
+  - '--pull'
+  - '-t'
+  - '${_IMG}:${_TAG}'
+  - '-f'
+  - 'images/prow-tests/Dockerfile'
+  - '.'
 - name: gcr.io/cloud-builders/docker
-  args: [ 'tag',
-          '${_IMG}:${_TAG}',
-          '${_IMG}:beta']
+  args:
+  - 'tag'
+  - '${_IMG}:${_TAG}'
+  - '${_IMG}:beta'
 - name: gcr.io/cloud-builders/docker
-  args: [ 'tag',
-          '${_IMG}:${_TAG}',
-          '${_IMG}:latest']
+  args:
+  - 'tag'
+  - '${_IMG}:${_TAG}'
+  - '${_IMG}:latest'
 images:
 - '${_IMG}:${_TAG}'
 - '${_IMG}:beta'


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
1. Use cloud build to build the prow-tests image
2. Add a postsubmit job to auto push the image if related files change

I have tested it in https://prow.knative.dev/view/gs/knative-prow/logs/post-knative-test-infra-image-push-test-chizhg/1308608127268032512 

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #2434 

/cc @coryrc @chaodaiG @albertomilan 


