### PR TITLE
enable prow to send slack messages for nightly discovery failures

### DIFF
--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -886,6 +886,12 @@ periodics:
   knative-sandbox/discovery:
   - continuous: true
   - nightly: true
+    reporter_config:
+      slack:
+        channel: eventing-sources
+        job_states_to_report:
+        - failure
+        report_template: '"The nightly release job for discovery failed, check the log: <{{.Status.URL}}|View logs>"'
   - dot-release: true
   - auto-release: true
   knative-sandbox/eventing-kafka:

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -12497,6 +12497,12 @@ periodics:
   name: ci-knative-sandbox-discovery-nightly-release
   agent: kubernetes
   decorate: true
+  reporter_config:
+    slack:
+      channel: eventing-sources
+      report_template: "The nightly release job for discovery failed, check the log: <{{.Status.URL}}|View logs>"
+      job_states_to_report:
+      - "failure"
   cluster: "build-knative"
   extra_refs:
   - org: knative-sandbox


### PR DESCRIPTION
will send errors to #eventing-sources