### PR TITLE
Disable the bespoke coverage job for a few repos.

### DIFF
--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -21,8 +21,7 @@ presubmits:
         memory: 12Gi
       limits:
         memory: 16Gi
-  - go-coverage: true
-    go-coverage-threshold: 80
+  - go-coverage: false
   - custom-test: istio-latest-mesh
     needs-monitor: true
     always-run: false
@@ -322,7 +321,7 @@ presubmits:
   - build-tests: true
   - unit-tests: true
   - integration-tests: true
-  - go-coverage: true
+  - go-coverage: false
   knative/test-infra:
   - build-tests: true
   - unit-tests: true
@@ -341,7 +340,7 @@ presubmits:
   - build-tests: true
   - unit-tests: true
   - integration-tests: true
-  - go-coverage: true
+  - go-coverage: false
   knative-sandbox/sample-controller:
   - build-tests: true
   - unit-tests: true
@@ -383,7 +382,7 @@ presubmits:
   - build-tests: true
   - unit-tests: true
   - integration-tests: true
-  - go-coverage: true
+  - go-coverage: false
   knative-sandbox/net-certmanager:
   - build-tests: true
   - unit-tests: true
@@ -393,12 +392,12 @@ presubmits:
   - build-tests: true
   - unit-tests: true
   - integration-tests: true
-  - go-coverage: true
+  - go-coverage: false
   knative-sandbox/net-http01:
   - build-tests: true
   - unit-tests: true
   - integration-tests: true
-  - go-coverage: true
+  - go-coverage: false
   knative-sandbox/net-istio:
   - build-tests: true
   - unit-tests: true

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -143,66 +143,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-serving-go-coverage
-    agent: kubernetes
-    context: pull-knative-serving-go-coverage
-    always_run: true
-    rerun_command: "/test pull-knative-serving-go-coverage"
-    trigger: "(?m)^/test (all|pull-knative-serving-go-coverage),?(\\s+|$)"
-    optional: true
-    decorate: true
-    path_alias: knative.dev/serving
-    cluster: "build-knative"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "coverage"
-        - "--postsubmit-job-name=post-knative-serving-go-coverage"
-        - "--artifacts=$(ARTIFACTS)"
-        - "--cov-threshold-percentage=80"
-        - "--github-token=/etc/covbot-token/token"
-        volumeMounts:
-        - name: covbot-token
-          mountPath: /etc/covbot-token
-          readOnly: true
-      volumes:
-      - name: covbot-token
-        secret:
-          secretName: covbot-token
-  - name: pull-knative-serving-go-coverage-dev
-    agent: kubernetes
-    context: pull-knative-serving-go-coverage-dev
-    always_run: false
-    rerun_command: "/test pull-knative-serving-go-coverage-dev"
-    trigger: "(?m)^/test (pull-knative-serving-go-coverage-dev),?(\\s+|$)"
-    optional: true
-    decorate: true
-    path_alias: knative.dev/serving
-    cluster: "build-knative"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:coverage-dev
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "coverage"
-        - "--postsubmit-job-name=post-knative-serving-go-coverage"
-        - "--artifacts=$(ARTIFACTS)"
-        - "--cov-threshold-percentage=80"
-        - "--github-token=/etc/covbot-token/token"
-        volumeMounts:
-        - name: covbot-token
-          mountPath: /etc/covbot-token
-          readOnly: true
-      volumes:
-      - name: covbot-token
-        secret:
-          secretName: covbot-token
   - name: pull-knative-serving-istio-latest-mesh
     agent: kubernetes
     labels:
@@ -1959,36 +1899,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-pkg-go-coverage
-    agent: kubernetes
-    context: pull-knative-pkg-go-coverage
-    always_run: true
-    rerun_command: "/test pull-knative-pkg-go-coverage"
-    trigger: "(?m)^/test (all|pull-knative-pkg-go-coverage),?(\\s+|$)"
-    optional: true
-    decorate: true
-    path_alias: knative.dev/pkg
-    cluster: "build-knative"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "coverage"
-        - "--postsubmit-job-name=post-knative-pkg-go-coverage"
-        - "--artifacts=$(ARTIFACTS)"
-        - "--cov-threshold-percentage=50"
-        - "--github-token=/etc/covbot-token/token"
-        volumeMounts:
-        - name: covbot-token
-          mountPath: /etc/covbot-token
-          readOnly: true
-      volumes:
-      - name: covbot-token
-        secret:
-          secretName: covbot-token
   knative/test-infra:
   - name: pull-knative-test-infra-build-tests
     agent: kubernetes
@@ -2296,36 +2206,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-caching-go-coverage
-    agent: kubernetes
-    context: pull-knative-caching-go-coverage
-    always_run: true
-    rerun_command: "/test pull-knative-caching-go-coverage"
-    trigger: "(?m)^/test (all|pull-knative-caching-go-coverage),?(\\s+|$)"
-    optional: true
-    decorate: true
-    path_alias: knative.dev/caching
-    cluster: "build-knative"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "coverage"
-        - "--postsubmit-job-name=post-knative-caching-go-coverage"
-        - "--artifacts=$(ARTIFACTS)"
-        - "--cov-threshold-percentage=50"
-        - "--github-token=/etc/covbot-token/token"
-        volumeMounts:
-        - name: covbot-token
-          mountPath: /etc/covbot-token
-          readOnly: true
-      volumes:
-      - name: covbot-token
-        secret:
-          secretName: covbot-token
   knative-sandbox/sample-controller:
   - name: pull-knative-sandbox-sample-controller-build-tests
     agent: kubernetes
@@ -2781,36 +2661,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-networking-go-coverage
-    agent: kubernetes
-    context: pull-knative-networking-go-coverage
-    always_run: true
-    rerun_command: "/test pull-knative-networking-go-coverage"
-    trigger: "(?m)^/test (all|pull-knative-networking-go-coverage),?(\\s+|$)"
-    optional: true
-    decorate: true
-    path_alias: knative.dev/networking
-    cluster: "build-knative"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "coverage"
-        - "--postsubmit-job-name=post-knative-networking-go-coverage"
-        - "--artifacts=$(ARTIFACTS)"
-        - "--cov-threshold-percentage=50"
-        - "--github-token=/etc/covbot-token/token"
-        volumeMounts:
-        - name: covbot-token
-          mountPath: /etc/covbot-token
-          readOnly: true
-      volumes:
-      - name: covbot-token
-        secret:
-          secretName: covbot-token
   knative-sandbox/net-certmanager:
   - name: pull-knative-sandbox-net-certmanager-build-tests
     agent: kubernetes
@@ -3065,36 +2915,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-sandbox-net-contour-go-coverage
-    agent: kubernetes
-    context: pull-knative-sandbox-net-contour-go-coverage
-    always_run: true
-    rerun_command: "/test pull-knative-sandbox-net-contour-go-coverage"
-    trigger: "(?m)^/test (all|pull-knative-sandbox-net-contour-go-coverage),?(\\s+|$)"
-    optional: true
-    decorate: true
-    path_alias: knative.dev/net-contour
-    cluster: "build-knative"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "coverage"
-        - "--postsubmit-job-name=post-knative-sandbox-net-contour-go-coverage"
-        - "--artifacts=$(ARTIFACTS)"
-        - "--cov-threshold-percentage=50"
-        - "--github-token=/etc/covbot-token/token"
-        volumeMounts:
-        - name: covbot-token
-          mountPath: /etc/covbot-token
-          readOnly: true
-      volumes:
-      - name: covbot-token
-        secret:
-          secretName: covbot-token
   knative-sandbox/net-http01:
   - name: pull-knative-sandbox-net-http01-build-tests
     agent: kubernetes
@@ -3207,36 +3027,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-sandbox-net-http01-go-coverage
-    agent: kubernetes
-    context: pull-knative-sandbox-net-http01-go-coverage
-    always_run: true
-    rerun_command: "/test pull-knative-sandbox-net-http01-go-coverage"
-    trigger: "(?m)^/test (all|pull-knative-sandbox-net-http01-go-coverage),?(\\s+|$)"
-    optional: true
-    decorate: true
-    path_alias: knative.dev/net-http01
-    cluster: "build-knative"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "coverage"
-        - "--postsubmit-job-name=post-knative-sandbox-net-http01-go-coverage"
-        - "--artifacts=$(ARTIFACTS)"
-        - "--cov-threshold-percentage=50"
-        - "--github-token=/etc/covbot-token/token"
-        volumeMounts:
-        - name: covbot-token
-          mountPath: /etc/covbot-token
-          readOnly: true
-      volumes:
-      - name: covbot-token
-        secret:
-          secretName: covbot-token
   knative-sandbox/net-istio:
   - name: pull-knative-sandbox-net-istio-build-tests
     agent: kubernetes
@@ -5608,54 +5398,6 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "0 1 * * *"
-  name: ci-knative-serving-go-coverage
-  labels:
-      prow.k8s.io/pubsub.project: knative-tests
-      prow.k8s.io/pubsub.topic: knative-monitoring
-      prow.k8s.io/pubsub.runID: ci-knative-serving-go-coverage
-  agent: kubernetes
-  decorate: true
-  cluster: "build-knative"
-  extra_refs:
-  - org: knative
-    repo: serving
-    path_alias: knative.dev/serving
-    base_ref: master
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - "runner.sh"
-      args:
-      - "coverage"
-      - "--artifacts=$(ARTIFACTS)"
-      - "--cov-threshold-percentage=80"
-- cron: "44 7 * * *"
-  name: ci-knative-serving-go-coverage-beta-prow-tests
-  labels:
-      prow.k8s.io/pubsub.project: knative-tests
-      prow.k8s.io/pubsub.topic: knative-monitoring
-      prow.k8s.io/pubsub.runID: ci-knative-serving-go-coverage
-  agent: kubernetes
-  decorate: true
-  cluster: "build-knative"
-  extra_refs:
-  - org: knative
-    repo: serving
-    path_alias: knative.dev/serving
-    base_ref: master
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:beta
-      imagePullPolicy: Always
-      command:
-      - "runner.sh"
-      args:
-      - "coverage"
-      - "--artifacts=$(ARTIFACTS)"
-      - "--cov-threshold-percentage=80"
 - cron: "53 * * * *"
   name: ci-knative-client-continuous
   agent: kubernetes
@@ -9219,54 +8961,6 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "0 1 * * *"
-  name: ci-knative-pkg-go-coverage
-  labels:
-      prow.k8s.io/pubsub.project: knative-tests
-      prow.k8s.io/pubsub.topic: knative-monitoring
-      prow.k8s.io/pubsub.runID: ci-knative-pkg-go-coverage
-  agent: kubernetes
-  decorate: true
-  cluster: "build-knative"
-  extra_refs:
-  - org: knative
-    repo: pkg
-    path_alias: knative.dev/pkg
-    base_ref: master
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - "runner.sh"
-      args:
-      - "coverage"
-      - "--artifacts=$(ARTIFACTS)"
-      - "--cov-threshold-percentage=50"
-- cron: "38 7 * * *"
-  name: ci-knative-pkg-go-coverage-beta-prow-tests
-  labels:
-      prow.k8s.io/pubsub.project: knative-tests
-      prow.k8s.io/pubsub.topic: knative-monitoring
-      prow.k8s.io/pubsub.runID: ci-knative-pkg-go-coverage
-  agent: kubernetes
-  decorate: true
-  cluster: "build-knative"
-  extra_refs:
-  - org: knative
-    repo: pkg
-    path_alias: knative.dev/pkg
-    base_ref: master
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:beta
-      imagePullPolicy: Always
-      command:
-      - "runner.sh"
-      args:
-      - "coverage"
-      - "--artifacts=$(ARTIFACTS)"
-      - "--cov-threshold-percentage=50"
 - cron: "47 * * * *"
   name: ci-knative-caching-continuous
   agent: kubernetes
@@ -9331,54 +9025,6 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
-- cron: "0 1 * * *"
-  name: ci-knative-caching-go-coverage
-  labels:
-      prow.k8s.io/pubsub.project: knative-tests
-      prow.k8s.io/pubsub.topic: knative-monitoring
-      prow.k8s.io/pubsub.runID: ci-knative-caching-go-coverage
-  agent: kubernetes
-  decorate: true
-  cluster: "build-knative"
-  extra_refs:
-  - org: knative
-    repo: caching
-    path_alias: knative.dev/caching
-    base_ref: master
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - "runner.sh"
-      args:
-      - "coverage"
-      - "--artifacts=$(ARTIFACTS)"
-      - "--cov-threshold-percentage=50"
-- cron: "45 7 * * *"
-  name: ci-knative-caching-go-coverage-beta-prow-tests
-  labels:
-      prow.k8s.io/pubsub.project: knative-tests
-      prow.k8s.io/pubsub.topic: knative-monitoring
-      prow.k8s.io/pubsub.runID: ci-knative-caching-go-coverage
-  agent: kubernetes
-  decorate: true
-  cluster: "build-knative"
-  extra_refs:
-  - org: knative
-    repo: caching
-    path_alias: knative.dev/caching
-    base_ref: master
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:beta
-      imagePullPolicy: Always
-      command:
-      - "runner.sh"
-      args:
-      - "coverage"
-      - "--artifacts=$(ARTIFACTS)"
-      - "--cov-threshold-percentage=50"
 - cron: "5 * * * *"
   name: ci-knative-sandbox-sample-controller-continuous
   agent: kubernetes
@@ -10959,54 +10605,6 @@ periodics:
     - name: release-account
       secret:
         secretName: release-account
-- cron: "0 1 * * *"
-  name: ci-knative-sandbox-net-contour-go-coverage
-  labels:
-      prow.k8s.io/pubsub.project: knative-tests
-      prow.k8s.io/pubsub.topic: knative-monitoring
-      prow.k8s.io/pubsub.runID: ci-knative-sandbox-net-contour-go-coverage
-  agent: kubernetes
-  decorate: true
-  cluster: "build-knative"
-  extra_refs:
-  - org: knative-sandbox
-    repo: net-contour
-    path_alias: knative.dev/net-contour
-    base_ref: master
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - "runner.sh"
-      args:
-      - "coverage"
-      - "--artifacts=$(ARTIFACTS)"
-      - "--cov-threshold-percentage=50"
-- cron: "34 7 * * *"
-  name: ci-knative-sandbox-net-contour-go-coverage-beta-prow-tests
-  labels:
-      prow.k8s.io/pubsub.project: knative-tests
-      prow.k8s.io/pubsub.topic: knative-monitoring
-      prow.k8s.io/pubsub.runID: ci-knative-sandbox-net-contour-go-coverage
-  agent: kubernetes
-  decorate: true
-  cluster: "build-knative"
-  extra_refs:
-  - org: knative-sandbox
-    repo: net-contour
-    path_alias: knative.dev/net-contour
-    base_ref: master
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:beta
-      imagePullPolicy: Always
-      command:
-      - "runner.sh"
-      args:
-      - "coverage"
-      - "--artifacts=$(ARTIFACTS)"
-      - "--cov-threshold-percentage=50"
 - cron: "9 * * * *"
   name: ci-knative-sandbox-net-http01-continuous
   agent: kubernetes
@@ -11196,54 +10794,6 @@ periodics:
     - name: release-account
       secret:
         secretName: release-account
-- cron: "0 1 * * *"
-  name: ci-knative-sandbox-net-http01-go-coverage
-  labels:
-      prow.k8s.io/pubsub.project: knative-tests
-      prow.k8s.io/pubsub.topic: knative-monitoring
-      prow.k8s.io/pubsub.runID: ci-knative-sandbox-net-http01-go-coverage
-  agent: kubernetes
-  decorate: true
-  cluster: "build-knative"
-  extra_refs:
-  - org: knative-sandbox
-    repo: net-http01
-    path_alias: knative.dev/net-http01
-    base_ref: master
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - "runner.sh"
-      args:
-      - "coverage"
-      - "--artifacts=$(ARTIFACTS)"
-      - "--cov-threshold-percentage=50"
-- cron: "31 7 * * *"
-  name: ci-knative-sandbox-net-http01-go-coverage-beta-prow-tests
-  labels:
-      prow.k8s.io/pubsub.project: knative-tests
-      prow.k8s.io/pubsub.topic: knative-monitoring
-      prow.k8s.io/pubsub.runID: ci-knative-sandbox-net-http01-go-coverage
-  agent: kubernetes
-  decorate: true
-  cluster: "build-knative"
-  extra_refs:
-  - org: knative-sandbox
-    repo: net-http01
-    path_alias: knative.dev/net-http01
-    base_ref: master
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:beta
-      imagePullPolicy: Always
-      command:
-      - "runner.sh"
-      args:
-      - "coverage"
-      - "--artifacts=$(ARTIFACTS)"
-      - "--cov-threshold-percentage=50"
 - cron: "8 * * * *"
   name: ci-knative-sandbox-net-istio-continuous
   agent: kubernetes
@@ -13805,54 +13355,6 @@ periodics:
     - name: release-account
       secret:
         secretName: release-account
-- cron: "0 1 * * *"
-  name: ci-knative-networking-go-coverage
-  labels:
-      prow.k8s.io/pubsub.project: knative-tests
-      prow.k8s.io/pubsub.topic: knative-monitoring
-      prow.k8s.io/pubsub.runID: ci-knative-networking-go-coverage
-  agent: kubernetes
-  decorate: true
-  cluster: "build-knative"
-  extra_refs:
-  - org: knative
-    repo: networking
-    path_alias: knative.dev/networking
-    base_ref: master
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - "runner.sh"
-      args:
-      - "coverage"
-      - "--artifacts=$(ARTIFACTS)"
-      - "--cov-threshold-percentage=50"
-- cron: "2 7 * * *"
-  name: ci-knative-networking-go-coverage-beta-prow-tests
-  labels:
-      prow.k8s.io/pubsub.project: knative-tests
-      prow.k8s.io/pubsub.topic: knative-monitoring
-      prow.k8s.io/pubsub.runID: ci-knative-networking-go-coverage
-  agent: kubernetes
-  decorate: true
-  cluster: "build-knative"
-  extra_refs:
-  - org: knative
-    repo: networking
-    path_alias: knative.dev/networking
-    base_ref: master
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:beta
-      imagePullPolicy: Always
-      command:
-      - "runner.sh"
-      args:
-      - "coverage"
-      - "--artifacts=$(ARTIFACTS)"
-      - "--cov-threshold-percentage=50"
 - cron: "30 07 * * *"
   name: ci-knative-serving-recreate-clusters
   agent: kubernetes
@@ -14131,40 +13633,6 @@ postsubmits:
       - name: performance-test
         secret:
           secretName: performance-test
-  - name: post-knative-serving-go-coverage
-    branches:
-    - master
-    agent: kubernetes
-    decorate: true
-    cluster: "build-knative"
-    path_alias: knative.dev/serving
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "coverage"
-        - "--artifacts=$(ARTIFACTS)"
-        - "--cov-threshold-percentage=0"
-  - name: post-knative-serving-go-coverage-dev
-    branches:
-    - master
-    agent: kubernetes
-    decorate: true
-    cluster: "build-knative"
-    path_alias: knative.dev/serving
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:coverage-dev
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "coverage"
-        - "--artifacts=$(ARTIFACTS)"
-        - "--cov-threshold-percentage=0"
   knative/client:
   - name: post-knative-client-go-coverage
     branches:
@@ -14274,24 +13742,6 @@ postsubmits:
         - "coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=0"
-  knative/pkg:
-  - name: post-knative-pkg-go-coverage
-    branches:
-    - master
-    agent: kubernetes
-    decorate: true
-    cluster: "build-knative"
-    path_alias: knative.dev/pkg
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "coverage"
-        - "--artifacts=$(ARTIFACTS)"
-        - "--cov-threshold-percentage=0"
   knative/test-infra:
   - name: post-knative-test-infra-go-coverage
     branches:
@@ -14300,24 +13750,6 @@ postsubmits:
     decorate: true
     cluster: "build-knative"
     path_alias: knative.dev/test-infra
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "coverage"
-        - "--artifacts=$(ARTIFACTS)"
-        - "--cov-threshold-percentage=0"
-  knative/caching:
-  - name: post-knative-caching-go-coverage
-    branches:
-    - master
-    agent: kubernetes
-    decorate: true
-    cluster: "build-knative"
-    path_alias: knative.dev/caching
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -14382,24 +13814,6 @@ postsubmits:
         - "coverage"
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=0"
-  knative/networking:
-  - name: post-knative-networking-go-coverage
-    branches:
-    - master
-    agent: kubernetes
-    decorate: true
-    cluster: "build-knative"
-    path_alias: knative.dev/networking
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "coverage"
-        - "--artifacts=$(ARTIFACTS)"
-        - "--cov-threshold-percentage=0"
   knative-sandbox/net-certmanager:
   - name: post-knative-sandbox-net-certmanager-go-coverage
     branches:
@@ -14408,42 +13822,6 @@ postsubmits:
     decorate: true
     cluster: "build-knative"
     path_alias: knative.dev/net-certmanager
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "coverage"
-        - "--artifacts=$(ARTIFACTS)"
-        - "--cov-threshold-percentage=0"
-  knative-sandbox/net-contour:
-  - name: post-knative-sandbox-net-contour-go-coverage
-    branches:
-    - master
-    agent: kubernetes
-    decorate: true
-    cluster: "build-knative"
-    path_alias: knative.dev/net-contour
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "coverage"
-        - "--artifacts=$(ARTIFACTS)"
-        - "--cov-threshold-percentage=0"
-  knative-sandbox/net-http01:
-  - name: post-knative-sandbox-net-http01-go-coverage
-    branches:
-    - master
-    agent: kubernetes
-    decorate: true
-    cluster: "build-knative"
-    path_alias: knative.dev/net-http01
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable

--- a/config/prod/prow/testgrid/testgrid.yaml
+++ b/config/prod/prow/testgrid/testgrid.yaml
@@ -101,9 +101,6 @@ test_groups:
 - name: ci-knative-serving-webhook-apicoverage
   gcs_prefix: knative-prow/logs/ci-knative-serving-webhook-apicoverage
   alert_stale_results_hours: 48
-- name: ci-knative-serving-test-coverage
-  gcs_prefix: knative-prow/logs/ci-knative-serving-go-coverage
-  short_text_metric: "coverage"
 - name: ci-knative-client-continuous
   gcs_prefix: knative-prow/logs/ci-knative-client-continuous
   alert_stale_results_hours: 3
@@ -167,15 +164,9 @@ test_groups:
 - name: ci-knative-pkg-continuous
   gcs_prefix: knative-prow/logs/ci-knative-pkg-continuous
   alert_stale_results_hours: 3
-- name: ci-knative-pkg-test-coverage
-  gcs_prefix: knative-prow/logs/ci-knative-pkg-go-coverage
-  short_text_metric: "coverage"
 - name: ci-knative-caching-continuous
   gcs_prefix: knative-prow/logs/ci-knative-caching-continuous
   alert_stale_results_hours: 3
-- name: ci-knative-caching-test-coverage
-  gcs_prefix: knative-prow/logs/ci-knative-caching-go-coverage
-  short_text_metric: "coverage"
 - name: ci-knative-test-infra-continuous
   gcs_prefix: knative-prow/logs/ci-knative-test-infra-continuous
   alert_stale_results_hours: 3
@@ -510,9 +501,6 @@ test_groups:
   alert_options:
     alert_mail_to_addresses: "serverless-engprod-sea@google.com"
   num_failures_to_alert: 1
-- name: ci-knative-sandbox-net-contour-test-coverage
-  gcs_prefix: knative-prow/logs/ci-knative-sandbox-net-contour-go-coverage
-  short_text_metric: "coverage"
 - name: ci-knative-sandbox-net-http01-continuous
   gcs_prefix: knative-prow/logs/ci-knative-sandbox-net-http01-continuous
   alert_stale_results_hours: 3
@@ -532,9 +520,6 @@ test_groups:
   alert_options:
     alert_mail_to_addresses: "serverless-engprod-sea@google.com"
   num_failures_to_alert: 1
-- name: ci-knative-sandbox-net-http01-test-coverage
-  gcs_prefix: knative-prow/logs/ci-knative-sandbox-net-http01-go-coverage
-  short_text_metric: "coverage"
 - name: ci-knative-sandbox-net-istio-continuous
   gcs_prefix: knative-prow/logs/ci-knative-sandbox-net-istio-continuous
   alert_stale_results_hours: 3
@@ -787,9 +772,6 @@ test_groups:
   gcs_prefix: knative-prow/logs/ci-knative-serving-0.16-continuous-beta-prow-tests
 - name: ci-knative-serving-0.17-continuous-beta-prow-tests
   gcs_prefix: knative-prow/logs/ci-knative-serving-0.17-continuous-beta-prow-tests
-- name: ci-knative-serving-go-coverage-beta-prow-tests
-  gcs_prefix: knative-prow/logs/ci-knative-serving-go-coverage-beta-prow-tests
-  short_text_metric: "coverage"
 - name: ci-knative-client-continuous-beta-prow-tests
   gcs_prefix: knative-prow/logs/ci-knative-client-continuous-beta-prow-tests
 - name: ci-knative-client-0.14-continuous-beta-prow-tests
@@ -850,14 +832,8 @@ test_groups:
   gcs_prefix: knative-prow/logs/ci-knative-sandbox-eventing-prometheus-continuous-beta-prow-tests
 - name: ci-knative-pkg-continuous-beta-prow-tests
   gcs_prefix: knative-prow/logs/ci-knative-pkg-continuous-beta-prow-tests
-- name: ci-knative-pkg-go-coverage-beta-prow-tests
-  gcs_prefix: knative-prow/logs/ci-knative-pkg-go-coverage-beta-prow-tests
-  short_text_metric: "coverage"
 - name: ci-knative-caching-continuous-beta-prow-tests
   gcs_prefix: knative-prow/logs/ci-knative-caching-continuous-beta-prow-tests
-- name: ci-knative-caching-go-coverage-beta-prow-tests
-  gcs_prefix: knative-prow/logs/ci-knative-caching-go-coverage-beta-prow-tests
-  short_text_metric: "coverage"
 - name: ci-knative-sandbox-sample-controller-continuous-beta-prow-tests
   gcs_prefix: knative-prow/logs/ci-knative-sandbox-sample-controller-continuous-beta-prow-tests
 - name: ci-knative-sandbox-sample-source-continuous-beta-prow-tests
@@ -887,14 +863,8 @@ test_groups:
   short_text_metric: "coverage"
 - name: ci-knative-sandbox-net-contour-continuous-beta-prow-tests
   gcs_prefix: knative-prow/logs/ci-knative-sandbox-net-contour-continuous-beta-prow-tests
-- name: ci-knative-sandbox-net-contour-go-coverage-beta-prow-tests
-  gcs_prefix: knative-prow/logs/ci-knative-sandbox-net-contour-go-coverage-beta-prow-tests
-  short_text_metric: "coverage"
 - name: ci-knative-sandbox-net-http01-continuous-beta-prow-tests
   gcs_prefix: knative-prow/logs/ci-knative-sandbox-net-http01-continuous-beta-prow-tests
-- name: ci-knative-sandbox-net-http01-go-coverage-beta-prow-tests
-  gcs_prefix: knative-prow/logs/ci-knative-sandbox-net-http01-go-coverage-beta-prow-tests
-  short_text_metric: "coverage"
 - name: ci-knative-sandbox-net-istio-continuous-beta-prow-tests
   gcs_prefix: knative-prow/logs/ci-knative-sandbox-net-istio-continuous-beta-prow-tests
 - name: ci-knative-sandbox-net-istio-go-coverage-beta-prow-tests
@@ -932,9 +902,6 @@ test_groups:
   gcs_prefix: knative-prow/logs/ci-knative-sandbox-eventing-kafka-broker-continuous-beta-prow-tests
 - name: ci-knative-sandbox-eventing-kafka-broker-go-coverage-beta-prow-tests
   gcs_prefix: knative-prow/logs/ci-knative-sandbox-eventing-kafka-broker-go-coverage-beta-prow-tests
-  short_text_metric: "coverage"
-- name: ci-knative-networking-go-coverage-beta-prow-tests
-  gcs_prefix: knative-prow/logs/ci-knative-networking-go-coverage-beta-prow-tests
   short_text_metric: "coverage"
 - name: ci-knative-backup-artifacts
   gcs_prefix: knative-prow/logs/ci-knative-backup-artifacts
@@ -1051,9 +1018,6 @@ dashboards:
   - name: webhook-apicoverage
     test_group_name: ci-knative-serving-webhook-apicoverage
     base_options: "sort-by-name="
-  - name: coverage
-    test_group_name: ci-knative-serving-test-coverage
-    base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
 - name: client
   dashboard_tab:
   - name: continuous
@@ -1153,9 +1117,6 @@ dashboards:
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
     num_failures_to_alert: 3
-  - name: coverage
-    test_group_name: ci-knative-pkg-test-coverage
-    base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
 - name: caching
   dashboard_tab:
   - name: continuous
@@ -1164,9 +1125,6 @@ dashboards:
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
     num_failures_to_alert: 3
-  - name: coverage
-    test_group_name: ci-knative-caching-test-coverage
-    base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
 - name: test-infra
   dashboard_tab:
   - name: continuous
@@ -1386,9 +1344,6 @@ dashboards:
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
     num_failures_to_alert: 1
-  - name: coverage
-    test_group_name: ci-knative-sandbox-net-contour-test-coverage
-    base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
 - name: net-http01
   dashboard_tab:
   - name: continuous
@@ -1415,9 +1370,6 @@ dashboards:
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
     num_failures_to_alert: 1
-  - name: coverage
-    test_group_name: ci-knative-sandbox-net-http01-test-coverage
-    base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
 - name: net-istio
   dashboard_tab:
   - name: continuous
@@ -1972,9 +1924,6 @@ dashboards:
   - name: ci-knative-serving-0.17-continuous
     test_group_name: ci-knative-serving-0.17-continuous-beta-prow-tests
     base_options: "sort-by-failures="
-  - name: ci-knative-serving-go-coverage
-    test_group_name: ci-knative-serving-go-coverage-beta-prow-tests
-    base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
   - name: ci-knative-client-continuous
     test_group_name: ci-knative-client-continuous-beta-prow-tests
     base_options: "sort-by-failures="
@@ -2059,15 +2008,9 @@ dashboards:
   - name: ci-knative-pkg-continuous
     test_group_name: ci-knative-pkg-continuous-beta-prow-tests
     base_options: "sort-by-failures="
-  - name: ci-knative-pkg-go-coverage
-    test_group_name: ci-knative-pkg-go-coverage-beta-prow-tests
-    base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
   - name: ci-knative-caching-continuous
     test_group_name: ci-knative-caching-continuous-beta-prow-tests
     base_options: "sort-by-failures="
-  - name: ci-knative-caching-go-coverage
-    test_group_name: ci-knative-caching-go-coverage-beta-prow-tests
-    base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
   - name: ci-knative-sandbox-sample-controller-continuous
     test_group_name: ci-knative-sandbox-sample-controller-continuous-beta-prow-tests
     base_options: "sort-by-failures="
@@ -2107,15 +2050,9 @@ dashboards:
   - name: ci-knative-sandbox-net-contour-continuous
     test_group_name: ci-knative-sandbox-net-contour-continuous-beta-prow-tests
     base_options: "sort-by-failures="
-  - name: ci-knative-sandbox-net-contour-go-coverage
-    test_group_name: ci-knative-sandbox-net-contour-go-coverage-beta-prow-tests
-    base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
   - name: ci-knative-sandbox-net-http01-continuous
     test_group_name: ci-knative-sandbox-net-http01-continuous-beta-prow-tests
     base_options: "sort-by-failures="
-  - name: ci-knative-sandbox-net-http01-go-coverage
-    test_group_name: ci-knative-sandbox-net-http01-go-coverage-beta-prow-tests
-    base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
   - name: ci-knative-sandbox-net-istio-continuous
     test_group_name: ci-knative-sandbox-net-istio-continuous-beta-prow-tests
     base_options: "sort-by-failures="
@@ -2163,9 +2100,6 @@ dashboards:
     base_options: "sort-by-failures="
   - name: ci-knative-sandbox-eventing-kafka-broker-go-coverage
     test_group_name: ci-knative-sandbox-eventing-kafka-broker-go-coverage-beta-prow-tests
-    base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
-  - name: ci-knative-networking-go-coverage
-    test_group_name: ci-knative-networking-go-coverage-beta-prow-tests
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
 - name: utilities
   dashboard_tab:


### PR DESCRIPTION
/hold
/assign @tcnghia @markusthoemmes @vagababov 

This disables the presubmit job for a handful of repos now running codecov via actions, which also seems to disable things in testgrid (surprising 🤔 ), but generally I think the codecov UX (pre and post submit) is pretty slick.  The old leg never blocked submit, so it's really no real change from what I can see.

I'm happy to disable this for more (or less) repos, but given the set that are in here now, I've tried to tag interested parties.

cc @chaodaiG @chizhg 