### PR TITLE
[Automated] Fix misspellings

### DIFF
--- a/config/prod/build-cluster/create-build-cluster.sh
+++ b/config/prod/build-cluster/create-build-cluster.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # Runs create-build-cluster.sh with config arguments specific to the prow.knative.dev instance.
-# Requries gcloud and kubectl.
+# Requires gcloud and kubectl.
 
 # Example usage:
 # ./create-build-cluster.sh

--- a/config/prod/prow/pj-on-kind.sh
+++ b/config/prod/prow/pj-on-kind.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Runs prow/pj-on-kind.sh with config arguments specific to the prow.knative.dev instance.
-# Requries go, docker, and kubectl.
+# Requires go, docker, and kubectl.
 
 # Documentation: https://github.com/kubernetes/test-infra/blob/master/prow/build_test_update.md#using-pj-on-kindsh
 # Example usage:

--- a/tools/flaky-test-reporter/README.md
+++ b/tools/flaky-test-reporter/README.md
@@ -58,7 +58,7 @@ go run [REPO_ROOT]/tools/flaky-test-reporter --service-account "[PATH_OF_GCP_TOK
 
 ## Considerations
 
-### Criterias for a test to be considered flaky/passed
+### Criteria for a test to be considered flaky/passed
 
 This tool scans latest 10 runs. A test is considered flaky if it failed in some
 but not all runs. For a test to be considered pass, it has to pass in all runs.


### PR DESCRIPTION
Produced via:
```shell
export FILES=( $(find . -type f -not -path './vendor/*' -not -path './third_party/*' -not -path './.git/*') )
misspell -w "${FILES[@]}"
```
/cc chaodaig chizhg
/assign chaodaig chizhg