### PR TITLE
Increase unit test coverage from 46% to 82% for config-generator tool

### DIFF
--- a/tools/config-generator/customjobs_test.go
+++ b/tools/config-generator/customjobs_test.go
@@ -42,6 +42,7 @@ type singleCustomJob struct {
 }
 
 func TestEnsureCustomJob(t *testing.T) {
+	SetupForTesting()
 	validJobs := sets.NewString()
 	filepath.Walk(defaultTemplateConfigPath, func(path string, info os.FileInfo, err error) error {
 		if strings.HasSuffix(path, ".yaml") {
@@ -75,5 +76,15 @@ func TestEnsureCustomJob(t *testing.T) {
 		if !validJobs.Has(job) {
 			t.Fatalf("Job %q doesn't exist in %q", job, defaultTemplateConfigPath)
 		}
+	}
+}
+
+func TestAddCustomJobsTestgrid(t *testing.T) {
+	SetupForTesting()
+	addCustomJobsTestgrid()
+	if len(metaData.nonAligned) != len(customJobnames) {
+		t.Errorf("Mismatch in number of nonaligned jobs: expected %d, Actual %d",
+			len(customJobnames),
+			len(metaData.nonAligned))
 	}
 }

--- a/tools/config-generator/getlivebranch_test.go
+++ b/tools/config-generator/getlivebranch_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-github/v27/github"
+	"knative.dev/test-infra/pkg/ghutil/fakeghutil"
+)
+
+func TestLatestReleaseBranch(t *testing.T) {
+	SetupForTesting()
+	fgc := fakeghutil.NewFakeGithubClient()
+
+	names := []string{
+		"release-0.1",
+		"release-1.0",
+		"release-3.4",
+		"release-0.2",
+	}
+
+	branches := []*github.Branch{}
+	for i := range names {
+		branches = append(branches, &github.Branch{Name: &names[i]})
+	}
+
+	fgc.Branches = map[string][]*github.Branch{
+		"my-repo": branches,
+	}
+
+	_, err := latestReleaseBranch(fgc, "no slash")
+	if err == nil {
+		t.Errorf("Format was not ORG/REPO, expected error.")
+	}
+	latest, _ := latestReleaseBranch(fgc, "my-org/my-repo")
+	if diff := cmp.Diff(latest, "3.4"); diff != "" {
+		t.Errorf("Did not find latest version (-got +want)\n%s", diff)
+	}
+}
+
+func TestFilterLatest(t *testing.T) {
+	SetupForTesting()
+	names := []string{
+		"release-0.1",
+		"release-1.0",
+		"release-3.4",
+		"release-0.2",
+	}
+
+	branches := []*github.Branch{}
+	for i := range names {
+		branches = append(branches, &github.Branch{Name: &names[i]})
+	}
+
+	res := filterLatest(branches)
+	if diff := cmp.Diff(res, "3.4"); diff != "" {
+		t.Errorf("Did not find latest version (-got +want)\n%s", diff)
+	}
+}

--- a/tools/config-generator/getlivebranch_test.go
+++ b/tools/config-generator/getlivebranch_test.go
@@ -46,11 +46,11 @@ func TestLatestReleaseBranch(t *testing.T) {
 
 	_, err := latestReleaseBranch(fgc, "no slash")
 	if err == nil {
-		t.Errorf("Format was not ORG/REPO, expected error.")
+		t.Fatalf("Format was not ORG/REPO, expected error.")
 	}
 	latest, _ := latestReleaseBranch(fgc, "my-org/my-repo")
 	if diff := cmp.Diff(latest, "3.4"); diff != "" {
-		t.Errorf("Did not find latest version (-got +want)\n%s", diff)
+		t.Fatalf("Did not find latest version (-got +want)\n%s", diff)
 	}
 }
 
@@ -70,6 +70,6 @@ func TestFilterLatest(t *testing.T) {
 
 	res := filterLatest(branches)
 	if diff := cmp.Diff(res, "3.4"); diff != "" {
-		t.Errorf("Did not find latest version (-got +want)\n%s", diff)
+		t.Fatalf("Did not find latest version (-got +want)\n%s", diff)
 	}
 }

--- a/tools/config-generator/main_test.go
+++ b/tools/config-generator/main_test.go
@@ -34,12 +34,12 @@ func TestOutputConfig(t *testing.T) {
 	SetupForTesting()
 	output.outputConfig("")
 	if diff := cmp.Diff(GetOutput(), ""); diff != "" {
-		t.Errorf("Incorrect output for empty string: (-got +want)\n%s", diff)
+		t.Fatalf("Incorrect output for empty string: (-got +want)\n%s", diff)
 	}
 
 	output.outputConfig(" \t\n")
 	if diff := cmp.Diff(GetOutput(), ""); diff != "" {
-		t.Errorf("Incorrect output for whitespace string: (-got +want)\n%s", diff)
+		t.Fatalf("Incorrect output for whitespace string: (-got +want)\n%s", diff)
 	}
 	if output.count != 0 {
 		t.Fatalf("Output count should have been 0, but was %d", output.count)
@@ -48,7 +48,7 @@ func TestOutputConfig(t *testing.T) {
 	inputLine := "some-key: some-value"
 	output.outputConfig(inputLine)
 	if diff := cmp.Diff(GetOutput(), inputLine+"\n"); diff != "" {
-		t.Errorf("Incorrect output for whitespace string: (-got +want)\n%s", diff)
+		t.Fatalf("Incorrect output for whitespace string: (-got +want)\n%s", diff)
 	}
 	if output.count != 1 {
 		t.Fatalf("Output count should have been exactly 1, but was %d", output.count)
@@ -59,12 +59,12 @@ func TestReadTemplate(t *testing.T) {
 	SetupForTesting()
 	templatesCache["foo"] = "bar"
 	if diff := cmp.Diff(readTemplate("foo"), "bar"); diff != "" {
-		t.Errorf("Cached template was not returned: (-got +want)\n%s", diff)
+		t.Fatalf("Cached template was not returned: (-got +want)\n%s", diff)
 	}
 
 	readTemplate("non/existent/file/path")
 	if logFatalCalls != 1 {
-		t.Errorf("Non existent file should have caused error")
+		t.Fatalf("Non existent file should have caused error")
 	}
 
 	delete(templatesCache, "foo")
@@ -74,20 +74,20 @@ func TestNewbaseProwJobTemplateData(t *testing.T) {
 	SetupForTesting()
 	out := newbaseProwJobTemplateData("foo/subrepo")
 	if diff := cmp.Diff(out.PathAlias, ""); diff != "" {
-		t.Errorf("Unexpected path alias: (-got +want)\n%s", diff)
+		t.Fatalf("Unexpected path alias: (-got +want)\n%s", diff)
 	}
 
 	pathAliasOrgs.Insert("foo")
 	out = newbaseProwJobTemplateData("foo/subrepo")
 	expected := "path_alias: knative.dev/subrepo"
 	if diff := cmp.Diff(out.PathAlias, expected); diff != "" {
-		t.Errorf("Unexpected path alias: (-got +want)\n%s", diff)
+		t.Fatalf("Unexpected path alias: (-got +want)\n%s", diff)
 	}
 
 	nonPathAliasRepos.Insert("foo/subrepo")
 	out = newbaseProwJobTemplateData("foo/subrepo")
 	if diff := cmp.Diff(out.PathAlias, ""); diff != "" {
-		t.Errorf("Unexpected path alias: (-got +want)\n%s", diff)
+		t.Fatalf("Unexpected path alias: (-got +want)\n%s", diff)
 	}
 
 	// don't pollute the global setup
@@ -102,14 +102,14 @@ func TestCreateCommand(t *testing.T) {
 	out := createCommand(in)
 	expected := []string{"foo", "bar", "baz"}
 	if diff := cmp.Diff(out, expected); diff != "" {
-		t.Errorf("Unexpected command & args list: (-got +want)\n%s", diff)
+		t.Fatalf("Unexpected command & args list: (-got +want)\n%s", diff)
 	}
 
 	preCommand = "expelliarmus"
 	out = createCommand(in)
 	expected = []string{"expelliarmus", "foo", "bar", "baz"}
 	if diff := cmp.Diff(out, expected); diff != "" {
-		t.Errorf("Unexpected command & args list: (-got +want)\n%s", diff)
+		t.Fatalf("Unexpected command & args list: (-got +want)\n%s", diff)
 	}
 
 	preCommand = ""
@@ -118,14 +118,14 @@ func TestCreateCommand(t *testing.T) {
 func TestEnvNameToKey(t *testing.T) {
 	SetupForTesting()
 	if diff := cmp.Diff(envNameToKey("foo"), "- name: foo"); diff != "" {
-		t.Errorf("Unexpected name to key conversion: (-got +want)\n%s", diff)
+		t.Fatalf("Unexpected name to key conversion: (-got +want)\n%s", diff)
 	}
 }
 
 func TestEnvValueToValue(t *testing.T) {
 	SetupForTesting()
 	if diff := cmp.Diff(envValueToValue("bar"), "  value: bar"); diff != "" {
-		t.Errorf("Unexpected env value conversion: (-got +want)\n%s", diff)
+		t.Fatalf("Unexpected env value conversion: (-got +want)\n%s", diff)
 	}
 }
 
@@ -134,19 +134,19 @@ func TestAddEnvToJob(t *testing.T) {
 	job := baseProwJobTemplateData{}
 	job.addEnvToJob("foo", "bar")
 	if diff := cmp.Diff(job.Env[0], "- name: foo"); diff != "" {
-		t.Errorf("Unexpected env name: (-got +want)\n%s", diff)
+		t.Fatalf("Unexpected env name: (-got +want)\n%s", diff)
 	}
 	if diff := cmp.Diff(job.Env[1], "  value: bar"); diff != "" {
-		t.Errorf("Unexpected env value: (-got +want)\n%s", diff)
+		t.Fatalf("Unexpected env value: (-got +want)\n%s", diff)
 	}
 
 	job = baseProwJobTemplateData{}
 	job.addEnvToJob("num", "42")
 	if diff := cmp.Diff(job.Env[0], "- name: num"); diff != "" {
-		t.Errorf("Unexpected env name: (-got +want)\n%s", diff)
+		t.Fatalf("Unexpected env name: (-got +want)\n%s", diff)
 	}
 	if diff := cmp.Diff(job.Env[1], "  value: \"42\""); diff != "" {
-		t.Errorf("Unexpected env value: (-got +want)\n%s", diff)
+		t.Fatalf("Unexpected env value: (-got +want)\n%s", diff)
 	}
 }
 
@@ -157,7 +157,7 @@ func TestAddLabelToJob(t *testing.T) {
 
 	expected := []string{"foo: bar"}
 	if diff := cmp.Diff(job.Labels, expected); diff != "" {
-		t.Errorf("Unexpected label string: (-got +want)\n%s", diff)
+		t.Fatalf("Unexpected label string: (-got +want)\n%s", diff)
 	}
 }
 
@@ -171,7 +171,7 @@ func TestAddMonitoringPubsubLabelsToJob(t *testing.T) {
 		"prow.k8s.io/pubsub.runID: foobar",
 	}
 	if diff := cmp.Diff(job.Labels, expected); diff != "" {
-		t.Errorf("Unexpected pubsub label: (-got +want)\n%s", diff)
+		t.Fatalf("Unexpected pubsub label: (-got +want)\n%s", diff)
 	}
 }
 
@@ -189,7 +189,7 @@ func TestAddVolumeToJob(t *testing.T) {
 		"  mountPath: somePath",
 	}
 	if diff := cmp.Diff(job.VolumeMounts, expectedVolumeMounts); diff != "" {
-		t.Errorf("Unexpected volume mount: (-got +want)\n%s", diff)
+		t.Fatalf("Unexpected volume mount: (-got +want)\n%s", diff)
 	}
 	expectedVolumes := []string{
 		"- name: foo",
@@ -198,7 +198,7 @@ func TestAddVolumeToJob(t *testing.T) {
 	}
 	for i := range expectedVolumes {
 		if diff := cmp.Diff(job.Volumes[i], expectedVolumes[i]); diff != "" {
-			t.Errorf("Unexpected volume: (-got +want)\n%s", diff)
+			t.Fatalf("Unexpected volume: (-got +want)\n%s", diff)
 		}
 	}
 
@@ -211,7 +211,7 @@ func TestAddVolumeToJob(t *testing.T) {
 		"  readOnly: true",
 	}
 	if diff := cmp.Diff(job.VolumeMounts, expectedVolumeMounts); diff != "" {
-		t.Errorf("Unexpected volume mount: (-got +want)\n%s", diff)
+		t.Fatalf("Unexpected volume mount: (-got +want)\n%s", diff)
 	}
 	expectedVolumes = []string{
 		"- name: foo",
@@ -221,7 +221,7 @@ func TestAddVolumeToJob(t *testing.T) {
 		"  baz",
 	}
 	if diff := cmp.Diff(job.Volumes, expectedVolumes); diff != "" {
-		t.Errorf("Unexpected volume: (-got +want)\n%s", diff)
+		t.Fatalf("Unexpected volume: (-got +want)\n%s", diff)
 	}
 }
 
@@ -230,7 +230,7 @@ func TestConfigureServiceAccountForJob(t *testing.T) {
 	job := baseProwJobTemplateData{ServiceAccount: ""}
 	configureServiceAccountForJob(&job)
 	if logFatalCalls != 0 || len(job.Volumes) != 0 {
-		t.Errorf("Service Account was not specified, but action was performed")
+		t.Fatalf("Service Account was not specified, but action was performed")
 	}
 
 	badAccounts := []string{
@@ -243,7 +243,7 @@ func TestConfigureServiceAccountForJob(t *testing.T) {
 		job = baseProwJobTemplateData{ServiceAccount: acct}
 		configureServiceAccountForJob(&job)
 		if logFatalCalls != 1 {
-			t.Errorf("Service account %v did not cause error", acct)
+			t.Fatalf("Service account %v did not cause error", acct)
 		}
 		logFatalCalls = 0
 	}
@@ -256,7 +256,7 @@ func TestConfigureServiceAccountForJob(t *testing.T) {
 		"  readOnly: true",
 	}
 	if diff := cmp.Diff(job.VolumeMounts, expectedVolumeMounts); diff != "" {
-		t.Errorf("Unexpected volume mount: (-got +want)\n%s", diff)
+		t.Fatalf("Unexpected volume mount: (-got +want)\n%s", diff)
 	}
 	expectedVolumes := []string{
 		"- name: foo",
@@ -264,7 +264,7 @@ func TestConfigureServiceAccountForJob(t *testing.T) {
 		"    secretName: foo",
 	}
 	if diff := cmp.Diff(job.Volumes, expectedVolumes); diff != "" {
-		t.Errorf("Unexpected volume: (-got +want)\n%s", diff)
+		t.Fatalf("Unexpected volume: (-got +want)\n%s", diff)
 	}
 }
 
@@ -275,16 +275,16 @@ func TestAddExtraEnvVarsToJob(t *testing.T) {
 	in := []string{"foo=bar"}
 	addExtraEnvVarsToJob(in, &job)
 	if diff := cmp.Diff(job.Env[0], "- name: foo"); diff != "" {
-		t.Errorf("Unexpected env name: (-got +want)\n%s", diff)
+		t.Fatalf("Unexpected env name: (-got +want)\n%s", diff)
 	}
 	if diff := cmp.Diff(job.Env[1], "  value: bar"); diff != "" {
-		t.Errorf("Unexpected env value: (-got +want)\n%s", diff)
+		t.Fatalf("Unexpected env value: (-got +want)\n%s", diff)
 	}
 
 	in = []string{"foobar"}
 	addExtraEnvVarsToJob(in, &job)
 	if logFatalCalls != 1 {
-		t.Errorf("Invalid string 'foobar' should have caused error")
+		t.Fatalf("Invalid string 'foobar' should have caused error")
 	}
 }
 
@@ -293,10 +293,10 @@ func TestSetupDockerInDockerForJob(t *testing.T) {
 	job := baseProwJobTemplateData{}
 	setupDockerInDockerForJob(&job)
 	if len(job.Volumes) == 0 || len(job.VolumeMounts) == 0 {
-		t.Errorf("Docker in Docker setup did not create volumes and/or mounts")
+		t.Fatalf("Docker in Docker setup did not create volumes and/or mounts")
 	}
 	if len(job.Env) == 0 || len(job.SecurityContext) == 0 {
-		t.Errorf("Docker in Docker setup did not add env and/or set security context")
+		t.Fatalf("Docker in Docker setup did not add env and/or set security context")
 	}
 }
 
@@ -325,7 +325,7 @@ func TestSetResourcesReqForJob(t *testing.T) {
 		"    disk: 16Ti",
 	}
 	if diff := cmp.Diff(job.Resources, expectedResources); diff != "" {
-		t.Errorf("Unexpected volume mount: (-got +want)\n%s", diff)
+		t.Fatalf("Unexpected volume mount: (-got +want)\n%s", diff)
 	}
 }
 
@@ -348,11 +348,11 @@ func TestSetReporterConfigReqForJob(t *testing.T) {
 		"    report_template: Report Template",
 	}
 	if diff := cmp.Diff(job.ReporterConfig, expectedConfig); diff != "" {
-		t.Errorf("Unexpected reporter config: (-got +want)\n%s", diff)
+		t.Fatalf("Unexpected reporter config: (-got +want)\n%s", diff)
 	}
 	expectedJobStates := []string{"bar", "baz"}
 	if diff := cmp.Diff(job.JobStatesToReport, expectedJobStates); diff != "" {
-		t.Errorf("Unexpected job states: (-got +want)\n%s", diff)
+		t.Fatalf("Unexpected job states: (-got +want)\n%s", diff)
 	}
 }
 
@@ -405,47 +405,47 @@ func TestParseBasicJobConfigOverrides(t *testing.T) {
 
 	expected := []string{"  base_ref: my_repo_branch"}
 	if diff := cmp.Diff(job.ExtraRefs, expected); diff != "" {
-		t.Errorf("Unexpected base ref: (-got +want)\n%s", diff)
+		t.Fatalf("Unexpected base ref: (-got +want)\n%s", diff)
 	}
 	expected = []string{"skip", "branches"}
 	if diff := cmp.Diff(job.SkipBranches, expected); diff != "" {
-		t.Errorf("Unexpected skip branches: (-got +want)\n%s", diff)
+		t.Fatalf("Unexpected skip branches: (-got +want)\n%s", diff)
 	}
 	expected = []string{"branch1", "branch2"}
 	if diff := cmp.Diff(job.Branches, expected); diff != "" {
-		t.Errorf("Unexpected branches: (-got +want)\n%s", diff)
+		t.Fatalf("Unexpected branches: (-got +want)\n%s", diff)
 	}
 	expected = []string{"arg1", "arg2"}
 	if diff := cmp.Diff(job.Args, expected); diff != "" {
-		t.Errorf("Unexpected args: (-got +want)\n%s", diff)
+		t.Fatalf("Unexpected args: (-got +want)\n%s", diff)
 	}
 	if job.Timeout != 42 {
-		t.Errorf("Unexpected timeout: %v", job.Timeout)
+		t.Fatalf("Unexpected timeout: %v", job.Timeout)
 	}
 	if diff := cmp.Diff(job.Command, "foo_command"); diff != "" {
-		t.Errorf("Unexpected command: (-got +want)\n%s", diff)
+		t.Fatalf("Unexpected command: (-got +want)\n%s", diff)
 	}
 	if !job.NeedsMonitor {
-		t.Errorf("Expected job.NeedsMonitor to be true")
+		t.Fatalf("Expected job.NeedsMonitor to be true")
 	}
 	if len(job.Volumes) == 0 || len(job.VolumeMounts) == 0 || len(job.SecurityContext) == 0 {
-		t.Errorf("Error in Docker in Docker setup")
+		t.Fatalf("Error in Docker in Docker setup")
 	}
 	if !job.AlwaysRun {
-		t.Errorf("Expected job.AlwaysRun to be true")
+		t.Fatalf("Expected job.AlwaysRun to be true")
 	}
 	if !repositories[0].EnablePerformanceTests {
-		t.Errorf("Repository performance test should have been enabled")
+		t.Fatalf("Repository performance test should have been enabled")
 	}
 	// Note that the first 2 Env variables are from the Docker in Docker setup
 	if diff := cmp.Diff(job.Env[2], "- name: foo"); diff != "" {
-		t.Errorf("Unexpected env name: (-got +want)\n%s", diff)
+		t.Fatalf("Unexpected env name: (-got +want)\n%s", diff)
 	}
 	if diff := cmp.Diff(job.Env[3], "  value: bar"); diff != "" {
-		t.Errorf("Unexpected env value: (-got +want)\n%s", diff)
+		t.Fatalf("Unexpected env value: (-got +want)\n%s", diff)
 	}
 	if diff := cmp.Diff(job.Optional, "optional: true"); diff != "" {
-		t.Errorf("Unexpected job.Optional value: (-got +want)\n%s", diff)
+		t.Fatalf("Unexpected job.Optional value: (-got +want)\n%s", diff)
 	}
 	expectedResources := []string{
 		"  requests:",
@@ -456,7 +456,7 @@ func TestParseBasicJobConfigOverrides(t *testing.T) {
 		"    disk: 16Ti",
 	}
 	if diff := cmp.Diff(job.Resources, expectedResources); diff != "" {
-		t.Errorf("Unexpected volume mount: (-got +want)\n%s", diff)
+		t.Fatalf("Unexpected volume mount: (-got +want)\n%s", diff)
 	}
 
 	expectedReporterConfig := []string{
@@ -465,17 +465,17 @@ func TestParseBasicJobConfigOverrides(t *testing.T) {
 		"    report_template: Report Template",
 	}
 	if diff := cmp.Diff(job.ReporterConfig, expectedReporterConfig); diff != "" {
-		t.Errorf("Unexpected reporter config: (-got +want)\n%s", diff)
+		t.Fatalf("Unexpected reporter config: (-got +want)\n%s", diff)
 	}
 	expectedJobStates := []string{"bar", "baz"}
 	if diff := cmp.Diff(job.JobStatesToReport, expectedJobStates); diff != "" {
-		t.Errorf("Unexpected job states: (-got +want)\n%s", diff)
+		t.Fatalf("Unexpected job states: (-got +want)\n%s", diff)
 	}
 
 	timeoutOverride = 999
 	parseBasicJobConfigOverrides(&job, config)
 	if job.Timeout != 999 {
-		t.Errorf("Timeout override did not work")
+		t.Fatalf("Timeout override did not work")
 	}
 }
 
@@ -497,10 +497,10 @@ func TestGetProwConfigData(t *testing.T) {
 
 	expectedRepos := []string{"bar-repo", "bar-repo-test-infra", "dup-repo", "foo-repo"}
 	if diff := cmp.Diff(out.TideRepos, expectedRepos); diff != "" {
-		t.Errorf("Unexpected TideRepos: (-got +want)\n%s", diff)
+		t.Fatalf("Unexpected TideRepos: (-got +want)\n%s", diff)
 	}
 	if diff := cmp.Diff(out.TestInfraRepo, "bar-repo-test-infra"); diff != "" {
-		t.Errorf("Unexpected test-infra repo: (-got +want)\n%s", diff)
+		t.Fatalf("Unexpected test-infra repo: (-got +want)\n%s", diff)
 	}
 }
 func TestParseSection(t *testing.T) {
@@ -548,14 +548,14 @@ func TestParseSection(t *testing.T) {
 		"pet-store, cats, Twitch, Siamese",
 	}
 	if diff := cmp.Diff(generated, expected); diff != "" {
-		t.Errorf("Unexpected generated output: (-got +want)\n%s", diff)
+		t.Fatalf("Unexpected generated output: (-got +want)\n%s", diff)
 	}
 	expected = []string{
 		"pet-store, dogs",
 		"pet-store, cats",
 	}
 	if diff := cmp.Diff(finalized, expected); diff != "" {
-		t.Errorf("Unexpected finalized output: (-got +want)\n%s", diff)
+		t.Fatalf("Unexpected finalized output: (-got +want)\n%s", diff)
 	}
 }
 
@@ -565,17 +565,17 @@ func TestGitHubRepo(t *testing.T) {
 	in := baseProwJobTemplateData{RepoURI: "repoURI"}
 
 	if diff := cmp.Diff(gitHubRepo(in), "repoURI"); diff != "" {
-		t.Errorf("Bad output when RepoBranch unset and no override: (-got +want)\n%s", diff)
+		t.Fatalf("Bad output when RepoBranch unset and no override: (-got +want)\n%s", diff)
 	}
 
 	in = baseProwJobTemplateData{RepoURI: "repoURI", RepoBranch: "repoBranch"}
 	if diff := cmp.Diff(gitHubRepo(in), "repoURI=repoBranch"); diff != "" {
-		t.Errorf("Bad output when RepoBranch set and no override: (-got +want)\n%s", diff)
+		t.Fatalf("Bad output when RepoBranch set and no override: (-got +want)\n%s", diff)
 	}
 
 	repositoryOverride = "repoOverride"
 	if diff := cmp.Diff(gitHubRepo(in), "repoOverride"); diff != "" {
-		t.Errorf("Bad output when override set: (-got +want)\n%s", diff)
+		t.Fatalf("Bad output when override set: (-got +want)\n%s", diff)
 	}
 }
 
@@ -601,21 +601,21 @@ func TestExecuteJobTemplate(t *testing.T) {
 	jobNameFilter = "xyz"
 	executeJobTemplate(name, templ, title, repoName, jobName, groupByRepo, data)
 	if logFatalCalls != 0 {
-		t.Errorf("Fatal log call recorded")
+		t.Fatalf("Fatal log call recorded")
 	}
 	expected := ""
 	if diff := cmp.Diff(GetOutput(), expected); diff != "" {
-		t.Errorf("Expected job to be filtered: (-got +want)\n%s", diff)
+		t.Fatalf("Expected job to be filtered: (-got +want)\n%s", diff)
 	}
 
 	ResetOutput()
 	jobNameFilter = "my-job-name"
 	executeJobTemplate(name, templ, title, repoName, jobName, groupByRepo, data)
 	if logFatalCalls != 0 {
-		t.Errorf("Fatal log call recorded")
+		t.Fatalf("Fatal log call recorded")
 	}
 	if GetOutput() == "" {
-		t.Errorf("Job should not have been filtered")
+		t.Fatalf("Job should not have been filtered")
 	}
 
 	ResetOutput()
@@ -623,22 +623,22 @@ func TestExecuteJobTemplate(t *testing.T) {
 	sectionMap[title] = false
 	executeJobTemplate(name, templ, title, repoName, jobName, groupByRepo, data)
 	if logFatalCalls != 0 {
-		t.Errorf("Fatal log call recorded")
+		t.Fatalf("Fatal log call recorded")
 	}
 	expected = "my-title:\n- foo: Foo\nbar:\n  \"Bar\"\n  \"Baz\"\n"
 	if diff := cmp.Diff(GetOutput(), expected); diff != "" {
-		t.Errorf("Bad execute job template output: (-got +want)\n%s", diff)
+		t.Fatalf("Bad execute job template output: (-got +want)\n%s", diff)
 	}
 
 	ResetOutput()
 	sectionMap[title] = true
 	executeJobTemplate(name, templ, title, repoName, jobName, groupByRepo, data)
 	if logFatalCalls != 0 {
-		t.Errorf("Fatal log call recorded")
+		t.Fatalf("Fatal log call recorded")
 	}
 	expected = "- foo: Foo\nbar:\n  \"Bar\"\n  \"Baz\"\n"
 	if diff := cmp.Diff(GetOutput(), expected); diff != "" {
-		t.Errorf("Bad execute job template output: (-got +want)\n%s", diff)
+		t.Fatalf("Bad execute job template output: (-got +want)\n%s", diff)
 	}
 
 	ResetOutput()
@@ -646,11 +646,11 @@ func TestExecuteJobTemplate(t *testing.T) {
 	sectionMap[title+repoName] = false
 	executeJobTemplate(name, templ, title, repoName, jobName, groupByRepo, data)
 	if logFatalCalls != 0 {
-		t.Errorf("Fatal log call recorded")
+		t.Fatalf("Fatal log call recorded")
 	}
 	expected = "  my-repo-name:\n- foo: Foo\nbar:\n  \"Bar\"\n  \"Baz\"\n"
 	if diff := cmp.Diff(GetOutput(), expected); diff != "" {
-		t.Errorf("Bad execute job template output: (-got +want)\n%s", diff)
+		t.Fatalf("Bad execute job template output: (-got +want)\n%s", diff)
 	}
 }
 
@@ -671,20 +671,20 @@ func TestExecuteTemplate(t *testing.T) {
 	executeTemplate(name, templ, data)
 
 	if logFatalCalls != 0 {
-		t.Errorf("Fatal log call recorded")
+		t.Fatalf("Fatal log call recorded")
 	}
 	expected :=
 		"- foo: Foo\nbar:\n  \"Bar\"\n  \"Baz\"\n"
 
 	if diff := cmp.Diff(GetOutput(), expected); diff != "" {
-		t.Errorf("Bad execute template output: (-got +want)\n%s", diff)
+		t.Fatalf("Bad execute template output: (-got +want)\n%s", diff)
 	}
 }
 func TestStringArrayFlagString(t *testing.T) {
 	SetupForTesting()
 	arr := stringArrayFlag{"a", "b", "c"}
 	if diff := cmp.Diff(arr.String(), "a, b, c"); diff != "" {
-		t.Errorf("(-got +want)\n%s", diff)
+		t.Fatalf("(-got +want)\n%s", diff)
 	}
 }
 func TestStringArrayFlagSet(t *testing.T) {
@@ -692,7 +692,7 @@ func TestStringArrayFlagSet(t *testing.T) {
 	arr := stringArrayFlag{"a", "b", "c"}
 	arr.Set("d")
 	if diff := cmp.Diff(arr.String(), "a, b, c, d"); diff != "" {
-		t.Errorf("(-got +want)\n%s", diff)
+		t.Fatalf("(-got +want)\n%s", diff)
 	}
 }
 
@@ -714,12 +714,12 @@ func TestParseJob(t *testing.T) {
 	out := parseJob(pets, "dogs")
 	expected := "[{Spot Dalmatian} {Fido Terrier}]"
 	if diff := cmp.Diff(fmt.Sprintf("%v", out), expected); diff != "" {
-		t.Errorf("ParseJob did not return expected slice. (-got +want)\n%s", diff)
+		t.Fatalf("ParseJob did not return expected slice. (-got +want)\n%s", diff)
 	}
 
 	out = parseJob(pets, "hamsters")
 	if logFatalCalls != 1 {
-		t.Errorf("ParseJob did not return error as expected.")
+		t.Fatalf("ParseJob did not return error as expected.")
 	}
 }
 
@@ -747,10 +747,10 @@ func TestParseGoCoverageMap(t *testing.T) {
 
 	out := parseGoCoverageMap(config)
 	if out["cat-repo"] {
-		t.Errorf("Go coverage should not have been enabled for cat-repo")
+		t.Fatalf("Go coverage should not have been enabled for cat-repo")
 	}
 	if !out["dog-repo"] {
-		t.Errorf("Go coverage should have been enabled for dog-repo")
+		t.Fatalf("Go coverage should have been enabled for dog-repo")
 	}
 }
 
@@ -793,17 +793,17 @@ func TestCollectMetaData(t *testing.T) {
 
 	expected := []string{"red-a", "red-b", "dot-release", "continuous"}
 	if diff := cmp.Diff(metaData.md["red-proj"]["red-repo"], expected); diff != "" {
-		t.Errorf("Unexpected metadata for red proj/repo. (-got +want)\n%s", diff)
+		t.Fatalf("Unexpected metadata for red proj/repo. (-got +want)\n%s", diff)
 	}
 
 	expected = []string{"custom-job-name"}
 	if diff := cmp.Diff(metaData.md["blu-proj-0.1.2"]["blu-repo"], expected); diff != "" {
-		t.Errorf("Unexpected metadata for blu proj/repo. (-got +want)\n%s", diff)
+		t.Fatalf("Unexpected metadata for blu proj/repo. (-got +want)\n%s", diff)
 	}
 
 	expected = []string{"red-proj", "blu-proj", "blu-proj-0.1.2"}
 	if diff := cmp.Diff(metaData.projNames, expected); diff != "" {
-		t.Errorf("Unexpected list of project names. (-got +want)\n%s", diff)
+		t.Fatalf("Unexpected list of project names. (-got +want)\n%s", diff)
 	}
 }
 
@@ -816,11 +816,11 @@ func TestUpdateTestCoverageJobDataIfNeeded(t *testing.T) {
 	}
 	updateTestCoverageJobDataIfNeeded(jobDetailMap, repoName)
 	if len(goCoverageMap) != 0 {
-		t.Errorf("foo-repo was not deleted from goCoverageMap")
+		t.Fatalf("foo-repo was not deleted from goCoverageMap")
 	}
 	expected := []string{"test-coverage"}
 	if diff := cmp.Diff(jobDetailMap[repoName], expected); diff != "" {
-		t.Errorf("Unexpected entry for repoName in job detail map (-got +want)\n%s", diff)
+		t.Fatalf("Unexpected entry for repoName in job detail map (-got +want)\n%s", diff)
 	}
 }
 
@@ -841,7 +841,7 @@ func TestAddRemainingTestCoverageJobs(t *testing.T) {
 
 	expected := []string{"test-coverage"}
 	if diff := cmp.Diff(jobDetailMap["bar-repo"], expected); diff != "" {
-		t.Errorf("Unexpected entry for bar-repo in job detail map (-got +want)\n%s", diff)
+		t.Fatalf("Unexpected entry for bar-repo in job detail map (-got +want)\n%s", diff)
 	}
 }
 func TestBuildProjRepoStr(t *testing.T) {
@@ -852,7 +852,7 @@ func TestBuildProjRepoStr(t *testing.T) {
 	expected := "project-name-repo-name"
 	actual := buildProjRepoStr(projName, repoName)
 	if diff := cmp.Diff(actual, expected); diff != "" {
-		t.Errorf("Unexpected project repo string: (-got +want)\n%s", diff)
+		t.Fatalf("Unexpected project repo string: (-got +want)\n%s", diff)
 	}
 
 	projName = "knative-sandbox-0.15"
@@ -860,7 +860,7 @@ func TestBuildProjRepoStr(t *testing.T) {
 	expected = "knative-sandbox-repo-name-0.15"
 	actual = buildProjRepoStr(projName, repoName)
 	if diff := cmp.Diff(actual, expected); diff != "" {
-		t.Errorf("Unexpected project repo string: (-got +want)\n%s", diff)
+		t.Fatalf("Unexpected project repo string: (-got +want)\n%s", diff)
 	}
 }
 func TestIsReleased(t *testing.T) {
@@ -869,12 +869,12 @@ func TestIsReleased(t *testing.T) {
 	invalid := []string{"-4.5.6", "abc-1.2.3g"}
 	for _, v := range valid {
 		if !isReleased(v) {
-			t.Errorf("Should be valid: %v", v)
+			t.Fatalf("Should be valid: %v", v)
 		}
 	}
 	for _, v := range invalid {
 		if isReleased(v) {
-			t.Errorf("Should be invalid: %v", v)
+			t.Fatalf("Should be invalid: %v", v)
 		}
 	}
 }
@@ -883,7 +883,7 @@ func TestSetOutput(t *testing.T) {
 	SetupForTesting()
 	setOutput("")
 	if logFatalCalls != 0 {
-		t.Errorf("Fatal log call recorded")
+		t.Fatalf("Fatal log call recorded")
 	}
 	// don't test setting an output file since this will create
 	// a local file system change

--- a/tools/config-generator/perf_config_test.go
+++ b/tools/config-generator/perf_config_test.go
@@ -25,7 +25,7 @@ import (
 func TestGeneratePerfClusterUpdatePeriodicJobs(t *testing.T) {
 	SetupForTesting()
 	repositories = []repositoryData{
-		repositoryData{
+		{
 			Name:                   "enabled-repo",
 			EnablePerformanceTests: true,
 		},
@@ -37,7 +37,7 @@ func TestGeneratePerfClusterUpdatePeriodicJobs(t *testing.T) {
 
 	SetupForTesting()
 	repositories = []repositoryData{
-		repositoryData{
+		{
 			Name:                   "disabled-repo",
 			EnablePerformanceTests: false,
 		},

--- a/tools/config-generator/perf_config_test.go
+++ b/tools/config-generator/perf_config_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestGeneratePerfClusterUpdatePeriodicJobs(t *testing.T) {
+	SetupForTesting()
+	repositories = []repositoryData{
+		repositoryData{
+			Name:                   "enabled-repo",
+			EnablePerformanceTests: true,
+		},
+	}
+	generatePerfClusterUpdatePeriodicJobs()
+	if logFatalCalls != 0 || len(GetOutput()) == 0 {
+		t.Errorf("Expected job to be written without errors")
+	}
+
+	SetupForTesting()
+	repositories = []repositoryData{
+		repositoryData{
+			Name:                   "disabled-repo",
+			EnablePerformanceTests: false,
+		},
+	}
+	generatePerfClusterUpdatePeriodicJobs()
+	if len(GetOutput()) != 0 {
+		t.Errorf("Expected nothing to be written")
+	}
+}
+
+func TestGeneratePerfClusterPostsubmitJob(t *testing.T) {
+	SetupForTesting()
+	generatePerfClusterPostsubmitJob(repositoryData{Name: "my-repo"})
+	if logFatalCalls != 0 || len(GetOutput()) == 0 {
+		t.Errorf("Expected job to be written without errors")
+	}
+}
+
+func TestPerfClusterPeriodicJob(t *testing.T) {
+	SetupForTesting()
+	repoData := repositoryData{Name: "my-repo"}
+	perfClusterPeriodicJob("postfix", "cronString", "command", []string{"arg1", "arg2"}, repoData, "sa")
+
+	if logFatalCalls != 0 || len(GetOutput()) == 0 {
+		t.Errorf("Expected job to be written without errors")
+	}
+}
+
+func TestPerfClusterReconcilePostsubmitJob(t *testing.T) {
+	SetupForTesting()
+	repoData := repositoryData{Name: "my-repo"}
+	perfClusterReconcilePostsubmitJob("postfix", "command", []string{"arg1", "arg2"}, repoData, "sa")
+
+	if logFatalCalls != 0 || len(GetOutput()) == 0 {
+		t.Errorf("Expected job to be written without errors")
+	}
+}
+
+func TestPerfClusterBaseProwJob(t *testing.T) {
+	SetupForTesting()
+	command := "command"
+	args := []string{"arg1", "arg2"}
+	repoName := "org-name/repo-name"
+	sa := "foo"
+	res := perfClusterBaseProwJob(command, args, repoName, sa)
+
+	if diff := cmp.Diff(res.Command, command); diff != "" {
+		t.Errorf("Incorrect command: (-got +want)\n%s", diff)
+	}
+	if diff := cmp.Diff(res.Args, args); diff != "" {
+		t.Errorf("Incorrect args: (-got +want)\n%s", diff)
+	}
+	if diff := cmp.Diff(res.Command, command); diff != "" {
+		t.Errorf("Incorrect command: (-got +want)\n%s", diff)
+	}
+	if len(res.Env) != 8 {
+		t.Errorf("Expected 8 environments, got %d", len(res.Env))
+	}
+}

--- a/tools/config-generator/perf_config_test.go
+++ b/tools/config-generator/perf_config_test.go
@@ -93,7 +93,7 @@ func TestPerfClusterBaseProwJob(t *testing.T) {
 	if diff := cmp.Diff(res.Command, command); diff != "" {
 		t.Errorf("Incorrect command: (-got +want)\n%s", diff)
 	}
-	if len(res.Env) != 8 {
+	if want, got := 8, len(res.Env); want != got {
 		t.Errorf("Expected 8 environments, got %d", len(res.Env))
 	}
 }

--- a/tools/config-generator/periodic_config_test.go
+++ b/tools/config-generator/periodic_config_test.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"gopkg.in/yaml.v2"
+)
+
+func TestClone(t *testing.T) {
+	SetupForTesting()
+	base := baseProwJobTemplateData{OrgName: "org-name"}
+	data := periodicJobTemplateData{
+		Base:            base,
+		PeriodicJobName: "periodic-job-name",
+		CronString:      "cron-string",
+		PeriodicCommand: []string{"string-a", "string-b"},
+	}
+	if diff := cmp.Diff(data.Clone(), data); diff != "" {
+		t.Errorf("Incorrect output for empty string: (-got +want)\n%s", diff)
+	}
+}
+
+func TestGetUTCtime(t *testing.T) {
+	SetupForTesting()
+	for i := 0; i < 24; i++ {
+		utcTime := getUTCtime(i)
+		expected := (i + 7) % 24
+		if utcTime != expected {
+			t.Errorf("Expected %d, got %d", expected, utcTime)
+		}
+	}
+}
+
+func TestCalculateMinuteOffset(t *testing.T) {
+	SetupForTesting()
+	out1 := calculateMinuteOffset("foo")
+	out2 := calculateMinuteOffset("foo")
+	if out1 != out2 {
+		t.Errorf("Same input should always yield same offset")
+	}
+}
+
+func TestGenerateCron(t *testing.T) {
+	SetupForTesting()
+	jobName := "job-name"
+	tests := []struct {
+		jobType  string
+		repoName string
+		timeout  int
+		expected string
+	}{
+		{
+			jobType:  "not-supported",
+			expected: "",
+		},
+		{
+			jobType:  "continuous",
+			timeout:  54,
+			expected: fmt.Sprintf("%d * * * *", calculateMinuteOffset("continuous", jobName)),
+		},
+		{
+			jobType:  "continuous",
+			timeout:  55,
+			expected: fmt.Sprintf("%d */2 * * *", calculateMinuteOffset("continuous", jobName)),
+		},
+		{
+			jobType:  "continuous",
+			timeout:  60 + 55,
+			expected: fmt.Sprintf("%d */3 * * *", calculateMinuteOffset("continuous", jobName)),
+		},
+		{
+			jobType:  "custom-job",
+			timeout:  54,
+			expected: fmt.Sprintf("%d * * * *", calculateMinuteOffset("custom-job", jobName)),
+		},
+		{
+			jobType:  "auto-release",
+			timeout:  54,
+			expected: fmt.Sprintf("%d * * * *", calculateMinuteOffset("auto-release", jobName)),
+		},
+		{
+			jobType:  "branch-ci",
+			expected: fmt.Sprintf("%d 8 * * *", calculateMinuteOffset("branch-ci", jobName)),
+		},
+		{
+			jobType:  "nightly",
+			expected: fmt.Sprintf("%d 9 * * *", calculateMinuteOffset("nightly", jobName)),
+		},
+		{
+			jobType:  "dot-release",
+			repoName: "foo",
+			expected: fmt.Sprintf("%d 9 * * 2", calculateMinuteOffset("dot-release", jobName)),
+		},
+		{
+			jobType:  "dot-release",
+			repoName: "foo-operator",
+			expected: fmt.Sprintf("%d 19 * * 2", calculateMinuteOffset("dot-release", jobName)),
+		},
+		{
+			jobType:  "webhook-apicoverage",
+			expected: fmt.Sprintf("%d 9 * * *", calculateMinuteOffset("webhook-apicoverage", jobName)),
+		},
+	}
+	for _, tc := range tests {
+		out := generateCron(tc.jobType, jobName, tc.repoName, tc.timeout)
+		if diff := cmp.Diff(out, tc.expected); diff != "" {
+			t.Errorf("For jobType %v and timeout %d: (-got +want)\n%s", tc.jobType, tc.timeout, diff)
+		}
+	}
+}
+
+func TestGeneratePeriodic(t *testing.T) {
+	SetupForTesting()
+	title := "title"
+	repoName := "repoName"
+	items := []yaml.MapItem{
+		{Key: "continuous", Value: true},
+		{Key: "nightly", Value: true},
+		{Key: "branch-ci", Value: true},
+		{Key: "dot-release", Value: true},
+		{Key: "auto-release", Value: true},
+	}
+	var periodicConfig yaml.MapSlice
+	for _, item := range items {
+		periodicConfig = yaml.MapSlice{item}
+		generatePeriodic(title, repoName, periodicConfig)
+		outputLen := len(GetOutput())
+		if outputLen == 0 {
+			t.Errorf("Failure for key %d: No output", outputLen)
+		}
+		if logFatalCalls != 0 {
+			t.Errorf("Failure for key %s: LogFatal was called.", item.Key)
+		}
+		SetupForTesting()
+	}
+}
+
+func TestGenerateGoCoveragePeriodic(t *testing.T) {
+	SetupForTesting()
+	repositories = []repositoryData{
+		repositoryData{
+			Name:                "repo-name",
+			EnableGoCoverage:    true,
+			GoCoverageThreshold: 80,
+		},
+	}
+	generateGoCoveragePeriodic("title", "repo-name", nil)
+	if len(GetOutput()) == 0 {
+		t.Errorf("No output")
+	}
+	if logFatalCalls != 0 {
+		t.Errorf("LogFatal was called.")
+	}
+}

--- a/tools/config-generator/periodic_config_test.go
+++ b/tools/config-generator/periodic_config_test.go
@@ -156,7 +156,7 @@ func TestGeneratePeriodic(t *testing.T) {
 func TestGenerateGoCoveragePeriodic(t *testing.T) {
 	SetupForTesting()
 	repositories = []repositoryData{
-		repositoryData{
+		{
 			Name:                "repo-name",
 			EnableGoCoverage:    true,
 			GoCoverageThreshold: 80,

--- a/tools/config-generator/periodic_config_test.go
+++ b/tools/config-generator/periodic_config_test.go
@@ -34,7 +34,7 @@ func TestClone(t *testing.T) {
 		PeriodicCommand: []string{"string-a", "string-b"},
 	}
 	if diff := cmp.Diff(data.Clone(), data); diff != "" {
-		t.Errorf("Incorrect output for empty string: (-got +want)\n%s", diff)
+		t.Fatalf("Incorrect output for empty string: (-got +want)\n%s", diff)
 	}
 }
 
@@ -44,7 +44,7 @@ func TestGetUTCtime(t *testing.T) {
 		utcTime := getUTCtime(i)
 		expected := (i + 7) % 24
 		if utcTime != expected {
-			t.Errorf("Expected %d, got %d", expected, utcTime)
+			t.Fatalf("Expected %d, got %d", expected, utcTime)
 		}
 	}
 }
@@ -53,8 +53,8 @@ func TestCalculateMinuteOffset(t *testing.T) {
 	SetupForTesting()
 	out1 := calculateMinuteOffset("foo")
 	out2 := calculateMinuteOffset("foo")
-	if out1 != out2 {
-		t.Errorf("Same input should always yield same offset")
+	if diff := cmp.Diff(out1, out2); diff != "" {
+		t.Fatalf("Same input should always yield same offset")
 	}
 }
 
@@ -122,7 +122,7 @@ func TestGenerateCron(t *testing.T) {
 	for _, tc := range tests {
 		out := generateCron(tc.jobType, jobName, tc.repoName, tc.timeout)
 		if diff := cmp.Diff(out, tc.expected); diff != "" {
-			t.Errorf("For jobType %v and timeout %d: (-got +want)\n%s", tc.jobType, tc.timeout, diff)
+			t.Fatalf("For jobType %v and timeout %d: (-got +want)\n%s", tc.jobType, tc.timeout, diff)
 		}
 	}
 }
@@ -144,10 +144,10 @@ func TestGeneratePeriodic(t *testing.T) {
 		generatePeriodic(title, repoName, periodicConfig)
 		outputLen := len(GetOutput())
 		if outputLen == 0 {
-			t.Errorf("Failure for key %d: No output", outputLen)
+			t.Fatalf("Failure for key %d: No output", outputLen)
 		}
 		if logFatalCalls != 0 {
-			t.Errorf("Failure for key %s: LogFatal was called.", item.Key)
+			t.Fatalf("Failure for key %s: LogFatal was called.", item.Key)
 		}
 		SetupForTesting()
 	}
@@ -164,9 +164,9 @@ func TestGenerateGoCoveragePeriodic(t *testing.T) {
 	}
 	generateGoCoveragePeriodic("title", "repo-name", nil)
 	if len(GetOutput()) == 0 {
-		t.Errorf("No output")
+		t.Fatalf("No output")
 	}
 	if logFatalCalls != 0 {
-		t.Errorf("LogFatal was called.")
+		t.Fatalf("LogFatal was called.")
 	}
 }

--- a/tools/config-generator/postsubmit_config_test.go
+++ b/tools/config-generator/postsubmit_config_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+)
+
+func TestGenerateGoCoveragePostsubmit(t *testing.T) {
+	SetupForTesting()
+	generateGoCoveragePostsubmit("title", "knative-serving", nil)
+	if len(GetOutput()) == 0 {
+		t.Errorf("No output")
+	}
+	if logFatalCalls != 0 {
+		t.Errorf("LogFatal was called.")
+	}
+}

--- a/tools/config-generator/presubmit_config_test.go
+++ b/tools/config-generator/presubmit_config_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v2"
+)
+
+func TestGeneratePresubmit(t *testing.T) {
+	SetupForTesting()
+	title := "title"
+	repoName := "repoName"
+	items := []yaml.MapItem{
+		{Key: "build-tests", Value: true},
+		{Key: "unit-tests", Value: true},
+		{Key: "integration-tests", Value: true},
+		{Key: "go-coverage", Value: true},
+		{Key: "custom-test", Value: "foo"},
+		{Key: "go-coverage-threshold", Value: 80},
+		{Key: "run-if-changed", Value: "foo"},
+	}
+	var presubmitConfig yaml.MapSlice
+	for _, item := range items {
+		presubmitConfig = yaml.MapSlice{item}
+		generatePresubmit(title, repoName, presubmitConfig)
+		outputLen := len(GetOutput())
+		if outputLen == 0 {
+			t.Errorf("Failure for key %s: No output", item.Key)
+		}
+		if logFatalCalls != 0 {
+			t.Errorf("Failure for key %s: LogFatal was called.", item.Key)
+		}
+		SetupForTesting()
+	}
+}

--- a/tools/config-generator/testgrid_config_test.go
+++ b/tools/config-generator/testgrid_config_test.go
@@ -107,7 +107,7 @@ func TestTestGridMetaDataGenerateNonAlignedTestGroups(t *testing.T) {
 	SetupForTesting()
 	data := NewTestGridMetaData()
 	data.nonAligned = []NonAlignedTestGroup{
-		NonAlignedTestGroup{
+		{
 			CIJobName: "ci-job-name",
 			Extra:     map[string]string{},
 		},
@@ -249,7 +249,7 @@ func TestGenerateNonAlignedDashboardGroups(t *testing.T) {
 	SetupForTesting()
 	data := NewTestGridMetaData()
 	data.nonAligned = []NonAlignedTestGroup{
-		NonAlignedTestGroup{
+		{
 			DashboardName:  "dashboard-name",
 			DashboardGroup: "dashboard-group",
 		},

--- a/tools/config-generator/testgrid_config_test.go
+++ b/tools/config-generator/testgrid_config_test.go
@@ -1,0 +1,296 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestNewBaseTestgridTemplateData(t *testing.T) {
+	SetupForTesting()
+	data := newBaseTestgridTemplateData("foo")
+	if diff := cmp.Diff(data.TestGroupName, "foo"); diff != "" {
+		t.Errorf("(-got +want)\n%s", diff)
+	}
+}
+
+func TestTestGridMetaDataGet(t *testing.T) {
+	SetupForTesting()
+	data := NewTestGridMetaData()
+	jobDetails := data.Get("foo")
+	if diff := cmp.Diff(jobDetails, data.md["foo"]); diff != "" {
+		t.Errorf("(-got +want\n%s", diff)
+	}
+}
+
+func TestTestGridMetaDataEnsureExists(t *testing.T) {
+	SetupForTesting()
+	data := NewTestGridMetaData()
+	out := data.EnsureExists("foo")
+	if out {
+		t.Errorf("foo did not exist but function returned true")
+	}
+	if _, exists := data.md["foo"]; !exists {
+		t.Errorf("foo should have been added but was not")
+	}
+	out = data.EnsureExists("foo")
+	if !out {
+		t.Errorf("foo existed but the function returned false")
+	}
+	if diff := cmp.Diff(data.projNames, []string{"foo"}); diff != "" {
+		t.Errorf("(-got +want\n%s", diff)
+	}
+}
+
+func TestTestGridMetaDataEnsureRepo(t *testing.T) {
+	SetupForTesting()
+	data := NewTestGridMetaData()
+	out := data.EnsureRepo("proj-name", "repo-name")
+	if out {
+		t.Errorf("repo did not exist but function returned true")
+	}
+	if data.repoNames[0] != "repo-name" {
+		t.Errorf("Should have added repo-name but did not")
+	}
+	out = data.EnsureRepo("proj-name", "repo-name")
+	if !out {
+		t.Errorf("repo existed but function returned false")
+	}
+}
+
+func TestTestGridMetaDataGenerateTestGridSection(t *testing.T) {
+	SetupForTesting()
+	data := NewTestGridMetaData()
+	data.projNames = []string{"project-a", "project-b"}
+	data.repoNames = []string{"repo-1", "repo-2", "repo-3"}
+	data.md["project-a"] = JobDetailMap{
+		"repo-1": []string{"job-1a", "job-1b"},
+		"repo-2": []string{"job-2a", "job-2b"},
+	}
+	data.md["project-b"] = JobDetailMap{
+		"repo-3": []string{"job-3a", "job-3b"},
+	}
+	skipReleasedProj := false
+	outputs := []string{}
+	generator := func(proj, repo string, jobs []string) {
+		outputs = append(outputs, fmt.Sprintf("%s %s %v", proj, repo, jobs))
+	}
+	data.generateTestGridSection("section-name", generator, skipReleasedProj)
+	expected := []string{
+		"project-a repo-1 [job-1a job-1b]",
+		"project-a repo-2 [job-2a job-2b]",
+		"project-b repo-3 [job-3a job-3b]",
+	}
+	if diff := cmp.Diff(outputs, expected); diff != "" {
+		t.Errorf("(-got +want): \n%s", diff)
+	}
+}
+
+func TestTestGridMetaDataGenerateNonAlignedTestGroups(t *testing.T) {
+	SetupForTesting()
+	data := NewTestGridMetaData()
+	data.nonAligned = []NonAlignedTestGroup{
+		NonAlignedTestGroup{
+			CIJobName: "ci-job-name",
+			Extra:     map[string]string{},
+		},
+	}
+	data.generateNonAlignedTestGroups()
+	if len(GetOutput()) == 0 {
+		t.Errorf("No output")
+	}
+	if logFatalCalls != 0 {
+		t.Errorf("LogFatal was called.")
+	}
+}
+
+func TestTestGridMetaDataAddNonAlignedTest(t *testing.T) {
+	SetupForTesting()
+	data := NewTestGridMetaData()
+	data.AddNonAlignedTest(NonAlignedTestGroup{})
+	if len(data.nonAligned) != 1 {
+		t.Errorf("Test was not appended.")
+	}
+}
+
+func TestGetGcsLogDir(t *testing.T) {
+	SetupForTesting()
+	GCSBucket = "gcs-bucket"
+	LogsDir = "logs-dir"
+	expected := "gcs-bucket/logs-dir/tg-name"
+	if diff := cmp.Diff(getGcsLogDir("tg-name"), expected); diff != "" {
+		t.Errorf("(-got +want): \n%s", diff)
+	}
+}
+
+func TestTestGridMetaDataGenerateTestGroup(t *testing.T) {
+	SetupForTesting()
+	data := NewTestGridMetaData()
+	projName := "proj-name"
+	repoName := "repo-name"
+	jobNames := []string{"continuous", "dot-release", "webhook-api-coverage", "test-coverage", "default"}
+	data.generateTestGroup(projName, repoName, jobNames)
+	if len(GetOutput()) == 0 {
+		t.Errorf("No output")
+	}
+	if logFatalCalls != 0 {
+		t.Errorf("LogFatal was called.")
+	}
+}
+
+func TestExecuteTestGroupTemplate(t *testing.T) {
+	SetupForTesting()
+	executeTestGroupTemplate("tg-name", "gcs-log-dir", map[string]string{})
+	if len(GetOutput()) == 0 {
+		t.Errorf("No output")
+	}
+	if logFatalCalls != 0 {
+		t.Errorf("LogFatal was called.")
+	}
+}
+
+func TestGenerateDashboard(t *testing.T) {
+	SetupForTesting()
+	projName := "proj-name"
+	repoName := "repo-name"
+	jobNames := []string{"continuous", "dot-release", "webhook-api-coverage", "nightly", "test-coverage", "default"}
+	generateDashboard(projName, repoName, jobNames)
+	if len(GetOutput()) == 0 {
+		t.Errorf("No output")
+	}
+	if logFatalCalls != 0 {
+		t.Errorf("LogFatal was called.")
+	}
+}
+
+func TestExecuteDashboardTabTemplate(t *testing.T) {
+	SetupForTesting()
+	executeDashboardTabTemplate("tab-name", "tg-name", "base-opts", map[string]string{})
+	if len(GetOutput()) == 0 {
+		t.Errorf("No output")
+	}
+	if logFatalCalls != 0 {
+		t.Errorf("LogFatal was called.")
+	}
+}
+
+func TestGetTestGroupName(t *testing.T) {
+	SetupForTesting()
+	out := getTestGroupName("foo", "bar")
+	expected := "ci-foo-bar"
+	if diff := cmp.Diff(out, expected); diff != "" {
+		t.Errorf("(-got +want): \n%s", diff)
+	}
+
+	out = getTestGroupName("foo", "nightly")
+	expected = "ci-foo-nightly-release"
+	if diff := cmp.Diff(out, expected); diff != "" {
+		t.Errorf("(-got +want): \n%s", diff)
+	}
+}
+
+func TestGenerateNonAlignedDashboards(t *testing.T) {
+	SetupForTesting()
+	data := NewTestGridMetaData()
+	data.AddNonAlignedTest(NonAlignedTestGroup{
+		DashboardName: "dashboard-name",
+		HumanTabName:  "human-tab-name",
+		CIJobName:     "ci-job-name",
+		BaseOptions:   "base-opts",
+	})
+	data.generateNonAlignedDashboards()
+	if len(GetOutput()) == 0 {
+		t.Errorf("No output")
+	}
+	if logFatalCalls != 0 {
+		t.Errorf("LogFatal was called.")
+	}
+}
+
+func TestGenerateDashboardsForReleases(t *testing.T) {
+	SetupForTesting()
+	data := NewTestGridMetaData()
+	data.projNames = []string{"project-a", "project-b-2.0"}
+	data.repoNames = []string{"repo-1", "repo-2", "repo-3"}
+	data.md["project-a"] = JobDetailMap{
+		"repo-1": []string{"job-1a", "job-1b"},
+		"repo-2": []string{"job-2a", "job-2b"},
+	}
+	data.md["project-b"] = JobDetailMap{
+		"repo-3": []string{"job-3a", "job-3b"},
+	}
+	data.generateDashboardsForReleases()
+	if len(GetOutput()) == 0 {
+		t.Errorf("No output")
+	}
+	if logFatalCalls != 0 {
+		t.Errorf("LogFatal was called.")
+	}
+}
+
+func TestGenerateNonAlignedDashboardGroups(t *testing.T) {
+	SetupForTesting()
+	data := NewTestGridMetaData()
+	data.nonAligned = []NonAlignedTestGroup{
+		NonAlignedTestGroup{
+			DashboardName:  "dashboard-name",
+			DashboardGroup: "dashboard-group",
+		},
+	}
+	data.generateNonAlignedDashboardGroups()
+	if len(GetOutput()) == 0 {
+		t.Errorf("No output")
+	}
+	if logFatalCalls != 0 {
+		t.Errorf("LogFatal was called.")
+	}
+}
+
+func TestGenerateDashboardGroups(t *testing.T) {
+	SetupForTesting()
+	data := NewTestGridMetaData()
+	data.projNames = []string{"project-a", "project-b-2.0"}
+	data.repoNames = []string{"repo-1", "repo-2", "repo-3"}
+	data.md["project-a"] = JobDetailMap{
+		"repo-1": []string{"job-1a", "job-1b"},
+		"repo-2": []string{"job-2a", "job-2b"},
+	}
+	data.md["project-b"] = JobDetailMap{
+		"repo-3": []string{"job-3a", "job-3b"},
+	}
+	data.generateDashboardGroups()
+	if len(GetOutput()) == 0 {
+		t.Errorf("No output")
+	}
+	if logFatalCalls != 0 {
+		t.Errorf("LogFatal was called.")
+	}
+}
+
+func TestExecuteDashboardGroupTemplate(t *testing.T) {
+	SetupForTesting()
+	executeDashboardGroupTemplate("group-name", []string{"repo1", "repo2"})
+	if len(GetOutput()) == 0 {
+		t.Errorf("No output")
+	}
+	if logFatalCalls != 0 {
+		t.Errorf("LogFatal was called.")
+	}
+}


### PR DESCRIPTION
/lint

**What this PR does, why we need it**:
Increase unit test coverage from 46% to 82% for config-generator tool.

**Which issue(s) this PR fixes**:
Fixes #2419 

