### PR TITLE
Remove optional markdown checks from docs pre-submit test

### DIFF
--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -312,11 +312,6 @@ presubmits:
   - integration-tests: true
     needs-dind: true
   - go-coverage: true
-  - custom-test: markdown-link-check
-    always-run: true
-    optional: true
-    command:
-    - ./test/presubmit-link-check.sh
   knative/pkg:
   - build-tests: true
   - unit-tests: true

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -1757,36 +1757,6 @@ presubmits:
       - name: covbot-token
         secret:
           secretName: covbot-token
-  - name: pull-knative-docs-markdown-link-check
-    agent: kubernetes
-    context: pull-knative-docs-markdown-link-check
-    always_run: true
-    rerun_command: "/test pull-knative-docs-markdown-link-check"
-    trigger: "(?m)^/test (all|pull-knative-docs-markdown-link-check),?(\\s+|$)"
-    decorate: true
-    optional: true
-    cluster: "build-knative"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-link-check.sh"
-        volumeMounts:
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-      volumes:
-      - name: test-account
-        secret:
-          secretName: test-account
   knative/pkg:
   - name: pull-knative-pkg-build-tests
     agent: kubernetes


### PR DESCRIPTION
This patch removes optional markdown checks from docs pre-submit test.

For some context:
https://github.com/knative/test-infra/pull/2476 removed `markdown_build_tests` from scripts/presubmit-tests.sh because of github action migration. But knative/docs still runs [the function](https://github.com/knative/docs/blob/e4d95cdf0746ec187d6f3c729a7b8b3380798f42/test/presubmit-link-check.sh#L33).
And it started failing in https://github.com/knative/docs/pull/2889 / [log](https://prow.knative.dev/view/gs/knative-prow/pr-logs/pull/knative_docs/2889/pull-knative-docs-markdown-link-check/1313310691062452228) when updating the deps.

/cc @chizhg @n3wscott
