### PR TITLE
introduce a bash entry point for update deps

### DIFF
--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -18,36 +18,6 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-export GO111MODULE=on
-export GOFLAGS=""
-
 source $(dirname "$0")/../scripts/library.sh
 
-cd "${REPO_ROOT_DIR}"
-
-# Parse flags to determine any we should pass to dep.
-GO_GET=0
-while [[ $# -ne 0 ]]; do
-  parameter=$1
-  case ${parameter} in
-    --upgrade) GO_GET=1 ;;
-    *) abort "unknown option ${parameter}" ;;
-  esac
-  shift
-done
-readonly GO_GET
-
-
-if (( GO_GET )); then
-  # We track the latest minor of all dependencies.
-  go get -u ./...
-fi
-# Prune modules.
-go mod tidy
-go mod vendor
-
-rm -rf $(find vendor/ -name 'OWNERS')
-rm -rf $(find vendor/ -name 'OWNERS_ALIASES')
-rm -rf $(find vendor/ -name '*_test.go')
-
-update_licenses third_party/VENDOR-LICENSE "./..."
+go_update_deps "$@"

--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -519,6 +519,8 @@ function add_trap {
 #   "--release <version>" used with upgrade. The release version to upgrade
 #                         Knative components. ex: --release v0.18. Defaults to
 #                         "master".
+# Additional dependencies can be included in the upgrade by providing them in a
+# global env var: FLOATING_DEPS
 function go_update_deps() {
   cd "${REPO_ROOT_DIR}" || return 1
 
@@ -541,9 +543,9 @@ function go_update_deps() {
 
   if (( UPGRADE )); then
     echo "--- Upgrading to ${VERSION}"
-    FLOATING_DEPS=( $(run_go_tool knative.dev/test-infra/buoy buoy float ${REPO_ROOT_DIR}/go.mod --release ${VERSION} --domain knative.dev) )
+    FLOATING_DEPS+=( $(run_go_tool knative.dev/test-infra/buoy buoy float ${REPO_ROOT_DIR}/go.mod --release ${VERSION} --domain knative.dev) )
     if (( ${#FLOATING_DEPS[@]} )); then
-      echo "floating deps to ${FLOATING_DEPS[@]}"
+      echo "Floating deps to ${FLOATING_DEPS[@]}"
       go get -d ${FLOATING_DEPS[@]}
     else
       echo "Nothing to upgrade."

--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -513,6 +513,63 @@ function add_trap {
   done
 }
 
+# Update go deps.
+# Parameters (parsed as flags):
+#   "--upgrade", bool, do upgrade.
+#   "--release <version>" used with upgrade. The release version to upgrade
+#                         Knative components. ex: --release v0.18. Defaults to
+#                         "master".
+function go_update_deps() {
+  cd "${REPO_ROOT_DIR}" || return 1
+
+  export GO111MODULE=on
+  export GOFLAGS=""
+
+  echo "=== Update Deps for Golang"
+
+  local UPGRADE=0
+  local VERSION="master"
+  while [[ $# -ne 0 ]]; do
+    parameter=$1
+    case ${parameter} in
+      --upgrade) UPGRADE=1 ;;
+      --release) shift; VERSION="$1" ;;
+      *) abort "unknown option ${parameter}" ;;
+    esac
+    shift
+  done
+
+  if (( UPGRADE )); then
+    echo "--- Upgrading to ${VERSION}"
+    FLOATING_DEPS=( $(run_go_tool knative.dev/test-infra/buoy buoy float ${REPO_ROOT_DIR}/go.mod --release ${VERSION} --domain knative.dev) )
+    if (( ${#FLOATING_DEPS[@]} )); then
+      echo "floating deps to ${FLOATING_DEPS[@]}"
+      go get -d ${FLOATING_DEPS[@]}
+    else
+      echo "Nothing to upgrade."
+    fi
+  fi
+
+  echo "--- Go mod tidy and vendor"
+
+  # Prune modules.
+  go mod tidy
+  go mod vendor
+
+  echo "--- Removing unwanted vendor files"
+
+  # Remove unwanted vendor files
+  find vendor/ \( -name "OWNERS" -o -name "*_test.go" \) -print0 | xargs -0 rm -f
+
+  export GOFLAGS=-mod=vendor
+
+  echo "--- Updating licenses"
+  update_licenses third_party/VENDOR-LICENSE "./..."
+
+  echo "--- Removing broken symlinks"
+  remove_broken_symlinks ./vendor
+}
+
 # Run kntest tool, error out and ask users to install it if it's not currently installed.
 # Parameters: $1..$n - parameters passed to the tool.
 function run_kntest() {


### PR DESCRIPTION
**What this PR does, why we need it**:
This will standardize how knative upses update deps from test-infra.
