### PR TITLE
Add Sample Source to release/nightlies

### DIFF
--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -791,6 +791,8 @@ periodics:
   - continuous: true
   knative-sandbox/sample-source:
   - continuous: true
+  - nightly: true
+  - auto-release: true
   knative/test-infra:
   - continuous: true
     needs-dind: true

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -9339,6 +9339,82 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
+- cron: "10 9 * * *"
+  name: ci-knative-sandbox-sample-source-nightly-release
+  agent: kubernetes
+  decorate: true
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative-sandbox
+    repo: sample-source
+    path_alias: knative.dev/sample-source
+    base_ref: master
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--publish"
+      - "--tag-release"
+      volumeMounts:
+      - name: nightly-account
+        mountPath: /etc/nightly-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/nightly-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: nightly-account
+      secret:
+        secretName: nightly-account
+- cron: "54 */2 * * *"
+  name: ci-knative-sandbox-sample-source-auto-release
+  agent: kubernetes
+  decorate: true
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative-sandbox
+    repo: sample-source
+    path_alias: knative.dev/sample-source
+    base_ref: master
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--auto-release"
+      - "--release-gcs knative-releases/sample-source"
+      - "--release-gcr gcr.io/knative-releases"
+      - "--github-token /etc/hub-token/token"
+      volumeMounts:
+      - name: hub-token
+        mountPath: /etc/hub-token
+        readOnly: true
+      - name: release-account
+        mountPath: /etc/release-account
+        readOnly: true
+      env:
+      - name: ORG_NAME
+        value: knative-sandbox
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: hub-token
+      secret:
+        secretName: hub-token
+    - name: release-account
+      secret:
+        secretName: release-account
 - cron: "49 * * * *"
   name: ci-knative-test-infra-continuous
   agent: kubernetes

--- a/config/prod/prow/testgrid/testgrid.yaml
+++ b/config/prod/prow/testgrid/testgrid.yaml
@@ -488,6 +488,16 @@ test_groups:
 - name: ci-knative-sandbox-sample-source-continuous
   gcs_prefix: knative-prow/logs/ci-knative-sandbox-sample-source-continuous
   alert_stale_results_hours: 3
+- name: ci-knative-sandbox-sample-source-nightly-release
+  gcs_prefix: knative-prow/logs/ci-knative-sandbox-sample-source-nightly-release
+  alert_options:
+    alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+  num_failures_to_alert: 1
+- name: ci-knative-sandbox-sample-source-auto-release
+  gcs_prefix: knative-prow/logs/ci-knative-sandbox-sample-source-auto-release
+  alert_options:
+    alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+  num_failures_to_alert: 1
 - name: ci-knative-sandbox-net-certmanager-continuous
   gcs_prefix: knative-prow/logs/ci-knative-sandbox-net-certmanager-continuous
   alert_stale_results_hours: 3
@@ -1374,6 +1384,18 @@ dashboards:
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
     num_failures_to_alert: 3
+  - name: nightly
+    test_group_name: ci-knative-sandbox-sample-source-nightly-release
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 1
+  - name: auto-release
+    test_group_name: ci-knative-sandbox-sample-source-auto-release
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 1
 - name: net-certmanager
   dashboard_tab:
   - name: continuous


### PR DESCRIPTION

/lint

**What this PR does, why we need it**:

After trying to use sample-source as an example in environments where the `ko` tool wasn't available, it'd be nice to have upstream images of the controller and receive adapter.  This is also true of wanting to see the state of sample-source over the course of different knative versions.

