### PR TITLE
Fix shellcheck file search

### DIFF
--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -727,7 +727,7 @@ function get_latest_knative_yaml_source() {
 function shellcheck_new_files() {
   declare -a array_of_files
   local failed=0
-  readarray -t -d '\n' array_of_files < <(list_changed_files)
+  readarray -t array_of_files < <(list_changed_files)
   for filename in "${array_of_files[@]}"; do
     if echo "${filename}" | grep -q "^vendor/"; then
       continue

--- a/scripts/shellcheck-presubmit.sh
+++ b/scripts/shellcheck-presubmit.sh
@@ -29,4 +29,6 @@ if (( ! IS_PROW )); then
   echo " and/or currently staged."
 fi
 
-shellcheck_new_files
+if [[ "$1" == "--run" ]]; then
+  shellcheck_new_files
+fi


### PR DESCRIPTION
readarray defaults to newline. Oops

This is breaking shellcheck presubmit

/cc @chizhg 
/assign @chizhg 