### PR TITLE
Add prow job for knative-gcp conformance tests

### DIFF
--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -372,6 +372,11 @@ presubmits:
     args:
     - --run-test
     - ./test/e2e-wi-tests.sh
+  - custom-test: conformance-tests
+    needs-monitor: true
+    args:
+    - --run-test
+    - ./test/e2e-conformance-tests.sh
   - go-coverage: true
   knative/networking:
   - build-tests: true

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -2450,52 +2450,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-google-knative-gcp-conformance-tests
-    agent: kubernetes
-    labels:
-      prow.k8s.io/pubsub.project: knative-tests
-      prow.k8s.io/pubsub.topic: knative-monitoring
-      prow.k8s.io/pubsub.runID: pull-google-knative-gcp-conformance-tests
-    context: pull-google-knative-gcp-conformance-tests
-    always_run: true
-    rerun_command: "/test pull-google-knative-gcp-conformance-tests"
-    trigger: "(?m)^/test (all|pull-google-knative-gcp-conformance-tests),?(\\s+|$)"
-    decorate: true
-    cluster: "build-knative"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--run-test"
-        - "./test/e2e-conformance-tests.sh"
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-        resources:
-          requests:
-            memory: 12Gi
-          limits:
-            memory: 16Gi
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: test-account
-        secret:
-          secretName: test-account
   - name: pull-google-knative-gcp-wi-tests
     agent: kubernetes
     labels:
@@ -2532,6 +2486,41 @@ presubmits:
             memory: 12Gi
           limits:
             memory: 16Gi
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-google-knative-gcp-conformance-tests
+    agent: kubernetes
+    labels:
+      prow.k8s.io/pubsub.project: knative-tests
+      prow.k8s.io/pubsub.topic: knative-monitoring
+      prow.k8s.io/pubsub.runID: pull-google-knative-gcp-conformance-tests
+    context: pull-google-knative-gcp-conformance-tests
+    always_run: true
+    rerun_command: "/test pull-google-knative-gcp-conformance-tests"
+    trigger: "(?m)^/test (all|pull-google-knative-gcp-conformance-tests),?(\\s+|$)"
+    decorate: true
+    cluster: "build-knative"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-conformance-tests.sh"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
       volumes:
       - name: test-account
         secret:

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -2450,6 +2450,52 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
+  - name: pull-google-knative-gcp-conformance-tests
+    agent: kubernetes
+    labels:
+      prow.k8s.io/pubsub.project: knative-tests
+      prow.k8s.io/pubsub.topic: knative-monitoring
+      prow.k8s.io/pubsub.runID: pull-google-knative-gcp-conformance-tests
+    context: pull-google-knative-gcp-conformance-tests
+    always_run: true
+    rerun_command: "/test pull-google-knative-gcp-conformance-tests"
+    trigger: "(?m)^/test (all|pull-google-knative-gcp-conformance-tests),?(\\s+|$)"
+    decorate: true
+    cluster: "build-knative"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-conformance-tests.sh"
+        volumeMounts:
+        - name: repoview-token
+          mountPath: /etc/repoview-token
+          readOnly: true
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+        resources:
+          requests:
+            memory: 12Gi
+          limits:
+            memory: 16Gi
+      volumes:
+      - name: repoview-token
+        secret:
+          secretName: repoview-token
+      - name: test-account
+        secret:
+          secretName: test-account
   - name: pull-google-knative-gcp-wi-tests
     agent: kubernetes
     labels:

--- a/config/prod/prow/testgrid/testgrid.yaml
+++ b/config/prod/prow/testgrid/testgrid.yaml
@@ -1719,12 +1719,6 @@ dashboards:
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
     num_failures_to_alert: 3
-  - name: conformance
-    test_group_name: ci-google-knative-gcp-continuous
-    base_options: "include-filter-by-regex=test/conformance/&sort-by-name="
-    alert_options:
-      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
-    num_failures_to_alert: 3
   - name: nightly
     test_group_name: ci-google-knative-gcp-nightly-release
     base_options: "sort-by-name="

--- a/config/prod/prow/testgrid/testgrid.yaml
+++ b/config/prod/prow/testgrid/testgrid.yaml
@@ -1719,6 +1719,12 @@ dashboards:
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
     num_failures_to_alert: 3
+  - name: conformance
+    test_group_name: ci-google-knative-gcp-continuous
+    base_options: "include-filter-by-regex=test/conformance/&sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
   - name: nightly
     test_group_name: ci-google-knative-gcp-nightly-release
     base_options: "sort-by-name="


### PR DESCRIPTION
**What this PR does, why we need it**:

Adds prow job for running conformance tests in knative-gcp.

This is a follow-up to https://github.com/google/knative-gcp/pull/1837.