### PR TITLE
Bump golang default to 1.14

### DIFF
--- a/images/prow-tests/runner.sh
+++ b/images/prow-tests/runner.sh
@@ -18,8 +18,8 @@ ORIGINAL_GOPATH="${GOPATH}"
 
 source "${HOME}/.gvm/scripts/gvm"
 
-# By default using Go version 1.13.
-version="go1.13"
+# By default using Go version 1.14.
+version="go1.14"
 # Extract the go version if the project is using go mod.
 if [[ -f "go.mod" ]]; then
   version="go$(sed -n 's/^go //p' go.mod | tr -d '[:space:]')"


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:

Nothing in Knative should be using Golang 1.13 explicitly at this point. Having 1.14 as the default seems reasonable (and will fix my problem with client-contrib still running 1.13 and breaking on a dependency upgrade).
