### PR TITLE
bypass the golang proxy for upgrades if GOPROXY is not set

### DIFF
--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -555,7 +555,7 @@ function go_update_deps() {
       echo "Respecting 'GOPROXY=${GOPROXY}'."
     fi
     FLOATING_DEPS+=( $(run_go_tool knative.dev/test-infra/buoy buoy float ${REPO_ROOT_DIR}/go.mod --release ${VERSION} --domain knative.dev) )
-    if [[ ${FLOATING_DEPS[@]} ]]; then
+    if [[ ${#FLOATING_DEPS[@]} > 0 ]]; then
       echo "Floating deps to ${FLOATING_DEPS[@]}"
       go get -d ${FLOATING_DEPS[@]}
     else

--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -544,7 +544,7 @@ function go_update_deps() {
 
   if [[ $UPGRADE == 1 ]]; then
     echo "--- Upgrading to ${VERSION}"
-    # From shell parameter expeansion:
+    # From shell parameter expansion:
     # ${parameter:+word}
     # If parameter is null or unset, nothing is substituted, otherwise the expansion of word is substituted.
     # -z is if the length of the string, so skip setting GOPROXY if GOPROXY is already set.

--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -521,6 +521,7 @@ function add_trap {
 #                         "master".
 # Additional dependencies can be included in the upgrade by providing them in a
 # global env var: FLOATING_DEPS
+# --upgrade will set GOPROXY to direct unless it is already set.
 function go_update_deps() {
   cd "${REPO_ROOT_DIR}" || return 1
 
@@ -543,6 +544,12 @@ function go_update_deps() {
 
   if (( UPGRADE )); then
     echo "--- Upgrading to ${VERSION}"
+    if [ -z ${GOPROXY+x} ]; then
+      export GOPROXY=direct
+      echo "Using 'GOPROXY=direct'."
+    else
+      echo "Respecting 'GOPROXY=${GOPROXY}'."
+    fi
     FLOATING_DEPS+=( $(run_go_tool knative.dev/test-infra/buoy buoy float ${REPO_ROOT_DIR}/go.mod --release ${VERSION} --domain knative.dev) )
     if (( ${#FLOATING_DEPS[@]} )); then
       echo "Floating deps to ${FLOATING_DEPS[@]}"

--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -542,16 +542,20 @@ function go_update_deps() {
     shift
   done
 
-  if (( UPGRADE )); then
+  if [[ $UPGRADE == 1 ]]; then
     echo "--- Upgrading to ${VERSION}"
-    if [ -z ${GOPROXY+x} ]; then
+    # From shell parameter expeansion:
+    # ${parameter:+word}
+    # If parameter is null or unset, nothing is substituted, otherwise the expansion of word is substituted.
+    # -z is if the length of the string, so skip setting GOPROXY if GOPROXY is already set.
+    if [[ -z ${GOPROXY:+skip} ]]; then
       export GOPROXY=direct
       echo "Using 'GOPROXY=direct'."
     else
       echo "Respecting 'GOPROXY=${GOPROXY}'."
     fi
     FLOATING_DEPS+=( $(run_go_tool knative.dev/test-infra/buoy buoy float ${REPO_ROOT_DIR}/go.mod --release ${VERSION} --domain knative.dev) )
-    if (( ${#FLOATING_DEPS[@]} )); then
+    if [[ ${FLOATING_DEPS[@]} ]]; then
       echo "Floating deps to ${FLOATING_DEPS[@]}"
       go get -d ${FLOATING_DEPS[@]}
     else


### PR DESCRIPTION
**What this PR does, why we need it**:

Automation that runs just after a merge to an upstream repo misses updates because golang by default uses the global proxy.

This will bypass the default `GOPROXY` and use `direct` if `GOPROXY` is not set, allowing automation to quickly update downstream dependencies.
