### PR TITLE
Specify resource requirements in knative-gcp conformance tests

### DIFF
--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -373,6 +373,11 @@ presubmits:
     - --run-test
     - ./test/e2e-wi-tests.sh
   - custom-test: conformance-tests
+    resources:
+      requests:
+        memory: 12Gi
+      limits:
+        memory: 16Gi
     needs-monitor: true
     args:
     - --run-test

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -2521,6 +2521,11 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-central1
+        resources:
+          requests:
+            memory: 12Gi
+          limits:
+            memory: 16Gi
       volumes:
       - name: test-account
         secret:


### PR DESCRIPTION
**What this PR does, why we need it**:

Specify resource requirements in knative-gcp conformance tests. Without this, the knative-gcp conformance tests fail during initialization.