### PR TITLE
Use random cluster name for e2e tests and another nit update

### DIFF
--- a/kntest/pkg/kubetest2/gke/options.go
+++ b/kntest/pkg/kubetest2/gke/options.go
@@ -29,7 +29,7 @@ func addOptions(gkeCmd *cobra.Command, cfg *kubetest2.GKEClusterConfig) {
 	f.StringVar(&cfg.CommandGroup, "command-group", "beta", "The gcloud command group, must be alpha, beta or empty.")
 	f.StringVar(&cfg.GCPProjectID, "gcp-project-id", "", "GCP project ID for creating the cluster")
 
-	f.StringVar(&cfg.Name, "name", "e2e-cls", "The GKE cluster name.")
+	f.StringVar(&cfg.Name, "name", "", "The GKE cluster name.")
 	f.StringVar(&cfg.Region, "region", "us-central1", "The region to create the GKE cluster.")
 	f.StringSliceVar(&cfg.BackupRegions, "backup-regions", []string{"us-west1", "us-east1"}, "The backup regions if the cluster creation runs into stockout issue in the primary region.")
 	f.StringVar(&cfg.Machine, "machine", "e2-standard-4", "The machine type for the GKE cluster.")


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
1. As per discussions in https://knative.slack.com/archives/CA1DTGZ2N/p1603309779069700, generate and use random cluster name for e2e tests
2. Now kubetest2 allows specifying version to be `latest` when `--release-channel` is not empty, so also allows it in kntest

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc

