### PR TITLE
Build stripped binaries to reduce sizes

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -100,6 +100,8 @@ ARTIFACTS_TO_PUBLISH=""
 FROM_NIGHTLY_RELEASE=""
 FROM_NIGHTLY_RELEASE_GCS=""
 export KO_DOCKER_REPO="gcr.io/knative-nightly"
+# Build stripped binary to reduce size
+export GOFLAGS="-ldflags=-s -ldflags=-w"
 export GITHUB_TOKEN=""
 
 # Convenience function to run the hub tool.


### PR DESCRIPTION

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Build stripped binaries to reduce sizes. See https://github.com/knative/serving/issues/9957#issuecomment-717491411.


**Which issue(s) this PR fixes**:
Part of https://github.com/knative/serving/issues/9957

**Special notes to reviewers**:

**User-visible changes in this PR**: reduced Knative binaries sizes

