### PR TITLE
fix prow-tests image; go-licenses is a terrible tool

### DIFF
--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -128,6 +128,7 @@ COPY --from=test-infra-builds /go/bin/* /go/bin/
 RUN rm -f /usr/local/bin/source-gvm-and-run.sh
 
 # This tool is poorly written and requires its mod cache to be present to function!
+# (The purpose of the multiple stages is to keep the mod cache out of the final image)
 RUN GO111MODULE=on go get -u github.com/google/go-licenses
 
 # Extract versions

--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -92,7 +92,6 @@ RUN go get -u github.com/golang/dep/cmd/dep
 RUN go get -u github.com/jstemmer/go-junit-report
 RUN GO111MODULE=on go get -u gotest.tools/gotestsum
 RUN GO111MODULE=on go get -u github.com/raviqqe/liche@v0.0.0-20200229003944-f57a5d1c5be4  # stable liche version for checking md links
-RUN GO111MODULE=on go get -u github.com/google/go-licenses
 RUN GO111MODULE=on go get sigs.k8s.io/kind@v0.9.0
 RUN GO111MODULE=on go get -u sigs.k8s.io/kubetest2
 RUN GO111MODULE=on go get -u sigs.k8s.io/kubetest2/kubetest2-gke
@@ -127,6 +126,9 @@ COPY --from=test-infra-builds /go/bin/* /go/bin/
 
 # Only needed in this Dockerfile
 RUN rm -f /usr/local/bin/source-gvm-and-run.sh
+
+# This tool is poorly written and requires its mod cache to be present to function!
+RUN GO111MODULE=on go get -u github.com/google/go-licenses
 
 # Extract versions
 RUN bazel version > /bazel_version


### PR DESCRIPTION
I think that's the only part of the beta flow broken and it's passing when I manually pushed this image to `prow-tests:beta`:
https://prow.knative.dev/view/gs/knative-prow/logs/ci-knative-serving-continuous-beta-prow-tests/1321209297299836928#1:build-log.txt%3A309

/assign @chizhg 
/cc @chizhg 
