### PR TITLE
Add a heartbeat job

### DIFF
--- a/config/prod/prow/jobs/custom/test-infra.yaml
+++ b/config/prod/prow/jobs/custom/test-infra.yaml
@@ -81,11 +81,18 @@ presubmits:
           secretName: test-account
 
 periodics:
+# ci-knative-heartbeat is used for prometheus, alert(s) will be sent
+# if this job hadn't been succeeded for some time
 - cron: "*/3 * * * *" # Every 3 minutes
   name: ci-knative-heartbeat
   agent: kubernetes
   decorate: true
   cluster: "default"
+  extra_refs:
+  - org: knative
+    repo: test-infra
+    base_ref: master
+    path_alias: knative.dev/test-infra
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -93,10 +100,11 @@ periodics:
       command:
       - "runner.sh"
       args:
-      - "go"
-      - "test"
-      - "-v"
-      - "./..."
+      - "echo"
+      - "Everything is fine!"
+      resources:
+        requests:
+          memory: 1Gi
 - cron: "15 9 * * *"
   name: ci-knative-backup-artifacts
   agent: kubernetes

--- a/config/prod/prow/jobs/custom/test-infra.yaml
+++ b/config/prod/prow/jobs/custom/test-infra.yaml
@@ -81,6 +81,22 @@ presubmits:
           secretName: test-account
 
 periodics:
+- cron: "*/3 * * * *" # Every 3 minutes
+  name: ci-knative-heartbeat
+  agent: kubernetes
+  decorate: true
+  cluster: "default"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - "runner.sh"
+      args:
+      - "go"
+      - "test"
+      - "-v"
+      - "./..."
 - cron: "15 9 * * *"
   name: ci-knative-backup-artifacts
   agent: kubernetes


### PR DESCRIPTION
This is for monitoring prow purpose, so that there is always a job to check for whether prow had been functioning. There will be a prometheus alert rule checking the liveness of this job and sends out alert(s) if this job hadn't been succeeded for some time