### PR TITLE
Heartbeat job requests only 0.1CPU

### DIFF
--- a/config/prod/prow/jobs/custom/test-infra.yaml
+++ b/config/prod/prow/jobs/custom/test-infra.yaml
@@ -104,6 +104,7 @@ periodics:
       - "Everything is fine!"
       resources:
         requests:
+          cpu: 100m
           memory: 1Gi
 - cron: "15 9 * * *"
   name: ci-knative-backup-artifacts


### PR DESCRIPTION
It's just an echo command, doesn't need that much CPU(Default is 2CPU)

/cc @chizhg @coryrc 