### PR TITLE
Also set eventing continuous tests timeout to be 180m

### DIFF
--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -658,7 +658,6 @@ periodics:
     needs-dind: true
   knative/eventing:
   - continuous: true
-    timeout: 90
     resources:
       requests:
         memory: 12Gi

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -6823,12 +6823,12 @@ periodics:
       - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
-- cron: "52 */2 * * *"
+- cron: "52 */4 * * *"
   name: ci-knative-eventing-continuous
   agent: kubernetes
   decorate: true
   decoration_config:
-    timeout: 90m
+    timeout: 180m
   cluster: "build-knative"
   extra_refs:
   - org: knative
@@ -6871,7 +6871,7 @@ periodics:
   agent: kubernetes
   decorate: true
   decoration_config:
-    timeout: 90m
+    timeout: 180m
   cluster: "build-knative"
   extra_refs:
   - org: knative


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Only eventing has this `90m` timeout, not sure why and when it was added.
Removing it to also have the default `180m` timeout.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

/cc @grantr @vaikas 

