### PR TITLE
Added integration-test-channel-consolidated and distributed

### DIFF
--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -465,10 +465,12 @@ presubmits:
   - integration-tests: false
   knative-sandbox/eventing-kafka:
   - custom-test: integration-test-channel-consolidated
+    needs-dind: true
     args:
     - --run-test
     - ./test/e2e-tests.sh --consolidated
   - custom-test: integration-test-channel-distributed
+    needs-dind: true
     args:
     - --run-test
     - ./test/e2e-tests.sh --distributed

--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -465,12 +465,10 @@ presubmits:
   - integration-tests: false
   knative-sandbox/eventing-kafka:
   - custom-test: integration-test-channel-consolidated
-    needs-dind: true
     args:
     - --run-test
     - ./test/e2e-tests.sh --consolidated
   - custom-test: integration-test-channel-distributed
-    needs-dind: true
     args:
     - --run-test
     - ./test/e2e-tests.sh --distributed

--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -464,11 +464,18 @@ presubmits:
   - unit-tests: false
   - integration-tests: false
   knative-sandbox/eventing-kafka:
+  - custom-test: integration-test-channel-consolidated
+    args:
+    - --run-test
+    - ./test/e2e-tests.sh --consolidated
+  - custom-test: integration-test-channel-distributed
+    args:
+    - --run-test
+    - ./test/e2e-tests.sh --distributed
+  - integration-tests: false
   - build-tests: true
     needs-dind: true
   - unit-tests: true
-    needs-dind: true
-  - integration-tests: true
     needs-dind: true
   - go-coverage: true
     needs-dind: true

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -3971,6 +3971,72 @@ presubmits:
         secret:
           secretName: test-account
   knative-sandbox/eventing-kafka:
+  - name: pull-knative-sandbox-eventing-kafka-integration-test-channel-consolidated
+    agent: kubernetes
+    context: pull-knative-sandbox-eventing-kafka-integration-test-channel-consolidated
+    always_run: true
+    optional: false
+    rerun_command: "/test pull-knative-sandbox-eventing-kafka-integration-test-channel-consolidated"
+    trigger: "(?m)^/test (all|pull-knative-sandbox-eventing-kafka-integration-test-channel-consolidated),?(\\s+|$)"
+    decorate: true
+    path_alias: knative.dev/eventing-kafka
+    cluster: "build-knative"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-tests.sh --consolidated"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-sandbox-eventing-kafka-integration-test-channel-distributed
+    agent: kubernetes
+    context: pull-knative-sandbox-eventing-kafka-integration-test-channel-distributed
+    always_run: true
+    optional: false
+    rerun_command: "/test pull-knative-sandbox-eventing-kafka-integration-test-channel-distributed"
+    trigger: "(?m)^/test (all|pull-knative-sandbox-eventing-kafka-integration-test-channel-distributed),?(\\s+|$)"
+    decorate: true
+    path_alias: knative.dev/eventing-kafka
+    cluster: "build-knative"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-tests.sh --distributed"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
   - name: pull-knative-sandbox-eventing-kafka-build-tests
     agent: kubernetes
     context: pull-knative-sandbox-eventing-kafka-build-tests
@@ -4048,64 +4114,6 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--unit-tests"
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - name: repoview-token
-          mountPath: /etc/repoview-token
-          readOnly: true
-        - name: docker-graph
-          mountPath: /docker-graph
-        - name: modules
-          mountPath: /lib/modules
-        - name: cgroup
-          mountPath: /sys/fs/cgroup
-        - name: test-account
-          mountPath: /etc/test-account
-          readOnly: true
-        env:
-        - name: DOCKER_IN_DOCKER_ENABLED
-          value: "true"
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
-        - name: E2E_CLUSTER_REGION
-          value: us-central1
-      volumes:
-      - name: repoview-token
-        secret:
-          secretName: repoview-token
-      - name: docker-graph
-        emptyDir: {}
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-      - name: test-account
-        secret:
-          secretName: test-account
-  - name: pull-knative-sandbox-eventing-kafka-integration-tests
-    agent: kubernetes
-    context: pull-knative-sandbox-eventing-kafka-integration-tests
-    always_run: true
-    optional: false
-    rerun_command: "/test pull-knative-sandbox-eventing-kafka-integration-tests"
-    trigger: "(?m)^/test (all|pull-knative-sandbox-eventing-kafka-integration-tests),?(\\s+|$)"
-    decorate: true
-    path_alias: knative.dev/eventing-kafka
-    cluster: "build-knative"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "./test/presubmit-tests.sh"
-        - "--integration-tests"
         securityContext:
           privileged: true
         volumeMounts:

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -3991,16 +3991,36 @@ presubmits:
         - "./test/presubmit-tests.sh"
         - "--run-test"
         - "./test/e2e-tests.sh --consolidated"
+        securityContext:
+          privileged: true
         volumeMounts:
+        - name: docker-graph
+          mountPath: /docker-graph
+        - name: modules
+          mountPath: /lib/modules
+        - name: cgroup
+          mountPath: /sys/fs/cgroup
         - name: test-account
           mountPath: /etc/test-account
           readOnly: true
         env:
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: "true"
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-central1
       volumes:
+      - name: docker-graph
+        emptyDir: {}
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
       - name: test-account
         secret:
           secretName: test-account
@@ -4024,16 +4044,36 @@ presubmits:
         - "./test/presubmit-tests.sh"
         - "--run-test"
         - "./test/e2e-tests.sh --distributed"
+        securityContext:
+          privileged: true
         volumeMounts:
+        - name: docker-graph
+          mountPath: /docker-graph
+        - name: modules
+          mountPath: /lib/modules
+        - name: cgroup
+          mountPath: /sys/fs/cgroup
         - name: test-account
           mountPath: /etc/test-account
           readOnly: true
         env:
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: "true"
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-central1
       volumes:
+      - name: docker-graph
+        emptyDir: {}
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
       - name: test-account
         secret:
           secretName: test-account

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -3991,36 +3991,16 @@ presubmits:
         - "./test/presubmit-tests.sh"
         - "--run-test"
         - "./test/e2e-tests.sh --consolidated"
-        securityContext:
-          privileged: true
         volumeMounts:
-        - name: docker-graph
-          mountPath: /docker-graph
-        - name: modules
-          mountPath: /lib/modules
-        - name: cgroup
-          mountPath: /sys/fs/cgroup
         - name: test-account
           mountPath: /etc/test-account
           readOnly: true
         env:
-        - name: DOCKER_IN_DOCKER_ENABLED
-          value: "true"
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-central1
       volumes:
-      - name: docker-graph
-        emptyDir: {}
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
       - name: test-account
         secret:
           secretName: test-account
@@ -4044,36 +4024,16 @@ presubmits:
         - "./test/presubmit-tests.sh"
         - "--run-test"
         - "./test/e2e-tests.sh --distributed"
-        securityContext:
-          privileged: true
         volumeMounts:
-        - name: docker-graph
-          mountPath: /docker-graph
-        - name: modules
-          mountPath: /lib/modules
-        - name: cgroup
-          mountPath: /sys/fs/cgroup
         - name: test-account
           mountPath: /etc/test-account
           readOnly: true
         env:
-        - name: DOCKER_IN_DOCKER_ENABLED
-          value: "true"
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-central1
       volumes:
-      - name: docker-graph
-        emptyDir: {}
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
       - name: test-account
         secret:
           secretName: test-account


### PR DESCRIPTION
**What this PR does, why we need it**:

The eventing-kafka project needs two separate integration tests for the distributed and consolidated channel types.  I am hoping that this small change will do it, but I could really use some expert eyes as I have never changed anything in this repository before.

**References**
eventing-kafka e2e test PR (should be merged first):  https://github.com/knative-sandbox/eventing-kafka/pull/146 
