### PR TITLE
Run branch-protector Prow job for Knative org

### DIFF
--- a/config/branch_protector/rules.yaml
+++ b/config/branch_protector/rules.yaml
@@ -23,6 +23,15 @@ branch-protection:
         - tide
       # Enforce all configured restrictions above for administrators.
       enforce_admins: true
+    knative:
+      # Protect all branches in knative
+      protect: true
+      required_status_checks:
+        contexts:
+        - cla/google
+        - tide
+      # Enforce all configured restrictions above for administrators.
+      enforce_admins: true
     google:
       repos:
         # Protect all branches in google/knative-gcp

--- a/config/prod/prow/jobs/custom/branchprotector.yaml
+++ b/config/prod/prow/jobs/custom/branchprotector.yaml
@@ -15,34 +15,35 @@
 # branchprotector is a tool implemented by k8s sig-testing.
 # It can configures github branch protection rules according to the specified policy in a YAML file.
 
-presubmits:
-  knative/test-infra:
-  - name: pull-knative-test-infra-branchprotector
-    agent: kubernetes
-    decorate: true
-    path_alias: knative.dev/test-infra
-    run_if_changed: "^config/branch_protector/rules.yaml$"
-    cluster: "prow-trusted"
-    branches:
-    - "master"
-    spec:
-      containers:
-      - name: branchprotector
-        image: gcr.io/k8s-prow/branchprotector:v20201103-bb494c0354
-        command:
-        - /app/prow/cmd/branchprotector/app.binary
-        args:
-        - --config-path=config/branch_protector/rules.yaml
-        - --github-token-path=/etc/github/token
-        - --confirm=false
-        volumeMounts:
-        - name: oauth
-          mountPath: /etc/github
-          readOnly: true
-      volumes:
-      - name: oauth
-        secret:
-          secretName: github-token-for-branchprotector
+# Do not enable presubmit tests for now since it's taking extra long time.
+#presubmits:
+#  knative/test-infra:
+#  - name: pull-knative-test-infra-branchprotector
+#    agent: kubernetes
+#    decorate: true
+#    path_alias: knative.dev/test-infra
+#    run_if_changed: "^config/branch_protector/rules.yaml$"
+#    cluster: "prow-trusted"
+#    branches:
+#    - "master"
+#    spec:
+#      containers:
+#      - name: branchprotector
+#        image: gcr.io/k8s-prow/branchprotector:v20201103-bb494c0354
+#        command:
+#        - /app/prow/cmd/branchprotector/app.binary
+#        args:
+#        - --config-path=config/branch_protector/rules.yaml
+#        - --github-token-path=/etc/github/token
+#        - --confirm=false
+#        volumeMounts:
+#        - name: oauth
+#          mountPath: /etc/github
+#          readOnly: true
+#      volumes:
+#      - name: oauth
+#        secret:
+#          secretName: github-token-for-branchprotector
 
 periodics:
 # Run at 10AM PST.
@@ -52,9 +53,9 @@ periodics:
   decorate: true
   cluster: "prow-trusted"
   extra_refs:
-  - org: chizhg
+  - org: knative
     repo: test-infra
-    base_ref: configure-branch-protector
+    base_ref: master
     path_alias: knative.dev/test-infra
   spec:
     containers:

--- a/config/prod/prow/jobs/custom/branchprotector.yaml
+++ b/config/prod/prow/jobs/custom/branchprotector.yaml
@@ -15,7 +15,8 @@
 # branchprotector is a tool implemented by k8s sig-testing.
 # It can configures github branch protection rules according to the specified policy in a YAML file.
 
-# Do not enable presubmit tests for now since it's taking extra long time.
+# Do not enable presubmit test for now since it's taking extra long time.
+# TODO(chizhg): reenable it if we can run it in a more lightweight mode - https://github.com/knative/test-infra/pull/2555
 #presubmits:
 #  knative/test-infra:
 #  - name: pull-knative-test-infra-branchprotector


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
We had been running `branch-protector` job for `knative-sandbox` org for a while, and no issues were reported, so enable it for `knative` org as well.

Note the previous Prow job was mistakenly configured to run on one of my test branch, and one day I deleted it, so the Prow jobs had been failing for a while due to `branch cannot be found` error. I have fixed it in this PR.

/cc @mattmoor 

