### PR TITLE
Ensure generated k8s-testgrid config have deterministic order

### DIFF
--- a/config/prod/prow/k8s-testgrid/k8s-testgrid.yaml
+++ b/config/prod/prow/k8s-testgrid/k8s-testgrid.yaml
@@ -54,6 +54,9 @@ dashboards:
 - name: serving
 - name: test-infra
 dashboard_groups:
+  - name: google
+    dashboard_names:
+      - "knative-gcp"
   - name: knative
     dashboard_names:
       - "caching"
@@ -90,6 +93,3 @@ dashboard_groups:
       - "net-kourier"
       - "sample-controller"
       - "sample-source"
-  - name: google
-    dashboard_names:
-      - "knative-gcp"

--- a/tools/config-generator/k8s_testgrid_config.go
+++ b/tools/config-generator/k8s_testgrid_config.go
@@ -32,8 +32,14 @@ type k8sTestgridData struct {
 
 func generateK8sTestgrid(orgsAndRepos map[string][]string) {
 	allReposSet := make(map[string]struct{})
-	for _, repos := range orgsAndRepos {
-		for _, repo := range repos {
+	// Sort orgsAndRepos to maintain the output order
+	var orgs []string
+	for org := range orgsAndRepos {
+		orgs = append(orgs, org)
+	}
+	sort.Strings(orgs)
+	for _, org := range orgs {
+		for _, repo := range orgsAndRepos[org] {
 			allReposSet["name: "+repo] = struct{}{}
 		}
 	}
@@ -44,7 +50,8 @@ func generateK8sTestgrid(orgsAndRepos map[string][]string) {
 		readTemplate(k8sTestgridTempl),
 		struct{ AllRepos []string }{allRepos})
 
-	for org, repos := range orgsAndRepos {
+	for _, org := range orgs {
+		repos := orgsAndRepos[org]
 		sort.Strings(repos)
 		executeTemplate("k8s testgrid group",
 			readTemplate(k8sTestgridGroupTempl),


### PR DESCRIPTION
So that verify-codegen isn't flaky any more

/cc @joshua-bone @n3wscott 