### PR TITLE
adding labels to allow more kind labels for PRs.

### DIFF
--- a/config/label_sync/labels.yaml
+++ b/config/label_sync/labels.yaml
@@ -64,6 +64,7 @@ default:
       target: both
       addedBy: humans
     - color: 6103a0
+      description: Categorizes issue or PR as related to removing dead code, or a feature that had been marked deprecation.
       name: kind/removal
       target: both
       prowPlugin: label

--- a/config/label_sync/labels.yaml
+++ b/config/label_sync/labels.yaml
@@ -27,39 +27,66 @@ default:
       description: Parked issue that required triaging/revisit in a near future.
       name: kind/TBD
       target: issues
+      prowPlugin: label
       addedBy: humans
     - color: 7057ff
       description: Denotes an issue ready for a new contributor.
       name: kind/good-first-issue
       target: issues
+      prowPlugin: label
+      addedBy: anyone
+    - color: e11d21
+      description: Categorizes issue or PR as related to adding, removing, or otherwise changing an API
+      name: kind/api-change
+      target: both
+      prowPlugin: label
       addedBy: anyone
     - color: ff0000
+      description: Categorizes issue or PR as related to a bug.
       name: kind/bug
-      target: issues
+      target: both
+      prowPlugin: label
       addedBy: humans
     - color: f9d3c4
       name: kind/proposal
+      description: Issues or PRs related to proposals.
       target: issues
+      prowPlugin: label
       addedBy: humans
     - color: 030ba0
+      description: Categorizes issue or PR as related to cleaning up code, process, or technical debt.
       name: kind/cleanup
-      target: issues
+      target: both
+      addedBy: humans
+    - color: e11d21
+      description: Categorizes issue or PR as related to a feature/enhancement marked for deprecation.
+      name: kind/deprecation
+      target: both
+      addedBy: humans
+    - color: 6103a0
+      name: kind/removal
+      target: both
+      prowPlugin: label
       addedBy: humans
     - color: f9d7c4
       name: kind/feature-request
       target: issues
+      prowPlugin: label
       addedBy: humans
     - color: f9d0c4
       name: kind/documentation
-      target: issues
+      target: both
+      prowPlugin: label
       addedBy: humans
     - color: a2eeef
       name: kind/enhancement
       target: issues
+      prowPlugin: both
       addedBy: humans
     - color: bfd4f2
       name: kind/performance
-      target: issues
+      target: both
+      prowPlugin: label
       addedBy: humans
 
     #############################################################################

--- a/config/label_sync/labels.yaml
+++ b/config/label_sync/labels.yaml
@@ -64,7 +64,7 @@ default:
       target: both
       addedBy: humans
     - color: 6103a0
-      description: Categorizes issue or PR as related to removing dead code, or a feature that had been marked deprecation.
+      description: Categorizes issue or PR as related to removing dead code, or deprecated apis/features.
       name: kind/removal
       target: both
       prowPlugin: label


### PR DESCRIPTION
/lint

**What this PR does, why we need it**:

Adding more labels to support:

```
/kind [api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance]
```

**Special notes to reviewers**:

These kinds are used for the release note generation process. See an example: https://github.com/knative/eventing/actions?query=workflow%3A%22Release+Notes%22

**User-visible changes in this PR**:

Release notes will be categorized better

