### PR TITLE
Adding two different jobs for eventing-kafka repo

### DIFF
--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -473,6 +473,14 @@ presubmits:
     args:
     - --run-test
     - ./test/e2e-tests.sh --consolidated
+  - custom-test: integration-test-channel-consolidated-tls
+    args:
+    - --run-test
+    - ./test/e2e-tests.sh --consolidated-tls
+  - custom-test: integration-test-channel-consolidated-sasl
+    args:
+    - --run-test
+    - ./test/e2e-tests.sh --consolidated-sasl
   - custom-test: integration-test-channel-distributed
     args:
     - --run-test

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -4149,6 +4149,72 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
+  - name: pull-knative-sandbox-eventing-kafka-integration-test-channel-consolidated-tls
+    agent: kubernetes
+    context: pull-knative-sandbox-eventing-kafka-integration-test-channel-consolidated-tls
+    always_run: true
+    optional: false
+    rerun_command: "/test pull-knative-sandbox-eventing-kafka-integration-test-channel-consolidated-tls"
+    trigger: "(?m)^/test (all|pull-knative-sandbox-eventing-kafka-integration-test-channel-consolidated-tls),?(\\s+|$)"
+    decorate: true
+    path_alias: knative.dev/eventing-kafka
+    cluster: "build-knative"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-tests.sh --consolidated-tls"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-sandbox-eventing-kafka-integration-test-channel-consolidated-sasl
+    agent: kubernetes
+    context: pull-knative-sandbox-eventing-kafka-integration-test-channel-consolidated-sasl
+    always_run: true
+    optional: false
+    rerun_command: "/test pull-knative-sandbox-eventing-kafka-integration-test-channel-consolidated-sasl"
+    trigger: "(?m)^/test (all|pull-knative-sandbox-eventing-kafka-integration-test-channel-consolidated-sasl),?(\\s+|$)"
+    decorate: true
+    path_alias: knative.dev/eventing-kafka
+    cluster: "build-knative"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-tests.sh --consolidated-sasl"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
   - name: pull-knative-sandbox-eventing-kafka-integration-test-channel-distributed
     agent: kubernetes
     context: pull-knative-sandbox-eventing-kafka-integration-test-channel-distributed


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

-->
**Which issue(s) this PR fixes**:
Fixes #2582

**Special notes to reviewers**:

Two new jobs/runs on the eventing-kafka repo, for different AUTH configurations (TLS/SASL)


**User-visible changes in this PR**:

