### PR TITLE
Change upgrade test to required as PR presubmit in knative-gcp

### DIFF
--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -386,7 +386,7 @@ presubmits:
       limits:
         memory: 16Gi
     needs-monitor: true
-    optional: true
+    optional: false
     args:
     - --run-test
     - ./test/e2e-upgrade-tests.sh

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -2761,7 +2761,7 @@ presubmits:
       prow.k8s.io/pubsub.runID: pull-google-knative-gcp-upgrade-tests
     context: pull-google-knative-gcp-upgrade-tests
     always_run: true
-    optional: true
+    optional: false
     rerun_command: "/test pull-google-knative-gcp-upgrade-tests"
     trigger: "(?m)^/test (all|pull-google-knative-gcp-upgrade-tests),?(\\s+|$)"
     decorate: true


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:

We want upgrade test as a required presumbit test for knative-gcp.

