### PR TITLE
Disable go-coverage job for kn-plugin-source-kafka

### DIFF
--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -278,7 +278,7 @@ presubmits:
   - build-tests: true
   - unit-tests: true
   - integration-tests: true
-  - go-coverage: true
+  - go-coverage: false
   knative/eventing:
   - repo-settings: null
     performance: true

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -1500,36 +1500,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-sandbox-kn-plugin-source-kafka-go-coverage
-    agent: kubernetes
-    context: pull-knative-sandbox-kn-plugin-source-kafka-go-coverage
-    always_run: true
-    rerun_command: "/test pull-knative-sandbox-kn-plugin-source-kafka-go-coverage"
-    trigger: "(?m)^/test (all|pull-knative-sandbox-kn-plugin-source-kafka-go-coverage),?(\\s+|$)"
-    optional: true
-    decorate: true
-    path_alias: knative.dev/kn-plugin-source-kafka
-    cluster: "build-knative"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "coverage"
-        - "--postsubmit-job-name=post-knative-sandbox-kn-plugin-source-kafka-go-coverage"
-        - "--artifacts=$(ARTIFACTS)"
-        - "--cov-threshold-percentage=50"
-        - "--github-token=/etc/covbot-token/token"
-        volumeMounts:
-        - name: covbot-token
-          mountPath: /etc/covbot-token
-          readOnly: true
-      volumes:
-      - name: covbot-token
-        secret:
-          secretName: covbot-token
   knative/eventing:
   - name: pull-knative-eventing-build-tests
     agent: kubernetes
@@ -16404,54 +16374,6 @@ periodics:
       - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
-- cron: "0 1 * * *"
-  name: ci-knative-sandbox-kn-plugin-source-kafka-go-coverage
-  labels:
-      prow.k8s.io/pubsub.project: knative-tests
-      prow.k8s.io/pubsub.topic: knative-monitoring
-      prow.k8s.io/pubsub.runID: ci-knative-sandbox-kn-plugin-source-kafka-go-coverage
-  agent: kubernetes
-  decorate: true
-  cluster: "build-knative"
-  extra_refs:
-  - org: knative-sandbox
-    repo: kn-plugin-source-kafka
-    path_alias: knative.dev/kn-plugin-source-kafka
-    base_ref: master
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - "runner.sh"
-      args:
-      - "coverage"
-      - "--artifacts=$(ARTIFACTS)"
-      - "--cov-threshold-percentage=50"
-- cron: "10 7 * * *"
-  name: ci-knative-sandbox-kn-plugin-source-kafka-go-coverage-beta-prow-tests
-  labels:
-      prow.k8s.io/pubsub.project: knative-tests
-      prow.k8s.io/pubsub.topic: knative-monitoring
-      prow.k8s.io/pubsub.runID: ci-knative-sandbox-kn-plugin-source-kafka-go-coverage
-  agent: kubernetes
-  decorate: true
-  cluster: "build-knative"
-  extra_refs:
-  - org: knative-sandbox
-    repo: kn-plugin-source-kafka
-    path_alias: knative.dev/kn-plugin-source-kafka
-    base_ref: master
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:beta
-      imagePullPolicy: Always
-      command:
-      - "runner.sh"
-      args:
-      - "coverage"
-      - "--artifacts=$(ARTIFACTS)"
-      - "--cov-threshold-percentage=50"
 - cron: "30 07 * * *"
   name: ci-knative-serving-recreate-clusters
   agent: kubernetes
@@ -16756,24 +16678,6 @@ postsubmits:
     decorate: true
     cluster: "build-knative"
     path_alias: knative.dev/kn-plugin-diag
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "coverage"
-        - "--artifacts=$(ARTIFACTS)"
-        - "--cov-threshold-percentage=0"
-  knative-sandbox/kn-plugin-source-kafka:
-  - name: post-knative-sandbox-kn-plugin-source-kafka-go-coverage
-    branches:
-    - master
-    agent: kubernetes
-    decorate: true
-    cluster: "build-knative"
-    path_alias: knative.dev/kn-plugin-source-kafka
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable

--- a/config/prod/prow/testgrid/testgrid.yaml
+++ b/config/prod/prow/testgrid/testgrid.yaml
@@ -129,9 +129,6 @@ test_groups:
 - name: ci-knative-kn-plugin-source-kafka-continuous
   gcs_prefix: knative-prow/logs/ci-knative-kn-plugin-source-kafka-continuous
   alert_stale_results_hours: 3
-- name: ci-knative-kn-plugin-source-kafka-test-coverage
-  gcs_prefix: knative-prow/logs/ci-knative-kn-plugin-source-kafka-go-coverage
-  short_text_metric: "coverage"
 - name: ci-knative-docs-continuous
   gcs_prefix: knative-prow/logs/ci-knative-docs-continuous
   alert_stale_results_hours: 3
@@ -1005,9 +1002,6 @@ test_groups:
 - name: ci-knative-sandbox-kn-plugin-diag-go-coverage-beta-prow-tests
   gcs_prefix: knative-prow/logs/ci-knative-sandbox-kn-plugin-diag-go-coverage-beta-prow-tests
   short_text_metric: "coverage"
-- name: ci-knative-sandbox-kn-plugin-source-kafka-go-coverage-beta-prow-tests
-  gcs_prefix: knative-prow/logs/ci-knative-sandbox-kn-plugin-source-kafka-go-coverage-beta-prow-tests
-  short_text_metric: "coverage"
 - name: ci-knative-backup-artifacts
   gcs_prefix: knative-prow/logs/ci-knative-backup-artifacts
   alert_options:
@@ -1173,9 +1167,6 @@ dashboards:
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
     num_failures_to_alert: 3
-  - name: coverage
-    test_group_name: ci-knative-kn-plugin-source-kafka-test-coverage
-    base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
 - name: docs
   dashboard_tab:
   - name: continuous
@@ -2349,9 +2340,6 @@ dashboards:
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
   - name: ci-knative-sandbox-kn-plugin-diag-go-coverage
     test_group_name: ci-knative-sandbox-kn-plugin-diag-go-coverage-beta-prow-tests
-    base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
-  - name: ci-knative-sandbox-kn-plugin-source-kafka-go-coverage
-    test_group_name: ci-knative-sandbox-kn-plugin-source-kafka-go-coverage-beta-prow-tests
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
 - name: utilities
   dashboard_tab:


### PR DESCRIPTION
**What this PR does, why we need it**:
 CI job complains
```
 No build found for bucket 'knative-prow' and object 'logs/post-knative-sandbox-kn-plugin-source-kafka-go-coverage'
```
see CI job [logs](https://prow.knative.dev/view/gs/knative-prow/pr-logs/pull/knative-sandbox_kn-plugin-source-kafka/4/pull-knative-sandbox-kn-plugin-source-kafka-go-coverage/1331967762993516544#1:build-log.txt%3A366)

**Special notes to reviewers**:
Is there any other config required to make sure the go-coverage job works ?

**User-visible changes in this PR**:
No co-coverage report for the repo knative-sandbox/kn-plugin-source-kafka

