### PR TITLE
Add prow jobs for knative-sandbox/kn-plugin-admin

### DIFF
--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -279,6 +279,11 @@ presubmits:
   - unit-tests: true
   - integration-tests: true
   - go-coverage: false
+  knative-sandbox/kn-admin:
+  - build-tests: true
+  - unit-tests: true
+  - integration-tests: true
+  - go-coverage: false
   knative/eventing:
   - repo-settings: null
     performance: true
@@ -688,6 +693,8 @@ periodics:
   knative/kn-plugin-diag:
   - continuous: true
   knative/kn-plugin-source-kafka:
+  - continuous: true
+  knative/kn-plugin-admin:
   - continuous: true
   knative/docs:
   - continuous: true

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -1500,6 +1500,121 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
+  knative-sandbox/kn-admin:
+  - name: pull-knative-sandbox-kn-admin-build-tests
+    agent: kubernetes
+    context: pull-knative-sandbox-kn-admin-build-tests
+    always_run: true
+    optional: false
+    rerun_command: "/test pull-knative-sandbox-kn-admin-build-tests"
+    trigger: "(?m)^/test (all|pull-knative-sandbox-kn-admin-build-tests),?(\\s+|$)"
+    decorate: true
+    path_alias: knative.dev/kn-admin
+    cluster: "build-knative"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--build-tests"
+        volumeMounts:
+        - name: repoview-token
+          mountPath: /etc/repoview-token
+          readOnly: true
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: repoview-token
+        secret:
+          secretName: repoview-token
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-sandbox-kn-admin-unit-tests
+    agent: kubernetes
+    context: pull-knative-sandbox-kn-admin-unit-tests
+    always_run: true
+    optional: false
+    rerun_command: "/test pull-knative-sandbox-kn-admin-unit-tests"
+    trigger: "(?m)^/test (all|pull-knative-sandbox-kn-admin-unit-tests),?(\\s+|$)"
+    decorate: true
+    path_alias: knative.dev/kn-admin
+    cluster: "build-knative"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--unit-tests"
+        volumeMounts:
+        - name: repoview-token
+          mountPath: /etc/repoview-token
+          readOnly: true
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: repoview-token
+        secret:
+          secretName: repoview-token
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-sandbox-kn-admin-integration-tests
+    agent: kubernetes
+    context: pull-knative-sandbox-kn-admin-integration-tests
+    always_run: true
+    optional: false
+    rerun_command: "/test pull-knative-sandbox-kn-admin-integration-tests"
+    trigger: "(?m)^/test (all|pull-knative-sandbox-kn-admin-integration-tests),?(\\s+|$)"
+    decorate: true
+    path_alias: knative.dev/kn-admin
+    cluster: "build-knative"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--integration-tests"
+        volumeMounts:
+        - name: repoview-token
+          mountPath: /etc/repoview-token
+          readOnly: true
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: repoview-token
+        secret:
+          secretName: repoview-token
+      - name: test-account
+        secret:
+          secretName: test-account
   knative/eventing:
   - name: pull-knative-eventing-build-tests
     agent: kubernetes
@@ -7317,6 +7432,82 @@ periodics:
     base_ref: master
   annotations:
     testgrid-dashboards: kn-plugin-source-kafka
+    testgrid-tab-name: continuous
+    testgrid-alert-stale-results-hours: "3"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:beta
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./test/presubmit-tests.sh"
+      - "--all-tests"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "39 */4 * * *"
+  name: ci-knative-kn-plugin-admin-continuous
+  agent: kubernetes
+  decorate: true
+  decoration_config:
+    timeout: 180m
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative
+    repo: kn-plugin-admin
+    path_alias: knative.dev/kn-plugin-admin
+    base_ref: master
+  annotations:
+    testgrid-dashboards: kn-plugin-admin
+    testgrid-tab-name: continuous
+    testgrid-alert-stale-results-hours: "3"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./test/presubmit-tests.sh"
+      - "--all-tests"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "59 8,11,22 * * *"
+  name: ci-knative-kn-plugin-admin-continuous-beta-prow-tests
+  agent: kubernetes
+  decorate: true
+  decoration_config:
+    timeout: 180m
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative
+    repo: kn-plugin-admin
+    path_alias: knative.dev/kn-plugin-admin
+    base_ref: master
+  annotations:
+    testgrid-dashboards: kn-plugin-admin
     testgrid-tab-name: continuous
     testgrid-alert-stale-results-hours: "3"
   spec:

--- a/config/prod/prow/k8s-testgrid/k8s-testgrid.yaml
+++ b/config/prod/prow/k8s-testgrid/k8s-testgrid.yaml
@@ -40,6 +40,7 @@ dashboards:
 - name: eventing-prometheus
 - name: eventing-rabbitmq
 - name: eventing-redis
+- name: kn-plugin-admin
 - name: kn-plugin-diag
 - name: kn-plugin-source-kafka
 - name: knative-gcp
@@ -67,6 +68,7 @@ dashboard_groups:
       - "docs"
       - "eventing"
       - "eventing-contrib"
+      - "kn-plugin-admin"
       - "kn-plugin-diag"
       - "kn-plugin-source-kafka"
       - "operator"

--- a/config/prod/prow/testgrid/testgrid.yaml
+++ b/config/prod/prow/testgrid/testgrid.yaml
@@ -129,6 +129,9 @@ test_groups:
 - name: ci-knative-kn-plugin-source-kafka-continuous
   gcs_prefix: knative-prow/logs/ci-knative-kn-plugin-source-kafka-continuous
   alert_stale_results_hours: 3
+- name: ci-knative-kn-plugin-admin-continuous
+  gcs_prefix: knative-prow/logs/ci-knative-kn-plugin-admin-continuous
+  alert_stale_results_hours: 3
 - name: ci-knative-docs-continuous
   gcs_prefix: knative-prow/logs/ci-knative-docs-continuous
   alert_stale_results_hours: 3
@@ -869,6 +872,8 @@ test_groups:
   gcs_prefix: knative-prow/logs/ci-knative-kn-plugin-diag-continuous-beta-prow-tests
 - name: ci-knative-kn-plugin-source-kafka-continuous-beta-prow-tests
   gcs_prefix: knative-prow/logs/ci-knative-kn-plugin-source-kafka-continuous-beta-prow-tests
+- name: ci-knative-kn-plugin-admin-continuous-beta-prow-tests
+  gcs_prefix: knative-prow/logs/ci-knative-kn-plugin-admin-continuous-beta-prow-tests
 - name: ci-knative-docs-continuous-beta-prow-tests
   gcs_prefix: knative-prow/logs/ci-knative-docs-continuous-beta-prow-tests
 - name: ci-knative-docs-go-coverage-beta-prow-tests
@@ -1157,6 +1162,14 @@ dashboards:
   dashboard_tab:
   - name: continuous
     test_group_name: ci-knative-kn-plugin-source-kafka-continuous
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
+- name: kn-plugin-admin
+  dashboard_tab:
+  - name: continuous
+    test_group_name: ci-knative-kn-plugin-admin-continuous
     base_options: "sort-by-name="
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
@@ -2158,6 +2171,9 @@ dashboards:
   - name: ci-knative-kn-plugin-source-kafka-continuous
     test_group_name: ci-knative-kn-plugin-source-kafka-continuous-beta-prow-tests
     base_options: "sort-by-failures="
+  - name: ci-knative-kn-plugin-admin-continuous
+    test_group_name: ci-knative-kn-plugin-admin-continuous-beta-prow-tests
+    base_options: "sort-by-failures="
   - name: ci-knative-docs-continuous
     test_group_name: ci-knative-docs-continuous-beta-prow-tests
     base_options: "sort-by-failures="
@@ -2372,6 +2388,7 @@ dashboard_groups:
   - "client-contrib"
   - "kn-plugin-diag"
   - "kn-plugin-source-kafka"
+  - "kn-plugin-admin"
   - "docs"
   - "eventing"
   - "eventing-contrib"


### PR DESCRIPTION
 What this PR does, why we need it:
 To complete the process mentioned in https://github.com/knative/client-contrib/issues/75

 Which issue(s) this PR fixes:
 Fixes # https://github.com/knative/client-contrib/issues/75

 Special notes to reviewers:
 Disabled prow go-coverage tests

 User-visible changes in this PR:
 None