### PR TITLE
Fixes and improvements to the rundk tool

### DIFF
--- a/rundk/README.md
+++ b/rundk/README.md
@@ -23,7 +23,7 @@ go get knative.dev/test-infra/rundk
 
 ```shell
 Usage of rundk:
-  --test-image string
+  --image string
       The image we use to run the test flow. (default "gcr.io/knative-tests/test-infra/prow-tests:stable")
   --entrypoint string
       The entrypoint executable that runs the test commands. (default "runner.sh")
@@ -52,11 +52,11 @@ Usage of rundk:
 Run E2E tests for a Knative repository:
 
 ```shell
-rundk --use-local-gcloud-credentials ./test/e2e-tests.sh --gcp-project-id=one-project-for-testing
+rundk --use-local-gcloud-credentials -- ./test/e2e-tests.sh --gcp-project-id=one-project-for-testing
 ```
 
 ```shell
-rundk --use-local-kubeconfig ./test/e2e-tests.sh --run-tests
+rundk --use-local-kubeconfig -- ./test/e2e-tests.sh --run-tests
 ```
 
 > Note: the `rundk` command must be run under the root or sub directory of your


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
- `--image` is a better flag name than `--test-image`, since this tool can be used to run all the flows other than just tests
- `pflag` lib requires all the extra args to be delimited with other flags with `--`, so add it in the examples
- We should only expect users to provide one way to authenticating to `gcloud` and `kubectl`, so change the logics there to be `if ... else ...`

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
