### PR TITLE
Add prow jobs for knative-sandbox/net-ingressv2

### DIFF
--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -430,6 +430,11 @@ presubmits:
   - unit-tests: true
   - integration-tests: true
   - go-coverage: false
+  knative-sandbox/net-ingressv2:
+  - build-tests: true
+  - unit-tests: true
+  - integration-tests: true
+  - go-coverage: true
   knative-sandbox/net-istio:
   - build-tests: true
   - unit-tests: true
@@ -986,6 +991,17 @@ periodics:
     reporter_config:
       slack:
         channel: net-http01
+        job_states_to_report:
+        - failure
+        report_template: '"The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"'
+  - dot-release: true
+  - auto-release: true
+  knative-sandbox/net-ingressv2:
+  - continuous: true
+  - nightly: true
+    reporter_config:
+      slack:
+        channel: net-ingressv2
         job_states_to_report:
         - failure
         report_template: '"The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"'

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -3554,6 +3554,151 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
+  knative-sandbox/net-ingressv2:
+  - name: pull-knative-sandbox-net-ingressv2-build-tests
+    agent: kubernetes
+    context: pull-knative-sandbox-net-ingressv2-build-tests
+    always_run: true
+    optional: false
+    rerun_command: "/test pull-knative-sandbox-net-ingressv2-build-tests"
+    trigger: "(?m)^/test (all|pull-knative-sandbox-net-ingressv2-build-tests),?(\\s+|$)"
+    decorate: true
+    path_alias: knative.dev/net-ingressv2
+    cluster: "build-knative"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--build-tests"
+        volumeMounts:
+        - name: repoview-token
+          mountPath: /etc/repoview-token
+          readOnly: true
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: repoview-token
+        secret:
+          secretName: repoview-token
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-sandbox-net-ingressv2-unit-tests
+    agent: kubernetes
+    context: pull-knative-sandbox-net-ingressv2-unit-tests
+    always_run: true
+    optional: false
+    rerun_command: "/test pull-knative-sandbox-net-ingressv2-unit-tests"
+    trigger: "(?m)^/test (all|pull-knative-sandbox-net-ingressv2-unit-tests),?(\\s+|$)"
+    decorate: true
+    path_alias: knative.dev/net-ingressv2
+    cluster: "build-knative"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--unit-tests"
+        volumeMounts:
+        - name: repoview-token
+          mountPath: /etc/repoview-token
+          readOnly: true
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: repoview-token
+        secret:
+          secretName: repoview-token
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-sandbox-net-ingressv2-integration-tests
+    agent: kubernetes
+    context: pull-knative-sandbox-net-ingressv2-integration-tests
+    always_run: true
+    optional: false
+    rerun_command: "/test pull-knative-sandbox-net-ingressv2-integration-tests"
+    trigger: "(?m)^/test (all|pull-knative-sandbox-net-ingressv2-integration-tests),?(\\s+|$)"
+    decorate: true
+    path_alias: knative.dev/net-ingressv2
+    cluster: "build-knative"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--integration-tests"
+        volumeMounts:
+        - name: repoview-token
+          mountPath: /etc/repoview-token
+          readOnly: true
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: repoview-token
+        secret:
+          secretName: repoview-token
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-sandbox-net-ingressv2-go-coverage
+    agent: kubernetes
+    context: pull-knative-sandbox-net-ingressv2-go-coverage
+    always_run: true
+    rerun_command: "/test pull-knative-sandbox-net-ingressv2-go-coverage"
+    trigger: "(?m)^/test (all|pull-knative-sandbox-net-ingressv2-go-coverage),?(\\s+|$)"
+    optional: true
+    decorate: true
+    path_alias: knative.dev/net-ingressv2
+    cluster: "build-knative"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "coverage"
+        - "--postsubmit-job-name=post-knative-sandbox-net-ingressv2-go-coverage"
+        - "--artifacts=$(ARTIFACTS)"
+        - "--cov-threshold-percentage=50"
+        - "--github-token=/etc/covbot-token/token"
+        volumeMounts:
+        - name: covbot-token
+          mountPath: /etc/covbot-token
+          readOnly: true
+      volumes:
+      - name: covbot-token
+        secret:
+          secretName: covbot-token
   knative-sandbox/net-istio:
   - name: pull-knative-sandbox-net-istio-build-tests
     agent: kubernetes
@@ -13397,6 +13542,283 @@ periodics:
     - name: release-account
       secret:
         secretName: release-account
+- cron: "17 */4 * * *"
+  name: ci-knative-sandbox-net-ingressv2-continuous
+  agent: kubernetes
+  decorate: true
+  decoration_config:
+    timeout: 180m
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative-sandbox
+    repo: net-ingressv2
+    path_alias: knative.dev/net-ingressv2
+    base_ref: master
+  annotations:
+    testgrid-dashboards: knative-sandbox-net-ingressv2
+    testgrid-tab-name: knative-sandbox-net-ingressv2-continuous
+    testgrid-alert-stale-results-hours: "3"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./test/presubmit-tests.sh"
+      - "--all-tests"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "5 8,11,22 * * *"
+  name: ci-knative-sandbox-net-ingressv2-continuous-beta-prow-tests
+  agent: kubernetes
+  decorate: true
+  decoration_config:
+    timeout: 180m
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative-sandbox
+    repo: net-ingressv2
+    path_alias: knative.dev/net-ingressv2
+    base_ref: master
+  annotations:
+    testgrid-dashboards: knative-prow-tests
+    testgrid-tab-name: knative-sandbox-net-ingressv2-continuous-beta-prow-tests
+    testgrid-alert-stale-results-hours: "3"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:beta
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./test/presubmit-tests.sh"
+      - "--all-tests"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "23 9 * * *"
+  name: ci-knative-sandbox-net-ingressv2-nightly-release
+  agent: kubernetes
+  decorate: true
+  reporter_config:
+    slack:
+      channel: net-ingressv2
+      report_template: "The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"
+      job_states_to_report:
+      - "failure"
+  decoration_config:
+    timeout: 180m
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative-sandbox
+    repo: net-ingressv2
+    path_alias: knative.dev/net-ingressv2
+    base_ref: master
+  annotations:
+    testgrid-dashboards: knative-sandbox-net-ingressv2
+    testgrid-tab-name: knative-sandbox-net-ingressv2-nightly-release
+    testgrid-alert-email: "serverless-engprod-sea@google.com"
+    testgrid-num-failures-to-alert: "1"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--publish"
+      - "--tag-release"
+      volumeMounts:
+      - name: nightly-account
+        mountPath: /etc/nightly-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/nightly-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: nightly-account
+      secret:
+        secretName: nightly-account
+- cron: "31 9 * * 2"
+  name: ci-knative-sandbox-net-ingressv2-dot-release
+  agent: kubernetes
+  decorate: true
+  decoration_config:
+    timeout: 180m
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative-sandbox
+    repo: net-ingressv2
+    path_alias: knative.dev/net-ingressv2
+    base_ref: master
+  annotations:
+    testgrid-dashboards: knative-sandbox-net-ingressv2
+    testgrid-tab-name: knative-sandbox-net-ingressv2-dot-release
+    testgrid-alert-stale-results-hours: "170"
+    testgrid-alert-email: "serverless-engprod-sea@google.com"
+    testgrid-num-failures-to-alert: "1"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--dot-release"
+      - "--release-gcs knative-releases/net-ingressv2"
+      - "--release-gcr gcr.io/knative-releases"
+      - "--github-token /etc/hub-token/token"
+      volumeMounts:
+      - name: hub-token
+        mountPath: /etc/hub-token
+        readOnly: true
+      - name: release-account
+        mountPath: /etc/release-account
+        readOnly: true
+      env:
+      - name: ORG_NAME
+        value: knative-sandbox
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: hub-token
+      secret:
+        secretName: hub-token
+    - name: release-account
+      secret:
+        secretName: release-account
+- cron: "49 */4 * * *"
+  name: ci-knative-sandbox-net-ingressv2-auto-release
+  agent: kubernetes
+  decorate: true
+  decoration_config:
+    timeout: 180m
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative-sandbox
+    repo: net-ingressv2
+    path_alias: knative.dev/net-ingressv2
+    base_ref: master
+  annotations:
+    testgrid-dashboards: knative-sandbox-net-ingressv2
+    testgrid-tab-name: knative-sandbox-net-ingressv2-auto-release
+    testgrid-alert-email: "serverless-engprod-sea@google.com"
+    testgrid-num-failures-to-alert: "1"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--auto-release"
+      - "--release-gcs knative-releases/net-ingressv2"
+      - "--release-gcr gcr.io/knative-releases"
+      - "--github-token /etc/hub-token/token"
+      volumeMounts:
+      - name: hub-token
+        mountPath: /etc/hub-token
+        readOnly: true
+      - name: release-account
+        mountPath: /etc/release-account
+        readOnly: true
+      env:
+      - name: ORG_NAME
+        value: knative-sandbox
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: hub-token
+      secret:
+        secretName: hub-token
+    - name: release-account
+      secret:
+        secretName: release-account
+- cron: "0 1 * * *"
+  name: ci-knative-sandbox-net-ingressv2-go-coverage
+  labels:
+      prow.k8s.io/pubsub.project: knative-tests
+      prow.k8s.io/pubsub.topic: knative-monitoring
+      prow.k8s.io/pubsub.runID: ci-knative-sandbox-net-ingressv2-go-coverage
+  agent: kubernetes
+  decorate: true
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative-sandbox
+    repo: net-ingressv2
+    path_alias: knative.dev/net-ingressv2
+    base_ref: master
+  annotations:
+    testgrid-dashboards: knative-sandbox-net-ingressv2
+    testgrid-tab-name: knative-sandbox-net-ingressv2-go-coverage
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - "runner.sh"
+      args:
+      - "coverage"
+      - "--artifacts=$(ARTIFACTS)"
+      - "--cov-threshold-percentage=50"
+- cron: "19 7 * * *"
+  name: ci-knative-sandbox-net-ingressv2-go-coverage-beta-prow-tests
+  labels:
+      prow.k8s.io/pubsub.project: knative-tests
+      prow.k8s.io/pubsub.topic: knative-monitoring
+      prow.k8s.io/pubsub.runID: ci-knative-sandbox-net-ingressv2-go-coverage
+  agent: kubernetes
+  decorate: true
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative-sandbox
+    repo: net-ingressv2
+    path_alias: knative.dev/net-ingressv2
+    base_ref: master
+  annotations:
+    testgrid-dashboards: knative-prow-tests
+    testgrid-tab-name: knative-sandbox-net-ingressv2-go-coverage-beta-prow-tests
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:beta
+      imagePullPolicy: Always
+      command:
+      - "runner.sh"
+      args:
+      - "coverage"
+      - "--artifacts=$(ARTIFACTS)"
+      - "--cov-threshold-percentage=50"
 - cron: "8 */4 * * *"
   name: ci-knative-sandbox-net-istio-continuous
   agent: kubernetes
@@ -17365,6 +17787,26 @@ postsubmits:
     decorate: true
     cluster: "build-knative"
     path_alias: knative.dev/net-certmanager
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "coverage"
+        - "--artifacts=$(ARTIFACTS)"
+        - "--cov-threshold-percentage=0"
+  knative-sandbox/net-ingressv2:
+  - name: post-knative-sandbox-net-ingressv2-go-coverage
+    branches:
+    - master
+    annotations:
+      testgrid-create-test-group: "false"
+    agent: kubernetes
+    decorate: true
+    cluster: "build-knative"
+    path_alias: knative.dev/net-ingressv2
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable

--- a/config/prod/prow/k8s-testgrid/k8s-testgrid.yaml
+++ b/config/prod/prow/k8s-testgrid/k8s-testgrid.yaml
@@ -51,6 +51,7 @@ dashboards:
 - name: knative-sandbox-net-certmanager
 - name: knative-sandbox-net-contour
 - name: knative-sandbox-net-http01
+- name: knative-sandbox-net-ingressv2
 - name: knative-sandbox-net-istio
 - name: knative-sandbox-net-kourier
 - name: knative-sandbox-sample-controller
@@ -97,6 +98,7 @@ dashboard_groups:
       - "knative-sandbox-net-certmanager"
       - "knative-sandbox-net-contour"
       - "knative-sandbox-net-http01"
+      - "knative-sandbox-net-ingressv2"
       - "knative-sandbox-net-istio"
       - "knative-sandbox-net-kourier"
       - "knative-sandbox-sample-controller"

--- a/config/prod/prow/testgrid/testgrid.yaml
+++ b/config/prod/prow/testgrid/testgrid.yaml
@@ -584,6 +584,28 @@ test_groups:
   alert_options:
     alert_mail_to_addresses: "serverless-engprod-sea@google.com"
   num_failures_to_alert: 1
+- name: ci-knative-sandbox-net-ingressv2-continuous
+  gcs_prefix: knative-prow/logs/ci-knative-sandbox-net-ingressv2-continuous
+  alert_stale_results_hours: 3
+- name: ci-knative-sandbox-net-ingressv2-nightly-release
+  gcs_prefix: knative-prow/logs/ci-knative-sandbox-net-ingressv2-nightly-release
+  alert_options:
+    alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+  num_failures_to_alert: 1
+- name: ci-knative-sandbox-net-ingressv2-dot-release
+  gcs_prefix: knative-prow/logs/ci-knative-sandbox-net-ingressv2-dot-release
+  alert_options:
+    alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+  alert_stale_results_hours: 170
+  num_failures_to_alert: 1
+- name: ci-knative-sandbox-net-ingressv2-auto-release
+  gcs_prefix: knative-prow/logs/ci-knative-sandbox-net-ingressv2-auto-release
+  alert_options:
+    alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+  num_failures_to_alert: 1
+- name: ci-knative-sandbox-net-ingressv2-test-coverage
+  gcs_prefix: knative-prow/logs/ci-knative-sandbox-net-ingressv2-go-coverage
+  short_text_metric: "coverage"
 - name: ci-knative-sandbox-net-istio-continuous
   gcs_prefix: knative-prow/logs/ci-knative-sandbox-net-istio-continuous
   alert_stale_results_hours: 3
@@ -987,6 +1009,11 @@ test_groups:
   gcs_prefix: knative-prow/logs/ci-knative-sandbox-net-contour-continuous-beta-prow-tests
 - name: ci-knative-sandbox-net-http01-continuous-beta-prow-tests
   gcs_prefix: knative-prow/logs/ci-knative-sandbox-net-http01-continuous-beta-prow-tests
+- name: ci-knative-sandbox-net-ingressv2-continuous-beta-prow-tests
+  gcs_prefix: knative-prow/logs/ci-knative-sandbox-net-ingressv2-continuous-beta-prow-tests
+- name: ci-knative-sandbox-net-ingressv2-go-coverage-beta-prow-tests
+  gcs_prefix: knative-prow/logs/ci-knative-sandbox-net-ingressv2-go-coverage-beta-prow-tests
+  short_text_metric: "coverage"
 - name: ci-knative-sandbox-net-istio-continuous-beta-prow-tests
   gcs_prefix: knative-prow/logs/ci-knative-sandbox-net-istio-continuous-beta-prow-tests
 - name: ci-knative-sandbox-net-istio-go-coverage-beta-prow-tests
@@ -1575,6 +1602,35 @@ dashboards:
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
     num_failures_to_alert: 1
+- name: net-ingressv2
+  dashboard_tab:
+  - name: continuous
+    test_group_name: ci-knative-sandbox-net-ingressv2-continuous
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
+  - name: nightly
+    test_group_name: ci-knative-sandbox-net-ingressv2-nightly-release
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 1
+  - name: dot-release
+    test_group_name: ci-knative-sandbox-net-ingressv2-dot-release
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 1
+  - name: auto-release
+    test_group_name: ci-knative-sandbox-net-ingressv2-auto-release
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 1
+  - name: coverage
+    test_group_name: ci-knative-sandbox-net-ingressv2-test-coverage
+    base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
 - name: net-istio
   dashboard_tab:
   - name: continuous
@@ -2349,6 +2405,12 @@ dashboards:
   - name: ci-knative-sandbox-net-http01-continuous
     test_group_name: ci-knative-sandbox-net-http01-continuous-beta-prow-tests
     base_options: "sort-by-failures="
+  - name: ci-knative-sandbox-net-ingressv2-continuous
+    test_group_name: ci-knative-sandbox-net-ingressv2-continuous-beta-prow-tests
+    base_options: "sort-by-failures="
+  - name: ci-knative-sandbox-net-ingressv2-go-coverage
+    test_group_name: ci-knative-sandbox-net-ingressv2-go-coverage-beta-prow-tests
+    base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
   - name: ci-knative-sandbox-net-istio-continuous
     test_group_name: ci-knative-sandbox-net-istio-continuous-beta-prow-tests
     base_options: "sort-by-failures="
@@ -2469,6 +2531,7 @@ dashboard_groups:
   - "net-certmanager"
   - "net-contour"
   - "net-http01"
+  - "net-ingressv2"
   - "net-istio"
   - "net-kourier"
   - "async-component"


### PR DESCRIPTION
As per title, this patch adds prow job for net-ingressv2 by:

- Add net-ingress to `config/prod/prow/config_knative.yaml`
- Run `./hack/generate-configs.sh` to regenerate config files as per [the doc](https://github.com/knative/test-infra/blob/master/guides/prow_knative_setup.md#setting-up-prow-for-a-new-repo-reviewers-assignment-and-auto-merge)

Please also refer to https://github.com/knative/community/issues/389

/kind enhancement

**Release Note**

```release-note
NONE
```

/cc @tcnghia @ZhiminXiang
