### PR TITLE
Revert "Change knative-gcp upgrade test to optional"

### DIFF
--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -395,7 +395,7 @@ presubmits:
       limits:
         memory: 16Gi
     needs-monitor: true
-    optional: true
+    optional: false
     args:
     - --run-test
     - ./test/e2e-upgrade-tests.sh

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -2961,7 +2961,7 @@ presubmits:
       prow.k8s.io/pubsub.runID: pull-google-knative-gcp-upgrade-tests
     context: pull-google-knative-gcp-upgrade-tests
     always_run: true
-    optional: true
+    optional: false
     rerun_command: "/test pull-google-knative-gcp-upgrade-tests"
     trigger: "(?m)^/test (all|pull-google-knative-gcp-upgrade-tests),?(\\s+|$)"
     decorate: true


### PR DESCRIPTION
This reverts commit c71f36c0ca3425d4305c9d9c125a54407969998a.

Make the upgrade test required again in knative-gcp CI.

