### PR TITLE
bump autobumper to working image

### DIFF
--- a/config/prod/prow/jobs/custom/test-infra.yaml
+++ b/config/prod/prow/jobs/custom/test-infra.yaml
@@ -316,7 +316,7 @@ periodics:
     path_alias: knative.dev/test-infra
   spec:
     containers:
-    - image: gcr.io/k8s-prow/autobump:v20201103-bb494c0354
+    - image: gcr.io/k8s-prow/autobump:v20210114-dfe4a7d4c0
       command:
       - /autobump.sh
       args:


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
autobumper.sh was broken and will not be able to bump itself out of being broken, so I am manually bumping the autobumper to the current k8s/test-infra image that has the fix.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #

**Special notes to reviewers**:

**User-visible changes in this PR**:

