### PR TITLE
Add an extra-env to knative-gcp workflows

### DIFF
--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -378,6 +378,8 @@ presubmits:
     args:
     - --run-test
     - ./test/e2e-tests.sh
+    env-vars:
+      - ENABLE_AUTH_CHECK_TEST=0
   - custom-test: wi-tests
     resources:
       requests:
@@ -388,6 +390,8 @@ presubmits:
     args:
     - --run-test
     - ./test/e2e-wi-tests.sh
+    env-vars:
+      - ENABLE_AUTH_CHECK_TEST=0
   - custom-test: upgrade-tests
     resources:
       requests:

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -2896,6 +2896,8 @@ presubmits:
           mountPath: /etc/test-account
           readOnly: true
         env:
+        - name: ENABLE_AUTH_CHECK_TEST
+          value: "0"
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
@@ -2940,6 +2942,8 @@ presubmits:
           mountPath: /etc/test-account
           readOnly: true
         env:
+        - name: ENABLE_AUTH_CHECK_TEST
+          value: "0"
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Add an extra-env to knative-gcp workflows (integration test and wi test), in order to optionally run auth check test for those two workflows

related auth check test PR: https://github.com/google/knative-gcp/pull/2070
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #

**Special notes to reviewers**:

**User-visible changes in this PR**:

