### PR TITLE
Run conformance tests in mesh mode in net-istio

### DIFF
--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -448,6 +448,16 @@ presubmits:
     args:
     - --run-test
     - ./test/e2e-tests.sh --istio-version latest
+  - custom-test: latest-mesh
+    optional: true
+    args:
+    - --run-test
+    - ./test/e2e-tests.sh --istio-version latest --mesh
+  - custom-test: stable-mesh
+    optional: true
+    args:
+    - --run-test
+    - ./test/e2e-tests.sh --istio-version stable --mesh
   knative-sandbox/net-kourier:
   - build-tests: true
   - unit-tests: true

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -3881,6 +3881,72 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
+  - name: pull-knative-sandbox-net-istio-latest-mesh
+    agent: kubernetes
+    context: pull-knative-sandbox-net-istio-latest-mesh
+    always_run: true
+    optional: true
+    rerun_command: "/test pull-knative-sandbox-net-istio-latest-mesh"
+    trigger: "(?m)^/test (all|pull-knative-sandbox-net-istio-latest-mesh),?(\\s+|$)"
+    decorate: true
+    path_alias: knative.dev/net-istio
+    cluster: "build-knative"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-tests.sh --istio-version latest --mesh"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-sandbox-net-istio-stable-mesh
+    agent: kubernetes
+    context: pull-knative-sandbox-net-istio-stable-mesh
+    always_run: true
+    optional: true
+    rerun_command: "/test pull-knative-sandbox-net-istio-stable-mesh"
+    trigger: "(?m)^/test (all|pull-knative-sandbox-net-istio-stable-mesh),?(\\s+|$)"
+    decorate: true
+    path_alias: knative.dev/net-istio
+    cluster: "build-knative"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-tests.sh --istio-version stable --mesh"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
   knative-sandbox/net-kourier:
   - name: pull-knative-sandbox-net-kourier-build-tests
     agent: kubernetes


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
- Run conformance tests in mesh mode in net-istio; we've been bitten by bugs in Istio where injection breaks things before. These PR jobs would catch these sorts of bugs before they get merged.

**Which issue(s) this PR fixes**:
Fixes knative-sandbox/net-istio#136


