### PR TITLE
run with same flags as in post except confirm stays as false

### DIFF
--- a/config/prod/prow/jobs/custom/peribolos.yaml
+++ b/config/prod/prow/jobs/custom/peribolos.yaml
@@ -35,6 +35,13 @@ presubmits:
         - "--config-path=peribolos/knative.yaml"
         - "--github-token-path=/etc/github/token"
         - "--min-admins=5"
+        - "--fix-org=true"
+        - "--fix-org-members=true"
+        - "--fix-teams=true"
+        - "--fix-team-members=true"
+        - "--fix-team-repos=true"
+        - "--fix-repos=true"
+        - "--tokens=1200"
         # Set --confirm=false to only validate the configuration file.
         - "--confirm=false"
         volumeMounts:
@@ -63,6 +70,13 @@ presubmits:
         - "--config-path=peribolos/knative-sandbox.yaml"
         - "--github-token-path=/etc/github/token"
         - "--min-admins=5"
+        - "--fix-org=true"
+        - "--fix-org-members=true"
+        - "--fix-teams=true"
+        - "--fix-team-members=true"
+        - "--fix-team-repos=true"
+        - "--fix-repos=true"
+        - "--tokens=1200"
         # Set --confirm=false to only validate the configuration file.
         - "--confirm=false"
         volumeMounts:


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Add the following flags to pull-knative-peribolos and pull-knative-sandbox-peribolos runs. 

```
        - "--fix-org=true"
        - "--fix-org-members=true"
        - "--fix-teams=true"
        - "--fix-team-members=true"
        - "--fix-team-repos=true"
        - "--fix-repos=true"
```
Confirm still stays as false so no actions are performed. However, without these flags it does not seem like we do enough validation to prevent #2652 

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Addresses #2652 not sure it completely fixes it, but at least it should process the file more thoroughly.

**Special notes to reviewers**:

**User-visible changes in this PR**:

