### PR TITLE
add dot releases for .19 .20 for rqbbitmq/natss

### DIFF
--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -1180,8 +1180,11 @@ periodics:
         job_states_to_report:
         - failure
         report_template: '"The nightly release job for eventing-rabbitmq failed, check the log: <{{.Status.URL}}|View logs>"'
-  - dot-release: true
   - auto-release: true
+  - dot-release: true
+    release: "0.19"
+  - dot-release: true
+    release: "0.20"
   knative-sandbox/eventing-natss:
   - nightly: true
     reporter_config:
@@ -1191,6 +1194,9 @@ periodics:
         - failure
         report_template: '"The nightly release job for eventing-natss failed, check the log: <{{.Status.URL}}|View logs>"'
   - dot-release: true
+    release: "0.19"
+  - dot-release: true
+    release: "0.20"
   - auto-release: true
   knative-sandbox/eventing-autoscaler-keda:
   - continuous: true

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -17267,57 +17267,6 @@ periodics:
     - name: nightly-account
       secret:
         secretName: nightly-account
-- cron: "51 9 * * 2"
-  name: ci-knative-sandbox-eventing-rabbitmq-dot-release
-  agent: kubernetes
-  decorate: true
-  decoration_config:
-    timeout: 180m
-  cluster: "build-knative"
-  extra_refs:
-  - org: knative-sandbox
-    repo: eventing-rabbitmq
-    path_alias: knative.dev/eventing-rabbitmq
-    base_ref: master
-  annotations:
-    testgrid-dashboards: knative-sandbox-eventing-rabbitmq
-    testgrid-tab-name: knative-sandbox-eventing-rabbitmq-dot-release
-    testgrid-alert-stale-results-hours: "170"
-    testgrid-alert-email: "serverless-engprod-sea@google.com"
-    testgrid-num-failures-to-alert: "1"
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./hack/release.sh"
-      - "--dot-release"
-      - "--release-gcs knative-releases/eventing-rabbitmq"
-      - "--release-gcr gcr.io/knative-releases"
-      - "--github-token /etc/hub-token/token"
-      volumeMounts:
-      - name: hub-token
-        mountPath: /etc/hub-token
-        readOnly: true
-      - name: release-account
-        mountPath: /etc/release-account
-        readOnly: true
-      env:
-      - name: ORG_NAME
-        value: knative-sandbox
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/release-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-    volumes:
-    - name: hub-token
-      secret:
-        secretName: hub-token
-    - name: release-account
-      secret:
-        secretName: release-account
 - cron: "9 */4 * * *"
   name: ci-knative-sandbox-eventing-rabbitmq-auto-release
   agent: kubernetes
@@ -17361,6 +17310,110 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
+    volumes:
+    - name: hub-token
+      secret:
+        secretName: hub-token
+    - name: release-account
+      secret:
+        secretName: release-account
+- cron: "2 9 * * 2"
+  name: ci-knative-sandbox-eventing-rabbitmq-0.19-dot-release
+  agent: kubernetes
+  decorate: true
+  decoration_config:
+    timeout: 180m
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative-sandbox
+    repo: eventing-rabbitmq
+    path_alias: knative.dev/eventing-rabbitmq
+    base_ref: release-0.19
+  annotations:
+    testgrid-dashboards: knative-sandbox-eventing-rabbitmq
+    testgrid-tab-name: knative-sandbox-eventing-rabbitmq-0.19-dot-release
+    testgrid-alert-stale-results-hours: "3"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--dot-release"
+      - "--release-gcs knative-releases/eventing-rabbitmq"
+      - "--release-gcr gcr.io/knative-releases"
+      - "--github-token /etc/hub-token/token"
+      - "--branch release-0.19"
+      volumeMounts:
+      - name: hub-token
+        mountPath: /etc/hub-token
+        readOnly: true
+      - name: release-account
+        mountPath: /etc/release-account
+        readOnly: true
+      env:
+      - name: ORG_NAME
+        value: knative-sandbox
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.19
+    volumes:
+    - name: hub-token
+      secret:
+        secretName: hub-token
+    - name: release-account
+      secret:
+        secretName: release-account
+- cron: "34 9 * * 2"
+  name: ci-knative-sandbox-eventing-rabbitmq-0.20-dot-release
+  agent: kubernetes
+  decorate: true
+  decoration_config:
+    timeout: 180m
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative-sandbox
+    repo: eventing-rabbitmq
+    path_alias: knative.dev/eventing-rabbitmq
+    base_ref: release-0.20
+  annotations:
+    testgrid-dashboards: knative-sandbox-eventing-rabbitmq
+    testgrid-tab-name: knative-sandbox-eventing-rabbitmq-0.20-dot-release
+    testgrid-alert-stale-results-hours: "3"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--dot-release"
+      - "--release-gcs knative-releases/eventing-rabbitmq"
+      - "--release-gcr gcr.io/knative-releases"
+      - "--github-token /etc/hub-token/token"
+      - "--branch release-0.20"
+      volumeMounts:
+      - name: hub-token
+        mountPath: /etc/hub-token
+        readOnly: true
+      - name: release-account
+        mountPath: /etc/release-account
+        readOnly: true
+      env:
+      - name: ORG_NAME
+        value: knative-sandbox
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.20
     volumes:
     - name: hub-token
       secret:
@@ -17414,8 +17467,8 @@ periodics:
     - name: nightly-account
       secret:
         secretName: nightly-account
-- cron: "34 9 * * 2"
-  name: ci-knative-sandbox-eventing-natss-dot-release
+- cron: "41 9 * * 2"
+  name: ci-knative-sandbox-eventing-natss-0.19-dot-release
   agent: kubernetes
   decorate: true
   decoration_config:
@@ -17425,13 +17478,11 @@ periodics:
   - org: knative-sandbox
     repo: eventing-natss
     path_alias: knative.dev/eventing-natss
-    base_ref: master
+    base_ref: release-0.19
   annotations:
     testgrid-dashboards: knative-sandbox-eventing-natss
-    testgrid-tab-name: knative-sandbox-eventing-natss-dot-release
-    testgrid-alert-stale-results-hours: "170"
-    testgrid-alert-email: "serverless-engprod-sea@google.com"
-    testgrid-num-failures-to-alert: "1"
+    testgrid-tab-name: knative-sandbox-eventing-natss-0.19-dot-release
+    testgrid-alert-stale-results-hours: "3"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -17444,6 +17495,7 @@ periodics:
       - "--release-gcs knative-releases/eventing-natss"
       - "--release-gcr gcr.io/knative-releases"
       - "--github-token /etc/hub-token/token"
+      - "--branch release-0.19"
       volumeMounts:
       - name: hub-token
         mountPath: /etc/hub-token
@@ -17458,6 +17510,60 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.19
+    volumes:
+    - name: hub-token
+      secret:
+        secretName: hub-token
+    - name: release-account
+      secret:
+        secretName: release-account
+- cron: "13 9 * * 2"
+  name: ci-knative-sandbox-eventing-natss-0.20-dot-release
+  agent: kubernetes
+  decorate: true
+  decoration_config:
+    timeout: 180m
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative-sandbox
+    repo: eventing-natss
+    path_alias: knative.dev/eventing-natss
+    base_ref: release-0.20
+  annotations:
+    testgrid-dashboards: knative-sandbox-eventing-natss
+    testgrid-tab-name: knative-sandbox-eventing-natss-0.20-dot-release
+    testgrid-alert-stale-results-hours: "3"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--dot-release"
+      - "--release-gcs knative-releases/eventing-natss"
+      - "--release-gcr gcr.io/knative-releases"
+      - "--github-token /etc/hub-token/token"
+      - "--branch release-0.20"
+      volumeMounts:
+      - name: hub-token
+        mountPath: /etc/hub-token
+        readOnly: true
+      - name: release-account
+        mountPath: /etc/release-account
+        readOnly: true
+      env:
+      - name: ORG_NAME
+        value: knative-sandbox
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.20
     volumes:
     - name: hub-token
       secret:

--- a/config/prod/prow/testgrid/testgrid.yaml
+++ b/config/prod/prow/testgrid/testgrid.yaml
@@ -745,12 +745,6 @@ test_groups:
   alert_options:
     alert_mail_to_addresses: "serverless-engprod-sea@google.com"
   num_failures_to_alert: 1
-- name: ci-knative-sandbox-eventing-rabbitmq-dot-release
-  gcs_prefix: knative-prow/logs/ci-knative-sandbox-eventing-rabbitmq-dot-release
-  alert_options:
-    alert_mail_to_addresses: "serverless-engprod-sea@google.com"
-  alert_stale_results_hours: 170
-  num_failures_to_alert: 1
 - name: ci-knative-sandbox-eventing-rabbitmq-auto-release
   gcs_prefix: knative-prow/logs/ci-knative-sandbox-eventing-rabbitmq-auto-release
   alert_options:
@@ -760,12 +754,6 @@ test_groups:
   gcs_prefix: knative-prow/logs/ci-knative-sandbox-eventing-natss-nightly-release
   alert_options:
     alert_mail_to_addresses: "serverless-engprod-sea@google.com"
-  num_failures_to_alert: 1
-- name: ci-knative-sandbox-eventing-natss-dot-release
-  gcs_prefix: knative-prow/logs/ci-knative-sandbox-eventing-natss-dot-release
-  alert_options:
-    alert_mail_to_addresses: "serverless-engprod-sea@google.com"
-  alert_stale_results_hours: 170
   num_failures_to_alert: 1
 - name: ci-knative-sandbox-eventing-natss-auto-release
   gcs_prefix: knative-prow/logs/ci-knative-sandbox-eventing-natss-auto-release
@@ -827,6 +815,18 @@ test_groups:
     alert_mail_to_addresses: "serverless-engprod-sea@google.com"
   alert_stale_results_hours: 170
   num_failures_to_alert: 1
+- name: ci-knative-sandbox-eventing-rabbitmq-0.19-dot-release
+  gcs_prefix: knative-prow/logs/ci-knative-sandbox-eventing-rabbitmq-0.19-dot-release
+  alert_options:
+    alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+  alert_stale_results_hours: 170
+  num_failures_to_alert: 1
+- name: ci-knative-sandbox-eventing-natss-0.19-dot-release
+  gcs_prefix: knative-prow/logs/ci-knative-sandbox-eventing-natss-0.19-dot-release
+  alert_options:
+    alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+  alert_stale_results_hours: 170
+  num_failures_to_alert: 1
 - name: ci-knative-eventing-contrib-0.15-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-contrib-0.15-continuous
   alert_options:
@@ -857,6 +857,18 @@ test_groups:
   num_failures_to_alert: 1
 - name: ci-knative-sandbox-net-istio-0.20-dot-release
   gcs_prefix: knative-prow/logs/ci-knative-sandbox-net-istio-0.20-dot-release
+  alert_options:
+    alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+  alert_stale_results_hours: 170
+  num_failures_to_alert: 1
+- name: ci-knative-sandbox-eventing-rabbitmq-0.20-dot-release
+  gcs_prefix: knative-prow/logs/ci-knative-sandbox-eventing-rabbitmq-0.20-dot-release
+  alert_options:
+    alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+  alert_stale_results_hours: 170
+  num_failures_to_alert: 1
+- name: ci-knative-sandbox-eventing-natss-0.20-dot-release
+  gcs_prefix: knative-prow/logs/ci-knative-sandbox-eventing-natss-0.20-dot-release
   alert_options:
     alert_mail_to_addresses: "serverless-engprod-sea@google.com"
   alert_stale_results_hours: 170
@@ -1866,12 +1878,6 @@ dashboards:
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
     num_failures_to_alert: 1
-  - name: dot-release
-    test_group_name: ci-knative-sandbox-eventing-rabbitmq-dot-release
-    base_options: "sort-by-name="
-    alert_options:
-      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
-    num_failures_to_alert: 1
   - name: auto-release
     test_group_name: ci-knative-sandbox-eventing-rabbitmq-auto-release
     base_options: "sort-by-name="
@@ -1882,12 +1888,6 @@ dashboards:
   dashboard_tab:
   - name: nightly
     test_group_name: ci-knative-sandbox-eventing-natss-nightly-release
-    base_options: "sort-by-name="
-    alert_options:
-      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
-    num_failures_to_alert: 1
-  - name: dot-release
-    test_group_name: ci-knative-sandbox-eventing-natss-dot-release
     base_options: "sort-by-name="
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
@@ -2211,6 +2211,18 @@ dashboards:
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
     num_failures_to_alert: 3
+  - name: eventing-rabbitmq-dot-release
+    test_group_name: ci-knative-sandbox-eventing-rabbitmq-0.19-dot-release
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
+  - name: eventing-natss-dot-release
+    test_group_name: ci-knative-sandbox-eventing-natss-0.19-dot-release
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
 - name: knative-0.15
   dashboard_tab:
   - name: eventing-contrib-continuous
@@ -2249,6 +2261,18 @@ dashboards:
     num_failures_to_alert: 3
   - name: net-istio-dot-release
     test_group_name: ci-knative-sandbox-net-istio-0.20-dot-release
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
+  - name: eventing-rabbitmq-dot-release
+    test_group_name: ci-knative-sandbox-eventing-rabbitmq-0.20-dot-release
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
+  - name: eventing-natss-dot-release
+    test_group_name: ci-knative-sandbox-eventing-natss-0.20-dot-release
     base_options: "sort-by-name="
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Add dot releases for rabbitmq / natss for .19,.20.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
knative-sandbox/eventing-{natss,rabbitmq} do not release dot releases.

**Special notes to reviewers**:

**User-visible changes in this PR**:

