### PR TITLE
Add multi-tenant Kafka Source e2e tests in Prow Jobs

### DIFF
--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -520,6 +520,10 @@ presubmits:
     args:
     - --run-test
     - ./test/e2e-tests.sh --distributed
+  - custom-test: integration-test-mt-source
+    args:
+    - --run-test
+    - ./test/e2e-tests.sh --mt-source
   - integration-tests: false
   - build-tests: true
     needs-dind: true

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -4729,6 +4729,39 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
+  - name: pull-knative-sandbox-eventing-kafka-integration-test-mt-source
+    agent: kubernetes
+    context: pull-knative-sandbox-eventing-kafka-integration-test-mt-source
+    always_run: true
+    optional: false
+    rerun_command: "/test pull-knative-sandbox-eventing-kafka-integration-test-mt-source"
+    trigger: "(?m)^/test (all|pull-knative-sandbox-eventing-kafka-integration-test-mt-source),?(\\s+|$)"
+    decorate: true
+    path_alias: knative.dev/eventing-kafka
+    cluster: "build-knative"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-tests.sh --mt-source"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
   - name: pull-knative-sandbox-eventing-kafka-build-tests
     agent: kubernetes
     context: pull-knative-sandbox-eventing-kafka-build-tests


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Add multi-tenant Kafka Source e2e tests in Prow Jobs. (knative-sandbox/eventing-kafka repository)

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #

**Special notes to reviewers**:

**User-visible changes in this PR**:

