### PR TITLE
Add daily prow jobs running istio-head

### DIFF
--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -580,6 +580,22 @@ periodics:
     - ./test/e2e-tests.sh --istio-version latest --no-mesh
     - --run-test
     - ./test/e2e-auto-tls-tests.sh --istio-version latest --no-mesh
+  - custom-job: istio-head-mesh
+    command:
+    - ./test/presubmit-tests.sh
+    args:
+    - --run-test
+    - ./test/e2e-tests.sh --istio-version head --mesh
+    - --run-test
+    - ./test/e2e-auto-tls-tests.sh --istio-version head --mesh
+  - custom-job: istio-head-no-mesh
+    command:
+    - ./test/presubmit-tests.sh
+    args:
+    - --run-test
+    - ./test/e2e-tests.sh --istio-version head --no-mesh
+    - --run-test
+    - ./test/e2e-auto-tls-tests.sh --istio-version head --no-mesh
   - custom-job: istio-stable-mesh
     command:
     - ./test/presubmit-tests.sh

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -5972,6 +5972,88 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
+- cron: "27 7 * * *"
+  name: ci-knative-serving-istio-head-mesh
+  agent: kubernetes
+  decorate: true
+  decoration_config:
+    timeout: 120m
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative
+    repo: serving
+    path_alias: knative.dev/serving
+    base_ref: master
+  annotations:
+    testgrid-dashboards: knative-serving
+    testgrid-tab-name: knative-serving-istio-head-mesh
+    testgrid-alert-stale-results-hours: "3"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./test/presubmit-tests.sh"
+      - "--run-test"
+      - "./test/e2e-tests.sh --istio-version head --mesh"
+      - "--run-test"
+      - "./test/e2e-auto-tls-tests.sh --istio-version head --mesh"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "28 7 * * *"
+  name: ci-knative-serving-istio-head-no-mesh
+  agent: kubernetes
+  decorate: true
+  decoration_config:
+    timeout: 120m
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative
+    repo: serving
+    path_alias: knative.dev/serving
+    base_ref: master
+  annotations:
+    testgrid-dashboards: knative-serving
+    testgrid-tab-name: knative-serving-istio-head-no-mesh
+    testgrid-alert-stale-results-hours: "3"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./test/presubmit-tests.sh"
+      - "--run-test"
+      - "./test/e2e-tests.sh --istio-version head --no-mesh"
+      - "--run-test"
+      - "./test/e2e-auto-tls-tests.sh --istio-version head --no-mesh"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
 - cron: "12 */3 * * *"
   name: ci-knative-serving-gloo-0.17.1
   agent: kubernetes

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -5890,6 +5890,88 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
+- cron: "26 */3 * * *"
+  name: ci-knative-serving-istio-head-mesh
+  agent: kubernetes
+  decorate: true
+  decoration_config:
+    timeout: 120m
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative
+    repo: serving
+    path_alias: knative.dev/serving
+    base_ref: master
+  annotations:
+    testgrid-dashboards: knative-serving
+    testgrid-tab-name: knative-serving-istio-head-mesh
+    testgrid-alert-stale-results-hours: "3"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./test/presubmit-tests.sh"
+      - "--run-test"
+      - "./test/e2e-tests.sh --istio-version head --mesh"
+      - "--run-test"
+      - "./test/e2e-auto-tls-tests.sh --istio-version head --mesh"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "42 */3 * * *"
+  name: ci-knative-serving-istio-head-no-mesh
+  agent: kubernetes
+  decorate: true
+  decoration_config:
+    timeout: 120m
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative
+    repo: serving
+    path_alias: knative.dev/serving
+    base_ref: master
+  annotations:
+    testgrid-dashboards: knative-serving
+    testgrid-tab-name: knative-serving-istio-head-no-mesh
+    testgrid-alert-stale-results-hours: "3"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./test/presubmit-tests.sh"
+      - "--run-test"
+      - "./test/e2e-tests.sh --istio-version head --no-mesh"
+      - "--run-test"
+      - "./test/e2e-auto-tls-tests.sh --istio-version head --no-mesh"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
 - cron: "57 */3 * * *"
   name: ci-knative-serving-istio-stable-mesh
   agent: kubernetes
@@ -5959,88 +6041,6 @@ periodics:
       - "./test/e2e-tests.sh --istio-version stable --no-mesh"
       - "--run-test"
       - "./test/e2e-auto-tls-tests.sh --istio-version stable --no-mesh"
-      volumeMounts:
-      - name: test-account
-        mountPath: /etc/test-account
-        readOnly: true
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/test-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-    volumes:
-    - name: test-account
-      secret:
-        secretName: test-account
-- cron: "27 7 * * *"
-  name: ci-knative-serving-istio-head-mesh
-  agent: kubernetes
-  decorate: true
-  decoration_config:
-    timeout: 120m
-  cluster: "build-knative"
-  extra_refs:
-  - org: knative
-    repo: serving
-    path_alias: knative.dev/serving
-    base_ref: master
-  annotations:
-    testgrid-dashboards: knative-serving
-    testgrid-tab-name: knative-serving-istio-head-mesh
-    testgrid-alert-stale-results-hours: "3"
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./test/presubmit-tests.sh"
-      - "--run-test"
-      - "./test/e2e-tests.sh --istio-version head --mesh"
-      - "--run-test"
-      - "./test/e2e-auto-tls-tests.sh --istio-version head --mesh"
-      volumeMounts:
-      - name: test-account
-        mountPath: /etc/test-account
-        readOnly: true
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/test-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-    volumes:
-    - name: test-account
-      secret:
-        secretName: test-account
-- cron: "28 7 * * *"
-  name: ci-knative-serving-istio-head-no-mesh
-  agent: kubernetes
-  decorate: true
-  decoration_config:
-    timeout: 120m
-  cluster: "build-knative"
-  extra_refs:
-  - org: knative
-    repo: serving
-    path_alias: knative.dev/serving
-    base_ref: master
-  annotations:
-    testgrid-dashboards: knative-serving
-    testgrid-tab-name: knative-serving-istio-head-no-mesh
-    testgrid-alert-stale-results-hours: "3"
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./test/presubmit-tests.sh"
-      - "--run-test"
-      - "./test/e2e-tests.sh --istio-version head --no-mesh"
-      - "--run-test"
-      - "./test/e2e-auto-tls-tests.sh --istio-version head --no-mesh"
       volumeMounts:
       - name: test-account
         mountPath: /etc/test-account

--- a/config/prod/prow/testgrid/testgrid.yaml
+++ b/config/prod/prow/testgrid/testgrid.yaml
@@ -64,6 +64,12 @@ test_groups:
 - name: ci-knative-serving-istio-latest-no-mesh
   gcs_prefix: knative-prow/logs/ci-knative-serving-istio-latest-no-mesh
   alert_stale_results_hours: 3
+- name: ci-knative-serving-istio-head-mesh
+  gcs_prefix: knative-prow/logs/ci-knative-serving-istio-head-mesh
+  alert_stale_results_hours: 3
+- name: ci-knative-serving-istio-head-no-mesh
+  gcs_prefix: knative-prow/logs/ci-knative-serving-istio-head-no-mesh
+  alert_stale_results_hours: 3
 - name: ci-knative-serving-istio-stable-mesh
   gcs_prefix: knative-prow/logs/ci-knative-serving-istio-stable-mesh
   alert_stale_results_hours: 3
@@ -1158,6 +1164,12 @@ dashboards:
     base_options: "sort-by-name="
   - name: istio-latest-no-mesh
     test_group_name: ci-knative-serving-istio-latest-no-mesh
+    base_options: "sort-by-name="
+  - name: istio-head-mesh
+    test_group_name: ci-knative-serving-istio-head-mesh
+    base_options: "sort-by-name="
+  - name: istio-head-no-mesh
+    test_group_name: ci-knative-serving-istio-head-no-mesh
     base_options: "sort-by-name="
   - name: istio-stable-mesh
     test_group_name: ci-knative-serving-istio-stable-mesh


### PR DESCRIPTION
**What this PR does, why we need it**
Starts running daily tests against Istio HEAD. The Istio team has requested this so we don't find issues only after they release.

**Which issue(s) this PR fixes**:
Fixes knative-sandbox/net-istio/issues/496

**Special notes to reviewers**:

**User-visible changes in this PR**:
None
