### PR TITLE
mt-source test job is optional in eventing-kafka

### DIFF
--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -524,6 +524,7 @@ presubmits:
     args:
     - --run-test
     - ./test/e2e-tests.sh --mt-source
+    optional: true
   - integration-tests: false
   - build-tests: true
     needs-dind: true

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -4733,7 +4733,7 @@ presubmits:
     agent: kubernetes
     context: pull-knative-sandbox-eventing-kafka-integration-test-mt-source
     always_run: true
-    optional: false
+    optional: true
     rerun_command: "/test pull-knative-sandbox-eventing-kafka-integration-test-mt-source"
     trigger: "(?m)^/test (all|pull-knative-sandbox-eventing-kafka-integration-test-mt-source),?(\\s+|$)"
     decorate: true


### PR DESCRIPTION
This component is still experimental and very flaky, so it's better to make its job optional to unblock the rest of development happening on eventing-kafka.

Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

