### PR TITLE
Expand the CODEOWNERS canary to net-*

### DIFF
--- a/config/branch_protector/rules.yaml
+++ b/config/branch_protector/rules.yaml
@@ -26,9 +26,9 @@ branch-protection:
       # Enforce all configured restrictions above for administrators.
       enforce_admins: true
 
-      # net-contour is canarying some additional protections.
+      # These repos are canarying additional protections.
       repos:
-        net-contour:
+        net-contour: &codeowners
           required_status_checks:
             contexts:
             - cla/google
@@ -41,6 +41,12 @@ branch-protection:
             dismiss_stale_reviews: true
             required_approving_review_count: 1
             require_code_owner_reviews: true
+
+        net-certmanager: *codeowners
+        net-http01: *codeowners
+        net-ingressv2: *codeowners
+        net-istio: *codeowners
+        net-kourier: *codeowners
 
     knative:
       # Protect all branches in knative


### PR DESCRIPTION
/hold

This needs the following to land: 
 - new teams: https://github.com/knative/community/pull/479
 - plugin changes: https://github.com/GoogleCloudPlatform/oss-test-infra/pull/709
 - net-contour: DONE
 - net-certmanager: https://github.com/knative-sandbox/net-certmanager/pull/185
 - net-ingressv2: https://github.com/knative-sandbox/net-ingressv2/pull/7
 - net-http01: https://github.com/knative-sandbox/net-http01/pull/192
 - net-istio: https://github.com/knative-sandbox/net-istio/pull/525
 - net-kourier: https://github.com/knative-sandbox/net-kourier/pull/453
