### PR TITLE
Move the knative-sandbox org to CODEOWNERS

### DIFF
--- a/config/branch_protector/rules.yaml
+++ b/config/branch_protector/rules.yaml
@@ -26,37 +26,11 @@ branch-protection:
       # Enforce all configured restrictions above for administrators.
       enforce_admins: true
 
-      # These repos are canarying additional protections.
-      repos:
-        net-contour: &codeowners
-          required_status_checks:
-            contexts:
-            - cla/google
-            - tide
-          # Enforce all configured restrictions above for administrators.
-          enforce_admins: true
-
-          # The extra protections
-          required_pull_request_reviews:
-            dismiss_stale_reviews: true
-            required_approving_review_count: 1
-            require_code_owner_reviews: true
-
-        net-certmanager: *codeowners
-        net-http01: *codeowners
-        net-ingressv2: *codeowners
-        net-istio: *codeowners
-        net-kourier: *codeowners
-
-        sample-controller: *codeowners
-        sample-source: *codeowners
-
-        .github: *codeowners
-        downstream-test-go: *codeowners
-        integration: *codeowners
-        knobots: *codeowners
-        kperf: *codeowners
-        reconciler-test: *codeowners
+      # The knative-sandbox repositories are using CODEOWNERS for access control.
+      required_pull_request_reviews:
+        dismiss_stale_reviews: true
+        required_approving_review_count: 1
+        require_code_owner_reviews: true
 
     knative:
       # Protect all branches in knative


### PR DESCRIPTION
/hold
cc @lionelvillard @rhuss 

This should migrate the branch protections for all repos in `knative-sandbox` to require `CODEOWNERS` vs. the per-repo opt-in.  Waiting on the remaining repos to grow CODEOWNERS files, and then I'll coordinate this with a PR to the google oss-test-infra repo.