### PR TITLE
Allow 'main' to act as the correct branch as well

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -14,11 +14,13 @@
 
 # Do not allow server update from wrong branch or dirty working space
 # In emergency, could easily edit this file, deleting all these lines
-confirm-master:
+confirm-main:
 	@if git diff-index --quiet HEAD; then true; else echo "Git working space is dirty -- will not update server"; false; fi;
 # TODO(chizhg): change to `git branch --show-current` after we update the Git version in prow-tests image.
 ifneq ("$(shell git rev-parse --abbrev-ref HEAD)","master")
-	@echo "Branch is not master -- will not update server"
-	@false
+	ifneq ("$(shell git rev-parse --abbrev-ref HEAD)","main")
+		@echo "Branch is not master or main -- will not update server"
+		@false
+	endif
 endif
 

--- a/config/prow_common.mk
+++ b/config/prow_common.mk
@@ -69,10 +69,10 @@ unset-cluster-credentials:
 get-build-cluster-credentials: activate-serviceaccount
 	$(SET_BUILD_CLUSTER_CONTEXT)
 
-.PHONY: update-boskos-resource test update-testgrid-config confirm-master
+.PHONY: update-boskos-resource test update-testgrid-config confirm-main
 
 # Update the list of resources for Boskos
-update-boskos-resource: confirm-master
+update-boskos-resource: confirm-main
 	$(SET_BUILD_CLUSTER_CONTEXT)
 	kubectl create configmap resources --from-file=config=$(BOSKOS_RESOURCES) --dry-run --save-config -o yaml | kubectl --namespace="$(JOB_NAMESPACE)" apply -f -
 	$(UNSET_CONTEXT)
@@ -88,7 +88,7 @@ update-all: update-boskos-resource update-testgrid-config
 # Either export $GOOGLE_APPLICATION_CREDENTIALS pointing to a valid service
 # account key, or temporarily use your own credentials by running
 # gcloud auth application-default login
-update-testgrid-config: confirm-master
+update-testgrid-config: confirm-main
 	docker run -i --rm \
 		-v "$(PWD):$(PWD)" \
 		-v "$(realpath $(TESTGRID_CONFIG)):$(realpath $(TESTGRID_CONFIG))" \

--- a/images/prow-tests/Makefile
+++ b/images/prow-tests/Makefile
@@ -15,7 +15,7 @@
 IMAGE_NAME = prow-tests
 include ../simple-image.mk
 
-push: confirm-master
+push: confirm-main
 	gcloud builds submit --config=./cloudbuild.yaml --substitutions=_TAG=$(TAG),_IMG=$(IMG) \
 		--machine-type=n1-highcpu-8 \
 		--project=$(PROJECT) --timeout=1h ./../..

--- a/images/simple-image.mk
+++ b/images/simple-image.mk
@@ -47,9 +47,9 @@ iterative-build:
 iterative-shell:
 	docker run -it --entrypoint bash $(IMG):local
 
-push_versioned: confirm-master build
+push_versioned: confirm-main build
 	docker push $(IMG):$(TAG)
 
-push_latest: confirm-master build
+push_latest: confirm-main build
 	docker tag $(IMG):$(TAG) $(IMG):latest
 	docker push $(IMG):latest

--- a/tools/flaky-test-retryer/gke_deployment/Makefile
+++ b/tools/flaky-test-retryer/gke_deployment/Makefile
@@ -25,7 +25,7 @@ ZONE := us-central1-a
 DEPLOYMENT_YAML := retryer_service.yaml
 
 .PHONY: deploy
-deploy: confirm-master
+deploy: confirm-main
 ifdef GOOGLE_APPLICATION_CREDENTIALS
 	gcloud auth activate-service-account --key-file="$(GOOGLE_APPLICATION_CREDENTIALS)"
 endif


### PR DESCRIPTION
Fixes #2630

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:

As per title, this allows both `master` and `main` to act as the defining branches to update config from. This should allow us to migrate from `master` to `main`.

