### PR TITLE
Update knative autobump job to new generic autobump image

### DIFF
--- a/config/prod/prow/jobs/custom/test-infra.yaml
+++ b/config/prod/prow/jobs/custom/test-infra.yaml
@@ -339,37 +339,16 @@ periodics:
     path_alias: knative.dev/test-infra
   spec:
     containers:
-    - image: gcr.io/k8s-prow/autobump:v20210114-dfe4a7d4c0
+    - image: gcr.io/k8s-testimages/generic_autobump:v20210227-adfdf65
       command:
       - /autobump.sh
       args:
-      - /etc/prow-auto-bumper-github-token/token
-      - "Knative Prow Updater Robot"
-      - knative-prow-updater-robot@google.com
+      - --config = "config/prod/prow/knative-autobump-config.yaml"
       volumeMounts:
-      - name: test-account
-        mountPath: /etc/test-account
-        readOnly: true
       - name: prow-auto-bumper-github-token
         mountPath: /etc/prow-auto-bumper-github-token
         readOnly: true
-      env:
-      - name: GH_ORG
-        value: knative
-      - name: GH_REPO
-        value: test-infra
-      - name: PLANK_DEPLOYMENT_FILE # Just need a file contains an image tag
-        value: config/prod/prow/jobs/custom/test-infra.yaml
-      - name: COMPONENT_FILE_DIR
-        value: config/prod/prow/jobs # Let it bump twice is fine
-      - name: CONFIG_PATH
-        value: config/prod/prow/jobs/custom/test-infra.yaml # Trick autobump as this is required
-      - name: JOB_CONFIG_PATH
-        value: config/prod/prow/jobs
     volumes:
-    - name: test-account
-      secret:
-        secretName: test-account
     - name: prow-auto-bumper-github-token
       secret:
         secretName: prow-auto-bumper-github-token

--- a/config/prod/prow/knative-autobump-config.yaml
+++ b/config/prod/prow/knative-autobump-config.yaml
@@ -1,0 +1,20 @@
+gitHubLogin: "knative-prow-robot"
+gitHubToken: "/etc/prow-auto-bumper-github-token/token"
+skipPullRequest: false
+gitHubOrg: "knative"
+gitHubRepo: "test-infra"
+remoteName: "test-infra"
+headBranchName: "autobump-knative"
+upstreamURLBase: "https://raw.githubusercontent.com/kubernetes/test-infra/master"
+includedConfigPaths:
+  - "config/prod/prow/jobs"
+targetVersion: "upstream"
+extraFiles:
+  - "prow/oss/config.yaml"
+prefixes:
+  - name: "Prow"
+    prefix: "gcr.io/k8s-prow/"
+    repo: "https://github.com/kubernetes/test-infra"
+    refConfigFile: "config/prow/cluster/deck_deployment.yaml"
+    summarise: false
+    consistentImages: true


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
This PR replaces the (currently broken) autobump job with the new generic_autobump job. This is needed because we are hoping to deprecate the old autobump bash script. This should also fix the the autobump job. 

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #

**Special notes to reviewers**:

**User-visible changes in this PR**:

