### PR TITLE
Add ssh key for generic autobump job

### DIFF
--- a/config/prod/prow/jobs/custom/test-infra.yaml
+++ b/config/prod/prow/jobs/custom/test-infra.yaml
@@ -347,10 +347,16 @@ periodics:
       - name: prow-auto-bumper-github-token
         mountPath: /etc/prow-auto-bumper-github-token
         readOnly: true
+      - name: ssh
+        mountPath: /root/.ssh
     volumes:
     - name: prow-auto-bumper-github-token
       secret:
         secretName: prow-auto-bumper-github-token
+    - name: ssh
+      secret:
+        secretName: prow-updater-robot-ssh-key
+        defaultMode: 0400
 
 - cron: "0 */2 * * *" # Every other hour
   name: ci-knative-prow-jobs-syncer

--- a/config/prod/prow/knative-autobump-config.yaml
+++ b/config/prod/prow/knative-autobump-config.yaml
@@ -1,4 +1,4 @@
-gitHubLogin: "knative-prow-robot"
+gitHubLogin: "knative-prow-updater-robot"
 gitHubToken: "/etc/prow-auto-bumper-github-token/token"
 skipPullRequest: false
 gitHubOrg: "knative"


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Generic autobump job is not working for 2 reasons: the robot used for the job config was wrong, and it was missing a ssh key secret. This fixes those two issues
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #

**Special notes to reviewers**:

**User-visible changes in this PR**:

