### PR TITLE
Drop unnecessary occurrences of master

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![go.dev reference](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white)](https://pkg.go.dev/github.com/knative/test-infra)
 [![Go Report Card](https://goreportcard.com/badge/knative/test-infra)](https://goreportcard.com/report/knative/test-infra)
-[![LICENSE](https://img.shields.io/github/license/knative/test-infra.svg)](https://github.com/knative/test-infra/blob/master/LICENSE)
+[![LICENSE](https://img.shields.io/github/license/knative/test-infra.svg)](https://github.com/knative/test-infra/blob/main/LICENSE)
 [![Slack Status](https://img.shields.io/badge/slack-join_chat-white.svg?logo=slack&style=social)](https://knative.slack.com/archives/CCSNR4FCH)
 
 The `test-infra` repository contains a collection of tools for testing Knative,

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -5495,8 +5495,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
       resources:
         requests:
           memory: 12Gi
@@ -5540,8 +5538,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
       resources:
         requests:
           memory: 12Gi
@@ -6076,8 +6072,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -6119,8 +6113,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -6162,8 +6154,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -6205,8 +6195,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -6248,8 +6236,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -6291,8 +6277,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -6334,8 +6318,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -6377,8 +6359,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -6420,8 +6400,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -6463,8 +6441,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -6506,8 +6482,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -6549,8 +6523,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -6597,8 +6569,6 @@ periodics:
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
       resources:
         requests:
           memory: 12Gi
@@ -6869,8 +6839,6 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
       resources:
         requests:
           memory: 12Gi
@@ -6917,8 +6885,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -6957,8 +6923,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -7487,8 +7451,6 @@ periodics:
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: nightly-account
       secret:
@@ -7526,8 +7488,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -7773,8 +7733,6 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: hub-token
       secret:
@@ -7870,8 +7828,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -7910,8 +7866,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -7950,8 +7904,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -7990,8 +7942,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -8030,8 +7980,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -8070,8 +8018,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -8119,8 +8065,6 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: hub-token
       secret:
@@ -8164,8 +8108,6 @@ periodics:
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: nightly-account
       secret:
@@ -8360,8 +8302,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -8400,8 +8340,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -8449,8 +8387,6 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: hub-token
       secret:
@@ -8494,8 +8430,6 @@ periodics:
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: nightly-account
       secret:
@@ -8544,8 +8478,6 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: hub-token
       secret:
@@ -8596,8 +8528,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: docker-graph
       emptyDir: {}
@@ -8655,8 +8585,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: docker-graph
       emptyDir: {}
@@ -8757,8 +8685,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
       resources:
         requests:
           memory: 12Gi
@@ -8802,8 +8728,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
       resources:
         requests:
           memory: 12Gi
@@ -9343,8 +9267,6 @@ periodics:
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
       resources:
         requests:
           memory: 12Gi
@@ -9615,8 +9537,6 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
       resources:
         requests:
           memory: 12Gi
@@ -9717,8 +9637,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
       resources:
         requests:
           memory: 12Gi
@@ -9762,8 +9680,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
       resources:
         requests:
           memory: 12Gi
@@ -10297,8 +10213,6 @@ periodics:
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
       resources:
         requests:
           memory: 12Gi
@@ -10569,8 +10483,6 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
       resources:
         requests:
           memory: 12Gi
@@ -10671,8 +10583,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -10711,8 +10621,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -10753,8 +10661,6 @@ periodics:
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: nightly-account
       secret:
@@ -10802,8 +10708,6 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: hub-token
       secret:
@@ -10845,8 +10749,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -10885,8 +10787,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -10927,8 +10827,6 @@ periodics:
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: nightly-account
       secret:
@@ -10976,8 +10874,6 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: hub-token
       secret:
@@ -11019,8 +10915,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -11059,8 +10953,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -11101,8 +10993,6 @@ periodics:
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: nightly-account
       secret:
@@ -11150,8 +11040,6 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: hub-token
       secret:
@@ -11193,8 +11081,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -11233,8 +11119,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -11275,8 +11159,6 @@ periodics:
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: nightly-account
       secret:
@@ -11324,8 +11206,6 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: hub-token
       secret:
@@ -11367,8 +11247,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -11407,8 +11285,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -11449,8 +11325,6 @@ periodics:
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: nightly-account
       secret:
@@ -11726,8 +11600,6 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: hub-token
       secret:
@@ -11769,8 +11641,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -11809,8 +11679,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -11851,8 +11719,6 @@ periodics:
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: nightly-account
       secret:
@@ -11900,8 +11766,6 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: hub-token
       secret:
@@ -11943,8 +11807,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -11983,8 +11845,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -12025,8 +11885,6 @@ periodics:
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: nightly-account
       secret:
@@ -12074,8 +11932,6 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: hub-token
       secret:
@@ -12117,8 +11973,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -12157,8 +12011,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -12197,8 +12049,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -12237,8 +12087,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -12277,8 +12125,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -12317,8 +12163,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -12357,8 +12201,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -12397,8 +12239,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -12437,8 +12277,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -12477,8 +12315,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -12519,8 +12355,6 @@ periodics:
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: nightly-account
       secret:
@@ -12568,8 +12402,6 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: hub-token
       secret:
@@ -12621,8 +12453,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: docker-graph
       emptyDir: {}
@@ -12681,8 +12511,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: docker-graph
       emptyDir: {}
@@ -12784,8 +12612,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -12823,8 +12649,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -13386,8 +13210,6 @@ periodics:
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
       resources:
         requests:
           memory: 12Gi
@@ -13663,8 +13485,6 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
       resources:
         requests:
           memory: 12Gi
@@ -13763,8 +13583,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -13803,8 +13621,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -13851,8 +13667,6 @@ periodics:
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: nightly-account
       secret:
@@ -13901,8 +13715,6 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: hub-token
       secret:
@@ -13953,8 +13765,6 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: hub-token
       secret:
@@ -14050,8 +13860,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -14090,8 +13898,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -14138,8 +13944,6 @@ periodics:
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: nightly-account
       secret:
@@ -14188,8 +13992,6 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: hub-token
       secret:
@@ -14240,8 +14042,6 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: hub-token
       secret:
@@ -14283,8 +14083,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -14323,8 +14121,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -14371,8 +14167,6 @@ periodics:
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: nightly-account
       secret:
@@ -14421,8 +14215,6 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: hub-token
       secret:
@@ -14473,8 +14265,6 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: hub-token
       secret:
@@ -14516,8 +14306,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -14556,8 +14344,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -14604,8 +14390,6 @@ periodics:
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: nightly-account
       secret:
@@ -14654,8 +14438,6 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: hub-token
       secret:
@@ -14706,8 +14488,6 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: hub-token
       secret:
@@ -14803,8 +14583,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -14843,8 +14621,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -14891,8 +14667,6 @@ periodics:
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: nightly-account
       secret:
@@ -14932,8 +14706,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -15189,8 +14961,6 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: hub-token
       secret:
@@ -15286,8 +15056,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -15326,8 +15094,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -15374,8 +15140,6 @@ periodics:
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: nightly-account
       secret:
@@ -15424,8 +15188,6 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: hub-token
       secret:
@@ -15476,8 +15238,6 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: hub-token
       secret:
@@ -15573,8 +15333,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -15613,8 +15371,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -16183,8 +15939,6 @@ periodics:
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: nightly-account
       secret:
@@ -16450,8 +16204,6 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: hub-token
       secret:
@@ -16547,8 +16299,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -16587,8 +16337,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -16629,8 +16377,6 @@ periodics:
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: nightly-account
       secret:
@@ -16679,8 +16425,6 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: hub-token
       secret:
@@ -16731,8 +16475,6 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: hub-token
       secret:
@@ -16828,8 +16570,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -16868,8 +16608,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -16916,8 +16654,6 @@ periodics:
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: nightly-account
       secret:
@@ -16966,8 +16702,6 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: hub-token
       secret:
@@ -17018,8 +16752,6 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: hub-token
       secret:
@@ -17061,8 +16793,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -17101,8 +16831,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -17149,8 +16877,6 @@ periodics:
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: nightly-account
       secret:
@@ -17199,8 +16925,6 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: hub-token
       secret:
@@ -17251,8 +16975,6 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: hub-token
       secret:
@@ -17304,8 +17026,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: docker-graph
       emptyDir: {}
@@ -17364,8 +17084,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: docker-graph
       emptyDir: {}
@@ -17426,8 +17144,6 @@ periodics:
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: docker-graph
       emptyDir: {}
@@ -17496,8 +17212,6 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: hub-token
       secret:
@@ -17568,8 +17282,6 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: hub-token
       secret:
@@ -17685,8 +17397,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: docker-graph
       emptyDir: {}
@@ -17745,8 +17455,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: docker-graph
       emptyDir: {}
@@ -17807,8 +17515,6 @@ periodics:
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: docker-graph
       emptyDir: {}
@@ -17877,8 +17583,6 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: hub-token
       secret:
@@ -17949,8 +17653,6 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: hub-token
       secret:
@@ -18064,8 +17766,6 @@ periodics:
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: nightly-account
       secret:
@@ -18113,8 +17813,6 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: hub-token
       secret:
@@ -18320,8 +18018,6 @@ periodics:
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: nightly-account
       secret:
@@ -18525,8 +18221,6 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: hub-token
       secret:
@@ -18568,8 +18262,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -18608,8 +18300,6 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: test-account
       secret:
@@ -18650,8 +18340,6 @@ periodics:
         value: /etc/nightly-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: nightly-account
       secret:
@@ -18700,8 +18388,6 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: hub-token
       secret:
@@ -18752,8 +18438,6 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      - name: PULL_BASE_REF
-        value: main
     volumes:
     - name: hub-token
       secret:

--- a/config/prow_common.mk
+++ b/config/prow_common.mk
@@ -49,7 +49,7 @@ help:
 	@echo "Help"
 	@echo "'Update' means updating the servers and can only be run by oncall staff."
 	@echo "Common usage:"
-	@echo " make update-prow-cluster: Update all Prow things on the server to match the current branch. Errors if not master."
+	@echo " make update-prow-cluster: Update all Prow things on the server to match the current branch. Errors if not main or master."
 	@echo " make update-testgrid-config: Update the Testgrid config"
 	@echo " make get-cluster-credentials: Setup kubectl to point to Prow cluster"
 	@echo " make unset-cluster-credentials: Clear kubectl context"

--- a/guides/manual_release.md
+++ b/guides/manual_release.md
@@ -66,7 +66,7 @@ specified by the `--branch` flag.
 - `--version` Defines the version of the release, and must be in the form
   `X.Y.Z`, where X, Y and Z are numbers.
 - `--branch` Defines the branch in Knative repository from which the release
-  will be built. If not passed, the `master` branch at HEAD will be used. This
+  will be built. If not passed, the `main` branch at HEAD will be used. This
   branch must be created before the script is executed, and must be in the form
   `release-X.Y`, where X and Y must match the numbers used in the version passed
   in the `--version` flag. This flag has no effect unless `--version` is also

--- a/guides/prow_knative_setup.md
+++ b/guides/prow_knative_setup.md
@@ -43,7 +43,7 @@ All Prow config files for running Prow jobs for Knative projects are under
 1. Wait a few minutes, check that Prow is working by entering `/woof` as a
    comment in any PR in the new repo.
 
-1. Set **tide** as a required status check for the master branch.
+1. Set **tide** as a required status check for the default branch.
 
    ![Branch Checks](branch_checks.png)
 
@@ -64,7 +64,7 @@ All Prow config files for running Prow jobs for Knative projects are under
 1. Wait a few minutes, enter `/test [prow_job_name]` or `/test all` or `/retest`
    as a comment in any PR in the repo and ensure the test jobs are executed.
 
-1. Optionally, set the new test jobs as required status checks for the master
+1. Optionally, set the new test jobs as required status checks for the default
    branch.
 
    ![Branch Checks](branch_checks.png)

--- a/guides/release_setup.md
+++ b/guides/release_setup.md
@@ -8,7 +8,7 @@ get nightly and official releases with little effort. All automated releases are
 monitored through [TestGrid](http://testgrid.knative.dev).
 
 - **Nightly releases** are built every night between 2AM and 3 AM (PST), from
-  HEAD on the master branch. They are referenced by a date/commit label, in the
+  HEAD on the default branch. They are referenced by a date/commit label, in the
   form `vYYYYMMDD-<commit_short_hash>`. The job status can be checked in the
   `nightly` tab in the corresponding repository dashboard in TestGrid. Images
   are published to the `gcr.io/knative-nightly/MODULE` registry and manifests to
@@ -23,7 +23,7 @@ Versioned releases can be one of two kinds:
 
 - **Major or minor releases** are those with changes to the `X` or `Y` values in
   the version. They are cut only when a new release branch (which must be named
-  `release-X.Y`) is created from the master branch of a repository. Within about
+  `release-X.Y`) is created from the default branch of a repository. Within about
   2 to 3 hours the new release will be built and published. The job status can
   be checked in the `auto-release` tab in the corresponding repository dashboard
   in TestGrid. The release notes published to GitHub are empty, so you must
@@ -81,7 +81,7 @@ Versioned releases can be one of two kinds:
 
 1. Click the _Branch_ dropdown.
 1. Type the desired `release-X.Y` branch name into the search box.
-1. Click the `Create branch: release-X.Y from 'master'` button. _You must have
+1. Click the `Create branch: release-X.Y from 'main'` button. _You must have
    write permissions to the repo to create a branch._
 
 ### Starting the release from the Git CLI
@@ -92,10 +92,10 @@ Versioned releases can be one of two kinds:
     git fetch upstream
     ```
 
-1.  Create a `release-X.Y` branch from `upstream/master`.
+1.  Create a `release-X.Y` branch from `upstream/main`.
 
     ```sh
-    git branch --no-track release-X.Y upstream/master
+    git branch --no-track release-X.Y upstream/main
     ```
 
 1.  Push the branch to upstream.
@@ -131,7 +131,7 @@ Write release notes and add them to the release at
     git checkout -b my-backport-branch upstream/release-X.Y
     ```
 
-1.  Cherry-pick desired commits from master into the new branch.
+1.  Cherry-pick desired commits from main into the new branch.
 
     ```sh
     git cherry-pick <commitid>

--- a/images/README.md
+++ b/images/README.md
@@ -5,7 +5,7 @@ This directory contains custom Docker images used by our Prow jobs.
 ## Building and publishing a new image
 
 To build and push a new image, you can run `make push` from an image directory.
-This should only be done once a PR is approved and from the master branch.
+This should only be done once a PR is approved and from the default branch.
 
 Users typically keep their working directory at the repo root and run relative
 make commands, like `make -C images/prow-tests push`, but for brevity's sake

--- a/images/prow-tests/README.md
+++ b/images/prow-tests/README.md
@@ -28,12 +28,12 @@ something complicated, do some rudimentary exploration in the image by running
 `go get something`.
 
 With an image you feel comfortable with deploying, create a PR to
-knative/test-infra and get approval. Once merged, pull upstream into your master
+knative/test-infra and get approval. Once merged, pull upstream into your default
 branch and run `make cloud_build`. This will upload your image to the registry
 at http://gcr.io/knative-tests/test-infra/prow-tests with a date-commit_hash,
 `latest`, and `beta` tags. Let the image run at least a single overnight and
 ensure the jobs in the https://testgrid.knative.dev/beta-prow-tests testgrid are
-as good as the jobs at https://testgrid.knative.dev/knative for master branch
+as good as the jobs at https://testgrid.knative.dev/knative for default branch
 and releases under "knative-X.Y" at https://testgrid.knative.dev ; it's known
 that some are just bad so you will either learn to know them or just do a lot of
 clicking; it's unlikely to take more than ten minutes to review all the jobs

--- a/pkg/ghutil/fakeghutil/fakeghutil.go
+++ b/pkg/ghutil/fakeghutil/fakeghutil.go
@@ -208,7 +208,7 @@ func (fgc *FakeGithubClient) RemoveLabelForIssue(org, repo string, issueNumber i
 }
 
 // ListPullRequests lists pull requests within given repo, filters by head user and branch name if
-// provided as "user:ref-name", and by base name if provided, i.e. "master"
+// provided as "user:ref-name", and by base name if provided, i.e. "main"
 func (fgc *FakeGithubClient) ListPullRequests(org, repo, head, base string) ([]*github.PullRequest, error) {
 	var res []*github.PullRequest
 	PRs, ok := fgc.PullRequests[repo]
@@ -295,7 +295,7 @@ func (fgc *FakeGithubClient) EditPullRequest(org, repo string, ID int, title, bo
 	return PR, nil
 }
 
-// CreatePullRequest creates PullRequest, passing head user and branch name "user:ref-name", and base branch name like "master"
+// CreatePullRequest creates PullRequest, passing head user and branch name "user:ref-name", and base branch name like "main"
 func (fgc *FakeGithubClient) CreatePullRequest(org, repo, head, base, title, body string) (*github.PullRequest, error) {
 	PRNumber := fgc.getNextNumber()
 	stateStr := string(ghutil.PullRequestOpenState)

--- a/pkg/ghutil/pullrequest.go
+++ b/pkg/ghutil/pullrequest.go
@@ -37,7 +37,7 @@ const (
 type PullRequestState string
 
 // ListPullRequests lists pull requests within given repo, filters by head user and branch name if
-// provided as "user:ref-name", and by base name if provided, i.e. "master"
+// provided as "user:ref-name", and by base name if provided, i.e. "main"
 func (gc *GithubClient) ListPullRequests(org, repo, head, base string) ([]*github.PullRequest, error) {
 	PRsListOptions := github.PullRequestListOptions{
 		State: string(PullRequestAllState),
@@ -184,7 +184,7 @@ func (gc *GithubClient) EditPullRequest(org, repo string, ID int, title, body st
 	return res, err
 }
 
-// CreatePullRequest creates PullRequest, passing head user and branch name "user:ref-name", and base branch name like "master"
+// CreatePullRequest creates PullRequest, passing head user and branch name "user:ref-name", and base branch name like "main"
 func (gc *GithubClient) CreatePullRequest(org, repo, head, base, title, body string) (*github.PullRequest, error) {
 	b := true
 	PR := &github.NewPullRequest{

--- a/scripts/update-test-infra.sh
+++ b/scripts/update-test-infra.sh
@@ -24,7 +24,7 @@ set -e
 # --update
 #  Do the update
 # --ref X
-#  Defines which ref (branch, tag, commit) of test-infra to get scripts from; defaults to master
+#  Defines which ref (branch, tag, commit) of test-infra to get scripts from; defaults to main
 # --first-time
 #  Run this script from your repo root directory to install scripts for the first time
 #  Will also sed -i non-vendor scripts in the current repo to point to new path
@@ -34,7 +34,7 @@ set -e
 
 declare -i FIRST_TIME_SETUP=0
 declare -i DO_UPDATE=0
-declare SCRIPTS_REF=master
+declare SCRIPTS_REF=main
 
 while [[ $# -ne 0 ]]; do
   parameter="$1"

--- a/tools/config-generator/periodic_config.go
+++ b/tools/config-generator/periodic_config.go
@@ -244,7 +244,7 @@ func generatePeriodic(title string, repoName string, periodicConfig yaml.MapSlic
 		data.Base.addEnvToJob("GOOGLE_APPLICATION_CREDENTIALS", data.Base.ServiceAccount)
 		data.Base.addEnvToJob("E2E_CLUSTER_REGION", "us-central1")
 	}
-	if data.Base.RepoBranch != "" && data.Base.RepoBranch != "master" {
+	if data.Base.RepoBranch != "" && data.Base.RepoBranch != "main" {
 		// If it's a release version, add env var PULL_BASE_REF as ref name of the base branch.
 		// The reason for having it is in https://github.com/knative/test-infra/issues/780.
 		data.Base.addEnvToJob("PULL_BASE_REF", data.Base.RepoBranch)

--- a/tools/coverage/design.md
+++ b/tools/coverage/design.md
@@ -9,7 +9,7 @@ workflow type, explained below.
 
 ## Post-submit workflow
 
-Produces and stores a coverage profile for the master branch, for later
+Produces and stores a coverage profile for the default branch, for later
 presubmit jobs to compare against.
 
 1. A PR is merged.
@@ -25,8 +25,8 @@ robot GitHub account.
 1. Developer submits a new commit to an open PR on GitHub.
 1. Matching pre-submit Prow job is started.
 1. Test coverage profile generated.
-1. Calculate coverage change against master branch. Compare the coverage file
-   generated in this cycle against the coverage file in the master branch.
+1. Calculate coverage change against default branch. Compare the coverage file
+   generated in this cycle against the coverage file in the default branch.
 1. Using the PR data from GitHub, `.gitattributes` file, as well as coverage
    change data calculated above, produce a list of files that we care about in
    the line-by-line coverage report. Produce line by line coverage HTML files

--- a/tools/coverage/gcs/gcsPostsubmit.go
+++ b/tools/coverage/gcs/gcsPostsubmit.go
@@ -106,6 +106,6 @@ func (p *PostSubmit) searchForLatestHealthyBuild() int {
 // ProfileReader returns the reader for the most recent healthy profile
 func (p *PostSubmit) ProfileReader() *artifacts.ProfileReader {
 	profilePath := p.pathToGoodCoverageProfile()
-	log.Printf("Reading base (master) coverage from <%s>...\n", profilePath)
+	log.Printf("Reading base (main) coverage from <%s>...\n", profilePath)
 	return p.Client.ProfileReader(p.Ctx, p.Bucket, profilePath)
 }

--- a/tools/flaky-test-retryer/README.md
+++ b/tools/flaky-test-retryer/README.md
@@ -3,7 +3,7 @@
 Flaky-test-retryer is a tool that automatically detects when presubmit jobs fail
 due to test flakiness, and reruns them atmost 3 times. Test flakiness and other
 configuration details are determined by the
-[flaky-test-reporter](https://github.com/knative/test-infra/tree/master/tools/flaky-test-reporter).
+[flaky-test-reporter](https://github.com/knative/test-infra/tree/main/tools/flaky-test-reporter).
 
 ## Basic Usage
 
@@ -66,7 +66,7 @@ The Github comment bot is what keeps track of retries, as well as triggering the
 retries themselves. The number of previous retries attempted is determined by
 parsing the comment history of the PR itself, and retries are attempted up to a
 number set
-[here](https://github.com/knative/test-infra/blob/master/tools/flaky-test-retryer/github_commenter.go#L35).
+[here](https://github.com/knative/test-infra/blob/main/tools/flaky-test-retryer/github_commenter.go#L35).
 There are a number of different comments that can be posted, based on the failed
 tests and existing retry comments. They all follow a similar format:
 

--- a/tools/flaky-test-retryer/subscriber/subscriber_test.go
+++ b/tools/flaky-test-retryer/subscriber/subscriber_test.go
@@ -96,7 +96,7 @@ func TestToReportMessage(t *testing.T) {
 		{
 			name: "Valid report",
 			arg: &pubsub.Message{
-				Data: []byte(`{"project":"knative-tests","topic":"knative-monitoring","runid":"post-knative-serving-go-coverage-dev","status":"triggered","url":"","gcs_path":"gs://","refs":[{"org":"knative","repo":"serving","base_ref":"master","base_sha":"ce96dd74b1c85f024d63ce0991d4bf61aced582a","clone_uri":"https://github.com/knative/serving.git"}],"job_type":"postsubmit","job_name":"post-knative-serving-go-coverage-dev"}`)},
+				Data: []byte(`{"project":"knative-tests","topic":"knative-monitoring","runid":"post-knative-serving-go-coverage-dev","status":"triggered","url":"","gcs_path":"gs://","refs":[{"org":"knative","repo":"serving","base_ref":"main","base_sha":"ce96dd74b1c85f024d63ce0991d4bf61aced582a","clone_uri":"https://github.com/knative/serving.git"}],"job_type":"postsubmit","job_name":"post-knative-serving-go-coverage-dev"}`)},
 			want: &prowapi.ReportMessage{
 				Project: "knative-tests",
 				Topic:   "knative-monitoring",
@@ -108,7 +108,7 @@ func TestToReportMessage(t *testing.T) {
 					{
 						Org:      "knative",
 						Repo:     "serving",
-						BaseRef:  "master",
+						BaseRef:  "main",
 						BaseSHA:  "ce96dd74b1c85f024d63ce0991d4bf61aced582a",
 						CloneURI: "https://github.com/knative/serving.git",
 					},

--- a/tools/prow-jobs-syncer/config.go
+++ b/tools/prow-jobs-syncer/config.go
@@ -26,7 +26,7 @@ const (
 	// PRHead is branch name where the changes occur
 	PRHead = "releasebranch"
 	// PRBase is the branch name where PR targets
-	PRBase = "master"
+	PRBase = "main"
 
 	// Paths
 	repoPath           = "src/knative.dev/test-infra"


### PR DESCRIPTION
Went through and removed a few more unnecessary occurrences of `master`. I left buoy alone for this PR cc @n3wscott. Note the changes to the prow config, I suppose we forgot to adjust this piece before but it wasn't harmful?

/assign @chaodaiG 