### PR TITLE
Replace /k8s-testimages/generic_autobumper with /k8s-prow/generic-auto-bumper

### DIFF
--- a/config/prod/prow/jobs/custom/test-infra.yaml
+++ b/config/prod/prow/jobs/custom/test-infra.yaml
@@ -338,9 +338,9 @@ periodics:
     path_alias: knative.dev/test-infra
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/generic_autobump:v20210227-adfdf65
+    - image: gcr.io/k8s-prow/generic-autobumper:v20210310-a49501d5de
       command:
-      - /generic_autobump
+      - /app/prow/cmd/generic-autobumper/app.binary
       args:
       - --config=config/prod/prow/knative-autobump-config.yaml
       volumeMounts:


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
The generic autobumper was moved from k8s-testimages to k8s-prow https://github.com/kubernetes/test-infra/pull/20813
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #

**Special notes to reviewers**:

**User-visible changes in this PR**:

