### PR TITLE
Add eventing e2e tests on s390x architecture

### DIFF
--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -861,6 +861,26 @@ periodics:
         memory: 12Gi
       limits:
         memory: 16Gi
+  - custom-job: s390x-e2e-tests
+    cron: 0 8 * * *
+    command:
+    - bash
+    args:
+    - -c
+    - >-
+      mkdir -p /root/.kube &&
+      cp /opt/cluster/config /root/.kube/ &&
+      ./test/e2e-tests.sh --run-tests
+    env-vars:
+    - DISABLE_MD_LINTING="1"
+    - KO_FLAGS="--platform=linux/s390x"
+    - DEPLOY_KNATIVE_MONITORING="0"
+    - SYSTEM_NAMESPACE="knative-eventing"
+    - PLATFORM="linux/s390x"
+    - KUBECONFIG="/root/.kube/config"
+    - SSL_CERT_FILE="/opt/cluster/registry.crt"
+    external_cluster:
+      secret: s390x-cluster1
   knative/eventing-contrib:
   - continuous: true
     resources:

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -10122,6 +10122,70 @@ periodics:
     - name: release-account
       secret:
         secretName: release-account
+- cron: "0 8 * * *"
+  name: ci-knative-eventing-s390x-e2e-tests
+  agent: kubernetes
+  decorate: true
+  decoration_config:
+    timeout: 120m
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative
+    repo: eventing
+    path_alias: knative.dev/eventing
+    base_ref: main
+  annotations:
+    testgrid-dashboards: eventing
+    testgrid-tab-name: eventing-s390x-e2e-tests
+    testgrid-alert-stale-results-hours: "3"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "bash"
+      - "-c"
+      - "mkdir -p /root/.kube && cp /opt/cluster/config /root/.kube/ && ./test/e2e-tests.sh --run-tests"
+      volumeMounts:
+      - name: s390x-cluster1
+        mountPath: /opt/cluster
+        readOnly: true
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: DISABLE_MD_LINTING
+        value: "1"
+      - name: KO_FLAGS
+        value: "--platform=linux/s390x"
+      - name: DEPLOY_KNATIVE_MONITORING
+        value: "0"
+      - name: SYSTEM_NAMESPACE
+        value: "knative-eventing"
+      - name: PLATFORM
+        value: "linux/s390x"
+      - name: KUBECONFIG
+        value: "/root/.kube/config"
+      - name: SSL_CERT_FILE
+        value: "/opt/cluster/registry.crt"
+      - name: KO_DOCKER_REPO
+        valueFrom:
+          secretKeyRef:
+            name: s390x-cluster1
+            key: ko-docker-repo
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: s390x-cluster1
+      secret:
+        secretName: s390x-cluster1
+    - name: test-account
+      secret:
+        secretName: test-account
 - cron: "0 1 * * *"
   name: ci-knative-eventing-go-coverage
   labels:

--- a/config/prod/prow/testgrid/testgrid.yaml
+++ b/config/prod/prow/testgrid/testgrid.yaml
@@ -142,6 +142,9 @@ test_groups:
   alert_options:
     alert_mail_to_addresses: "serverless-engprod-sea@google.com"
   num_failures_to_alert: 1
+- name: ci-knative-eventing-s390x-e2e-tests
+  gcs_prefix: knative-prow/logs/ci-knative-eventing-s390x-e2e-tests
+  alert_stale_results_hours: 3
 - name: ci-knative-eventing-test-coverage
   gcs_prefix: knative-prow/logs/ci-knative-eventing-go-coverage
   short_text_metric: "coverage"
@@ -1337,6 +1340,9 @@ dashboards:
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
     num_failures_to_alert: 1
+  - name: s390x-e2e-tests
+    test_group_name: ci-knative-eventing-s390x-e2e-tests
+    base_options: "sort-by-name="
   - name: coverage
     test_group_name: ci-knative-eventing-test-coverage
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="


### PR DESCRIPTION
**What this PR does, why we need it**:

This PR proposes the standard way to run Knative tests on non-Intel architectures, as first step with s390x eventing e2e tests. The approach can be applied to other architectures and components. 
The idea that main job is running on Intel architecture, as any other standard test job, but the actual tests will be executed on another k8s arch-specific cluster. From non-Intel architecture k8s cluster and image registry should be provided.
The details:
- the project and test images are built for another architecture (with ko parameter `--platform=linux/<arch>`), despite the actual build is done on x86_64
- images are pushed to special registry (`KO_DOCKER_REPO` parameter)
- the deployment after build is done on remote k8s arch-specific cluster (`KUBECONFIG` parameter points to non-Intel architecture k8s cluster) 
- the tests are running also on remote k8s arch-specific cluster (`KUBECONFIG` parameter parameter points to non-Intel architecture k8s cluster) 

The s390x eventing Prow job:
- is the daily job to run eventing e2e tests on s390x hardware architecture
- it expects from Prow to be able to use `s390x-cluster1` secret to get access to s390x k8s cluster(config file) and image registry(registry.crt) for temporary test images (secrets should be added by Prow maintainer?)

`s390x` hardware is ready and accessible via kubeconfig for k8s cluster. Registry is also up and ready.

The proposed job is tested using mkpj and phaino tools as local Prow job running on Intel hardware with actual tests running on s390x k8s cluster.

config-generator functionality is extended to specify volume/volume mount/env variable for the job (to be able to use secrets with k8s config and registry certificate).