### PR TITLE
Fix flaky-test-reporter by matching the issue owner

### DIFF
--- a/pkg/ghutil/fakeghutil/fakeghutil.go
+++ b/pkg/ghutil/fakeghutil/fakeghutil.go
@@ -94,6 +94,9 @@ func (fgc *FakeGithubClient) CreateIssue(org, repo, title, body string) (*github
 	repoURL := fmt.Sprintf("%s/%s/%s", fgc.BaseURL, org, repo)
 	url := fmt.Sprintf("%s/%d", repoURL, issueNumber)
 	newIssue := &github.Issue{
+		User: &github.User{
+			Login: fgc.User.Login,
+		},
 		Title:         &title,
 		Body:          &body,
 		Number:        &issueNumber,

--- a/tools/flaky-test-reporter/github_issue.go
+++ b/tools/flaky-test-reporter/github_issue.go
@@ -376,7 +376,7 @@ func (gih *GithubIssueHandler) githubToFlakyIssue(issue *github.Issue, dryrun bo
 	issueID := reTestIdentifierRegex.FindStringSubmatch(issue.GetBody())
 	// Malformed issue, all auto flaky issues need to be identifiable.
 	if len(issueID) < 2 {
-		return nil, fmt.Errorf("test identifier '%s' is malformed", issueID)
+		return nil, fmt.Errorf("test identifier '%s' is malformed: %+v", issueID, issue)
 	}
 	autoComment, err := gih.findExistingComment(issue, issueID[1])
 	if err != nil {
@@ -408,6 +408,11 @@ func (gih *GithubIssueHandler) getFlakyIssues(repoDataAll []RepoData) (map[strin
 			return nil, err
 		}
 		for _, issue := range issues {
+			// Skip issues that are not created by the GitHub bot.
+			if issue.User.Login != gih.user.Login {
+				continue
+			}
+
 			fi, err := gih.githubToFlakyIssue(issue, false)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
flaky-test-reporter was broken by https://github.com/knative-sandbox/eventing-kafka-broker/issues/707. This PR fixes it by also matching the issue owner. Also print out the issue information for ease of debugging.

/cc @chaodaiG @albertomilan 

