### PR TITLE
Remove nightly release job and disable go-coverage for net-ingressv2

### DIFF
--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -1124,17 +1124,6 @@ periodics:
         report_template: '"The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"'
   - dot-release: true
   - auto-release: true
-  knative-sandbox/net-ingressv2:
-  - continuous: true
-  - nightly: true
-    reporter_config:
-      slack:
-        channel: net-ingressv2
-        job_states_to_report:
-        - failure
-        report_template: '"The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"'
-  - dot-release: true
-  - auto-release: true
   knative-sandbox/net-istio:
   - continuous: true
   - nightly: true

--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -470,7 +470,7 @@ presubmits:
   - build-tests: true
   - unit-tests: true
   - integration-tests: true
-  - go-coverage: true
+  - go-coverage: false
   knative-sandbox/net-istio:
   - build-tests: true
   - unit-tests: true

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -4212,36 +4212,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-sandbox-net-ingressv2-go-coverage
-    agent: kubernetes
-    context: pull-knative-sandbox-net-ingressv2-go-coverage
-    always_run: true
-    rerun_command: "/test pull-knative-sandbox-net-ingressv2-go-coverage"
-    trigger: "(?m)^/test (all|pull-knative-sandbox-net-ingressv2-go-coverage),?(\\s+|$)"
-    optional: true
-    decorate: true
-    path_alias: knative.dev/net-ingressv2
-    cluster: "build-knative"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "coverage"
-        - "--postsubmit-job-name=post-knative-sandbox-net-ingressv2-go-coverage"
-        - "--artifacts=$(ARTIFACTS)"
-        - "--cov-threshold-percentage=50"
-        - "--github-token=/etc/covbot-token/token"
-        volumeMounts:
-        - name: covbot-token
-          mountPath: /etc/covbot-token
-          readOnly: true
-      volumes:
-      - name: covbot-token
-        secret:
-          secretName: covbot-token
   knative-sandbox/net-istio:
   - name: pull-knative-sandbox-net-istio-build-tests
     agent: kubernetes
@@ -18741,60 +18711,6 @@ periodics:
     - name: release-account
       secret:
         secretName: release-account
-- cron: "0 1 * * *"
-  name: ci-knative-sandbox-net-ingressv2-go-coverage
-  labels:
-      prow.k8s.io/pubsub.project: knative-tests
-      prow.k8s.io/pubsub.topic: knative-monitoring
-      prow.k8s.io/pubsub.runID: ci-knative-sandbox-net-ingressv2-go-coverage
-  agent: kubernetes
-  decorate: true
-  cluster: "build-knative"
-  extra_refs:
-  - org: knative-sandbox
-    repo: net-ingressv2
-    path_alias: knative.dev/net-ingressv2
-    base_ref: main
-  annotations:
-    testgrid-dashboards: net-ingressv2
-    testgrid-tab-name: net-ingressv2-go-coverage
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - "runner.sh"
-      args:
-      - "coverage"
-      - "--artifacts=$(ARTIFACTS)"
-      - "--cov-threshold-percentage=50"
-- cron: "19 7 * * *"
-  name: ci-knative-sandbox-net-ingressv2-go-coverage-beta-prow-tests
-  labels:
-      prow.k8s.io/pubsub.project: knative-tests
-      prow.k8s.io/pubsub.topic: knative-monitoring
-      prow.k8s.io/pubsub.runID: ci-knative-sandbox-net-ingressv2-go-coverage
-  agent: kubernetes
-  decorate: true
-  cluster: "build-knative"
-  extra_refs:
-  - org: knative-sandbox
-    repo: net-ingressv2
-    path_alias: knative.dev/net-ingressv2
-    base_ref: main
-  annotations:
-    testgrid-dashboards: prow-tests
-    testgrid-tab-name: net-ingressv2-go-coverage-beta-prow-tests
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:beta
-      imagePullPolicy: Always
-      command:
-      - "runner.sh"
-      args:
-      - "coverage"
-      - "--artifacts=$(ARTIFACTS)"
-      - "--cov-threshold-percentage=50"
 - cron: "30 07 * * *"
   name: ci-knative-serving-recreate-clusters
   agent: kubernetes
@@ -19170,26 +19086,6 @@ postsubmits:
     decorate: true
     cluster: "build-knative"
     path_alias: knative.dev/net-certmanager
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "coverage"
-        - "--artifacts=$(ARTIFACTS)"
-        - "--cov-threshold-percentage=0"
-  knative-sandbox/net-ingressv2:
-  - name: post-knative-sandbox-net-ingressv2-go-coverage
-    branches:
-    - "main"
-    annotations:
-      testgrid-create-test-group: "false"
-    agent: kubernetes
-    decorate: true
-    cluster: "build-knative"
-    path_alias: knative.dev/net-ingressv2
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -14845,283 +14845,6 @@ periodics:
     - name: release-account
       secret:
         secretName: release-account
-- cron: "17 */4 * * *"
-  name: ci-knative-sandbox-net-ingressv2-continuous
-  agent: kubernetes
-  decorate: true
-  decoration_config:
-    timeout: 180m
-  cluster: "build-knative"
-  extra_refs:
-  - org: knative-sandbox
-    repo: net-ingressv2
-    path_alias: knative.dev/net-ingressv2
-    base_ref: main
-  annotations:
-    testgrid-dashboards: net-ingressv2
-    testgrid-tab-name: net-ingressv2-continuous
-    testgrid-alert-stale-results-hours: "3"
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./test/presubmit-tests.sh"
-      - "--all-tests"
-      volumeMounts:
-      - name: test-account
-        mountPath: /etc/test-account
-        readOnly: true
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/test-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-    volumes:
-    - name: test-account
-      secret:
-        secretName: test-account
-- cron: "5 8,11,22 * * *"
-  name: ci-knative-sandbox-net-ingressv2-continuous-beta-prow-tests
-  agent: kubernetes
-  decorate: true
-  decoration_config:
-    timeout: 180m
-  cluster: "build-knative"
-  extra_refs:
-  - org: knative-sandbox
-    repo: net-ingressv2
-    path_alias: knative.dev/net-ingressv2
-    base_ref: main
-  annotations:
-    testgrid-dashboards: prow-tests
-    testgrid-tab-name: net-ingressv2-continuous-beta-prow-tests
-    testgrid-alert-stale-results-hours: "3"
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:beta
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./test/presubmit-tests.sh"
-      - "--all-tests"
-      volumeMounts:
-      - name: test-account
-        mountPath: /etc/test-account
-        readOnly: true
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/test-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-    volumes:
-    - name: test-account
-      secret:
-        secretName: test-account
-- cron: "23 9 * * *"
-  name: ci-knative-sandbox-net-ingressv2-nightly-release
-  agent: kubernetes
-  decorate: true
-  reporter_config:
-    slack:
-      channel: net-ingressv2
-      report_template: "The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"
-      job_states_to_report:
-      - "failure"
-  decoration_config:
-    timeout: 180m
-  cluster: "build-knative"
-  extra_refs:
-  - org: knative-sandbox
-    repo: net-ingressv2
-    path_alias: knative.dev/net-ingressv2
-    base_ref: main
-  annotations:
-    testgrid-dashboards: net-ingressv2
-    testgrid-tab-name: net-ingressv2-nightly-release
-    testgrid-alert-email: "serverless-engprod-sea@google.com"
-    testgrid-num-failures-to-alert: "1"
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./hack/release.sh"
-      - "--publish"
-      - "--tag-release"
-      volumeMounts:
-      - name: nightly-account
-        mountPath: /etc/nightly-account
-        readOnly: true
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/nightly-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-    volumes:
-    - name: nightly-account
-      secret:
-        secretName: nightly-account
-- cron: "31 9 * * 2"
-  name: ci-knative-sandbox-net-ingressv2-dot-release
-  agent: kubernetes
-  decorate: true
-  decoration_config:
-    timeout: 180m
-  cluster: "build-knative"
-  extra_refs:
-  - org: knative-sandbox
-    repo: net-ingressv2
-    path_alias: knative.dev/net-ingressv2
-    base_ref: main
-  annotations:
-    testgrid-dashboards: net-ingressv2
-    testgrid-tab-name: net-ingressv2-dot-release
-    testgrid-alert-stale-results-hours: "170"
-    testgrid-alert-email: "serverless-engprod-sea@google.com"
-    testgrid-num-failures-to-alert: "1"
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./hack/release.sh"
-      - "--dot-release"
-      - "--release-gcs knative-releases/net-ingressv2"
-      - "--release-gcr gcr.io/knative-releases"
-      - "--github-token /etc/hub-token/token"
-      volumeMounts:
-      - name: hub-token
-        mountPath: /etc/hub-token
-        readOnly: true
-      - name: release-account
-        mountPath: /etc/release-account
-        readOnly: true
-      env:
-      - name: ORG_NAME
-        value: knative-sandbox
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/release-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-    volumes:
-    - name: hub-token
-      secret:
-        secretName: hub-token
-    - name: release-account
-      secret:
-        secretName: release-account
-- cron: "49 */4 * * *"
-  name: ci-knative-sandbox-net-ingressv2-auto-release
-  agent: kubernetes
-  decorate: true
-  decoration_config:
-    timeout: 180m
-  cluster: "build-knative"
-  extra_refs:
-  - org: knative-sandbox
-    repo: net-ingressv2
-    path_alias: knative.dev/net-ingressv2
-    base_ref: main
-  annotations:
-    testgrid-dashboards: net-ingressv2
-    testgrid-tab-name: net-ingressv2-auto-release
-    testgrid-alert-email: "serverless-engprod-sea@google.com"
-    testgrid-num-failures-to-alert: "1"
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - "./hack/release.sh"
-      - "--auto-release"
-      - "--release-gcs knative-releases/net-ingressv2"
-      - "--release-gcr gcr.io/knative-releases"
-      - "--github-token /etc/hub-token/token"
-      volumeMounts:
-      - name: hub-token
-        mountPath: /etc/hub-token
-        readOnly: true
-      - name: release-account
-        mountPath: /etc/release-account
-        readOnly: true
-      env:
-      - name: ORG_NAME
-        value: knative-sandbox
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/release-account/service-account.json
-      - name: E2E_CLUSTER_REGION
-        value: us-central1
-    volumes:
-    - name: hub-token
-      secret:
-        secretName: hub-token
-    - name: release-account
-      secret:
-        secretName: release-account
-- cron: "0 1 * * *"
-  name: ci-knative-sandbox-net-ingressv2-go-coverage
-  labels:
-      prow.k8s.io/pubsub.project: knative-tests
-      prow.k8s.io/pubsub.topic: knative-monitoring
-      prow.k8s.io/pubsub.runID: ci-knative-sandbox-net-ingressv2-go-coverage
-  agent: kubernetes
-  decorate: true
-  cluster: "build-knative"
-  extra_refs:
-  - org: knative-sandbox
-    repo: net-ingressv2
-    path_alias: knative.dev/net-ingressv2
-    base_ref: main
-  annotations:
-    testgrid-dashboards: net-ingressv2
-    testgrid-tab-name: net-ingressv2-go-coverage
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - "runner.sh"
-      args:
-      - "coverage"
-      - "--artifacts=$(ARTIFACTS)"
-      - "--cov-threshold-percentage=50"
-- cron: "19 7 * * *"
-  name: ci-knative-sandbox-net-ingressv2-go-coverage-beta-prow-tests
-  labels:
-      prow.k8s.io/pubsub.project: knative-tests
-      prow.k8s.io/pubsub.topic: knative-monitoring
-      prow.k8s.io/pubsub.runID: ci-knative-sandbox-net-ingressv2-go-coverage
-  agent: kubernetes
-  decorate: true
-  cluster: "build-knative"
-  extra_refs:
-  - org: knative-sandbox
-    repo: net-ingressv2
-    path_alias: knative.dev/net-ingressv2
-    base_ref: main
-  annotations:
-    testgrid-dashboards: prow-tests
-    testgrid-tab-name: net-ingressv2-go-coverage-beta-prow-tests
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:beta
-      imagePullPolicy: Always
-      command:
-      - "runner.sh"
-      args:
-      - "coverage"
-      - "--artifacts=$(ARTIFACTS)"
-      - "--cov-threshold-percentage=50"
 - cron: "8 */4 * * *"
   name: ci-knative-sandbox-net-istio-continuous
   agent: kubernetes
@@ -19018,6 +18741,60 @@ periodics:
     - name: release-account
       secret:
         secretName: release-account
+- cron: "0 1 * * *"
+  name: ci-knative-sandbox-net-ingressv2-go-coverage
+  labels:
+      prow.k8s.io/pubsub.project: knative-tests
+      prow.k8s.io/pubsub.topic: knative-monitoring
+      prow.k8s.io/pubsub.runID: ci-knative-sandbox-net-ingressv2-go-coverage
+  agent: kubernetes
+  decorate: true
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative-sandbox
+    repo: net-ingressv2
+    path_alias: knative.dev/net-ingressv2
+    base_ref: main
+  annotations:
+    testgrid-dashboards: net-ingressv2
+    testgrid-tab-name: net-ingressv2-go-coverage
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - "runner.sh"
+      args:
+      - "coverage"
+      - "--artifacts=$(ARTIFACTS)"
+      - "--cov-threshold-percentage=50"
+- cron: "19 7 * * *"
+  name: ci-knative-sandbox-net-ingressv2-go-coverage-beta-prow-tests
+  labels:
+      prow.k8s.io/pubsub.project: knative-tests
+      prow.k8s.io/pubsub.topic: knative-monitoring
+      prow.k8s.io/pubsub.runID: ci-knative-sandbox-net-ingressv2-go-coverage
+  agent: kubernetes
+  decorate: true
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative-sandbox
+    repo: net-ingressv2
+    path_alias: knative.dev/net-ingressv2
+    base_ref: main
+  annotations:
+    testgrid-dashboards: prow-tests
+    testgrid-tab-name: net-ingressv2-go-coverage-beta-prow-tests
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:beta
+      imagePullPolicy: Always
+      command:
+      - "runner.sh"
+      args:
+      - "coverage"
+      - "--artifacts=$(ARTIFACTS)"
+      - "--cov-threshold-percentage=50"
 - cron: "30 07 * * *"
   name: ci-knative-serving-recreate-clusters
   agent: kubernetes

--- a/config/prod/prow/k8s-testgrid/k8s-testgrid.yaml
+++ b/config/prod/prow/k8s-testgrid/k8s-testgrid.yaml
@@ -52,7 +52,6 @@ dashboards:
 - name: net-certmanager
 - name: net-contour
 - name: net-http01
-- name: net-ingressv2
 - name: net-istio
 - name: net-kourier
 - name: operator
@@ -106,7 +105,6 @@ dashboard_groups:
       - "net-certmanager"
       - "net-contour"
       - "net-http01"
-      - "net-ingressv2"
       - "net-istio"
       - "net-kourier"
       - "sample-controller"

--- a/config/prod/prow/testgrid/testgrid.yaml
+++ b/config/prod/prow/testgrid/testgrid.yaml
@@ -1135,9 +1135,6 @@ test_groups:
   short_text_metric: "coverage"
 - name: ci-knative-sandbox-eventing-autoscaler-keda-continuous-beta-prow-tests
   gcs_prefix: knative-prow/logs/ci-knative-sandbox-eventing-autoscaler-keda-continuous-beta-prow-tests
-- name: ci-knative-sandbox-net-ingressv2-go-coverage-beta-prow-tests
-  gcs_prefix: knative-prow/logs/ci-knative-sandbox-net-ingressv2-go-coverage-beta-prow-tests
-  short_text_metric: "coverage"
 - name: ci-knative-backup-artifacts
   gcs_prefix: knative-prow/logs/ci-knative-backup-artifacts
   alert_options:
@@ -2650,9 +2647,6 @@ dashboards:
   - name: ci-knative-sandbox-eventing-autoscaler-keda-continuous
     test_group_name: ci-knative-sandbox-eventing-autoscaler-keda-continuous-beta-prow-tests
     base_options: "sort-by-failures="
-  - name: ci-knative-sandbox-net-ingressv2-go-coverage
-    test_group_name: ci-knative-sandbox-net-ingressv2-go-coverage-beta-prow-tests
-    base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
 - name: utilities
   dashboard_tab:
   - name: ci-knative-backup-artifacts

--- a/config/prod/prow/testgrid/testgrid.yaml
+++ b/config/prod/prow/testgrid/testgrid.yaml
@@ -593,28 +593,6 @@ test_groups:
   alert_options:
     alert_mail_to_addresses: "serverless-engprod-sea@google.com"
   num_failures_to_alert: 1
-- name: ci-knative-sandbox-net-ingressv2-continuous
-  gcs_prefix: knative-prow/logs/ci-knative-sandbox-net-ingressv2-continuous
-  alert_stale_results_hours: 3
-- name: ci-knative-sandbox-net-ingressv2-nightly-release
-  gcs_prefix: knative-prow/logs/ci-knative-sandbox-net-ingressv2-nightly-release
-  alert_options:
-    alert_mail_to_addresses: "serverless-engprod-sea@google.com"
-  num_failures_to_alert: 1
-- name: ci-knative-sandbox-net-ingressv2-dot-release
-  gcs_prefix: knative-prow/logs/ci-knative-sandbox-net-ingressv2-dot-release
-  alert_options:
-    alert_mail_to_addresses: "serverless-engprod-sea@google.com"
-  alert_stale_results_hours: 170
-  num_failures_to_alert: 1
-- name: ci-knative-sandbox-net-ingressv2-auto-release
-  gcs_prefix: knative-prow/logs/ci-knative-sandbox-net-ingressv2-auto-release
-  alert_options:
-    alert_mail_to_addresses: "serverless-engprod-sea@google.com"
-  num_failures_to_alert: 1
-- name: ci-knative-sandbox-net-ingressv2-test-coverage
-  gcs_prefix: knative-prow/logs/ci-knative-sandbox-net-ingressv2-go-coverage
-  short_text_metric: "coverage"
 - name: ci-knative-sandbox-net-istio-continuous
   gcs_prefix: knative-prow/logs/ci-knative-sandbox-net-istio-continuous
   alert_stale_results_hours: 3
@@ -1113,11 +1091,6 @@ test_groups:
   gcs_prefix: knative-prow/logs/ci-knative-sandbox-net-contour-continuous-beta-prow-tests
 - name: ci-knative-sandbox-net-http01-continuous-beta-prow-tests
   gcs_prefix: knative-prow/logs/ci-knative-sandbox-net-http01-continuous-beta-prow-tests
-- name: ci-knative-sandbox-net-ingressv2-continuous-beta-prow-tests
-  gcs_prefix: knative-prow/logs/ci-knative-sandbox-net-ingressv2-continuous-beta-prow-tests
-- name: ci-knative-sandbox-net-ingressv2-go-coverage-beta-prow-tests
-  gcs_prefix: knative-prow/logs/ci-knative-sandbox-net-ingressv2-go-coverage-beta-prow-tests
-  short_text_metric: "coverage"
 - name: ci-knative-sandbox-net-istio-continuous-beta-prow-tests
   gcs_prefix: knative-prow/logs/ci-knative-sandbox-net-istio-continuous-beta-prow-tests
 - name: ci-knative-sandbox-net-istio-go-coverage-beta-prow-tests
@@ -1162,6 +1135,9 @@ test_groups:
   short_text_metric: "coverage"
 - name: ci-knative-sandbox-eventing-autoscaler-keda-continuous-beta-prow-tests
   gcs_prefix: knative-prow/logs/ci-knative-sandbox-eventing-autoscaler-keda-continuous-beta-prow-tests
+- name: ci-knative-sandbox-net-ingressv2-go-coverage-beta-prow-tests
+  gcs_prefix: knative-prow/logs/ci-knative-sandbox-net-ingressv2-go-coverage-beta-prow-tests
+  short_text_metric: "coverage"
 - name: ci-knative-backup-artifacts
   gcs_prefix: knative-prow/logs/ci-knative-backup-artifacts
   alert_options:
@@ -1756,35 +1732,6 @@ dashboards:
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
     num_failures_to_alert: 1
-- name: net-ingressv2
-  dashboard_tab:
-  - name: continuous
-    test_group_name: ci-knative-sandbox-net-ingressv2-continuous
-    base_options: "sort-by-name="
-    alert_options:
-      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
-    num_failures_to_alert: 3
-  - name: nightly
-    test_group_name: ci-knative-sandbox-net-ingressv2-nightly-release
-    base_options: "sort-by-name="
-    alert_options:
-      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
-    num_failures_to_alert: 1
-  - name: dot-release
-    test_group_name: ci-knative-sandbox-net-ingressv2-dot-release
-    base_options: "sort-by-name="
-    alert_options:
-      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
-    num_failures_to_alert: 1
-  - name: auto-release
-    test_group_name: ci-knative-sandbox-net-ingressv2-auto-release
-    base_options: "sort-by-name="
-    alert_options:
-      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
-    num_failures_to_alert: 1
-  - name: coverage
-    test_group_name: ci-knative-sandbox-net-ingressv2-test-coverage
-    base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
 - name: net-istio
   dashboard_tab:
   - name: continuous
@@ -2646,12 +2593,6 @@ dashboards:
   - name: ci-knative-sandbox-net-http01-continuous
     test_group_name: ci-knative-sandbox-net-http01-continuous-beta-prow-tests
     base_options: "sort-by-failures="
-  - name: ci-knative-sandbox-net-ingressv2-continuous
-    test_group_name: ci-knative-sandbox-net-ingressv2-continuous-beta-prow-tests
-    base_options: "sort-by-failures="
-  - name: ci-knative-sandbox-net-ingressv2-go-coverage
-    test_group_name: ci-knative-sandbox-net-ingressv2-go-coverage-beta-prow-tests
-    base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
   - name: ci-knative-sandbox-net-istio-continuous
     test_group_name: ci-knative-sandbox-net-istio-continuous-beta-prow-tests
     base_options: "sort-by-failures="
@@ -2709,6 +2650,9 @@ dashboards:
   - name: ci-knative-sandbox-eventing-autoscaler-keda-continuous
     test_group_name: ci-knative-sandbox-eventing-autoscaler-keda-continuous-beta-prow-tests
     base_options: "sort-by-failures="
+  - name: ci-knative-sandbox-net-ingressv2-go-coverage
+    test_group_name: ci-knative-sandbox-net-ingressv2-go-coverage-beta-prow-tests
+    base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
 - name: utilities
   dashboard_tab:
   - name: ci-knative-backup-artifacts
@@ -2778,7 +2722,6 @@ dashboard_groups:
   - "net-certmanager"
   - "net-contour"
   - "net-http01"
-  - "net-ingressv2"
   - "net-istio"
   - "net-kourier"
   - "async-component"


### PR DESCRIPTION
As net-ingressv2 adds test code only, nightly release is not
necessary. Also go-coverage should be disabled.

It is in the same manner as knative/networking repo.

/cc @ZhiminXiang @tcnghia @markusthoemmes 