### PR TITLE
Eventing Kafka upgrade tests

### DIFF
--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -556,6 +556,10 @@ presubmits:
     - --run-test
     - ./test/e2e-tests.sh --mt-source
     optional: true
+  - custom-test: upgrade-tests
+    args:
+    - --run-test
+    - ./test/e2e-upgrade-tests.sh
   - integration-tests: false
   - build-tests: true
     needs-dind: true

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -5367,6 +5367,39 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
+  - name: pull-knative-sandbox-eventing-kafka-upgrade-tests
+    agent: kubernetes
+    context: pull-knative-sandbox-eventing-kafka-upgrade-tests
+    always_run: true
+    optional: false
+    rerun_command: "/test pull-knative-sandbox-eventing-kafka-upgrade-tests"
+    trigger: "(?m)^/test (all|pull-knative-sandbox-eventing-kafka-upgrade-tests),?(\\s+|$)"
+    decorate: true
+    path_alias: knative.dev/eventing-kafka
+    cluster: "build-knative"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-upgrade-tests.sh"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
   - name: pull-knative-sandbox-eventing-kafka-build-tests
     agent: kubernetes
     context: pull-knative-sandbox-eventing-kafka-build-tests

--- a/hack/generate-configs.sh
+++ b/hack/generate-configs.sh
@@ -14,10 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -o errexit
-set -o nounset
+set -Eeuo pipefail
 
-REPO_ROOT_DIR="$(dirname "$0")/.."
+REPO_ROOT_DIR="$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")"
 
 # Generate Prow configs since we are using generator
 readonly CONFIG_GENERATOR_DIR="${REPO_ROOT_DIR}/tools/config-generator"


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Adds upgrade tests for Eventing Kafka to be run as presubmit check

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Related to knative-sandbox/eventing-kafka#467

**Special notes to reviewers**:
None

**User-visible changes in this PR**:
None

