### PR TITLE
Update OWNERS_ALIASES to match autogen in community

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,8 +2,8 @@
 
 approvers:
 - technical-oversight-committee
-- productivity-approvers
+- productivity-writers
 
 reviewers:
-- productivity-approvers
+- productivity-writers
 - productivity-reviewers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,17 +2,21 @@
 
 aliases:
   technical-oversight-committee:
-    - evankanderson
-    - grantr
-    - markusthoemmes
-    - mattmoor
-    - tcnghia
-  productivity-approvers:
-    - chaodaiG
-    - chizhg
-    - coryrc
-    - n3wscott
+  - evankanderson
+  - grantr
+  - markusthoemmes
+  - rhuss
+
+  productivity-writers:
+  - chaodaiG
+  - chizhg
+  - coryrc
+  - n3wscott
+  
   productivity-reviewers:
-    - steuhs
-    - peterfeifanchen
-    - efiturri
+  - coryrc
+  - efiturri
+  - evankanderson
+  - peterfeifanchen
+  - steuhs
+  - yt3liu


### PR DESCRIPTION
See https://github.com/knative/community/pull/552 for the addition of groups/full OWNERS_ALIASES that will be synced.

This is a preparatory PR for landing OWNERS_ALIASES automation across the Knative org (alternative to the CODEOWNERS changes in knative-sandbox).

If this seems to be expanding permissions or otherwise likely to cause a problem, `/hold` this PR and comment here or on https://github.com/knative/community/pull/552.
