### PR TITLE
k8s testgrid: add all missing tabs

### DIFF
--- a/config/prod/prow/jobs/custom/branchprotector.yaml
+++ b/config/prod/prow/jobs/custom/branchprotector.yaml
@@ -60,6 +60,11 @@ periodics:
     repo: test-infra
     base_ref: main
     path_alias: knative.dev/test-infra
+  annotations:
+    testgrid-dashboards: utilities
+    testgrid-tab-name: ci-knative-test-infra-branchprotector
+    testgrid-alert-email: "serverless-engprod-sea@google.com"
+    testgrid-num-failures-to-alert: "1"
   spec:
     containers:
     - name: branchprotector
@@ -92,6 +97,11 @@ postsubmits:
     cluster: "prow-trusted"
     branches:
     - "main"
+    annotations:
+      testgrid-dashboards: utilities
+      testgrid-tab-name: post-knative-test-infra-branchprotector
+      testgrid-alert-email: "serverless-engprod-sea@google.com"
+      testgrid-num-failures-to-alert: "1"
     spec:
       containers:
       - name: branchprotector

--- a/config/prod/prow/jobs/custom/label-sync.yaml
+++ b/config/prod/prow/jobs/custom/label-sync.yaml
@@ -59,6 +59,11 @@ periodics:
     repo: test-infra
     base_ref: main
     path_alias: knative.dev/test-infra
+  annotations:
+    testgrid-dashboards: utilities
+    testgrid-tab-name: ci-knative-test-infra-label-sync
+    testgrid-alert-email: "serverless-engprod-sea@google.com"
+    testgrid-num-failures-to-alert: "1"
   spec:
     containers:
     - name: label-sync
@@ -92,6 +97,11 @@ postsubmits:
     run_if_changed: "^config/label_sync/labels.yaml$"
     branches:
     - "main"
+    annotations:
+      testgrid-dashboards: utilities
+      testgrid-tab-name: post-knative-test-infra-label-sync
+      testgrid-alert-email: "serverless-engprod-sea@google.com"
+      testgrid-num-failures-to-alert: "1"
     spec:
       containers:
       - name: label-sync

--- a/config/prod/prow/jobs/custom/peribolos.yaml
+++ b/config/prod/prow/jobs/custom/peribolos.yaml
@@ -106,6 +106,11 @@ postsubmits:
         job_states_to_report:
           - failure
         report_template: '"The knative peribolos postsubmit job fails, check the log: <{{.Status.URL}}|View logs>"'
+    annotations:
+      testgrid-dashboards: utilities
+      testgrid-tab-name: post-knative-peribolos
+      testgrid-alert-email: "serverless-engprod-sea@google.com"
+      testgrid-num-failures-to-alert: "1"
     spec:
       containers:
       - image: gcr.io/k8s-prow/peribolos:v20210323-4a95c1446c
@@ -147,6 +152,11 @@ postsubmits:
         job_states_to_report:
           - failure
         report_template: '"The knative-sandbox peribolos postsubmit job fails, check the log: <{{.Status.URL}}|View logs>"'
+    annotations:
+      testgrid-dashboards: utilities
+      testgrid-tab-name: post-knative-sandbox-peribolos
+      testgrid-alert-email: "serverless-engprod-sea@google.com"
+      testgrid-num-failures-to-alert: "1"
     spec:
       containers:
       - image: gcr.io/k8s-prow/peribolos:v20210323-4a95c1446c
@@ -185,6 +195,11 @@ periodics:
     repo: community
     base_ref: main
     path_alias: knative.dev/community
+  annotations:
+    testgrid-dashboards: utilities
+    testgrid-tab-name: ci-knative-peribolos
+    testgrid-alert-email: "serverless-engprod-sea@google.com"
+    testgrid-num-failures-to-alert: "1"
   spec:
     containers:
     - image: gcr.io/k8s-prow/peribolos:v20210323-4a95c1446c
@@ -221,6 +236,11 @@ periodics:
     repo: community
     base_ref: main
     path_alias: knative.dev/community
+  annotations:
+    testgrid-dashboards: utilities
+    testgrid-tab-name: ci-knative-sandbox-peribolos
+    testgrid-alert-email: "serverless-engprod-sea@google.com"
+    testgrid-num-failures-to-alert: "1"
   spec:
     containers:
     - image: gcr.io/k8s-prow/peribolos:v20210323-4a95c1446c


### PR DESCRIPTION
configurator expects all postsubmit and periodic jobs to have testgrid tabs, adding them
