### PR TITLE
Fix run_if_changed to istio-latest/net-istio.yaml

### DIFF
--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -74,7 +74,7 @@ presubmits:
     needs-monitor: true
     always-run: false
     optional: true
-    run-if-changed: ^third_party/net-istio.yaml
+    run-if-changed: ^third_party/istio-latest/net-istio.yaml
     args:
     - --run-test
     - ./test/e2e-tests.sh --istio-version stable --mesh
@@ -87,7 +87,7 @@ presubmits:
     needs-monitor: true
     always-run: false
     optional: true
-    run-if-changed: ^third_party/net-istio.yaml
+    run-if-changed: ^third_party/istio-latest/net-istio.yaml
     args:
     - --run-test
     - ./test/e2e-auto-tls-tests.sh --istio-version stable --mesh

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -323,7 +323,7 @@ presubmits:
     context: pull-knative-serving-istio-stable-mesh
     always_run: false
     optional: true
-    run_if_changed: "^third_party/net-istio.yaml"
+    run_if_changed: "^third_party/istio-latest/net-istio.yaml"
     rerun_command: "/test pull-knative-serving-istio-stable-mesh"
     trigger: "(?m)^/test (all|pull-knative-serving-istio-stable-mesh),?(\\s+|$)"
     decorate: true
@@ -366,7 +366,7 @@ presubmits:
     context: pull-knative-serving-istio-stable-mesh-tls
     always_run: false
     optional: true
-    run_if_changed: "^third_party/net-istio.yaml"
+    run_if_changed: "^third_party/istio-latest/net-istio.yaml"
     rerun_command: "/test pull-knative-serving-istio-stable-mesh-tls"
     trigger: "(?m)^/test (all|pull-knative-serving-istio-stable-mesh-tls),?(\\s+|$)"
     decorate: true


### PR DESCRIPTION
Since https://github.com/knative/serving/commit/5dd75eb2745efc4b8a3a15f5625f82252a640e88
`third_party/net-istio.yaml` was changed to `third_party/istio-latest/net-istio.yaml`
so this patch fixes it in test-infra.