### PR TITLE
Add go 1.16 and bump prior versions

### DIFF
--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -70,8 +70,9 @@ RUN curl -s -S -L https://raw.githubusercontent.com/moovweb/gvm/master/binscript
 COPY images/prow-tests/source-gvm-and-run.sh /usr/local/bin
 # Install our versions of Go
 RUN source-gvm-and-run.sh install go1.13.15 --prefer-binary
-RUN source-gvm-and-run.sh install go1.14.12 --prefer-binary
-RUN source-gvm-and-run.sh install go1.15.5 --prefer-binary
+RUN source-gvm-and-run.sh install go1.14.15 --prefer-binary
+RUN source-gvm-and-run.sh install go1.15.12 --prefer-binary
+RUN source-gvm-and-run.sh install go1.16.4 --prefer-binary
 
 # protoc and required golang tooling
 ARG PROTOC_VERSION=3.15.8


### PR DESCRIPTION
**What this PR does, why we need it**:
Adds go 1.16.5 to the test image and bumps prior versions to the latest patch release. I just noticed that eventing has already bumped to 1.16 but the build still defaults to 1.15.5: https://prow.knative.dev/view/gs/knative-prow/pr-logs/pull/knative_eventing/5382/pull-knative-eventing-reconciler-tests/1392131979842949120