### PR TITLE
Adding self to OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -11,6 +11,7 @@ aliases:
   - chaodaiG
   - chizhg
   - coryrc
+  - efiturri
   - n3wscott
   
   productivity-reviewers:


### PR DESCRIPTION
**What this PR does, why we need it**:
Gives me permission to approve PRs during my oncall.

/assign @chaodaiG