### PR TITLE
Add productivity-reviewers as the approver for images and config dir

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -11,13 +11,12 @@ aliases:
   - chaodaiG
   - chizhg
   - coryrc
-  - efiturri
   - n3wscott
   
   productivity-reviewers:
-  - coryrc
+  - albertomilan
   - efiturri
   - evankanderson
-  - peterfeifanchen
+  - gerardo-lc
+  - joshua-bone
   - steuhs
-  - yt3liu

--- a/config/OWNERS
+++ b/config/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+- productivity-reviewers

--- a/config/prod/prow/OWNERS
+++ b/config/prod/prow/OWNERS
@@ -1,8 +1,0 @@
-approvers:
-- chaodaiG
-- coryrc
-- chizhg
-- steuhs
-- peterfeifanchen
-- efiturri
-- albertomilan

--- a/images/OWNERS
+++ b/images/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+- productivity-reviewers


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
1. In the future the `OWNERS_ALIASES` file will be generated and synced from the peribolos config file, update it to match with https://github.com/knative/community/pull/616
2. Add `productivity-reviewers` as the owner for `config` and `images` dir since these are the only files that need attention from oncall.

/cc @chaodaiG @efiturri 
