### PR TITLE
Switch to OWNERS from CODEOWNERS in knative-sandbox

### DIFF
--- a/config/branch_protector/rules.yaml
+++ b/config/branch_protector/rules.yaml
@@ -26,12 +26,6 @@ branch-protection:
       # Enforce all configured restrictions above for administrators.
       enforce_admins: true
 
-      # The knative-sandbox repositories are using CODEOWNERS for access control.
-      required_pull_request_reviews:
-        dismiss_stale_reviews: true
-        required_approving_review_count: 1
-        require_code_owner_reviews: true
-
     knative:
       # Protect all branches in knative
       protect: true


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:

Disables CODEOWNERS approval in `knative-sandbox`, switching back to `OWNERS` with the `OWNERS_ALIASES` sync.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes https://github.com/knative/test-infra/issues/2751

**Special notes to reviewers**:

**User-visible changes in this PR**:

* `/lgtm` and `/approve` should now work in `knative-sandbox`, including self-approve for PRs.
