### PR TITLE
Add custom jobs for s390x

### DIFF
--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -681,6 +681,36 @@ periodics:
     - ./test/e2e-tests.sh --https
     - --run-test
     - ./test/e2e-auto-tls-tests.sh --https
+  - custom-job: s390x-e2e-tests
+    cron: 0 5 * * *
+    command:
+    - bash
+    args:
+    - -c
+    - mkdir -p /root/.kube &&
+      server_addr=$(cat /opt/cluster/config) &&
+      ssh -o StrictHostKeyChecking=no
+      -i /opt/cluster/knative01.pem
+      linux1@${server_addr}
+      cat /home/linux1/.kube/config > /root/.kube/config &&
+      kubectl get cm s390x-config-serving -n default
+      -o jsonpath='{.data.adjustment-script}' > adjust.sh &&
+      chmod +x adjust.sh &&
+      ./adjust.sh &&
+      export TEST_OPTIONS=$TEST_OPTIONS' --ingressendpoint '${server_addr} &&
+      ./test/e2e-tests.sh
+      --run-tests --contour-version latest
+    env-vars:
+    - GO111MODULE="on"
+    - TEST_OPTIONS="--enable-alpha --enable-beta --resolvabledomain=false"
+    - DISABLE_MD_LINTING="1"
+    - KO_FLAGS="--platform=linux/s390x"
+    - SYSTEM_NAMESPACE="knative-serving"
+    - PLATFORM="linux/s390x"
+    - KUBECONFIG="/root/.kube/config"
+    - DOCKER_CONFIG="/opt/cluster"
+    external_cluster:
+      secret: s390x-cluster1
   - nightly: true
     reporter_config:
       slack:
@@ -750,6 +780,32 @@ periodics:
   - dot-release: true
     release: "0.23"
   - auto-release: true
+  - custom-job: s390x-e2e-tests
+    cron: 0 11 * * *
+    command:
+    - bash
+    args:
+    - -c
+    - mkdir -p /root/.kube &&
+      server_addr=$(cat /opt/cluster/config) &&
+      ssh -o StrictHostKeyChecking=no
+      -i /opt/cluster/knative01.pem
+      linux1@${server_addr}
+      cat /home/linux1/.kube/config > /root/.kube/config &&
+      kubectl get cm s390x-config-client -n default
+      -o jsonpath='{.data.adjustment-script}' > adjust.sh &&
+      chmod +x adjust.sh &&
+      ./adjust.sh &&
+      ./test/e2e-tests.sh --run-tests
+    env-vars:
+    - DISABLE_MD_LINTING="1"
+    - KO_FLAGS="--platform=linux/s390x"
+    - PLATFORM="linux/s390x"
+    - KUBECONFIG="/root/.kube/config"
+    - DOCKER_CONFIG="/opt/cluster"
+    - INGRESS_CLASS="contour.ingress.networking.knative.dev"
+    external_cluster:
+      secret: s390x-cluster1
   knative-sandbox/kn-plugin-diag:
   - continuous: true
   knative-sandbox/kn-plugin-event:
@@ -844,12 +900,22 @@ periodics:
       limits:
         memory: 16Gi
   - custom-job: s390x-e2e-tests
-    cron: 0 8 * * *
+    cron: 0 7 * * *
     command:
     - bash
     args:
     - -c
-    - mkdir -p /root/.kube && cp /opt/cluster/config /root/.kube/ && ./test/e2e-tests.sh --run-tests
+    - mkdir -p /root/.kube &&
+      server_addr=$(cat /opt/cluster/config) &&
+      ssh -o StrictHostKeyChecking=no
+      -i /opt/cluster/knative01.pem
+      linux1@${server_addr}
+      cat /home/linux1/.kube/config > /root/.kube/config &&
+      kubectl get cm s390x-config-eventing -n default
+      -o jsonpath='{.data.adjustment-script}' > adjust.sh &&
+      chmod +x adjust.sh &&
+      ./adjust.sh &&
+      ./test/e2e-tests.sh --run-tests
     env-vars:
     - DISABLE_MD_LINTING="1"
     - KO_FLAGS="--platform=linux/s390x"
@@ -857,7 +923,8 @@ periodics:
     - SYSTEM_NAMESPACE="knative-eventing"
     - PLATFORM="linux/s390x"
     - KUBECONFIG="/root/.kube/config"
-    - SSL_CERT_FILE="/opt/cluster/registry.crt"
+    - SCALE_CHAOSDUCK_TO_ZERO="1"
+    - DOCKER_CONFIG="/opt/cluster"
     external_cluster:
       secret: s390x-cluster1
   knative-sandbox/eventing-awssqs:
@@ -1163,6 +1230,32 @@ periodics:
       limits:
         memory: 16Gi
   - auto-release: true
+  - custom-job: s390x-e2e-tests
+    cron: 0 9 * * *
+    command:
+    - bash
+    args:
+    - -c
+    - mkdir -p /root/.kube &&
+      server_addr=$(cat /opt/cluster/config) &&
+      ssh -o StrictHostKeyChecking=no
+      -i /opt/cluster/knative01.pem
+      linux1@${server_addr}
+      cat /home/linux1/.kube/config > /root/.kube/config &&
+      kubectl get cm s390x-config-operator -n default
+      -o jsonpath='{.data.adjustment-script}' > adjust.sh &&
+      chmod +x adjust.sh &&
+      ./adjust.sh &&
+      ./test/e2e-tests.sh --run-tests
+    env-vars:
+    - DISABLE_MD_LINTING="1"
+    - KO_FLAGS="--platform=linux/s390x"
+    - PLATFORM="linux/s390x"
+    - KUBECONFIG="/root/.kube/config"
+    - DOCKER_CONFIG="/opt/cluster"
+    - INGRESS_CLASS="contour.ingress.networking.knative.dev"
+    external_cluster:
+      secret: s390x-cluster1
   knative-sandbox/async-component:
   - continuous: true
   - nightly: true

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -6780,6 +6780,72 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
+- cron: "0 5 * * *"
+  name: ci-knative-serving-s390x-e2e-tests
+  agent: kubernetes
+  decorate: true
+  decoration_config:
+    timeout: 120m
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative
+    repo: serving
+    path_alias: knative.dev/serving
+    base_ref: main
+  annotations:
+    testgrid-dashboards: serving
+    testgrid-tab-name: s390x-e2e-tests
+    testgrid-alert-stale-results-hours: "3"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "bash"
+      - "-c"
+      - "mkdir -p /root/.kube && server_addr=$(cat /opt/cluster/config) && ssh -o StrictHostKeyChecking=no -i /opt/cluster/knative01.pem linux1@${server_addr} cat /home/linux1/.kube/config > /root/.kube/config && kubectl get cm s390x-config-serving -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh && chmod +x adjust.sh && ./adjust.sh && export TEST_OPTIONS=$TEST_OPTIONS' --ingressendpoint '${server_addr} && ./test/e2e-tests.sh --run-tests --contour-version latest"
+      volumeMounts:
+      - name: s390x-cluster1
+        mountPath: /opt/cluster
+        readOnly: true
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GO111MODULE
+        value: "on"
+      - name: TEST_OPTIONS
+        value: "--enable-alpha --enable-beta --resolvabledomain=false"
+      - name: DISABLE_MD_LINTING
+        value: "1"
+      - name: KO_FLAGS
+        value: "--platform=linux/s390x"
+      - name: SYSTEM_NAMESPACE
+        value: "knative-serving"
+      - name: PLATFORM
+        value: "linux/s390x"
+      - name: KUBECONFIG
+        value: "/root/.kube/config"
+      - name: DOCKER_CONFIG
+        value: "/opt/cluster"
+      - name: KO_DOCKER_REPO
+        valueFrom:
+          secretKeyRef:
+            name: s390x-cluster1
+            key: ko-docker-repo
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: s390x-cluster1
+      secret:
+        secretName: s390x-cluster1
+    - name: test-account
+      secret:
+        secretName: test-account
 - cron: "20 9 * * *"
   name: ci-knative-serving-nightly-release
   agent: kubernetes
@@ -7993,6 +8059,68 @@ periodics:
     - name: release-account
       secret:
         secretName: release-account
+- cron: "0 11 * * *"
+  name: ci-knative-client-s390x-e2e-tests
+  agent: kubernetes
+  decorate: true
+  decoration_config:
+    timeout: 120m
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative
+    repo: client
+    path_alias: knative.dev/client
+    base_ref: main
+  annotations:
+    testgrid-dashboards: client
+    testgrid-tab-name: s390x-e2e-tests
+    testgrid-alert-stale-results-hours: "3"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "bash"
+      - "-c"
+      - "mkdir -p /root/.kube && server_addr=$(cat /opt/cluster/config) && ssh -o StrictHostKeyChecking=no -i /opt/cluster/knative01.pem linux1@${server_addr} cat /home/linux1/.kube/config > /root/.kube/config && kubectl get cm s390x-config-client -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh && chmod +x adjust.sh && ./adjust.sh && ./test/e2e-tests.sh --run-tests"
+      volumeMounts:
+      - name: s390x-cluster1
+        mountPath: /opt/cluster
+        readOnly: true
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: DISABLE_MD_LINTING
+        value: "1"
+      - name: KO_FLAGS
+        value: "--platform=linux/s390x"
+      - name: PLATFORM
+        value: "linux/s390x"
+      - name: KUBECONFIG
+        value: "/root/.kube/config"
+      - name: DOCKER_CONFIG
+        value: "/opt/cluster"
+      - name: INGRESS_CLASS
+        value: "contour.ingress.networking.knative.dev"
+      - name: KO_DOCKER_REPO
+        valueFrom:
+          secretKeyRef:
+            name: s390x-cluster1
+            key: ko-docker-repo
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: s390x-cluster1
+      secret:
+        secretName: s390x-cluster1
+    - name: test-account
+      secret:
+        secretName: test-account
 - cron: "0 1 * * *"
   name: ci-knative-client-go-coverage
   labels:
@@ -10158,7 +10286,7 @@ periodics:
     - name: release-account
       secret:
         secretName: release-account
-- cron: "0 8 * * *"
+- cron: "0 7 * * *"
   name: ci-knative-eventing-s390x-e2e-tests
   agent: kubernetes
   decorate: true
@@ -10183,7 +10311,7 @@ periodics:
       args:
       - "bash"
       - "-c"
-      - "mkdir -p /root/.kube && cp /opt/cluster/config /root/.kube/ && ./test/e2e-tests.sh --run-tests"
+      - "mkdir -p /root/.kube && server_addr=$(cat /opt/cluster/config) && ssh -o StrictHostKeyChecking=no -i /opt/cluster/knative01.pem linux1@${server_addr} cat /home/linux1/.kube/config > /root/.kube/config && kubectl get cm s390x-config-eventing -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh && chmod +x adjust.sh && ./adjust.sh && ./test/e2e-tests.sh --run-tests"
       volumeMounts:
       - name: s390x-cluster1
         mountPath: /opt/cluster
@@ -10204,8 +10332,10 @@ periodics:
         value: "linux/s390x"
       - name: KUBECONFIG
         value: "/root/.kube/config"
-      - name: SSL_CERT_FILE
-        value: "/opt/cluster/registry.crt"
+      - name: SCALE_CHAOSDUCK_TO_ZERO
+        value: "1"
+      - name: DOCKER_CONFIG
+        value: "/opt/cluster"
       - name: KO_DOCKER_REPO
         valueFrom:
           secretKeyRef:
@@ -15661,6 +15791,68 @@ periodics:
     - name: release-account
       secret:
         secretName: release-account
+- cron: "0 9 * * *"
+  name: ci-knative-operator-s390x-e2e-tests
+  agent: kubernetes
+  decorate: true
+  decoration_config:
+    timeout: 120m
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative
+    repo: operator
+    path_alias: knative.dev/operator
+    base_ref: main
+  annotations:
+    testgrid-dashboards: operator
+    testgrid-tab-name: s390x-e2e-tests
+    testgrid-alert-stale-results-hours: "3"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "bash"
+      - "-c"
+      - "mkdir -p /root/.kube && server_addr=$(cat /opt/cluster/config) && ssh -o StrictHostKeyChecking=no -i /opt/cluster/knative01.pem linux1@${server_addr} cat /home/linux1/.kube/config > /root/.kube/config && kubectl get cm s390x-config-operator -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh && chmod +x adjust.sh && ./adjust.sh && ./test/e2e-tests.sh --run-tests"
+      volumeMounts:
+      - name: s390x-cluster1
+        mountPath: /opt/cluster
+        readOnly: true
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: DISABLE_MD_LINTING
+        value: "1"
+      - name: KO_FLAGS
+        value: "--platform=linux/s390x"
+      - name: PLATFORM
+        value: "linux/s390x"
+      - name: KUBECONFIG
+        value: "/root/.kube/config"
+      - name: DOCKER_CONFIG
+        value: "/opt/cluster"
+      - name: INGRESS_CLASS
+        value: "contour.ingress.networking.knative.dev"
+      - name: KO_DOCKER_REPO
+        valueFrom:
+          secretKeyRef:
+            name: s390x-cluster1
+            key: ko-docker-repo
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: s390x-cluster1
+      secret:
+        secretName: s390x-cluster1
+    - name: test-account
+      secret:
+        secretName: test-account
 - cron: "0 1 * * *"
   name: ci-knative-operator-go-coverage
   labels:

--- a/config/prod/prow/testgrid/testgrid.yaml
+++ b/config/prod/prow/testgrid/testgrid.yaml
@@ -91,6 +91,9 @@ test_groups:
 - name: ci-knative-serving-https
   gcs_prefix: knative-prow/logs/ci-knative-serving-https
   alert_stale_results_hours: 3
+- name: ci-knative-serving-s390x-e2e-tests
+  gcs_prefix: knative-prow/logs/ci-knative-serving-s390x-e2e-tests
+  alert_stale_results_hours: 3
 - name: ci-knative-serving-nightly-release
   gcs_prefix: knative-prow/logs/ci-knative-serving-nightly-release
   alert_options:
@@ -117,6 +120,9 @@ test_groups:
   alert_options:
     alert_mail_to_addresses: "serverless-engprod-sea@google.com"
   num_failures_to_alert: 1
+- name: ci-knative-client-s390x-e2e-tests
+  gcs_prefix: knative-prow/logs/ci-knative-client-s390x-e2e-tests
+  alert_stale_results_hours: 3
 - name: ci-knative-client-test-coverage
   gcs_prefix: knative-prow/logs/ci-knative-client-go-coverage
   short_text_metric: "coverage"
@@ -170,6 +176,9 @@ test_groups:
   alert_options:
     alert_mail_to_addresses: "serverless-engprod-sea@google.com"
   num_failures_to_alert: 1
+- name: ci-knative-operator-s390x-e2e-tests
+  gcs_prefix: knative-prow/logs/ci-knative-operator-s390x-e2e-tests
+  alert_stale_results_hours: 3
 - name: ci-knative-operator-test-coverage
   gcs_prefix: knative-prow/logs/ci-knative-operator-go-coverage
   short_text_metric: "coverage"
@@ -1224,6 +1233,9 @@ dashboards:
   - name: https
     test_group_name: ci-knative-serving-https
     base_options: "sort-by-name="
+  - name: s390x-e2e-tests
+    test_group_name: ci-knative-serving-s390x-e2e-tests
+    base_options: "sort-by-name="
   - name: nightly
     test_group_name: ci-knative-serving-nightly-release
     base_options: "sort-by-name="
@@ -1259,6 +1271,9 @@ dashboards:
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
     num_failures_to_alert: 1
+  - name: s390x-e2e-tests
+    test_group_name: ci-knative-client-s390x-e2e-tests
+    base_options: "sort-by-name="
   - name: coverage
     test_group_name: ci-knative-client-test-coverage
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
@@ -1346,6 +1361,9 @@ dashboards:
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
     num_failures_to_alert: 1
+  - name: s390x-e2e-tests
+    test_group_name: ci-knative-operator-s390x-e2e-tests
+    base_options: "sort-by-name="
   - name: coverage
     test_group_name: ci-knative-operator-test-coverage
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:

Currently, a way of fetching the `kubeconfig` data from the external secret in the prow job `ci-knative-eventing-s390x-e2e-tests` does not look efficient, In the current configuration, the external secret update function should be provided somewhere for every recreation of the k8s test cluster, which drives up the cost. The `kubeconfig` can be fetched on the fly via ssh, which is free and easier to update without the gcp api. 

The new secret key `knative01.pem` is ready in the knative build cluster (see https://github.com/GoogleCloudPlatform/oss-test-infra/pull/874)

The PR also includes the configuration changes to turning off the `chaosduck`, setting `DOCKER_CONFIG` and setting a s390x specific adjustment.
 
It is tested locally via `phaino`.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #

**Special notes to reviewers**:

**User-visible changes in this PR**:

