### PR TITLE
Add new job trigger for mesh test with short option

### DIFF
--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -34,6 +34,18 @@ presubmits:
         memory: 12Gi
       limits:
         memory: 16Gi
+  - custom-test: istio-latest-mesh-short
+    needs-monitor: true
+    always-run: false
+    optional: true
+    args:
+    - --run-test
+    - ./test/e2e-tests.sh --istio-version latest --mesh --short
+    resources:
+      requests:
+        memory: 12Gi
+      limits:
+        memory: 16Gi
   - custom-test: istio-latest-mesh-tls
     needs-monitor: true
     always-run: false
@@ -78,6 +90,19 @@ presubmits:
     args:
     - --run-test
     - ./test/e2e-tests.sh --istio-version stable --mesh
+    resources:
+      requests:
+        memory: 12Gi
+      limits:
+        memory: 16Gi
+  - custom-test: istio-stable-mesh-short
+    needs-monitor: true
+    always-run: false
+    optional: true
+    run-if-changed: ^third_party/istio-latest/net-istio.yaml
+    args:
+    - --run-test
+    - ./test/e2e-tests.sh --istio-version stable --mesh --short
     resources:
       requests:
         memory: 12Gi

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -188,6 +188,48 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
+  - name: pull-knative-serving-istio-latest-mesh-short
+    agent: kubernetes
+    labels:
+      prow.k8s.io/pubsub.project: knative-tests
+      prow.k8s.io/pubsub.topic: knative-monitoring
+      prow.k8s.io/pubsub.runID: pull-knative-serving-istio-latest-mesh-short
+    context: pull-knative-serving-istio-latest-mesh-short
+    always_run: false
+    optional: true
+    rerun_command: "/test pull-knative-serving-istio-latest-mesh-short"
+    trigger: "(?m)^/test (all|pull-knative-serving-istio-latest-mesh-short),?(\\s+|$)"
+    decorate: true
+    path_alias: knative.dev/serving
+    cluster: "build-knative"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-tests.sh --istio-version latest --mesh --short"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+        resources:
+          requests:
+            memory: 12Gi
+          limits:
+            memory: 16Gi
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
   - name: pull-knative-serving-istio-latest-mesh-tls
     agent: kubernetes
     labels:
@@ -339,6 +381,49 @@ presubmits:
         - "./test/presubmit-tests.sh"
         - "--run-test"
         - "./test/e2e-tests.sh --istio-version stable --mesh"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+        resources:
+          requests:
+            memory: 12Gi
+          limits:
+            memory: 16Gi
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-serving-istio-stable-mesh-short
+    agent: kubernetes
+    labels:
+      prow.k8s.io/pubsub.project: knative-tests
+      prow.k8s.io/pubsub.topic: knative-monitoring
+      prow.k8s.io/pubsub.runID: pull-knative-serving-istio-stable-mesh-short
+    context: pull-knative-serving-istio-stable-mesh-short
+    always_run: false
+    optional: true
+    run_if_changed: "^third_party/istio-latest/net-istio.yaml"
+    rerun_command: "/test pull-knative-serving-istio-stable-mesh-short"
+    trigger: "(?m)^/test (all|pull-knative-serving-istio-stable-mesh-short),?(\\s+|$)"
+    decorate: true
+    path_alias: knative.dev/serving
+    cluster: "build-knative"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-tests.sh --istio-version stable --mesh --short"
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account


### PR DESCRIPTION
This patch adds new job trigger `pull-knative-serving-istio-stable-mesh-short` and `pull-knative-serving-istio-latest-mesh-short`.

About the jobs:
- Both jobs run mesh test with `--short` option.
- `/all` and `/pull-knative-serving-istio-{stable,latest}-mesh-short` in PR will trigger the job.
- `/pull-knative-serving-istio-stable-mesh-short` will be triggered when `third_party/istio-latest/net-istio.yaml` was changed.
- periodic job (test grid) does not run the jobs.

/cc @julz @dprotaso @ZhiminXiang @arturenault 
