### PR TITLE
Don't protect dependabot branches on knative-sandbox

### DIFF
--- a/config/branch_protector/rules.yaml
+++ b/config/branch_protector/rules.yaml
@@ -23,6 +23,8 @@ branch-protection:
         contexts:
         - cla/google
         - tide
+      exclude:
+      - "^dependabot/" # don't protect branches created by dependabot
       # Enforce all configured restrictions above for administrators.
       enforce_admins: true
 


### PR DESCRIPTION
eventing-kafka-broker uses dependabot and is getting swamped

@slinkydeveloper 

Fixes #2816