### PR TITLE
Generate dot release jobs for net-certmanager repo correctly

### DIFF
--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -1218,6 +1218,13 @@ periodics:
         - failure
         report_template: '"The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"'
   - dot-release: true
+    release: "0.22"
+  - dot-release: true
+    release: "0.23"
+  - dot-release: true
+    release: "0.24"
+  - dot-release: true
+    release: "0.25"
   - auto-release: true
   knative-sandbox/net-contour:
   - continuous: true

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -14455,8 +14455,8 @@ periodics:
     - name: nightly-account
       secret:
         secretName: nightly-account
-- cron: "9 9 * * 2"
-  name: ci-knative-sandbox-net-certmanager-dot-release
+- cron: "6 9 * * 2"
+  name: ci-knative-sandbox-net-certmanager-0.22-dot-release
   agent: kubernetes
   decorate: true
   decoration_config:
@@ -14466,13 +14466,11 @@ periodics:
   - org: knative-sandbox
     repo: net-certmanager
     path_alias: knative.dev/net-certmanager
-    base_ref: main
+    base_ref: release-0.22
   annotations:
-    testgrid-dashboards: net-certmanager
-    testgrid-tab-name: dot-release
-    testgrid-alert-stale-results-hours: "170"
-    testgrid-alert-email: "serverless-engprod-sea@google.com"
-    testgrid-num-failures-to-alert: "1"
+    testgrid-dashboards: knative-sandbox-0.22
+    testgrid-tab-name: net-certmanager-dot-release
+    testgrid-alert-stale-results-hours: "3"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
@@ -14485,6 +14483,7 @@ periodics:
       - "--release-gcs knative-releases/net-certmanager"
       - "--release-gcr gcr.io/knative-releases"
       - "--github-token /etc/hub-token/token"
+      - "--branch release-0.22"
       volumeMounts:
       - name: hub-token
         mountPath: /etc/hub-token
@@ -14499,6 +14498,164 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.22
+    volumes:
+    - name: hub-token
+      secret:
+        secretName: hub-token
+    - name: release-account
+      secret:
+        secretName: release-account
+- cron: "5 9 * * 2"
+  name: ci-knative-sandbox-net-certmanager-0.23-dot-release
+  agent: kubernetes
+  decorate: true
+  decoration_config:
+    timeout: 180m
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative-sandbox
+    repo: net-certmanager
+    path_alias: knative.dev/net-certmanager
+    base_ref: release-0.23
+  annotations:
+    testgrid-dashboards: knative-sandbox-0.23
+    testgrid-tab-name: net-certmanager-dot-release
+    testgrid-alert-stale-results-hours: "3"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--dot-release"
+      - "--release-gcs knative-releases/net-certmanager"
+      - "--release-gcr gcr.io/knative-releases"
+      - "--github-token /etc/hub-token/token"
+      - "--branch release-0.23"
+      volumeMounts:
+      - name: hub-token
+        mountPath: /etc/hub-token
+        readOnly: true
+      - name: release-account
+        mountPath: /etc/release-account
+        readOnly: true
+      env:
+      - name: ORG_NAME
+        value: knative-sandbox
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.23
+    volumes:
+    - name: hub-token
+      secret:
+        secretName: hub-token
+    - name: release-account
+      secret:
+        secretName: release-account
+- cron: "8 9 * * 2"
+  name: ci-knative-sandbox-net-certmanager-0.24-dot-release
+  agent: kubernetes
+  decorate: true
+  decoration_config:
+    timeout: 180m
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative-sandbox
+    repo: net-certmanager
+    path_alias: knative.dev/net-certmanager
+    base_ref: release-0.24
+  annotations:
+    testgrid-dashboards: knative-sandbox-0.24
+    testgrid-tab-name: net-certmanager-dot-release
+    testgrid-alert-stale-results-hours: "3"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--dot-release"
+      - "--release-gcs knative-releases/net-certmanager"
+      - "--release-gcr gcr.io/knative-releases"
+      - "--github-token /etc/hub-token/token"
+      - "--branch release-0.24"
+      volumeMounts:
+      - name: hub-token
+        mountPath: /etc/hub-token
+        readOnly: true
+      - name: release-account
+        mountPath: /etc/release-account
+        readOnly: true
+      env:
+      - name: ORG_NAME
+        value: knative-sandbox
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.24
+    volumes:
+    - name: hub-token
+      secret:
+        secretName: hub-token
+    - name: release-account
+      secret:
+        secretName: release-account
+- cron: "31 9 * * 2"
+  name: ci-knative-sandbox-net-certmanager-0.25-dot-release
+  agent: kubernetes
+  decorate: true
+  decoration_config:
+    timeout: 180m
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative-sandbox
+    repo: net-certmanager
+    path_alias: knative.dev/net-certmanager
+    base_ref: release-0.25
+  annotations:
+    testgrid-dashboards: knative-sandbox-0.25
+    testgrid-tab-name: net-certmanager-dot-release
+    testgrid-alert-stale-results-hours: "3"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--dot-release"
+      - "--release-gcs knative-releases/net-certmanager"
+      - "--release-gcr gcr.io/knative-releases"
+      - "--github-token /etc/hub-token/token"
+      - "--branch release-0.25"
+      volumeMounts:
+      - name: hub-token
+        mountPath: /etc/hub-token
+        readOnly: true
+      - name: release-account
+        mountPath: /etc/release-account
+        readOnly: true
+      env:
+      - name: ORG_NAME
+        value: knative-sandbox
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.25
     volumes:
     - name: hub-token
       secret:

--- a/config/prod/prow/testgrid/testgrid.yaml
+++ b/config/prod/prow/testgrid/testgrid.yaml
@@ -573,12 +573,6 @@ test_groups:
   alert_options:
     alert_mail_to_addresses: "serverless-engprod-sea@google.com"
   num_failures_to_alert: 1
-- name: ci-knative-sandbox-net-certmanager-dot-release
-  gcs_prefix: knative-prow/logs/ci-knative-sandbox-net-certmanager-dot-release
-  alert_options:
-    alert_mail_to_addresses: "serverless-engprod-sea@google.com"
-  alert_stale_results_hours: 170
-  num_failures_to_alert: 1
 - name: ci-knative-sandbox-net-certmanager-auto-release
   gcs_prefix: knative-prow/logs/ci-knative-sandbox-net-certmanager-auto-release
   alert_options:
@@ -822,6 +816,12 @@ test_groups:
     alert_mail_to_addresses: "serverless-engprod-sea@google.com"
   alert_stale_results_hours: 170
   num_failures_to_alert: 1
+- name: ci-knative-sandbox-net-certmanager-0.22-dot-release
+  gcs_prefix: knative-prow/logs/ci-knative-sandbox-net-certmanager-0.22-dot-release
+  alert_options:
+    alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+  alert_stale_results_hours: 170
+  num_failures_to_alert: 1
 - name: ci-knative-sandbox-net-contour-0.22-dot-release
   gcs_prefix: knative-prow/logs/ci-knative-sandbox-net-contour-0.22-dot-release
   alert_options:
@@ -866,6 +866,12 @@ test_groups:
   num_failures_to_alert: 1
 - name: ci-knative-sandbox-eventing-gitlab-0.23-dot-release
   gcs_prefix: knative-prow/logs/ci-knative-sandbox-eventing-gitlab-0.23-dot-release
+  alert_options:
+    alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+  alert_stale_results_hours: 170
+  num_failures_to_alert: 1
+- name: ci-knative-sandbox-net-certmanager-0.23-dot-release
+  gcs_prefix: knative-prow/logs/ci-knative-sandbox-net-certmanager-0.23-dot-release
   alert_options:
     alert_mail_to_addresses: "serverless-engprod-sea@google.com"
   alert_stale_results_hours: 170
@@ -918,6 +924,12 @@ test_groups:
     alert_mail_to_addresses: "serverless-engprod-sea@google.com"
   alert_stale_results_hours: 170
   num_failures_to_alert: 1
+- name: ci-knative-sandbox-net-certmanager-0.24-dot-release
+  gcs_prefix: knative-prow/logs/ci-knative-sandbox-net-certmanager-0.24-dot-release
+  alert_options:
+    alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+  alert_stale_results_hours: 170
+  num_failures_to_alert: 1
 - name: ci-knative-sandbox-net-contour-0.24-dot-release
   gcs_prefix: knative-prow/logs/ci-knative-sandbox-net-contour-0.24-dot-release
   alert_options:
@@ -962,6 +974,12 @@ test_groups:
   num_failures_to_alert: 1
 - name: ci-knative-sandbox-eventing-gitlab-0.25-dot-release
   gcs_prefix: knative-prow/logs/ci-knative-sandbox-eventing-gitlab-0.25-dot-release
+  alert_options:
+    alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+  alert_stale_results_hours: 170
+  num_failures_to_alert: 1
+- name: ci-knative-sandbox-net-certmanager-0.25-dot-release
+  gcs_prefix: knative-prow/logs/ci-knative-sandbox-net-certmanager-0.25-dot-release
   alert_options:
     alert_mail_to_addresses: "serverless-engprod-sea@google.com"
   alert_stale_results_hours: 170
@@ -1771,12 +1789,6 @@ dashboards:
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
     num_failures_to_alert: 1
-  - name: dot-release
-    test_group_name: ci-knative-sandbox-net-certmanager-dot-release
-    base_options: "sort-by-name="
-    alert_options:
-      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
-    num_failures_to_alert: 1
   - name: auto-release
     test_group_name: ci-knative-sandbox-net-certmanager-auto-release
     base_options: "sort-by-name="
@@ -2379,6 +2391,12 @@ dashboards:
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
     num_failures_to_alert: 3
+  - name: net-certmanager-dot-release
+    test_group_name: ci-knative-sandbox-net-certmanager-0.22-dot-release
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
   - name: net-contour-dot-release
     test_group_name: ci-knative-sandbox-net-contour-0.22-dot-release
     base_options: "sort-by-name="
@@ -2425,6 +2443,12 @@ dashboards:
     num_failures_to_alert: 3
   - name: eventing-gitlab-dot-release
     test_group_name: ci-knative-sandbox-eventing-gitlab-0.23-dot-release
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
+  - name: net-certmanager-dot-release
+    test_group_name: ci-knative-sandbox-net-certmanager-0.23-dot-release
     base_options: "sort-by-name="
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
@@ -2479,6 +2503,12 @@ dashboards:
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
     num_failures_to_alert: 3
+  - name: net-certmanager-dot-release
+    test_group_name: ci-knative-sandbox-net-certmanager-0.24-dot-release
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
   - name: net-contour-dot-release
     test_group_name: ci-knative-sandbox-net-contour-0.24-dot-release
     base_options: "sort-by-name="
@@ -2525,6 +2555,12 @@ dashboards:
     num_failures_to_alert: 3
   - name: eventing-gitlab-dot-release
     test_group_name: ci-knative-sandbox-eventing-gitlab-0.25-dot-release
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
+  - name: net-certmanager-dot-release
+    test_group_name: ci-knative-sandbox-net-certmanager-0.25-dot-release
     base_options: "sort-by-name="
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"


### PR DESCRIPTION
This is a same with https://github.com/knative/test-infra/pull/2865 but for net-certmanager.

/cc @dprotaso @ZhiminXiang 