### PR TITLE
Update kubectl to 1.21.4

### DIFF
--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -16,7 +16,7 @@ FROM gcr.io/k8s-testimages/kubekins-e2e:v20210113-cc576af-master AS stable-stuff
 
 ENV DEBIAN_FRONTEND noninteractive
 ARG GCLOUD_VERSION=317.0.0
-ARG KUBECTL_VERSION=v1.18.7
+ARG KUBECTL_VERSION=v1.21.4
 
 # If we don't run update, the apt-get install below don't work
 RUN apt-get update


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:

As per title. 1.18 is ooooold and our components rely on 1.21 now anyway. Specifically, I want this because `-ojsonpath` doesn't actually output JSON on 1.18 but does on 1.21.

/assign @chizhg 