### PR TITLE
Add CI confing for client-pkg repository

### DIFF
--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -280,7 +280,6 @@ presubmits:
   knative/client-pkg:
   - build-tests: true
   - unit-tests: true
-  - integration-tests: true
   - go-coverage: false
   knative/client-contrib:
   - build-tests: true
@@ -901,7 +900,7 @@ periodics:
     - INGRESS_CLASS="contour.ingress.networking.knative.dev"
     external_cluster:
       secret: s390x-cluster1
-  knative/client:
+  knative/client-pkg:
   - continuous: true
   - auto-release: true
   - nightly: true

--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -277,6 +277,11 @@ presubmits:
     always-run: true
     command:
     - ./test/presubmit-integration-tests-latest-release.sh
+  knative/client-pkg:
+  - build-tests: true
+  - unit-tests: true
+  - integration-tests: true
+  - go-coverage: false
   knative/client-contrib:
   - build-tests: true
   - unit-tests: true
@@ -896,6 +901,10 @@ periodics:
     - INGRESS_CLASS="contour.ingress.networking.knative.dev"
     external_cluster:
       secret: s390x-cluster1
+  knative/client:
+  - continuous: true
+  - auto-release: true
+  - nightly: true
   knative-sandbox/kn-plugin-diag:
   - continuous: true
   knative-sandbox/kn-plugin-event:

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -1167,6 +1167,83 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
+  knative/client-pkg:
+  - name: pull-knative-client-pkg-build-tests
+    agent: kubernetes
+    context: pull-knative-client-pkg-build-tests
+    always_run: true
+    optional: false
+    rerun_command: "/test pull-knative-client-pkg-build-tests"
+    trigger: "(?m)^/test (all|pull-knative-client-pkg-build-tests),?(\\s+|$)"
+    decorate: true
+    path_alias: knative.dev/client-pkg
+    cluster: "build-knative"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--build-tests"
+        volumeMounts:
+        - name: repoview-token
+          mountPath: /etc/repoview-token
+          readOnly: true
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: repoview-token
+        secret:
+          secretName: repoview-token
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-client-pkg-unit-tests
+    agent: kubernetes
+    context: pull-knative-client-pkg-unit-tests
+    always_run: true
+    optional: false
+    rerun_command: "/test pull-knative-client-pkg-unit-tests"
+    trigger: "(?m)^/test (all|pull-knative-client-pkg-unit-tests),?(\\s+|$)"
+    decorate: true
+    path_alias: knative.dev/client-pkg
+    cluster: "build-knative"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--unit-tests"
+        volumeMounts:
+        - name: repoview-token
+          mountPath: /etc/repoview-token
+          readOnly: true
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: repoview-token
+        secret:
+          secretName: repoview-token
+      - name: test-account
+        secret:
+          secretName: test-account
   knative/client-contrib:
   - name: pull-knative-client-contrib-build-tests
     agent: kubernetes
@@ -8725,6 +8802,170 @@ periodics:
       - "coverage"
       - "--artifacts=$(ARTIFACTS)"
       - "--cov-threshold-percentage=50"
+- cron: "44 */4 * * *"
+  name: ci-knative-client-pkg-continuous
+  agent: kubernetes
+  decorate: true
+  decoration_config:
+    timeout: 180m
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative
+    repo: client-pkg
+    path_alias: knative.dev/client-pkg
+    base_ref: main
+  annotations:
+    testgrid-dashboards: client-pkg
+    testgrid-tab-name: continuous
+    testgrid-alert-stale-results-hours: "3"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./test/presubmit-tests.sh"
+      - "--all-tests"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "56 8,11,22 * * *"
+  name: ci-knative-client-pkg-continuous-beta-prow-tests
+  agent: kubernetes
+  decorate: true
+  decoration_config:
+    timeout: 180m
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative
+    repo: client-pkg
+    path_alias: knative.dev/client-pkg
+    base_ref: main
+  annotations:
+    testgrid-dashboards: beta-prow-tests
+    testgrid-tab-name: ci-knative-client-pkg-continuous
+    testgrid-alert-stale-results-hours: "3"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:beta
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./test/presubmit-tests.sh"
+      - "--all-tests"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "8 */4 * * *"
+  name: ci-knative-client-pkg-auto-release
+  agent: kubernetes
+  decorate: true
+  decoration_config:
+    timeout: 180m
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative
+    repo: client-pkg
+    path_alias: knative.dev/client-pkg
+    base_ref: main
+  annotations:
+    testgrid-dashboards: client-pkg
+    testgrid-tab-name: auto-release
+    testgrid-alert-email: "serverless-engprod-sea@google.com"
+    testgrid-num-failures-to-alert: "1"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--auto-release"
+      - "--release-gcs knative-releases/client-pkg"
+      - "--release-gcr gcr.io/knative-releases"
+      - "--github-token /etc/hub-token/token"
+      volumeMounts:
+      - name: hub-token
+        mountPath: /etc/hub-token
+        readOnly: true
+      - name: release-account
+        mountPath: /etc/release-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: hub-token
+      secret:
+        secretName: hub-token
+    - name: release-account
+      secret:
+        secretName: release-account
+- cron: "28 9 * * *"
+  name: ci-knative-client-pkg-nightly-release
+  agent: kubernetes
+  decorate: true
+  decoration_config:
+    timeout: 180m
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative
+    repo: client-pkg
+    path_alias: knative.dev/client-pkg
+    base_ref: main
+  annotations:
+    testgrid-dashboards: client-pkg
+    testgrid-tab-name: nightly-release
+    testgrid-alert-email: "serverless-engprod-sea@google.com"
+    testgrid-num-failures-to-alert: "1"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--publish"
+      - "--tag-release"
+      volumeMounts:
+      - name: nightly-account
+        mountPath: /etc/nightly-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/nightly-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: nightly-account
+      secret:
+        secretName: nightly-account
 - cron: "1 */4 * * *"
   name: ci-knative-sandbox-kn-plugin-diag-continuous
   agent: kubernetes

--- a/config/prod/prow/k8s-testgrid/k8s-testgrid.yaml
+++ b/config/prod/prow/k8s-testgrid/k8s-testgrid.yaml
@@ -24,6 +24,7 @@ dashboards:
 - name: beta-prow-tests
 - name: caching
 - name: client
+- name: client-pkg
 - name: discovery
 - name: docs
 - name: eventing
@@ -84,6 +85,7 @@ dashboard_groups:
     dashboard_names:
       - "caching"
       - "client"
+      - "client-pkg"
       - "docs"
       - "eventing"
       - "operator"

--- a/config/prod/prow/testgrid/testgrid.yaml
+++ b/config/prod/prow/testgrid/testgrid.yaml
@@ -126,6 +126,19 @@ test_groups:
 - name: ci-knative-client-s390x-e2e-tests
   gcs_prefix: knative-prow/logs/ci-knative-client-s390x-e2e-tests
   alert_stale_results_hours: 3
+- name: ci-knative-client-pkg-continuous
+  gcs_prefix: knative-prow/logs/ci-knative-client-pkg-continuous
+  alert_stale_results_hours: 3
+- name: ci-knative-client-pkg-auto-release
+  gcs_prefix: knative-prow/logs/ci-knative-client-pkg-auto-release
+  alert_options:
+    alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+  num_failures_to_alert: 1
+- name: ci-knative-client-pkg-nightly-release
+  gcs_prefix: knative-prow/logs/ci-knative-client-pkg-nightly-release
+  alert_options:
+    alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+  num_failures_to_alert: 1
 - name: ci-knative-docs-continuous
   gcs_prefix: knative-prow/logs/ci-knative-docs-continuous
   alert_stale_results_hours: 3
@@ -1103,6 +1116,8 @@ test_groups:
 - name: ci-knative-client-go-coverage-beta-prow-tests
   gcs_prefix: knative-prow/logs/ci-knative-client-go-coverage-beta-prow-tests
   short_text_metric: "coverage"
+- name: ci-knative-client-pkg-continuous-beta-prow-tests
+  gcs_prefix: knative-prow/logs/ci-knative-client-pkg-continuous-beta-prow-tests
 - name: ci-knative-sandbox-kn-plugin-diag-continuous-beta-prow-tests
   gcs_prefix: knative-prow/logs/ci-knative-sandbox-kn-plugin-diag-continuous-beta-prow-tests
 - name: ci-knative-sandbox-kn-plugin-event-continuous-beta-prow-tests
@@ -1383,6 +1398,26 @@ dashboards:
   - name: s390x-e2e-tests
     test_group_name: ci-knative-client-s390x-e2e-tests
     base_options: "sort-by-name="
+- name: client-pkg
+  dashboard_tab:
+  - name: continuous
+    test_group_name: ci-knative-client-pkg-continuous
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
+  - name: auto-release
+    test_group_name: ci-knative-client-pkg-auto-release
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 1
+  - name: nightly
+    test_group_name: ci-knative-client-pkg-nightly-release
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 1
 - name: docs
   dashboard_tab:
   - name: continuous
@@ -2692,6 +2727,9 @@ dashboards:
   - name: ci-knative-client-go-coverage
     test_group_name: ci-knative-client-go-coverage-beta-prow-tests
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
+  - name: ci-knative-client-pkg-continuous
+    test_group_name: ci-knative-client-pkg-continuous-beta-prow-tests
+    base_options: "sort-by-failures="
   - name: ci-knative-sandbox-kn-plugin-diag-continuous
     test_group_name: ci-knative-sandbox-kn-plugin-diag-continuous-beta-prow-tests
     base_options: "sort-by-failures="
@@ -2915,6 +2953,7 @@ dashboard_groups:
   dashboard_names:
   - "serving"
   - "client"
+  - "client-pkg"
   - "docs"
   - "eventing"
   - "pkg"


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:

There's a new repository to share code between `kn` client and plugins. This PR enables CI jobs etc.

- Add CI confign for `client-pkg` repository



/cc @rhuss 