### PR TITLE
Add s390x custom-jobs for release-0.24

### DIFF
--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -761,6 +761,25 @@ periodics:
     - DOCKER_CONFIG="/opt/cluster"
     external_cluster:
       secret: s390x-cluster1
+  - custom-job: s390x-kourier-tests
+    release: "0.24"
+    cron: 0 12 * * *
+    command:
+    - bash
+    args:
+    - -c
+    - mkdir -p /root/.kube && server_addr=$(cat /opt/cluster/config) && ssh -o StrictHostKeyChecking=no -i /opt/cluster/knative01.pem linux1@${server_addr} cat /home/linux1/.kube/config > /root/.kube/config && kubectl get cm s390x-config-serving -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh && chmod +x adjust.sh && ./adjust.sh && export TEST_OPTIONS=$TEST_OPTIONS' --ingressendpoint '${server_addr} && ./test/e2e-tests.sh --run-tests --kourier-version latest
+    env-vars:
+    - GO111MODULE="on"
+    - TEST_OPTIONS="--enable-alpha --enable-beta --resolvabledomain=false"
+    - DISABLE_MD_LINTING="1"
+    - KO_FLAGS="--platform=linux/s390x"
+    - SYSTEM_NAMESPACE="knative-serving"
+    - PLATFORM="linux/s390x"
+    - KUBECONFIG="/root/.kube/config"
+    - DOCKER_CONFIG="/opt/cluster"
+    external_cluster:
+      secret: s390x-cluster1
   - custom-job: s390x-contour-tests
     cron: 0 5 * * *
     command:
@@ -782,6 +801,25 @@ periodics:
   - custom-job: s390x-contour-tests
     release: "0.23"
     cron: 0 17 * * *
+    command:
+    - bash
+    args:
+    - -c
+    - mkdir -p /root/.kube && server_addr=$(cat /opt/cluster/config) && ssh -o StrictHostKeyChecking=no -i /opt/cluster/knative01.pem linux1@${server_addr} cat /home/linux1/.kube/config > /root/.kube/config && kubectl get cm s390x-config-serving -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh && chmod +x adjust.sh && ./adjust.sh && export TEST_OPTIONS=$TEST_OPTIONS' --ingressendpoint '${server_addr} && ./test/e2e-tests.sh --run-tests --contour-version latest
+    env-vars:
+    - GO111MODULE="on"
+    - TEST_OPTIONS="--enable-alpha --enable-beta --resolvabledomain=false"
+    - DISABLE_MD_LINTING="1"
+    - KO_FLAGS="--platform=linux/s390x"
+    - SYSTEM_NAMESPACE="knative-serving"
+    - PLATFORM="linux/s390x"
+    - KUBECONFIG="/root/.kube/config"
+    - DOCKER_CONFIG="/opt/cluster"
+    external_cluster:
+      secret: s390x-cluster1
+  - custom-job: s390x-contour-tests
+    release: "0.24"
+    cron: 0 10 * * *
     command:
     - bash
     args:
@@ -886,6 +924,23 @@ periodics:
   - custom-job: s390x-e2e-tests
     release: "0.23"
     cron: 0 23 * * *
+    command:
+    - bash
+    args:
+    - -c
+    - mkdir -p /root/.kube && server_addr=$(cat /opt/cluster/config) && ssh -o StrictHostKeyChecking=no -i /opt/cluster/knative01.pem linux1@${server_addr} cat /home/linux1/.kube/config > /root/.kube/config && kubectl get cm s390x-config-client -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh && chmod +x adjust.sh && ./adjust.sh && ./test/e2e-tests.sh --run-tests
+    env-vars:
+    - DISABLE_MD_LINTING="1"
+    - KO_FLAGS="--platform=linux/s390x"
+    - PLATFORM="linux/s390x"
+    - KUBECONFIG="/root/.kube/config"
+    - DOCKER_CONFIG="/opt/cluster"
+    - INGRESS_CLASS="contour.ingress.networking.knative.dev"
+    external_cluster:
+      secret: s390x-cluster1
+  - custom-job: s390x-e2e-tests
+    release: "0.24"
+    cron: 0 4 * * *
     command:
     - bash
     args:
@@ -1023,6 +1078,25 @@ periodics:
   - custom-job: s390x-e2e-tests
     release: "0.23"
     cron: 0 19 * * *
+    command:
+    - bash
+    args:
+    - -c
+    - mkdir -p /root/.kube && server_addr=$(cat /opt/cluster/config) && ssh -o StrictHostKeyChecking=no -i /opt/cluster/knative01.pem linux1@${server_addr} cat /home/linux1/.kube/config > /root/.kube/config && kubectl get cm s390x-config-eventing -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh && chmod +x adjust.sh && ./adjust.sh && ./test/e2e-tests.sh --run-tests
+    env-vars:
+    - DISABLE_MD_LINTING="1"
+    - KO_FLAGS="--platform=linux/s390x"
+    - DEPLOY_KNATIVE_MONITORING="0"
+    - SYSTEM_NAMESPACE="knative-eventing"
+    - PLATFORM="linux/s390x"
+    - KUBECONFIG="/root/.kube/config"
+    - SCALE_CHAOSDUCK_TO_ZERO="1"
+    - DOCKER_CONFIG="/opt/cluster"
+    external_cluster:
+      secret: s390x-cluster1
+  - custom-job: s390x-e2e-tests
+    release: "0.24"
+    cron: 0 8 * * *
     command:
     - bash
     args:
@@ -1425,6 +1499,23 @@ periodics:
   - custom-job: s390x-e2e-tests
     release: "0.23"
     cron: 0 21 * * *
+    command:
+    - bash
+    args:
+    - -c
+    - mkdir -p /root/.kube && server_addr=$(cat /opt/cluster/config) && ssh -o StrictHostKeyChecking=no -i /opt/cluster/knative01.pem linux1@${server_addr} cat /home/linux1/.kube/config > /root/.kube/config && kubectl get cm s390x-config-operator -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh && chmod +x adjust.sh && ./adjust.sh && ./test/e2e-tests.sh --run-tests
+    env-vars:
+    - DISABLE_MD_LINTING="1"
+    - KO_FLAGS="--platform=linux/s390x"
+    - PLATFORM="linux/s390x"
+    - KUBECONFIG="/root/.kube/config"
+    - DOCKER_CONFIG="/opt/cluster"
+    - INGRESS_CLASS="contour.ingress.networking.knative.dev"
+    external_cluster:
+      secret: s390x-cluster1
+  - custom-job: s390x-e2e-tests
+    release: "0.24"
+    cron: 0 6 * * *
     command:
     - bash
     args:

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -7271,6 +7271,75 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
+- cron: "0 12 * * *"
+  name: ci-knative-serving-0.24-s390x-kourier-tests
+  agent: kubernetes
+  decorate: true
+  decoration_config:
+    timeout: 120m
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative
+    repo: serving
+    path_alias: knative.dev/serving
+    base_ref: release-0.24
+  annotations:
+    testgrid-dashboards: knative-0.24
+    testgrid-tab-name: serving-s390x-kourier-tests
+    testgrid-alert-stale-results-hours: "3"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "bash"
+      - "-c"
+      - "mkdir -p /root/.kube && server_addr=$(cat /opt/cluster/config) && ssh -o StrictHostKeyChecking=no -i /opt/cluster/knative01.pem linux1@${server_addr} cat /home/linux1/.kube/config > /root/.kube/config && kubectl get cm s390x-config-serving -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh && chmod +x adjust.sh && ./adjust.sh && export TEST_OPTIONS=$TEST_OPTIONS' --ingressendpoint '${server_addr} && ./test/e2e-tests.sh --run-tests --kourier-version latest"
+      volumeMounts:
+      - name: s390x-cluster1
+        mountPath: /opt/cluster
+        readOnly: true
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GO111MODULE
+        value: "on"
+      - name: TEST_OPTIONS
+        value: "--enable-alpha --enable-beta --resolvabledomain=false"
+      - name: DISABLE_MD_LINTING
+        value: "1"
+      - name: KO_FLAGS
+        value: "--platform=linux/s390x"
+      - name: SYSTEM_NAMESPACE
+        value: "knative-serving"
+      - name: PLATFORM
+        value: "linux/s390x"
+      - name: KUBECONFIG
+        value: "/root/.kube/config"
+      - name: DOCKER_CONFIG
+        value: "/opt/cluster"
+      - name: KO_DOCKER_REPO
+        valueFrom:
+          secretKeyRef:
+            name: s390x-cluster1
+            key: ko-docker-repo
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.24
+    volumes:
+    - name: s390x-cluster1
+      secret:
+        secretName: s390x-cluster1
+        defaultMode: 0600
+    - name: test-account
+      secret:
+        secretName: test-account
 - cron: "0 5 * * *"
   name: ci-knative-serving-s390x-contour-tests
   agent: kubernetes
@@ -7399,6 +7468,75 @@ periodics:
         value: us-central1
       - name: PULL_BASE_REF
         value: release-0.23
+    volumes:
+    - name: s390x-cluster1
+      secret:
+        secretName: s390x-cluster1
+        defaultMode: 0600
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "0 10 * * *"
+  name: ci-knative-serving-0.24-s390x-contour-tests
+  agent: kubernetes
+  decorate: true
+  decoration_config:
+    timeout: 120m
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative
+    repo: serving
+    path_alias: knative.dev/serving
+    base_ref: release-0.24
+  annotations:
+    testgrid-dashboards: knative-0.24
+    testgrid-tab-name: serving-s390x-contour-tests
+    testgrid-alert-stale-results-hours: "3"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "bash"
+      - "-c"
+      - "mkdir -p /root/.kube && server_addr=$(cat /opt/cluster/config) && ssh -o StrictHostKeyChecking=no -i /opt/cluster/knative01.pem linux1@${server_addr} cat /home/linux1/.kube/config > /root/.kube/config && kubectl get cm s390x-config-serving -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh && chmod +x adjust.sh && ./adjust.sh && export TEST_OPTIONS=$TEST_OPTIONS' --ingressendpoint '${server_addr} && ./test/e2e-tests.sh --run-tests --contour-version latest"
+      volumeMounts:
+      - name: s390x-cluster1
+        mountPath: /opt/cluster
+        readOnly: true
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GO111MODULE
+        value: "on"
+      - name: TEST_OPTIONS
+        value: "--enable-alpha --enable-beta --resolvabledomain=false"
+      - name: DISABLE_MD_LINTING
+        value: "1"
+      - name: KO_FLAGS
+        value: "--platform=linux/s390x"
+      - name: SYSTEM_NAMESPACE
+        value: "knative-serving"
+      - name: PLATFORM
+        value: "linux/s390x"
+      - name: KUBECONFIG
+        value: "/root/.kube/config"
+      - name: DOCKER_CONFIG
+        value: "/opt/cluster"
+      - name: KO_DOCKER_REPO
+        valueFrom:
+          secretKeyRef:
+            name: s390x-cluster1
+            key: ko-docker-repo
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.24
     volumes:
     - name: s390x-cluster1
       secret:
@@ -8740,6 +8878,71 @@ periodics:
         value: us-central1
       - name: PULL_BASE_REF
         value: release-0.23
+    volumes:
+    - name: s390x-cluster1
+      secret:
+        secretName: s390x-cluster1
+        defaultMode: 0600
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "0 4 * * *"
+  name: ci-knative-client-0.24-s390x-e2e-tests
+  agent: kubernetes
+  decorate: true
+  decoration_config:
+    timeout: 120m
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative
+    repo: client
+    path_alias: knative.dev/client
+    base_ref: release-0.24
+  annotations:
+    testgrid-dashboards: knative-0.24
+    testgrid-tab-name: client-s390x-e2e-tests
+    testgrid-alert-stale-results-hours: "3"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "bash"
+      - "-c"
+      - "mkdir -p /root/.kube && server_addr=$(cat /opt/cluster/config) && ssh -o StrictHostKeyChecking=no -i /opt/cluster/knative01.pem linux1@${server_addr} cat /home/linux1/.kube/config > /root/.kube/config && kubectl get cm s390x-config-client -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh && chmod +x adjust.sh && ./adjust.sh && ./test/e2e-tests.sh --run-tests"
+      volumeMounts:
+      - name: s390x-cluster1
+        mountPath: /opt/cluster
+        readOnly: true
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: DISABLE_MD_LINTING
+        value: "1"
+      - name: KO_FLAGS
+        value: "--platform=linux/s390x"
+      - name: PLATFORM
+        value: "linux/s390x"
+      - name: KUBECONFIG
+        value: "/root/.kube/config"
+      - name: DOCKER_CONFIG
+        value: "/opt/cluster"
+      - name: INGRESS_CLASS
+        value: "contour.ingress.networking.knative.dev"
+      - name: KO_DOCKER_REPO
+        valueFrom:
+          secretKeyRef:
+            name: s390x-cluster1
+            key: ko-docker-repo
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.24
     volumes:
     - name: s390x-cluster1
       secret:
@@ -11422,6 +11625,75 @@ periodics:
         value: us-central1
       - name: PULL_BASE_REF
         value: release-0.23
+    volumes:
+    - name: s390x-cluster1
+      secret:
+        secretName: s390x-cluster1
+        defaultMode: 0600
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "0 8 * * *"
+  name: ci-knative-eventing-0.24-s390x-e2e-tests
+  agent: kubernetes
+  decorate: true
+  decoration_config:
+    timeout: 120m
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative
+    repo: eventing
+    path_alias: knative.dev/eventing
+    base_ref: release-0.24
+  annotations:
+    testgrid-dashboards: knative-0.24
+    testgrid-tab-name: eventing-s390x-e2e-tests
+    testgrid-alert-stale-results-hours: "3"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "bash"
+      - "-c"
+      - "mkdir -p /root/.kube && server_addr=$(cat /opt/cluster/config) && ssh -o StrictHostKeyChecking=no -i /opt/cluster/knative01.pem linux1@${server_addr} cat /home/linux1/.kube/config > /root/.kube/config && kubectl get cm s390x-config-eventing -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh && chmod +x adjust.sh && ./adjust.sh && ./test/e2e-tests.sh --run-tests"
+      volumeMounts:
+      - name: s390x-cluster1
+        mountPath: /opt/cluster
+        readOnly: true
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: DISABLE_MD_LINTING
+        value: "1"
+      - name: KO_FLAGS
+        value: "--platform=linux/s390x"
+      - name: DEPLOY_KNATIVE_MONITORING
+        value: "0"
+      - name: SYSTEM_NAMESPACE
+        value: "knative-eventing"
+      - name: PLATFORM
+        value: "linux/s390x"
+      - name: KUBECONFIG
+        value: "/root/.kube/config"
+      - name: SCALE_CHAOSDUCK_TO_ZERO
+        value: "1"
+      - name: DOCKER_CONFIG
+        value: "/opt/cluster"
+      - name: KO_DOCKER_REPO
+        valueFrom:
+          secretKeyRef:
+            name: s390x-cluster1
+            key: ko-docker-repo
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.24
     volumes:
     - name: s390x-cluster1
       secret:
@@ -18641,6 +18913,71 @@ periodics:
         value: us-central1
       - name: PULL_BASE_REF
         value: release-0.23
+    volumes:
+    - name: s390x-cluster1
+      secret:
+        secretName: s390x-cluster1
+        defaultMode: 0600
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "0 6 * * *"
+  name: ci-knative-operator-0.24-s390x-e2e-tests
+  agent: kubernetes
+  decorate: true
+  decoration_config:
+    timeout: 120m
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative
+    repo: operator
+    path_alias: knative.dev/operator
+    base_ref: release-0.24
+  annotations:
+    testgrid-dashboards: knative-0.24
+    testgrid-tab-name: operator-s390x-e2e-tests
+    testgrid-alert-stale-results-hours: "3"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "bash"
+      - "-c"
+      - "mkdir -p /root/.kube && server_addr=$(cat /opt/cluster/config) && ssh -o StrictHostKeyChecking=no -i /opt/cluster/knative01.pem linux1@${server_addr} cat /home/linux1/.kube/config > /root/.kube/config && kubectl get cm s390x-config-operator -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh && chmod +x adjust.sh && ./adjust.sh && ./test/e2e-tests.sh --run-tests"
+      volumeMounts:
+      - name: s390x-cluster1
+        mountPath: /opt/cluster
+        readOnly: true
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: DISABLE_MD_LINTING
+        value: "1"
+      - name: KO_FLAGS
+        value: "--platform=linux/s390x"
+      - name: PLATFORM
+        value: "linux/s390x"
+      - name: KUBECONFIG
+        value: "/root/.kube/config"
+      - name: DOCKER_CONFIG
+        value: "/opt/cluster"
+      - name: INGRESS_CLASS
+        value: "contour.ingress.networking.knative.dev"
+      - name: KO_DOCKER_REPO
+        valueFrom:
+          secretKeyRef:
+            name: s390x-cluster1
+            key: ko-docker-repo
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.24
     volumes:
     - name: s390x-cluster1
       secret:

--- a/config/prod/prow/testgrid/testgrid.yaml
+++ b/config/prod/prow/testgrid/testgrid.yaml
@@ -264,9 +264,6 @@ test_groups:
 - name: ci-knative-client-0.23-s390x-e2e-tests
   gcs_prefix: knative-prow/logs/ci-knative-client-0.23-s390x-e2e-tests
   alert_stale_results_hours: 3
-- name: ci-knative-client-0.23-test-coverage
-  gcs_prefix: knative-prow/logs/ci-knative-client-0.23-go-coverage
-  short_text_metric: "coverage"
 - name: ci-knative-eventing-0.23-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-0.23-continuous
   alert_options:
@@ -281,9 +278,6 @@ test_groups:
 - name: ci-knative-eventing-0.23-s390x-e2e-tests
   gcs_prefix: knative-prow/logs/ci-knative-eventing-0.23-s390x-e2e-tests
   alert_stale_results_hours: 3
-- name: ci-knative-eventing-0.23-test-coverage
-  gcs_prefix: knative-prow/logs/ci-knative-eventing-0.23-go-coverage
-  short_text_metric: "coverage"
 - name: ci-knative-operator-0.23-continuous
   gcs_prefix: knative-prow/logs/ci-knative-operator-0.23-continuous
   alert_options:
@@ -298,14 +292,17 @@ test_groups:
 - name: ci-knative-operator-0.23-s390x-e2e-tests
   gcs_prefix: knative-prow/logs/ci-knative-operator-0.23-s390x-e2e-tests
   alert_stale_results_hours: 3
-- name: ci-knative-operator-0.23-test-coverage
-  gcs_prefix: knative-prow/logs/ci-knative-operator-0.23-go-coverage
-  short_text_metric: "coverage"
 - name: ci-knative-serving-0.24-continuous
   gcs_prefix: knative-prow/logs/ci-knative-serving-0.24-continuous
   alert_options:
     alert_mail_to_addresses: "serverless-engprod-sea@google.com"
   num_failures_to_alert: 3
+- name: ci-knative-serving-0.24-s390x-kourier-tests
+  gcs_prefix: knative-prow/logs/ci-knative-serving-0.24-s390x-kourier-tests
+  alert_stale_results_hours: 3
+- name: ci-knative-serving-0.24-s390x-contour-tests
+  gcs_prefix: knative-prow/logs/ci-knative-serving-0.24-s390x-contour-tests
+  alert_stale_results_hours: 3
 - name: ci-knative-serving-0.24-dot-release
   gcs_prefix: knative-prow/logs/ci-knative-serving-0.24-dot-release
   alert_options:
@@ -323,6 +320,12 @@ test_groups:
     alert_mail_to_addresses: "serverless-engprod-sea@google.com"
   alert_stale_results_hours: 170
   num_failures_to_alert: 1
+- name: ci-knative-client-0.24-s390x-e2e-tests
+  gcs_prefix: knative-prow/logs/ci-knative-client-0.24-s390x-e2e-tests
+  alert_stale_results_hours: 3
+- name: ci-knative-client-0.24-test-coverage
+  gcs_prefix: knative-prow/logs/ci-knative-client-0.24-go-coverage
+  short_text_metric: "coverage"
 - name: ci-knative-eventing-0.24-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-0.24-continuous
   alert_options:
@@ -334,6 +337,12 @@ test_groups:
     alert_mail_to_addresses: "serverless-engprod-sea@google.com"
   alert_stale_results_hours: 170
   num_failures_to_alert: 1
+- name: ci-knative-eventing-0.24-s390x-e2e-tests
+  gcs_prefix: knative-prow/logs/ci-knative-eventing-0.24-s390x-e2e-tests
+  alert_stale_results_hours: 3
+- name: ci-knative-eventing-0.24-test-coverage
+  gcs_prefix: knative-prow/logs/ci-knative-eventing-0.24-go-coverage
+  short_text_metric: "coverage"
 - name: ci-knative-operator-0.24-continuous
   gcs_prefix: knative-prow/logs/ci-knative-operator-0.24-continuous
   alert_options:
@@ -345,6 +354,12 @@ test_groups:
     alert_mail_to_addresses: "serverless-engprod-sea@google.com"
   alert_stale_results_hours: 170
   num_failures_to_alert: 1
+- name: ci-knative-operator-0.24-s390x-e2e-tests
+  gcs_prefix: knative-prow/logs/ci-knative-operator-0.24-s390x-e2e-tests
+  alert_stale_results_hours: 3
+- name: ci-knative-operator-0.24-test-coverage
+  gcs_prefix: knative-prow/logs/ci-knative-operator-0.24-go-coverage
+  short_text_metric: "coverage"
 - name: ci-knative-serving-0.25-continuous
   gcs_prefix: knative-prow/logs/ci-knative-serving-0.25-continuous
   alert_options:
@@ -2402,12 +2417,6 @@ dashboards:
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
     num_failures_to_alert: 3
-  - name: client-test-coverage
-    test_group_name: ci-knative-client-0.23-test-coverage
-    base_options: "sort-by-name="
-    alert_options:
-      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
-    num_failures_to_alert: 3
   - name: eventing-continuous
     test_group_name: ci-knative-eventing-0.23-continuous
     base_options: "sort-by-name="
@@ -2422,12 +2431,6 @@ dashboards:
     num_failures_to_alert: 3
   - name: eventing-s390x-e2e-tests
     test_group_name: ci-knative-eventing-0.23-s390x-e2e-tests
-    base_options: "sort-by-name="
-    alert_options:
-      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
-    num_failures_to_alert: 3
-  - name: eventing-test-coverage
-    test_group_name: ci-knative-eventing-0.23-test-coverage
     base_options: "sort-by-name="
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
@@ -2450,16 +2453,22 @@ dashboards:
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
     num_failures_to_alert: 3
-  - name: operator-test-coverage
-    test_group_name: ci-knative-operator-0.23-test-coverage
-    base_options: "sort-by-name="
-    alert_options:
-      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
-    num_failures_to_alert: 3
 - name: knative-0.24
   dashboard_tab:
   - name: serving-continuous
     test_group_name: ci-knative-serving-0.24-continuous
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
+  - name: serving-s390x-kourier-tests
+    test_group_name: ci-knative-serving-0.24-s390x-kourier-tests
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
+  - name: serving-s390x-contour-tests
+    test_group_name: ci-knative-serving-0.24-s390x-contour-tests
     base_options: "sort-by-name="
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
@@ -2482,6 +2491,18 @@ dashboards:
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
     num_failures_to_alert: 3
+  - name: client-s390x-e2e-tests
+    test_group_name: ci-knative-client-0.24-s390x-e2e-tests
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
+  - name: client-test-coverage
+    test_group_name: ci-knative-client-0.24-test-coverage
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
   - name: eventing-continuous
     test_group_name: ci-knative-eventing-0.24-continuous
     base_options: "sort-by-name="
@@ -2494,6 +2515,18 @@ dashboards:
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
     num_failures_to_alert: 3
+  - name: eventing-s390x-e2e-tests
+    test_group_name: ci-knative-eventing-0.24-s390x-e2e-tests
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
+  - name: eventing-test-coverage
+    test_group_name: ci-knative-eventing-0.24-test-coverage
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
   - name: operator-continuous
     test_group_name: ci-knative-operator-0.24-continuous
     base_options: "sort-by-name="
@@ -2502,6 +2535,18 @@ dashboards:
     num_failures_to_alert: 3
   - name: operator-dot-release
     test_group_name: ci-knative-operator-0.24-dot-release
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
+  - name: operator-s390x-e2e-tests
+    test_group_name: ci-knative-operator-0.24-s390x-e2e-tests
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
+  - name: operator-test-coverage
+    test_group_name: ci-knative-operator-0.24-test-coverage
     base_options: "sort-by-name="
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
This PR is to add 5 custom jobs for release-0.24 to the s390x integration test. This functions as an indicator of how the corresponding release of the downstream product works on Z. 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #

**Special notes to reviewers**:

**User-visible changes in this PR**:

