### PR TITLE
Workaround Prow CI failures with iptables change

### DIFF
--- a/images/prow-tests/runner.sh
+++ b/images/prow-tests/runner.sh
@@ -48,4 +48,7 @@ if [[ -n ${version} ]]; then
   export GOPATH="${ORIGINAL_GOPATH}"
 fi
 
+# Work around networking issues, see https://github.com/kubernetes/test-infra/issues/23741
+iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
+
 kubekins-runner.sh "$@"


### PR DESCRIPTION
`run.sh` is the entrypoint for all the Knative Prow jobs. Adding the command here will automatically apply to all Knative Prow jobs so we don't have to make the change to each Knative repo.