### PR TITLE
Update readme link to hack repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The Productivity Working Group also has other repos:
 
   Tools for github workflows
 
-- [knative/hack](https://github.com/knative/.github)
+- [knative/hack](https://github.com/knative/hack)
 
   Shellscripts used across the repos placed in a separate repo to avoid
   dependency cycles


### PR DESCRIPTION
**What this PR does, why we need it**:

Updates link to hack repo in the readme (previously was to the .github repo)