### PR TITLE
Remove go-coverage from container-freezer jobs

### DIFF
--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -622,7 +622,7 @@ presubmits:
   - build-tests: true
   - unit-tests: true
   - integration-tests: true
-  - go-coverage: true
+  - go-coverage: false
 periodics:
   knative/serving:
   - continuous: true

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -6167,36 +6167,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-knative-sandbox-container-freezer-go-coverage
-    agent: kubernetes
-    context: pull-knative-sandbox-container-freezer-go-coverage
-    always_run: true
-    rerun_command: "/test pull-knative-sandbox-container-freezer-go-coverage"
-    trigger: "(?m)^/test (all|pull-knative-sandbox-container-freezer-go-coverage),?(\\s+|$)"
-    optional: true
-    decorate: true
-    path_alias: knative.dev/container-freezer
-    cluster: "build-knative"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "coverage"
-        - "--postsubmit-job-name=post-knative-sandbox-container-freezer-go-coverage"
-        - "--artifacts=$(ARTIFACTS)"
-        - "--cov-threshold-percentage=50"
-        - "--github-token=/etc/covbot-token/token"
-        volumeMounts:
-        - name: covbot-token
-          mountPath: /etc/covbot-token
-          readOnly: true
-      volumes:
-      - name: covbot-token
-        secret:
-          secretName: covbot-token
 periodics:
 - cron: "0 */4 * * *"
   name: ci-knative-serving-continuous
@@ -22709,60 +22679,6 @@ periodics:
     - name: release-account
       secret:
         secretName: release-account
-- cron: "0 1 * * *"
-  name: ci-knative-sandbox-container-freezer-go-coverage
-  labels:
-      prow.k8s.io/pubsub.project: knative-tests
-      prow.k8s.io/pubsub.topic: knative-monitoring
-      prow.k8s.io/pubsub.runID: ci-knative-sandbox-container-freezer-go-coverage
-  agent: kubernetes
-  decorate: true
-  cluster: "build-knative"
-  extra_refs:
-  - org: knative-sandbox
-    repo: container-freezer
-    path_alias: knative.dev/container-freezer
-    base_ref: main
-  annotations:
-    testgrid-dashboards: container-freezer
-    testgrid-tab-name: container-freezer-go-coverage
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-      imagePullPolicy: Always
-      command:
-      - "runner.sh"
-      args:
-      - "coverage"
-      - "--artifacts=$(ARTIFACTS)"
-      - "--cov-threshold-percentage=50"
-- cron: "51 7 * * *"
-  name: ci-knative-sandbox-container-freezer-go-coverage-beta-prow-tests
-  labels:
-      prow.k8s.io/pubsub.project: knative-tests
-      prow.k8s.io/pubsub.topic: knative-monitoring
-      prow.k8s.io/pubsub.runID: ci-knative-sandbox-container-freezer-go-coverage
-  agent: kubernetes
-  decorate: true
-  cluster: "build-knative"
-  extra_refs:
-  - org: knative-sandbox
-    repo: container-freezer
-    path_alias: knative.dev/container-freezer
-    base_ref: main
-  annotations:
-    testgrid-dashboards: beta-prow-tests
-    testgrid-tab-name: ci-knative-sandbox-container-freezer-go-coverage
-  spec:
-    containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:beta
-      imagePullPolicy: Always
-      command:
-      - "runner.sh"
-      args:
-      - "coverage"
-      - "--artifacts=$(ARTIFACTS)"
-      - "--cov-threshold-percentage=50"
 - cron: "30 07 * * *"
   name: ci-knative-serving-recreate-clusters
   agent: kubernetes
@@ -23117,26 +23033,6 @@ postsubmits:
     decorate: true
     cluster: "build-knative"
     path_alias: knative.dev/eventing-kafka-broker
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - "coverage"
-        - "--artifacts=$(ARTIFACTS)"
-        - "--cov-threshold-percentage=0"
-  knative-sandbox/container-freezer:
-  - name: post-knative-sandbox-container-freezer-go-coverage
-    branches:
-    - "main"
-    annotations:
-      testgrid-create-test-group: "false"
-    agent: kubernetes
-    decorate: true
-    cluster: "build-knative"
-    path_alias: knative.dev/container-freezer
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable

--- a/config/prod/prow/testgrid/testgrid.yaml
+++ b/config/prod/prow/testgrid/testgrid.yaml
@@ -899,9 +899,6 @@ test_groups:
   alert_options:
     alert_mail_to_addresses: "serverless-engprod-sea@google.com"
   num_failures_to_alert: 1
-- name: ci-knative-sandbox-container-freezer-test-coverage
-  gcs_prefix: knative-prow/logs/ci-knative-sandbox-container-freezer-go-coverage
-  short_text_metric: "coverage"
 - name: ci-knative-sandbox-kn-plugin-source-kafka-0.23-dot-release
   gcs_prefix: knative-prow/logs/ci-knative-sandbox-kn-plugin-source-kafka-0.23-dot-release
   alert_options:
@@ -1482,9 +1479,6 @@ test_groups:
   gcs_prefix: knative-prow/logs/ci-knative-sandbox-eventing-kogito-continuous-beta-prow-tests
 - name: ci-knative-sandbox-container-freezer-continuous-beta-prow-tests
   gcs_prefix: knative-prow/logs/ci-knative-sandbox-container-freezer-continuous-beta-prow-tests
-- name: ci-knative-sandbox-container-freezer-go-coverage-beta-prow-tests
-  gcs_prefix: knative-prow/logs/ci-knative-sandbox-container-freezer-go-coverage-beta-prow-tests
-  short_text_metric: "coverage"
 - name: ci-knative-backup-artifacts
   gcs_prefix: knative-prow/logs/ci-knative-backup-artifacts
   alert_options:
@@ -2455,9 +2449,6 @@ dashboards:
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
     num_failures_to_alert: 1
-  - name: coverage
-    test_group_name: ci-knative-sandbox-container-freezer-test-coverage
-    base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
 - name: knative-gcp
   dashboard_tab:
   - name: continuous
@@ -3407,9 +3398,6 @@ dashboards:
   - name: ci-knative-sandbox-container-freezer-continuous
     test_group_name: ci-knative-sandbox-container-freezer-continuous-beta-prow-tests
     base_options: "sort-by-failures="
-  - name: ci-knative-sandbox-container-freezer-go-coverage
-    test_group_name: ci-knative-sandbox-container-freezer-go-coverage-beta-prow-tests
-    base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
 - name: utilities
   dashboard_tab:
   - name: ci-knative-backup-artifacts


### PR DESCRIPTION
**What this PR does, why we need it**:

Removes go-coverage test from the container-freezer repo (I'm an [approver](https://github.com/knative/community/blob/main/peribolos/knative-sandbox.yaml#L846-L854) for this repo)