### PR TITLE
use go1.17.2 by default

### DIFF
--- a/images/prow-tests/runner.sh
+++ b/images/prow-tests/runner.sh
@@ -18,7 +18,7 @@ ORIGINAL_GOPATH="${GOPATH}"
 
 source "${HOME}/.gvm/scripts/gvm"
 
-# By default do not switch the Go version and use the default.
+# By default use the latest go version we have installed
 version="go1.17.2"
 
 # If GO_VERSION is defined, use it as the version.

--- a/images/prow-tests/runner.sh
+++ b/images/prow-tests/runner.sh
@@ -19,12 +19,8 @@ ORIGINAL_GOPATH="${GOPATH}"
 source "${HOME}/.gvm/scripts/gvm"
 
 # By default do not switch the Go version and use the default.
-version=""
-# Extract the go version if the project is using go mod.
-if [[ -f "go.mod" ]]; then
-  version="go$(sed -n 's/^go //p' go.mod | tr -d '[:space:]')"
-  echo "Found go.mod file, using Go version '${version}' specified by it."
-fi
+version="go1.17.2"
+
 # If GO_VERSION is defined, use it as the version.
 # It has a higher priority than go.mod as it's specified more explicitly.
 if [[ -v GO_VERSION ]]; then


### PR DESCRIPTION
we no longer read the go.mod file as the toolchain should support compiling
modules that target a lower min version

Follow up to: https://github.com/knative/test-infra/pull/2898
