### PR TITLE
Remove GKE networking workaround

### DIFF
--- a/images/prow-tests/runner.sh
+++ b/images/prow-tests/runner.sh
@@ -44,7 +44,4 @@ if [[ -n ${version} ]]; then
   export GOPATH="${ORIGINAL_GOPATH}"
 fi
 
-# Work around networking issues, see https://github.com/kubernetes/test-infra/issues/23741
-iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
-
 kubekins-runner.sh "$@"


### PR DESCRIPTION
It wasn't working (we didn't grant the pod the permissions to modify iptables) and it has also been backed out of upstream Kubernetes.

We would just see lines like `getsockopt failed strangely: Operation not permitted` in our builds when this ran.