### PR TITLE
Fix go coverage tool by using the correct GOPATH

### DIFF
--- a/images/prow-tests/runner.sh
+++ b/images/prow-tests/runner.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ORIGINAL_GOPATH="${HOME}/go"
+ORIGINAL_GOPATH="/home/prow/go"
 
 source "${HOME}/.gvm/scripts/gvm"
 


### PR DESCRIPTION
This is a fix for https://github.com/knative/test-infra/pull/2913. I have manually built the image and tested the change, and it worked.