### PR TITLE
Add s390x custom-jobs for release-0.25 and 0.26

### DIFF
--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -784,6 +784,44 @@ periodics:
     - DOCKER_CONFIG="/opt/cluster"
     external_cluster:
       secret: s390x-cluster1
+  - custom-job: s390x-kourier-tests
+    release: "0.25"
+    cron: 0 0 * * *
+    command:
+    - bash
+    args:
+    - -c
+    - mkdir -p /root/.kube && server_addr=$(cat /opt/cluster/config) && ssh -o StrictHostKeyChecking=no -i /opt/cluster/knative01.pem linux1@${server_addr} cat /home/linux1/.kube/config > /root/.kube/config && kubectl get cm s390x-config-serving -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh && chmod +x adjust.sh && ./adjust.sh && export TEST_OPTIONS=$TEST_OPTIONS' --ingressendpoint '${server_addr} && ./test/e2e-tests.sh --run-tests --kourier-version latest
+    env-vars:
+    - GO111MODULE="on"
+    - TEST_OPTIONS="--enable-alpha --enable-beta --resolvabledomain=false"
+    - DISABLE_MD_LINTING="1"
+    - KO_FLAGS="--platform=linux/s390x"
+    - SYSTEM_NAMESPACE="knative-serving"
+    - PLATFORM="linux/s390x"
+    - KUBECONFIG="/root/.kube/config"
+    - DOCKER_CONFIG="/opt/cluster"
+    external_cluster:
+      secret: s390x-cluster1
+  - custom-job: s390x-kourier-tests
+    release: "0.26"
+    cron: 30 3 * * *
+    command:
+    - bash
+    args:
+    - -c
+    - mkdir -p /root/.kube && server_addr=$(cat /opt/cluster/config) && ssh -o StrictHostKeyChecking=no -i /opt/cluster/knative01.pem linux1@${server_addr} cat /home/linux1/.kube/config > /root/.kube/config && kubectl get cm s390x-config-serving -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh && chmod +x adjust.sh && ./adjust.sh && export TEST_OPTIONS=$TEST_OPTIONS' --ingressendpoint '${server_addr} && ./test/e2e-tests.sh --run-tests --kourier-version latest
+    env-vars:
+    - GO111MODULE="on"
+    - TEST_OPTIONS="--enable-alpha --enable-beta --resolvabledomain=false"
+    - DISABLE_MD_LINTING="1"
+    - KO_FLAGS="--platform=linux/s390x"
+    - SYSTEM_NAMESPACE="knative-serving"
+    - PLATFORM="linux/s390x"
+    - KUBECONFIG="/root/.kube/config"
+    - DOCKER_CONFIG="/opt/cluster"
+    external_cluster:
+      secret: s390x-cluster1
   - custom-job: s390x-contour-tests
     cron: 0 5 * * *
     command:
@@ -824,6 +862,44 @@ periodics:
   - custom-job: s390x-contour-tests
     release: "0.24"
     cron: 0 10 * * *
+    command:
+    - bash
+    args:
+    - -c
+    - mkdir -p /root/.kube && server_addr=$(cat /opt/cluster/config) && ssh -o StrictHostKeyChecking=no -i /opt/cluster/knative01.pem linux1@${server_addr} cat /home/linux1/.kube/config > /root/.kube/config && kubectl get cm s390x-config-serving -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh && chmod +x adjust.sh && ./adjust.sh && export TEST_OPTIONS=$TEST_OPTIONS' --ingressendpoint '${server_addr} && ./test/e2e-tests.sh --run-tests --contour-version latest
+    env-vars:
+    - GO111MODULE="on"
+    - TEST_OPTIONS="--enable-alpha --enable-beta --resolvabledomain=false"
+    - DISABLE_MD_LINTING="1"
+    - KO_FLAGS="--platform=linux/s390x"
+    - SYSTEM_NAMESPACE="knative-serving"
+    - PLATFORM="linux/s390x"
+    - KUBECONFIG="/root/.kube/config"
+    - DOCKER_CONFIG="/opt/cluster"
+    external_cluster:
+      secret: s390x-cluster1
+  - custom-job: s390x-contour-tests
+    release: "0.25"
+    cron: 0 22 * * *
+    command:
+    - bash
+    args:
+    - -c
+    - mkdir -p /root/.kube && server_addr=$(cat /opt/cluster/config) && ssh -o StrictHostKeyChecking=no -i /opt/cluster/knative01.pem linux1@${server_addr} cat /home/linux1/.kube/config > /root/.kube/config && kubectl get cm s390x-config-serving -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh && chmod +x adjust.sh && ./adjust.sh && export TEST_OPTIONS=$TEST_OPTIONS' --ingressendpoint '${server_addr} && ./test/e2e-tests.sh --run-tests --contour-version latest
+    env-vars:
+    - GO111MODULE="on"
+    - TEST_OPTIONS="--enable-alpha --enable-beta --resolvabledomain=false"
+    - DISABLE_MD_LINTING="1"
+    - KO_FLAGS="--platform=linux/s390x"
+    - SYSTEM_NAMESPACE="knative-serving"
+    - PLATFORM="linux/s390x"
+    - KUBECONFIG="/root/.kube/config"
+    - DOCKER_CONFIG="/opt/cluster"
+    external_cluster:
+      secret: s390x-cluster1
+  - custom-job: s390x-contour-tests
+    release: "0.26"
+    cron: 30 5 * * *
     command:
     - bash
     args:
@@ -945,6 +1021,40 @@ periodics:
   - custom-job: s390x-e2e-tests
     release: "0.24"
     cron: 0 4 * * *
+    command:
+    - bash
+    args:
+    - -c
+    - mkdir -p /root/.kube && server_addr=$(cat /opt/cluster/config) && ssh -o StrictHostKeyChecking=no -i /opt/cluster/knative01.pem linux1@${server_addr} cat /home/linux1/.kube/config > /root/.kube/config && kubectl get cm s390x-config-client -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh && chmod +x adjust.sh && ./adjust.sh && ./test/e2e-tests.sh --run-tests
+    env-vars:
+    - DISABLE_MD_LINTING="1"
+    - KO_FLAGS="--platform=linux/s390x"
+    - PLATFORM="linux/s390x"
+    - KUBECONFIG="/root/.kube/config"
+    - DOCKER_CONFIG="/opt/cluster"
+    - INGRESS_CLASS="contour.ingress.networking.knative.dev"
+    external_cluster:
+      secret: s390x-cluster1
+  - custom-job: s390x-e2e-tests
+    release: "0.25"
+    cron: 0 16 * * *
+    command:
+    - bash
+    args:
+    - -c
+    - mkdir -p /root/.kube && server_addr=$(cat /opt/cluster/config) && ssh -o StrictHostKeyChecking=no -i /opt/cluster/knative01.pem linux1@${server_addr} cat /home/linux1/.kube/config > /root/.kube/config && kubectl get cm s390x-config-client -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh && chmod +x adjust.sh && ./adjust.sh && ./test/e2e-tests.sh --run-tests
+    env-vars:
+    - DISABLE_MD_LINTING="1"
+    - KO_FLAGS="--platform=linux/s390x"
+    - PLATFORM="linux/s390x"
+    - KUBECONFIG="/root/.kube/config"
+    - DOCKER_CONFIG="/opt/cluster"
+    - INGRESS_CLASS="contour.ingress.networking.knative.dev"
+    external_cluster:
+      secret: s390x-cluster1
+  - custom-job: s390x-e2e-tests
+    release: "0.26"
+    cron: 30 11 * * *
     command:
     - bash
     args:
@@ -1082,7 +1192,6 @@ periodics:
     env-vars:
     - DISABLE_MD_LINTING="1"
     - KO_FLAGS="--platform=linux/s390x"
-    - DEPLOY_KNATIVE_MONITORING="0"
     - SYSTEM_NAMESPACE="knative-eventing"
     - PLATFORM="linux/s390x"
     - KUBECONFIG="/root/.kube/config"
@@ -1101,7 +1210,6 @@ periodics:
     env-vars:
     - DISABLE_MD_LINTING="1"
     - KO_FLAGS="--platform=linux/s390x"
-    - DEPLOY_KNATIVE_MONITORING="0"
     - SYSTEM_NAMESPACE="knative-eventing"
     - PLATFORM="linux/s390x"
     - KUBECONFIG="/root/.kube/config"
@@ -1120,7 +1228,42 @@ periodics:
     env-vars:
     - DISABLE_MD_LINTING="1"
     - KO_FLAGS="--platform=linux/s390x"
-    - DEPLOY_KNATIVE_MONITORING="0"
+    - SYSTEM_NAMESPACE="knative-eventing"
+    - PLATFORM="linux/s390x"
+    - KUBECONFIG="/root/.kube/config"
+    - SCALE_CHAOSDUCK_TO_ZERO="1"
+    - DOCKER_CONFIG="/opt/cluster"
+    external_cluster:
+      secret: s390x-cluster1
+  - custom-job: s390x-e2e-tests
+    release: "0.25"
+    cron: 0 20 * * *
+    command:
+    - bash
+    args:
+    - -c
+    - mkdir -p /root/.kube && server_addr=$(cat /opt/cluster/config) && ssh -o StrictHostKeyChecking=no -i /opt/cluster/knative01.pem linux1@${server_addr} cat /home/linux1/.kube/config > /root/.kube/config && kubectl get cm s390x-config-eventing -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh && chmod +x adjust.sh && ./adjust.sh && ./test/e2e-tests.sh --run-tests
+    env-vars:
+    - DISABLE_MD_LINTING="1"
+    - KO_FLAGS="--platform=linux/s390x"
+    - SYSTEM_NAMESPACE="knative-eventing"
+    - PLATFORM="linux/s390x"
+    - KUBECONFIG="/root/.kube/config"
+    - SCALE_CHAOSDUCK_TO_ZERO="1"
+    - DOCKER_CONFIG="/opt/cluster"
+    external_cluster:
+      secret: s390x-cluster1
+  - custom-job: s390x-e2e-tests
+    release: "0.26"
+    cron: 30 7 * * *
+    command:
+    - bash
+    args:
+    - -c
+    - mkdir -p /root/.kube && server_addr=$(cat /opt/cluster/config) && ssh -o StrictHostKeyChecking=no -i /opt/cluster/knative01.pem linux1@${server_addr} cat /home/linux1/.kube/config > /root/.kube/config && kubectl get cm s390x-config-eventing -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh && chmod +x adjust.sh && ./adjust.sh && ./test/e2e-tests.sh --run-tests
+    env-vars:
+    - DISABLE_MD_LINTING="1"
+    - KO_FLAGS="--platform=linux/s390x"
     - SYSTEM_NAMESPACE="knative-eventing"
     - PLATFORM="linux/s390x"
     - KUBECONFIG="/root/.kube/config"
@@ -1552,6 +1695,40 @@ periodics:
   - custom-job: s390x-e2e-tests
     release: "0.24"
     cron: 0 6 * * *
+    command:
+    - bash
+    args:
+    - -c
+    - mkdir -p /root/.kube && server_addr=$(cat /opt/cluster/config) && ssh -o StrictHostKeyChecking=no -i /opt/cluster/knative01.pem linux1@${server_addr} cat /home/linux1/.kube/config > /root/.kube/config && kubectl get cm s390x-config-operator -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh && chmod +x adjust.sh && ./adjust.sh && ./test/e2e-tests.sh --run-tests
+    env-vars:
+    - DISABLE_MD_LINTING="1"
+    - KO_FLAGS="--platform=linux/s390x"
+    - PLATFORM="linux/s390x"
+    - KUBECONFIG="/root/.kube/config"
+    - DOCKER_CONFIG="/opt/cluster"
+    - INGRESS_CLASS="contour.ingress.networking.knative.dev"
+    external_cluster:
+      secret: s390x-cluster1
+  - custom-job: s390x-e2e-tests
+    release: "0.25"
+    cron: 0 18 * * *
+    command:
+    - bash
+    args:
+    - -c
+    - mkdir -p /root/.kube && server_addr=$(cat /opt/cluster/config) && ssh -o StrictHostKeyChecking=no -i /opt/cluster/knative01.pem linux1@${server_addr} cat /home/linux1/.kube/config > /root/.kube/config && kubectl get cm s390x-config-operator -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh && chmod +x adjust.sh && ./adjust.sh && ./test/e2e-tests.sh --run-tests
+    env-vars:
+    - DISABLE_MD_LINTING="1"
+    - KO_FLAGS="--platform=linux/s390x"
+    - PLATFORM="linux/s390x"
+    - KUBECONFIG="/root/.kube/config"
+    - DOCKER_CONFIG="/opt/cluster"
+    - INGRESS_CLASS="contour.ingress.networking.knative.dev"
+    external_cluster:
+      secret: s390x-cluster1
+  - custom-job: s390x-e2e-tests
+    release: "0.26"
+    cron: 30 9 * * *
     command:
     - bash
     args:

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -7454,6 +7454,144 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
+- cron: "0 0 * * *"
+  name: ci-knative-serving-0.25-s390x-kourier-tests
+  agent: kubernetes
+  decorate: true
+  decoration_config:
+    timeout: 120m
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative
+    repo: serving
+    path_alias: knative.dev/serving
+    base_ref: release-0.25
+  annotations:
+    testgrid-dashboards: knative-0.25
+    testgrid-tab-name: serving-s390x-kourier-tests
+    testgrid-alert-stale-results-hours: "3"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "bash"
+      - "-c"
+      - "mkdir -p /root/.kube && server_addr=$(cat /opt/cluster/config) && ssh -o StrictHostKeyChecking=no -i /opt/cluster/knative01.pem linux1@${server_addr} cat /home/linux1/.kube/config > /root/.kube/config && kubectl get cm s390x-config-serving -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh && chmod +x adjust.sh && ./adjust.sh && export TEST_OPTIONS=$TEST_OPTIONS' --ingressendpoint '${server_addr} && ./test/e2e-tests.sh --run-tests --kourier-version latest"
+      volumeMounts:
+      - name: s390x-cluster1
+        mountPath: /opt/cluster
+        readOnly: true
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GO111MODULE
+        value: "on"
+      - name: TEST_OPTIONS
+        value: "--enable-alpha --enable-beta --resolvabledomain=false"
+      - name: DISABLE_MD_LINTING
+        value: "1"
+      - name: KO_FLAGS
+        value: "--platform=linux/s390x"
+      - name: SYSTEM_NAMESPACE
+        value: "knative-serving"
+      - name: PLATFORM
+        value: "linux/s390x"
+      - name: KUBECONFIG
+        value: "/root/.kube/config"
+      - name: DOCKER_CONFIG
+        value: "/opt/cluster"
+      - name: KO_DOCKER_REPO
+        valueFrom:
+          secretKeyRef:
+            name: s390x-cluster1
+            key: ko-docker-repo
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.25
+    volumes:
+    - name: s390x-cluster1
+      secret:
+        secretName: s390x-cluster1
+        defaultMode: 0600
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "30 3 * * *"
+  name: ci-knative-serving-0.26-s390x-kourier-tests
+  agent: kubernetes
+  decorate: true
+  decoration_config:
+    timeout: 120m
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative
+    repo: serving
+    path_alias: knative.dev/serving
+    base_ref: release-0.26
+  annotations:
+    testgrid-dashboards: knative-0.26
+    testgrid-tab-name: serving-s390x-kourier-tests
+    testgrid-alert-stale-results-hours: "3"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "bash"
+      - "-c"
+      - "mkdir -p /root/.kube && server_addr=$(cat /opt/cluster/config) && ssh -o StrictHostKeyChecking=no -i /opt/cluster/knative01.pem linux1@${server_addr} cat /home/linux1/.kube/config > /root/.kube/config && kubectl get cm s390x-config-serving -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh && chmod +x adjust.sh && ./adjust.sh && export TEST_OPTIONS=$TEST_OPTIONS' --ingressendpoint '${server_addr} && ./test/e2e-tests.sh --run-tests --kourier-version latest"
+      volumeMounts:
+      - name: s390x-cluster1
+        mountPath: /opt/cluster
+        readOnly: true
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GO111MODULE
+        value: "on"
+      - name: TEST_OPTIONS
+        value: "--enable-alpha --enable-beta --resolvabledomain=false"
+      - name: DISABLE_MD_LINTING
+        value: "1"
+      - name: KO_FLAGS
+        value: "--platform=linux/s390x"
+      - name: SYSTEM_NAMESPACE
+        value: "knative-serving"
+      - name: PLATFORM
+        value: "linux/s390x"
+      - name: KUBECONFIG
+        value: "/root/.kube/config"
+      - name: DOCKER_CONFIG
+        value: "/opt/cluster"
+      - name: KO_DOCKER_REPO
+        valueFrom:
+          secretKeyRef:
+            name: s390x-cluster1
+            key: ko-docker-repo
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.26
+    volumes:
+    - name: s390x-cluster1
+      secret:
+        secretName: s390x-cluster1
+        defaultMode: 0600
+    - name: test-account
+      secret:
+        secretName: test-account
 - cron: "0 5 * * *"
   name: ci-knative-serving-s390x-contour-tests
   agent: kubernetes
@@ -7651,6 +7789,144 @@ periodics:
         value: us-central1
       - name: PULL_BASE_REF
         value: release-0.24
+    volumes:
+    - name: s390x-cluster1
+      secret:
+        secretName: s390x-cluster1
+        defaultMode: 0600
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "0 22 * * *"
+  name: ci-knative-serving-0.25-s390x-contour-tests
+  agent: kubernetes
+  decorate: true
+  decoration_config:
+    timeout: 120m
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative
+    repo: serving
+    path_alias: knative.dev/serving
+    base_ref: release-0.25
+  annotations:
+    testgrid-dashboards: knative-0.25
+    testgrid-tab-name: serving-s390x-contour-tests
+    testgrid-alert-stale-results-hours: "3"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "bash"
+      - "-c"
+      - "mkdir -p /root/.kube && server_addr=$(cat /opt/cluster/config) && ssh -o StrictHostKeyChecking=no -i /opt/cluster/knative01.pem linux1@${server_addr} cat /home/linux1/.kube/config > /root/.kube/config && kubectl get cm s390x-config-serving -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh && chmod +x adjust.sh && ./adjust.sh && export TEST_OPTIONS=$TEST_OPTIONS' --ingressendpoint '${server_addr} && ./test/e2e-tests.sh --run-tests --contour-version latest"
+      volumeMounts:
+      - name: s390x-cluster1
+        mountPath: /opt/cluster
+        readOnly: true
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GO111MODULE
+        value: "on"
+      - name: TEST_OPTIONS
+        value: "--enable-alpha --enable-beta --resolvabledomain=false"
+      - name: DISABLE_MD_LINTING
+        value: "1"
+      - name: KO_FLAGS
+        value: "--platform=linux/s390x"
+      - name: SYSTEM_NAMESPACE
+        value: "knative-serving"
+      - name: PLATFORM
+        value: "linux/s390x"
+      - name: KUBECONFIG
+        value: "/root/.kube/config"
+      - name: DOCKER_CONFIG
+        value: "/opt/cluster"
+      - name: KO_DOCKER_REPO
+        valueFrom:
+          secretKeyRef:
+            name: s390x-cluster1
+            key: ko-docker-repo
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.25
+    volumes:
+    - name: s390x-cluster1
+      secret:
+        secretName: s390x-cluster1
+        defaultMode: 0600
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "30 5 * * *"
+  name: ci-knative-serving-0.26-s390x-contour-tests
+  agent: kubernetes
+  decorate: true
+  decoration_config:
+    timeout: 120m
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative
+    repo: serving
+    path_alias: knative.dev/serving
+    base_ref: release-0.26
+  annotations:
+    testgrid-dashboards: knative-0.26
+    testgrid-tab-name: serving-s390x-contour-tests
+    testgrid-alert-stale-results-hours: "3"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "bash"
+      - "-c"
+      - "mkdir -p /root/.kube && server_addr=$(cat /opt/cluster/config) && ssh -o StrictHostKeyChecking=no -i /opt/cluster/knative01.pem linux1@${server_addr} cat /home/linux1/.kube/config > /root/.kube/config && kubectl get cm s390x-config-serving -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh && chmod +x adjust.sh && ./adjust.sh && export TEST_OPTIONS=$TEST_OPTIONS' --ingressendpoint '${server_addr} && ./test/e2e-tests.sh --run-tests --contour-version latest"
+      volumeMounts:
+      - name: s390x-cluster1
+        mountPath: /opt/cluster
+        readOnly: true
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GO111MODULE
+        value: "on"
+      - name: TEST_OPTIONS
+        value: "--enable-alpha --enable-beta --resolvabledomain=false"
+      - name: DISABLE_MD_LINTING
+        value: "1"
+      - name: KO_FLAGS
+        value: "--platform=linux/s390x"
+      - name: SYSTEM_NAMESPACE
+        value: "knative-serving"
+      - name: PLATFORM
+        value: "linux/s390x"
+      - name: KUBECONFIG
+        value: "/root/.kube/config"
+      - name: DOCKER_CONFIG
+        value: "/opt/cluster"
+      - name: KO_DOCKER_REPO
+        valueFrom:
+          secretKeyRef:
+            name: s390x-cluster1
+            key: ko-docker-repo
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.26
     volumes:
     - name: s390x-cluster1
       secret:
@@ -9095,6 +9371,136 @@ periodics:
         value: us-central1
       - name: PULL_BASE_REF
         value: release-0.24
+    volumes:
+    - name: s390x-cluster1
+      secret:
+        secretName: s390x-cluster1
+        defaultMode: 0600
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "0 16 * * *"
+  name: ci-knative-client-0.25-s390x-e2e-tests
+  agent: kubernetes
+  decorate: true
+  decoration_config:
+    timeout: 120m
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative
+    repo: client
+    path_alias: knative.dev/client
+    base_ref: release-0.25
+  annotations:
+    testgrid-dashboards: knative-0.25
+    testgrid-tab-name: client-s390x-e2e-tests
+    testgrid-alert-stale-results-hours: "3"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "bash"
+      - "-c"
+      - "mkdir -p /root/.kube && server_addr=$(cat /opt/cluster/config) && ssh -o StrictHostKeyChecking=no -i /opt/cluster/knative01.pem linux1@${server_addr} cat /home/linux1/.kube/config > /root/.kube/config && kubectl get cm s390x-config-client -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh && chmod +x adjust.sh && ./adjust.sh && ./test/e2e-tests.sh --run-tests"
+      volumeMounts:
+      - name: s390x-cluster1
+        mountPath: /opt/cluster
+        readOnly: true
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: DISABLE_MD_LINTING
+        value: "1"
+      - name: KO_FLAGS
+        value: "--platform=linux/s390x"
+      - name: PLATFORM
+        value: "linux/s390x"
+      - name: KUBECONFIG
+        value: "/root/.kube/config"
+      - name: DOCKER_CONFIG
+        value: "/opt/cluster"
+      - name: INGRESS_CLASS
+        value: "contour.ingress.networking.knative.dev"
+      - name: KO_DOCKER_REPO
+        valueFrom:
+          secretKeyRef:
+            name: s390x-cluster1
+            key: ko-docker-repo
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.25
+    volumes:
+    - name: s390x-cluster1
+      secret:
+        secretName: s390x-cluster1
+        defaultMode: 0600
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "30 11 * * *"
+  name: ci-knative-client-0.26-s390x-e2e-tests
+  agent: kubernetes
+  decorate: true
+  decoration_config:
+    timeout: 120m
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative
+    repo: client
+    path_alias: knative.dev/client
+    base_ref: release-0.26
+  annotations:
+    testgrid-dashboards: knative-0.26
+    testgrid-tab-name: client-s390x-e2e-tests
+    testgrid-alert-stale-results-hours: "3"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "bash"
+      - "-c"
+      - "mkdir -p /root/.kube && server_addr=$(cat /opt/cluster/config) && ssh -o StrictHostKeyChecking=no -i /opt/cluster/knative01.pem linux1@${server_addr} cat /home/linux1/.kube/config > /root/.kube/config && kubectl get cm s390x-config-client -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh && chmod +x adjust.sh && ./adjust.sh && ./test/e2e-tests.sh --run-tests"
+      volumeMounts:
+      - name: s390x-cluster1
+        mountPath: /opt/cluster
+        readOnly: true
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: DISABLE_MD_LINTING
+        value: "1"
+      - name: KO_FLAGS
+        value: "--platform=linux/s390x"
+      - name: PLATFORM
+        value: "linux/s390x"
+      - name: KUBECONFIG
+        value: "/root/.kube/config"
+      - name: DOCKER_CONFIG
+        value: "/opt/cluster"
+      - name: INGRESS_CLASS
+        value: "contour.ingress.networking.knative.dev"
+      - name: KO_DOCKER_REPO
+        valueFrom:
+          secretKeyRef:
+            name: s390x-cluster1
+            key: ko-docker-repo
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.26
     volumes:
     - name: s390x-cluster1
       secret:
@@ -12257,8 +12663,6 @@ periodics:
         value: "1"
       - name: KO_FLAGS
         value: "--platform=linux/s390x"
-      - name: DEPLOY_KNATIVE_MONITORING
-        value: "0"
       - name: SYSTEM_NAMESPACE
         value: "knative-eventing"
       - name: PLATFORM
@@ -12324,8 +12728,6 @@ periodics:
         value: "1"
       - name: KO_FLAGS
         value: "--platform=linux/s390x"
-      - name: DEPLOY_KNATIVE_MONITORING
-        value: "0"
       - name: SYSTEM_NAMESPACE
         value: "knative-eventing"
       - name: PLATFORM
@@ -12393,8 +12795,6 @@ periodics:
         value: "1"
       - name: KO_FLAGS
         value: "--platform=linux/s390x"
-      - name: DEPLOY_KNATIVE_MONITORING
-        value: "0"
       - name: SYSTEM_NAMESPACE
         value: "knative-eventing"
       - name: PLATFORM
@@ -12416,6 +12816,140 @@ periodics:
         value: us-central1
       - name: PULL_BASE_REF
         value: release-0.24
+    volumes:
+    - name: s390x-cluster1
+      secret:
+        secretName: s390x-cluster1
+        defaultMode: 0600
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "0 20 * * *"
+  name: ci-knative-eventing-0.25-s390x-e2e-tests
+  agent: kubernetes
+  decorate: true
+  decoration_config:
+    timeout: 120m
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative
+    repo: eventing
+    path_alias: knative.dev/eventing
+    base_ref: release-0.25
+  annotations:
+    testgrid-dashboards: knative-0.25
+    testgrid-tab-name: eventing-s390x-e2e-tests
+    testgrid-alert-stale-results-hours: "3"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "bash"
+      - "-c"
+      - "mkdir -p /root/.kube && server_addr=$(cat /opt/cluster/config) && ssh -o StrictHostKeyChecking=no -i /opt/cluster/knative01.pem linux1@${server_addr} cat /home/linux1/.kube/config > /root/.kube/config && kubectl get cm s390x-config-eventing -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh && chmod +x adjust.sh && ./adjust.sh && ./test/e2e-tests.sh --run-tests"
+      volumeMounts:
+      - name: s390x-cluster1
+        mountPath: /opt/cluster
+        readOnly: true
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: DISABLE_MD_LINTING
+        value: "1"
+      - name: KO_FLAGS
+        value: "--platform=linux/s390x"
+      - name: SYSTEM_NAMESPACE
+        value: "knative-eventing"
+      - name: PLATFORM
+        value: "linux/s390x"
+      - name: KUBECONFIG
+        value: "/root/.kube/config"
+      - name: SCALE_CHAOSDUCK_TO_ZERO
+        value: "1"
+      - name: DOCKER_CONFIG
+        value: "/opt/cluster"
+      - name: KO_DOCKER_REPO
+        valueFrom:
+          secretKeyRef:
+            name: s390x-cluster1
+            key: ko-docker-repo
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.25
+    volumes:
+    - name: s390x-cluster1
+      secret:
+        secretName: s390x-cluster1
+        defaultMode: 0600
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "30 7 * * *"
+  name: ci-knative-eventing-0.26-s390x-e2e-tests
+  agent: kubernetes
+  decorate: true
+  decoration_config:
+    timeout: 120m
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative
+    repo: eventing
+    path_alias: knative.dev/eventing
+    base_ref: release-0.26
+  annotations:
+    testgrid-dashboards: knative-0.26
+    testgrid-tab-name: eventing-s390x-e2e-tests
+    testgrid-alert-stale-results-hours: "3"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "bash"
+      - "-c"
+      - "mkdir -p /root/.kube && server_addr=$(cat /opt/cluster/config) && ssh -o StrictHostKeyChecking=no -i /opt/cluster/knative01.pem linux1@${server_addr} cat /home/linux1/.kube/config > /root/.kube/config && kubectl get cm s390x-config-eventing -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh && chmod +x adjust.sh && ./adjust.sh && ./test/e2e-tests.sh --run-tests"
+      volumeMounts:
+      - name: s390x-cluster1
+        mountPath: /opt/cluster
+        readOnly: true
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: DISABLE_MD_LINTING
+        value: "1"
+      - name: KO_FLAGS
+        value: "--platform=linux/s390x"
+      - name: SYSTEM_NAMESPACE
+        value: "knative-eventing"
+      - name: PLATFORM
+        value: "linux/s390x"
+      - name: KUBECONFIG
+        value: "/root/.kube/config"
+      - name: SCALE_CHAOSDUCK_TO_ZERO
+        value: "1"
+      - name: DOCKER_CONFIG
+        value: "/opt/cluster"
+      - name: KO_DOCKER_REPO
+        valueFrom:
+          secretKeyRef:
+            name: s390x-cluster1
+            key: ko-docker-repo
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.26
     volumes:
     - name: s390x-cluster1
       secret:
@@ -19948,6 +20482,136 @@ periodics:
         value: us-central1
       - name: PULL_BASE_REF
         value: release-0.24
+    volumes:
+    - name: s390x-cluster1
+      secret:
+        secretName: s390x-cluster1
+        defaultMode: 0600
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "0 18 * * *"
+  name: ci-knative-operator-0.25-s390x-e2e-tests
+  agent: kubernetes
+  decorate: true
+  decoration_config:
+    timeout: 120m
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative
+    repo: operator
+    path_alias: knative.dev/operator
+    base_ref: release-0.25
+  annotations:
+    testgrid-dashboards: knative-0.25
+    testgrid-tab-name: operator-s390x-e2e-tests
+    testgrid-alert-stale-results-hours: "3"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "bash"
+      - "-c"
+      - "mkdir -p /root/.kube && server_addr=$(cat /opt/cluster/config) && ssh -o StrictHostKeyChecking=no -i /opt/cluster/knative01.pem linux1@${server_addr} cat /home/linux1/.kube/config > /root/.kube/config && kubectl get cm s390x-config-operator -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh && chmod +x adjust.sh && ./adjust.sh && ./test/e2e-tests.sh --run-tests"
+      volumeMounts:
+      - name: s390x-cluster1
+        mountPath: /opt/cluster
+        readOnly: true
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: DISABLE_MD_LINTING
+        value: "1"
+      - name: KO_FLAGS
+        value: "--platform=linux/s390x"
+      - name: PLATFORM
+        value: "linux/s390x"
+      - name: KUBECONFIG
+        value: "/root/.kube/config"
+      - name: DOCKER_CONFIG
+        value: "/opt/cluster"
+      - name: INGRESS_CLASS
+        value: "contour.ingress.networking.knative.dev"
+      - name: KO_DOCKER_REPO
+        valueFrom:
+          secretKeyRef:
+            name: s390x-cluster1
+            key: ko-docker-repo
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.25
+    volumes:
+    - name: s390x-cluster1
+      secret:
+        secretName: s390x-cluster1
+        defaultMode: 0600
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "30 9 * * *"
+  name: ci-knative-operator-0.26-s390x-e2e-tests
+  agent: kubernetes
+  decorate: true
+  decoration_config:
+    timeout: 120m
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative
+    repo: operator
+    path_alias: knative.dev/operator
+    base_ref: release-0.26
+  annotations:
+    testgrid-dashboards: knative-0.26
+    testgrid-tab-name: operator-s390x-e2e-tests
+    testgrid-alert-stale-results-hours: "3"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "bash"
+      - "-c"
+      - "mkdir -p /root/.kube && server_addr=$(cat /opt/cluster/config) && ssh -o StrictHostKeyChecking=no -i /opt/cluster/knative01.pem linux1@${server_addr} cat /home/linux1/.kube/config > /root/.kube/config && kubectl get cm s390x-config-operator -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh && chmod +x adjust.sh && ./adjust.sh && ./test/e2e-tests.sh --run-tests"
+      volumeMounts:
+      - name: s390x-cluster1
+        mountPath: /opt/cluster
+        readOnly: true
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: DISABLE_MD_LINTING
+        value: "1"
+      - name: KO_FLAGS
+        value: "--platform=linux/s390x"
+      - name: PLATFORM
+        value: "linux/s390x"
+      - name: KUBECONFIG
+        value: "/root/.kube/config"
+      - name: DOCKER_CONFIG
+        value: "/opt/cluster"
+      - name: INGRESS_CLASS
+        value: "contour.ingress.networking.knative.dev"
+      - name: KO_DOCKER_REPO
+        valueFrom:
+          secretKeyRef:
+            name: s390x-cluster1
+            key: ko-docker-repo
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-0.26
     volumes:
     - name: s390x-cluster1
       secret:

--- a/config/prod/prow/testgrid/testgrid.yaml
+++ b/config/prod/prow/testgrid/testgrid.yaml
@@ -279,9 +279,6 @@ test_groups:
 - name: ci-knative-client-0.24-s390x-e2e-tests
   gcs_prefix: knative-prow/logs/ci-knative-client-0.24-s390x-e2e-tests
   alert_stale_results_hours: 3
-- name: ci-knative-client-0.24-test-coverage
-  gcs_prefix: knative-prow/logs/ci-knative-client-0.24-go-coverage
-  short_text_metric: "coverage"
 - name: ci-knative-eventing-0.24-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-0.24-continuous
   alert_options:
@@ -296,9 +293,6 @@ test_groups:
 - name: ci-knative-eventing-0.24-s390x-e2e-tests
   gcs_prefix: knative-prow/logs/ci-knative-eventing-0.24-s390x-e2e-tests
   alert_stale_results_hours: 3
-- name: ci-knative-eventing-0.24-test-coverage
-  gcs_prefix: knative-prow/logs/ci-knative-eventing-0.24-go-coverage
-  short_text_metric: "coverage"
 - name: ci-knative-operator-0.24-continuous
   gcs_prefix: knative-prow/logs/ci-knative-operator-0.24-continuous
   alert_options:
@@ -313,14 +307,17 @@ test_groups:
 - name: ci-knative-operator-0.24-s390x-e2e-tests
   gcs_prefix: knative-prow/logs/ci-knative-operator-0.24-s390x-e2e-tests
   alert_stale_results_hours: 3
-- name: ci-knative-operator-0.24-test-coverage
-  gcs_prefix: knative-prow/logs/ci-knative-operator-0.24-go-coverage
-  short_text_metric: "coverage"
 - name: ci-knative-serving-0.25-continuous
   gcs_prefix: knative-prow/logs/ci-knative-serving-0.25-continuous
   alert_options:
     alert_mail_to_addresses: "serverless-engprod-sea@google.com"
   num_failures_to_alert: 3
+- name: ci-knative-serving-0.25-s390x-kourier-tests
+  gcs_prefix: knative-prow/logs/ci-knative-serving-0.25-s390x-kourier-tests
+  alert_stale_results_hours: 3
+- name: ci-knative-serving-0.25-s390x-contour-tests
+  gcs_prefix: knative-prow/logs/ci-knative-serving-0.25-s390x-contour-tests
+  alert_stale_results_hours: 3
 - name: ci-knative-serving-0.25-dot-release
   gcs_prefix: knative-prow/logs/ci-knative-serving-0.25-dot-release
   alert_options:
@@ -338,6 +335,9 @@ test_groups:
     alert_mail_to_addresses: "serverless-engprod-sea@google.com"
   alert_stale_results_hours: 170
   num_failures_to_alert: 1
+- name: ci-knative-client-0.25-s390x-e2e-tests
+  gcs_prefix: knative-prow/logs/ci-knative-client-0.25-s390x-e2e-tests
+  alert_stale_results_hours: 3
 - name: ci-knative-eventing-0.25-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-0.25-continuous
   alert_options:
@@ -349,6 +349,9 @@ test_groups:
     alert_mail_to_addresses: "serverless-engprod-sea@google.com"
   alert_stale_results_hours: 170
   num_failures_to_alert: 1
+- name: ci-knative-eventing-0.25-s390x-e2e-tests
+  gcs_prefix: knative-prow/logs/ci-knative-eventing-0.25-s390x-e2e-tests
+  alert_stale_results_hours: 3
 - name: ci-knative-operator-0.25-continuous
   gcs_prefix: knative-prow/logs/ci-knative-operator-0.25-continuous
   alert_options:
@@ -360,11 +363,20 @@ test_groups:
     alert_mail_to_addresses: "serverless-engprod-sea@google.com"
   alert_stale_results_hours: 170
   num_failures_to_alert: 1
+- name: ci-knative-operator-0.25-s390x-e2e-tests
+  gcs_prefix: knative-prow/logs/ci-knative-operator-0.25-s390x-e2e-tests
+  alert_stale_results_hours: 3
 - name: ci-knative-serving-0.26-continuous
   gcs_prefix: knative-prow/logs/ci-knative-serving-0.26-continuous
   alert_options:
     alert_mail_to_addresses: "serverless-engprod-sea@google.com"
   num_failures_to_alert: 3
+- name: ci-knative-serving-0.26-s390x-kourier-tests
+  gcs_prefix: knative-prow/logs/ci-knative-serving-0.26-s390x-kourier-tests
+  alert_stale_results_hours: 3
+- name: ci-knative-serving-0.26-s390x-contour-tests
+  gcs_prefix: knative-prow/logs/ci-knative-serving-0.26-s390x-contour-tests
+  alert_stale_results_hours: 3
 - name: ci-knative-serving-0.26-dot-release
   gcs_prefix: knative-prow/logs/ci-knative-serving-0.26-dot-release
   alert_options:
@@ -382,6 +394,12 @@ test_groups:
     alert_mail_to_addresses: "serverless-engprod-sea@google.com"
   alert_stale_results_hours: 170
   num_failures_to_alert: 1
+- name: ci-knative-client-0.26-s390x-e2e-tests
+  gcs_prefix: knative-prow/logs/ci-knative-client-0.26-s390x-e2e-tests
+  alert_stale_results_hours: 3
+- name: ci-knative-client-0.26-test-coverage
+  gcs_prefix: knative-prow/logs/ci-knative-client-0.26-go-coverage
+  short_text_metric: "coverage"
 - name: ci-knative-eventing-0.26-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-0.26-continuous
   alert_options:
@@ -393,6 +411,12 @@ test_groups:
     alert_mail_to_addresses: "serverless-engprod-sea@google.com"
   alert_stale_results_hours: 170
   num_failures_to_alert: 1
+- name: ci-knative-eventing-0.26-s390x-e2e-tests
+  gcs_prefix: knative-prow/logs/ci-knative-eventing-0.26-s390x-e2e-tests
+  alert_stale_results_hours: 3
+- name: ci-knative-eventing-0.26-test-coverage
+  gcs_prefix: knative-prow/logs/ci-knative-eventing-0.26-go-coverage
+  short_text_metric: "coverage"
 - name: ci-knative-operator-0.26-continuous
   gcs_prefix: knative-prow/logs/ci-knative-operator-0.26-continuous
   alert_options:
@@ -404,6 +428,12 @@ test_groups:
     alert_mail_to_addresses: "serverless-engprod-sea@google.com"
   alert_stale_results_hours: 170
   num_failures_to_alert: 1
+- name: ci-knative-operator-0.26-s390x-e2e-tests
+  gcs_prefix: knative-prow/logs/ci-knative-operator-0.26-s390x-e2e-tests
+  alert_stale_results_hours: 3
+- name: ci-knative-operator-0.26-test-coverage
+  gcs_prefix: knative-prow/logs/ci-knative-operator-0.26-go-coverage
+  short_text_metric: "coverage"
 - name: ci-knative-sandbox-kn-plugin-diag-continuous
   gcs_prefix: knative-prow/logs/ci-knative-sandbox-kn-plugin-diag-continuous
   alert_stale_results_hours: 3
@@ -2609,12 +2639,6 @@ dashboards:
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
     num_failures_to_alert: 3
-  - name: client-test-coverage
-    test_group_name: ci-knative-client-0.24-test-coverage
-    base_options: "sort-by-name="
-    alert_options:
-      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
-    num_failures_to_alert: 3
   - name: eventing-continuous
     test_group_name: ci-knative-eventing-0.24-continuous
     base_options: "sort-by-name="
@@ -2629,12 +2653,6 @@ dashboards:
     num_failures_to_alert: 3
   - name: eventing-s390x-e2e-tests
     test_group_name: ci-knative-eventing-0.24-s390x-e2e-tests
-    base_options: "sort-by-name="
-    alert_options:
-      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
-    num_failures_to_alert: 3
-  - name: eventing-test-coverage
-    test_group_name: ci-knative-eventing-0.24-test-coverage
     base_options: "sort-by-name="
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
@@ -2657,16 +2675,22 @@ dashboards:
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
     num_failures_to_alert: 3
-  - name: operator-test-coverage
-    test_group_name: ci-knative-operator-0.24-test-coverage
-    base_options: "sort-by-name="
-    alert_options:
-      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
-    num_failures_to_alert: 3
 - name: knative-0.25
   dashboard_tab:
   - name: serving-continuous
     test_group_name: ci-knative-serving-0.25-continuous
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
+  - name: serving-s390x-kourier-tests
+    test_group_name: ci-knative-serving-0.25-s390x-kourier-tests
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
+  - name: serving-s390x-contour-tests
+    test_group_name: ci-knative-serving-0.25-s390x-contour-tests
     base_options: "sort-by-name="
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
@@ -2689,6 +2713,12 @@ dashboards:
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
     num_failures_to_alert: 3
+  - name: client-s390x-e2e-tests
+    test_group_name: ci-knative-client-0.25-s390x-e2e-tests
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
   - name: eventing-continuous
     test_group_name: ci-knative-eventing-0.25-continuous
     base_options: "sort-by-name="
@@ -2697,6 +2727,12 @@ dashboards:
     num_failures_to_alert: 3
   - name: eventing-dot-release
     test_group_name: ci-knative-eventing-0.25-dot-release
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
+  - name: eventing-s390x-e2e-tests
+    test_group_name: ci-knative-eventing-0.25-s390x-e2e-tests
     base_options: "sort-by-name="
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
@@ -2713,10 +2749,28 @@ dashboards:
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
     num_failures_to_alert: 3
+  - name: operator-s390x-e2e-tests
+    test_group_name: ci-knative-operator-0.25-s390x-e2e-tests
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
 - name: knative-0.26
   dashboard_tab:
   - name: serving-continuous
     test_group_name: ci-knative-serving-0.26-continuous
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
+  - name: serving-s390x-kourier-tests
+    test_group_name: ci-knative-serving-0.26-s390x-kourier-tests
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
+  - name: serving-s390x-contour-tests
+    test_group_name: ci-knative-serving-0.26-s390x-contour-tests
     base_options: "sort-by-name="
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
@@ -2739,6 +2793,18 @@ dashboards:
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
     num_failures_to_alert: 3
+  - name: client-s390x-e2e-tests
+    test_group_name: ci-knative-client-0.26-s390x-e2e-tests
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
+  - name: client-test-coverage
+    test_group_name: ci-knative-client-0.26-test-coverage
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
   - name: eventing-continuous
     test_group_name: ci-knative-eventing-0.26-continuous
     base_options: "sort-by-name="
@@ -2751,6 +2817,18 @@ dashboards:
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
     num_failures_to_alert: 3
+  - name: eventing-s390x-e2e-tests
+    test_group_name: ci-knative-eventing-0.26-s390x-e2e-tests
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
+  - name: eventing-test-coverage
+    test_group_name: ci-knative-eventing-0.26-test-coverage
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
   - name: operator-continuous
     test_group_name: ci-knative-operator-0.26-continuous
     base_options: "sort-by-name="
@@ -2759,6 +2837,18 @@ dashboards:
     num_failures_to_alert: 3
   - name: operator-dot-release
     test_group_name: ci-knative-operator-0.26-dot-release
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
+  - name: operator-s390x-e2e-tests
+    test_group_name: ci-knative-operator-0.26-s390x-e2e-tests
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
+  - name: operator-test-coverage
+    test_group_name: ci-knative-operator-0.26-test-coverage
     base_options: "sort-by-name="
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
This PR is to add 10 custom jobs for release-0.25 and 0.26 to the s390x integration test. This functions as an indicator of how the corresponding release of the downstream product works on Z.
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #

**Special notes to reviewers**:

**User-visible changes in this PR**:

