### PR TITLE
[buoy] adding support for disconnected release versions and go package version families

### DIFF
--- a/buoy/commands/check.go
+++ b/buoy/commands/check.go
@@ -32,6 +32,7 @@ import (
 func addCheckCmd(root *cobra.Command) {
 	var domain string
 	var release string
+	var moduleRelease string
 	var rulesetFlag string
 	var ruleset git.RulesetType
 	var verbose bool
@@ -59,6 +60,9 @@ Rulesets,
 			if ruleset == git.InvalidRule {
 				return fmt.Errorf("invalid ruleset, please select one of: [%s]", strings.Join(git.Rulesets(), ", "))
 			}
+			if moduleRelease == "" {
+				moduleRelease = release
+			}
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -69,7 +73,7 @@ Rulesets,
 				out = cmd.OutOrStderr()
 			}
 
-			err := gomod.Check(gomodFile, release, domain, ruleset, out)
+			err := gomod.Check(gomodFile, release, moduleRelease, domain, ruleset, out)
 			if errors.Is(err, gomod.DependencyErr) {
 				_, _ = fmt.Fprintln(cmd.OutOrStdout(), err.Error())
 				os.Exit(1)
@@ -83,6 +87,7 @@ Rulesets,
 	_ = cmd.MarkFlagRequired("domain")
 	cmd.Flags().StringVarP(&release, "release", "r", "", "release should be '<major>.<minor>' (i.e.: 1.23 or v1.23) [required]")
 	_ = cmd.MarkFlagRequired("release")
+	cmd.Flags().StringVarP(&moduleRelease, "module-release", "m", "", "if the go modules are a different release set than the release, use --module-release, should be '<major>.<minor>' (i.e.: 0.12 or v0.12)")
 	cmd.Flags().StringVar(&rulesetFlag, "ruleset", git.ReleaseOrReleaseBranchRule.String(), fmt.Sprintf("The ruleset to evaluate the dependency refs. Rulesets: [%s]", strings.Join(git.Rulesets(), ", ")))
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Print verbose output.")
 

--- a/buoy/commands/exists.go
+++ b/buoy/commands/exists.go
@@ -28,15 +28,22 @@ import (
 
 func addExistsCmd(root *cobra.Command) {
 	var (
-		release string
-		verbose bool
-		tag     bool
+		release       string
+		moduleRelease string
+		verbose       bool
+		tag           bool
 	)
 
 	var cmd = &cobra.Command{
 		Use:   "exists go.mod",
 		Short: "Determine if the release branch exists for a given module.",
 		Args:  cobra.ExactArgs(1),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if moduleRelease == "" {
+				moduleRelease = release
+			}
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			gomodFile := args[0]
 
@@ -45,7 +52,7 @@ func addExistsCmd(root *cobra.Command) {
 				out = cmd.OutOrStderr()
 			}
 
-			meta, err := gomod.ReleaseStatus(gomodFile, release, out)
+			meta, err := gomod.ReleaseStatus(gomodFile, release, moduleRelease, out)
 			if err != nil {
 				return err
 			}
@@ -64,6 +71,7 @@ func addExistsCmd(root *cobra.Command) {
 
 	cmd.Flags().StringVarP(&release, "release", "r", "", "release should be '<major>.<minor>' (i.e.: 1.23 or v1.23) [required]")
 	_ = cmd.MarkFlagRequired("release")
+	cmd.Flags().StringVarP(&moduleRelease, "module-release", "m", "", "if the go modules are a different release set than the release, use --module-release, should be '<major>.<minor>' (i.e.: 0.12 or v0.12)")
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Print verbose output (stderr)")
 	cmd.Flags().BoolVarP(&tag, "next", "t", false, "Print the next release tag (stdout)")
 

--- a/buoy/commands/float.go
+++ b/buoy/commands/float.go
@@ -28,10 +28,11 @@ import (
 
 func addFloatCmd(root *cobra.Command) {
 	var (
-		domain      string
-		release     string
-		rulesetFlag string
-		ruleset     git.RulesetType
+		domain        string
+		release       string
+		moduleRelease string
+		rulesetFlag   string
+		ruleset       git.RulesetType
 	)
 
 	var cmd = &cobra.Command{
@@ -64,13 +65,16 @@ For rulesets that that restrict the selection process, no ref is selected.
 			if ruleset == git.InvalidRule {
 				return fmt.Errorf("invalid ruleset, please select one of: [%s]", strings.Join(git.Rulesets(), ", "))
 			}
+			if moduleRelease == "" {
+				moduleRelease = release
+			}
 			return nil
 		},
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			gomodFile := args[0]
 
-			refs, err := gomod.Float(gomodFile, release, domain, ruleset)
+			refs, err := gomod.Float(gomodFile, release, moduleRelease, domain, ruleset)
 			if err != nil {
 				return err
 			}
@@ -87,6 +91,7 @@ For rulesets that that restrict the selection process, no ref is selected.
 	cmd.Flags().StringVarP(&domain, "domain", "d", "knative.dev", "domain filter (i.e. knative.dev) [required]")
 	cmd.Flags().StringVarP(&release, "release", "r", "", "release should be '<major>.<minor>' (i.e.: 1.23 or v1.23) [required]")
 	_ = cmd.MarkFlagRequired("release")
+	cmd.Flags().StringVarP(&moduleRelease, "module-release", "m", "", "if the go modules are a different release set than the release, use --module-release, should be '<major>.<minor>' (i.e.: 0.12 or v0.12)")
 	cmd.Flags().StringVar(&rulesetFlag, "ruleset", git.AnyRule.String(), fmt.Sprintf("The ruleset to evaluate the dependency refs. Rulesets: [%s]", strings.Join(git.Rulesets(), ", ")))
 
 	root.AddCommand(cmd)

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -92,7 +92,7 @@ func (rt RefType) String() string {
 
 // BestRefFor Returns module@ref, isRelease based on the provided ruleset for
 // a this release.
-func (r *Repo) BestRefFor(this semver.Version, ruleset RulesetType) (string, RefType) {
+func (r *Repo) BestRefFor(release, moduleRelease semver.Version, ruleset RulesetType) (string, RefType) {
 	switch ruleset {
 	case AnyRule, ReleaseOrReleaseBranchRule, ReleaseRule:
 		var largest *semver.Version
@@ -104,7 +104,7 @@ func (r *Repo) BestRefFor(this semver.Version, ruleset RulesetType) (string, Ref
 				if v.Pre != nil || v.Build != nil {
 					continue
 				}
-				if v.Major == this.Major && v.Minor == this.Minor {
+				if v.Major == moduleRelease.Major && v.Minor == moduleRelease.Minor {
 					if largest == nil || largest.LT(v) {
 						largest = &v
 					}
@@ -124,7 +124,7 @@ func (r *Repo) BestRefFor(this semver.Version, ruleset RulesetType) (string, Ref
 			if bv, ok := normalizeBranchVersion(b); ok {
 				v, _ := semver.Make(bv)
 
-				if v.Major == this.Major && v.Minor == this.Minor {
+				if v.Major == release.Major && v.Minor == release.Minor {
 					if largest == nil || largest.LT(v) {
 						largest = &v
 					}

--- a/pkg/gomod/check_test.go
+++ b/pkg/gomod/check_test.go
@@ -27,81 +27,92 @@ import (
 // TestCheck - This is an integration test, it will make a call out to the internet.
 func TestCheck(t *testing.T) {
 	tests := map[string]struct {
-		gomod   string
-		release string
-		domain  string
-		rule    git.RulesetType
-		wantErr bool
+		gomod         string
+		release       string
+		moduleRelease string
+		domain        string
+		rule          git.RulesetType
+		wantErr       bool
 	}{
 		"demo1, v0.15, knative.dev, any rule": {
-			gomod:   "./testdata/gomod.check1",
-			release: "v0.15",
-			domain:  "knative.dev",
-			rule:    git.AnyRule,
+			gomod:         "./testdata/gomod.check1",
+			release:       "v0.15",
+			moduleRelease: "v0.15",
+			domain:        "knative.dev",
+			rule:          git.AnyRule,
 		},
 		"demo1, v0.15, knative.dev, release rule": {
-			gomod:   "./testdata/gomod.check1",
-			release: "v0.15",
-			domain:  "knative.dev",
-			rule:    git.ReleaseRule,
-			wantErr: true,
+			gomod:         "./testdata/gomod.check1",
+			release:       "v0.15",
+			moduleRelease: "v0.15",
+			domain:        "knative.dev",
+			rule:          git.ReleaseRule,
+			wantErr:       true,
 		},
 		"demo1, v0.15, knative.dev, release branch rule": {
-			gomod:   "./testdata/gomod.check1",
-			release: "v0.15",
-			domain:  "knative.dev",
-			rule:    git.ReleaseBranchRule,
+			gomod:         "./testdata/gomod.check1",
+			release:       "v0.15",
+			moduleRelease: "v0.15",
+			domain:        "knative.dev",
+			rule:          git.ReleaseBranchRule,
 		},
 		"demo1, v99.99, knative.dev, release branch or release rule": {
-			gomod:   "./testdata/gomod.check1",
-			release: "v99.99",
-			domain:  "knative.dev",
-			rule:    git.ReleaseOrReleaseBranchRule,
-			wantErr: true,
+			gomod:         "./testdata/gomod.check1",
+			release:       "v99.99",
+			moduleRelease: "v99.99",
+			domain:        "knative.dev",
+			rule:          git.ReleaseOrReleaseBranchRule,
+			wantErr:       true,
 		},
 		"demo1, v0.16, knative.dev, any rule": {
-			gomod:   "./testdata/gomod.check1",
-			release: "v0.16",
-			domain:  "knative.dev",
-			rule:    git.AnyRule,
+			gomod:         "./testdata/gomod.check1",
+			release:       "v0.16",
+			moduleRelease: "v0.16",
+			domain:        "knative.dev",
+			rule:          git.AnyRule,
 		},
-		"demo1, v0.16, k8s.io, any rule": {
-			gomod:   "./testdata/gomod.check1",
-			release: "v0.16",
-			domain:  "knative.dev",
-			rule:    git.AnyRule,
+		"demo1, v0.16, v0.15 mods, knative.dev, any rule": {
+			gomod:         "./testdata/gomod.check1",
+			release:       "v0.16",
+			moduleRelease: "v0.15",
+			domain:        "knative.dev",
+			rule:          git.AnyRule,
 		},
 		"demo1, v99.99, knative.dev, any rule": {
-			gomod:   "./testdata/gomod.check1",
-			release: "v99.99",
-			domain:  "knative.dev",
-			rule:    git.AnyRule,
+			gomod:         "./testdata/gomod.check1",
+			release:       "v99.99",
+			moduleRelease: "v99.99",
+			domain:        "knative.dev",
+			rule:          git.AnyRule,
 		},
 		"bad release": {
-			gomod:   "./testdata/gomod.check1",
-			release: "not gonna work",
-			domain:  "knative.dev",
-			rule:    git.AnyRule,
-			wantErr: true,
+			gomod:         "./testdata/gomod.check1",
+			release:       "not gonna work",
+			moduleRelease: "not gonna work",
+			domain:        "knative.dev",
+			rule:          git.AnyRule,
+			wantErr:       true,
 		},
 		"bad go module": {
-			gomod:   "./testdata/gomod.float1",
-			release: "v0.15",
-			domain:  "does-not-exist.nope",
-			rule:    git.AnyRule,
-			wantErr: true,
+			gomod:         "./testdata/gomod.float1",
+			release:       "v0.15",
+			moduleRelease: "v0.15",
+			domain:        "does-not-exist.nope",
+			rule:          git.AnyRule,
+			wantErr:       true,
 		},
 		"bad go mod file": {
-			gomod:   "./testdata/bad.example",
-			release: "v0.15",
-			domain:  "knative.dev",
-			rule:    git.AnyRule,
-			wantErr: true,
+			gomod:         "./testdata/bad.example",
+			release:       "v0.15",
+			moduleRelease: "v0.15",
+			domain:        "knative.dev",
+			rule:          git.AnyRule,
+			wantErr:       true,
 		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			err := Check(tt.gomod, tt.release, tt.domain, tt.rule, os.Stdout)
+			err := Check(tt.gomod, tt.release, tt.moduleRelease, tt.domain, tt.rule, os.Stdout)
 			if (tt.wantErr && err == nil) || (!tt.wantErr && err != nil) {
 				t.Errorf("unexpected error state, want error == %t, got %v", tt.wantErr, err)
 			}

--- a/pkg/gomod/float.go
+++ b/pkg/gomod/float.go
@@ -28,13 +28,18 @@ import (
 // Returns the set of module refs that were found. If no ref is found for a
 // dependency, Float omits that ref from the returned list. Float leverages
 // the same rules used by knative.dev/test-infra/pkg/git.Repo().BestRefFor
-func Float(gomod, release, domain string, ruleset git.RulesetType) ([]string, error) {
+func Float(gomod, release, moduleRelease, domain string, ruleset git.RulesetType) ([]string, error) {
 	_, packages, err := Modules([]string{gomod}, domain)
 	if err != nil {
 		return nil, err
 	}
 
-	this, err := semver.ParseTolerant(release)
+	r, err := semver.ParseTolerant(release)
+	if err != nil {
+		return nil, err
+	}
+
+	mr, err := semver.ParseTolerant(moduleRelease)
 	if err != nil {
 		return nil, err
 	}
@@ -46,7 +51,7 @@ func Float(gomod, release, domain string, ruleset git.RulesetType) ([]string, er
 			return nil, err
 		}
 
-		if ref, refType := repo.BestRefFor(this, ruleset); refType != git.NoRef {
+		if ref, refType := repo.BestRefFor(r, mr, ruleset); refType != git.NoRef {
 			refs = append(refs, ref)
 		}
 	}

--- a/pkg/gomod/float_test.go
+++ b/pkg/gomod/float_test.go
@@ -25,93 +25,137 @@ import (
 // TestFloat - This is an integration test, it will make a call out to the internet.
 func TestFloat(t *testing.T) {
 	tests := map[string]struct {
-		gomod   string
-		release string
-		domain  string
-		rule    git.RulesetType
-		want    map[string]git.RefType
+		gomod         string
+		release       string
+		moduleRelease string
+		domain        string
+		rule          git.RulesetType
+		want          map[string]git.RefType
+		wantRef       map[string]string // it is a bad idea to test with anything other than `release`.
 	}{
 		"demo1, v0.15, knative.dev, any rule": {
-			gomod:   "./testdata/gomod.float1",
-			release: "v0.15",
-			domain:  "knative.dev",
-			rule:    git.AnyRule,
+			gomod:         "./testdata/gomod.float1",
+			release:       "v0.15",
+			moduleRelease: "v0.15",
+			domain:        "knative.dev",
+			rule:          git.AnyRule,
 			want: map[string]git.RefType{
 				"knative.dev/pkg":      git.ReleaseBranchRef,
 				"knative.dev/eventing": git.ReleaseRef,
 			},
 		},
 		"demo1, v0.15, knative.dev, release rule": {
-			gomod:   "./testdata/gomod.float1",
-			release: "v0.15",
-			domain:  "knative.dev",
-			rule:    git.ReleaseRule,
+			gomod:         "./testdata/gomod.float1",
+			release:       "v0.15",
+			moduleRelease: "v0.15",
+			domain:        "knative.dev",
+			rule:          git.ReleaseRule,
 			want: map[string]git.RefType{
 				"knative.dev/eventing": git.ReleaseRef,
 			},
 		},
 		"demo1, v0.15, knative.dev, release branch rule": {
-			gomod:   "./testdata/gomod.float1",
-			release: "v0.15",
-			domain:  "knative.dev",
-			rule:    git.ReleaseBranchRule,
+			gomod:         "./testdata/gomod.float1",
+			release:       "v0.15",
+			moduleRelease: "v0.15",
+			domain:        "knative.dev",
+			rule:          git.ReleaseBranchRule,
 			want: map[string]git.RefType{
 				"knative.dev/pkg":      git.ReleaseBranchRef,
 				"knative.dev/eventing": git.ReleaseBranchRef,
 			},
 		},
 		"demo1, v99.99, knative.dev, release branch or release rule": {
-			gomod:   "./testdata/gomod.float1",
-			release: "v99.99",
-			domain:  "knative.dev",
-			rule:    git.ReleaseOrReleaseBranchRule,
-			want:    map[string]git.RefType{},
+			gomod:         "./testdata/gomod.float1",
+			release:       "v99.99",
+			moduleRelease: "v99.99",
+			domain:        "knative.dev",
+			rule:          git.ReleaseOrReleaseBranchRule,
+			want:          map[string]git.RefType{},
 		},
 		"demo1, v0.16, knative.dev, any rule": {
-			gomod:   "./testdata/gomod.float1",
-			release: "v0.16",
-			domain:  "knative.dev",
-			rule:    git.AnyRule,
+			gomod:         "./testdata/gomod.float1",
+			release:       "v0.16",
+			moduleRelease: "v0.16",
+			domain:        "knative.dev",
+			rule:          git.AnyRule,
 			want: map[string]git.RefType{
 				"knative.dev/pkg":      git.ReleaseBranchRef,
 				"knative.dev/eventing": git.ReleaseRef,
 			},
 		},
 		"demo1, v0.16, k8s.io, any rule": {
-			gomod:   "./testdata/gomod.float1",
-			release: "v0.16",
-			domain:  "knative.dev",
-			rule:    git.AnyRule,
+			gomod:         "./testdata/gomod.float1",
+			release:       "v0.16",
+			moduleRelease: "v0.16",
+			domain:        "knative.dev",
+			rule:          git.AnyRule,
 			want: map[string]git.RefType{
 				"knative.dev/pkg":      git.ReleaseBranchRef,
 				"knative.dev/eventing": git.ReleaseRef,
 			},
 		},
+		"demo1, v0.16, v0.15 mods, k8s.io, any rule": {
+			gomod:         "./testdata/gomod.float1",
+			release:       "v0.16",
+			moduleRelease: "v0.15",
+			domain:        "knative.dev",
+			rule:          git.AnyRule,
+			want: map[string]git.RefType{
+				"knative.dev/pkg":      git.ReleaseBranchRef,
+				"knative.dev/eventing": git.ReleaseRef,
+			},
+			wantRef: map[string]string{
+				"knative.dev/pkg": "release-0.16",
+			},
+		},
 		"demo1, v99.99, knative.dev, any rule": {
-			gomod:   "./testdata/gomod.float1",
-			release: "v99.99",
-			domain:  "knative.dev",
-			rule:    git.AnyRule,
+			gomod:         "./testdata/gomod.float1",
+			release:       "v99.99",
+			moduleRelease: "v99.99",
+			domain:        "knative.dev",
+			rule:          git.AnyRule,
 			want: map[string]git.RefType{
 				"knative.dev/pkg":      git.BranchRef,
 				"knative.dev/eventing": git.BranchRef,
 			},
 		},
+		"demo1, v0.15, v99.99 mods, knative.dev, any rule": {
+			gomod:         "./testdata/gomod.float1",
+			release:       "v0.15",
+			moduleRelease: "v99.99",
+			domain:        "knative.dev",
+			rule:          git.AnyRule,
+			want: map[string]git.RefType{
+				"knative.dev/pkg":      git.ReleaseBranchRef,
+				"knative.dev/eventing": git.ReleaseBranchRef,
+			},
+			wantRef: map[string]string{
+				"knative.dev/pkg":      "release-0.15",
+				"knative.dev/eventing": "release-0.15",
+			},
+		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			deps, err := Float(tt.gomod, tt.release, tt.domain, tt.rule)
+			deps, err := Float(tt.gomod, tt.release, tt.moduleRelease, tt.domain, tt.rule)
 			if err != nil {
 				t.Fatal(err)
 			}
 			for _, dep := range deps {
-				module, _, got := git.ParseRef(dep)
+				module, ref, got := git.ParseRef(dep)
 				if want, ok := tt.want[module]; ok {
 					if got != want {
-						t.Errorf("Float() %s; got %q, want: %q", module, got, want)
+						t.Errorf("[ref type] Float() %s; got %q, want: %q", module, got, want)
 					}
 				} else {
 					t.Error("untested float dep: ", dep)
+				}
+				// Optional test on returned ref.
+				if want, ok := tt.wantRef[module]; ok {
+					if got := ref; got != want {
+						t.Errorf("[ref value] Float() %s; got %q, want: %q", module, got, want)
+					}
 				}
 			}
 		})
@@ -147,7 +191,7 @@ func TestFloatUnhappy(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			_, err := Float(tt.gomod, tt.release, tt.domain, tt.rule)
+			_, err := Float(tt.gomod, tt.release, tt.release, tt.domain, tt.rule)
 			if err == nil {
 				t.Error("Expected an error")
 			}

--- a/pkg/gomod/release_meta_test.go
+++ b/pkg/gomod/release_meta_test.go
@@ -69,7 +69,7 @@ func TestReleaseStatus(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			got, err := ReleaseStatus(tt.gomod, tt.release, os.Stdout)
+			got, err := ReleaseStatus(tt.gomod, tt.release, tt.release, os.Stdout)
 			if (tt.wantErr && err == nil) || (!tt.wantErr && err != nil) {
 				t.Errorf("unexpected error state, want error == %t, got %v", tt.wantErr, err)
 			}


### PR DESCRIPTION
Signed-off-by: Scott Nichols <n3wscott@chainguard.dev>

**What this PR does, why we need it**:

Supporting knative 1.0.0 release madness.

**User-visible changes in this PR**:

Adds `--module-release` flags to `exists`, `float`, and `check`.

## Demo

The following demo shows using a module release of 0.22 or 0.23 and a release of 1.22 to float `k8s.io/apimachinery`.

```
[10:30:56] n3wscott@book ~/go/src/github.com/knative/test-infra (buoy-suppport-versions)
(╯°□°)╯︵  buoy float --domain k8s.io --module-release 0.22 --release 1.22 go.mod
k8s.io/apimachinery@v0.22.2
[10:32:52] n3wscott@book ~/go/src/github.com/knative/test-infra (buoy-suppport-versions)
(╯°□°)╯︵  buoy float --domain k8s.io --module-release 0.23 --release 1.22 go.mod
k8s.io/apimachinery@release-1.22
```
