### PR TITLE
Add continuous, nigthly, auto-released and test-grid for net-gateway-api

### DIFF
--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -1510,6 +1510,7 @@ periodics:
         job_states_to_report:
         - failure
         report_template: '"The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"'
+  - auto-release: true
   knative-sandbox/net-http01:
   - continuous: true
   - nightly: true

--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -1501,6 +1501,15 @@ periodics:
   - dot-release: true
     release: "1.0"
   - auto-release: true
+  knative-sandbox/net-gateway-api:
+  - continuous: true
+  - nightly: true
+    reporter_config:
+      slack:
+        channel: net-gateway-api
+        job_states_to_report:
+        - failure
+        report_template: '"The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"'
   knative-sandbox/net-http01:
   - continuous: true
   - nightly: true

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -18325,6 +18325,59 @@ periodics:
     - name: nightly-account
       secret:
         secretName: nightly-account
+- cron: "53 */4 * * *"
+  name: ci-knative-sandbox-net-gateway-api-auto-release
+  agent: kubernetes
+  decorate: true
+  decoration_config:
+    timeout: 180m
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative-sandbox
+    repo: net-gateway-api
+    path_alias: knative.dev/net-gateway-api
+    base_ref: main
+  annotations:
+    testgrid-dashboards: net-gateway-api
+    testgrid-tab-name: auto-release
+    testgrid-alert-email: "serverless-engprod-sea@google.com"
+    testgrid-num-failures-to-alert: "1"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--auto-release"
+      - "--release-gcs"
+      - "knative-releases/net-gateway-api"
+      - "--release-gcr"
+      - "gcr.io/knative-releases"
+      - "--github-token"
+      - "/etc/hub-token/token"
+      volumeMounts:
+      - name: hub-token
+        mountPath: /etc/hub-token
+        readOnly: true
+      - name: release-account
+        mountPath: /etc/release-account
+        readOnly: true
+      env:
+      - name: ORG_NAME
+        value: knative-sandbox
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: hub-token
+      secret:
+        secretName: hub-token
+    - name: release-account
+      secret:
+        secretName: release-account
 - cron: "9 */4 * * *"
   name: ci-knative-sandbox-net-http01-continuous
   agent: kubernetes

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -18203,6 +18203,128 @@ periodics:
     - name: release-account
       secret:
         secretName: release-account
+- cron: "29 */4 * * *"
+  name: ci-knative-sandbox-net-gateway-api-continuous
+  agent: kubernetes
+  decorate: true
+  decoration_config:
+    timeout: 180m
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative-sandbox
+    repo: net-gateway-api
+    path_alias: knative.dev/net-gateway-api
+    base_ref: main
+  annotations:
+    testgrid-dashboards: net-gateway-api
+    testgrid-tab-name: continuous
+    testgrid-alert-stale-results-hours: "3"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./test/presubmit-tests.sh"
+      - "--all-tests"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "29 8,11,22 * * *"
+  name: ci-knative-sandbox-net-gateway-api-continuous-beta-prow-tests
+  agent: kubernetes
+  decorate: true
+  decoration_config:
+    timeout: 180m
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative-sandbox
+    repo: net-gateway-api
+    path_alias: knative.dev/net-gateway-api
+    base_ref: main
+  annotations:
+    testgrid-dashboards: beta-prow-tests
+    testgrid-tab-name: ci-knative-sandbox-net-gateway-api-continuous
+    testgrid-alert-stale-results-hours: "3"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:beta
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./test/presubmit-tests.sh"
+      - "--all-tests"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "3 9 * * *"
+  name: ci-knative-sandbox-net-gateway-api-nightly-release
+  agent: kubernetes
+  decorate: true
+  reporter_config:
+    slack:
+      channel: net-gateway-api
+      report_template: "The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"
+      job_states_to_report:
+      - "failure"
+  decoration_config:
+    timeout: 180m
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative-sandbox
+    repo: net-gateway-api
+    path_alias: knative.dev/net-gateway-api
+    base_ref: main
+  annotations:
+    testgrid-dashboards: net-gateway-api
+    testgrid-tab-name: nightly-release
+    testgrid-alert-email: "serverless-engprod-sea@google.com"
+    testgrid-num-failures-to-alert: "1"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--publish"
+      - "--tag-release"
+      volumeMounts:
+      - name: nightly-account
+        mountPath: /etc/nightly-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/nightly-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: nightly-account
+      secret:
+        secretName: nightly-account
 - cron: "9 */4 * * *"
   name: ci-knative-sandbox-net-http01-continuous
   agent: kubernetes

--- a/config/prod/prow/k8s-testgrid/k8s-testgrid.yaml
+++ b/config/prod/prow/k8s-testgrid/k8s-testgrid.yaml
@@ -70,6 +70,7 @@ dashboards:
 - name: kperf
 - name: net-certmanager
 - name: net-contour
+- name: net-gateway-api
 - name: net-http01
 - name: net-istio
 - name: net-kourier
@@ -127,6 +128,7 @@ dashboard_groups:
       - "kperf"
       - "net-certmanager"
       - "net-contour"
+      - "net-gateway-api"
       - "net-http01"
       - "net-istio"
       - "net-kourier"

--- a/config/prod/prow/testgrid/testgrid.yaml
+++ b/config/prod/prow/testgrid/testgrid.yaml
@@ -697,6 +697,14 @@ test_groups:
   alert_options:
     alert_mail_to_addresses: "serverless-engprod-sea@google.com"
   num_failures_to_alert: 1
+- name: ci-knative-sandbox-net-gateway-api-continuous
+  gcs_prefix: knative-prow/logs/ci-knative-sandbox-net-gateway-api-continuous
+  alert_stale_results_hours: 3
+- name: ci-knative-sandbox-net-gateway-api-nightly-release
+  gcs_prefix: knative-prow/logs/ci-knative-sandbox-net-gateway-api-nightly-release
+  alert_options:
+    alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+  num_failures_to_alert: 1
 - name: ci-knative-sandbox-net-http01-continuous
   gcs_prefix: knative-prow/logs/ci-knative-sandbox-net-http01-continuous
   alert_stale_results_hours: 3
@@ -1458,6 +1466,8 @@ test_groups:
   short_text_metric: "coverage"
 - name: ci-knative-sandbox-net-contour-continuous-beta-prow-tests
   gcs_prefix: knative-prow/logs/ci-knative-sandbox-net-contour-continuous-beta-prow-tests
+- name: ci-knative-sandbox-net-gateway-api-continuous-beta-prow-tests
+  gcs_prefix: knative-prow/logs/ci-knative-sandbox-net-gateway-api-continuous-beta-prow-tests
 - name: ci-knative-sandbox-net-http01-continuous-beta-prow-tests
   gcs_prefix: knative-prow/logs/ci-knative-sandbox-net-http01-continuous-beta-prow-tests
 - name: ci-knative-sandbox-net-istio-continuous-beta-prow-tests
@@ -2162,6 +2172,20 @@ dashboards:
     num_failures_to_alert: 1
   - name: auto-release
     test_group_name: ci-knative-sandbox-net-contour-auto-release
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 1
+- name: net-gateway-api
+  dashboard_tab:
+  - name: continuous
+    test_group_name: ci-knative-sandbox-net-gateway-api-continuous
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
+  - name: nightly
+    test_group_name: ci-knative-sandbox-net-gateway-api-nightly-release
     base_options: "sort-by-name="
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
@@ -3428,6 +3452,9 @@ dashboards:
   - name: ci-knative-sandbox-net-contour-continuous
     test_group_name: ci-knative-sandbox-net-contour-continuous-beta-prow-tests
     base_options: "sort-by-failures="
+  - name: ci-knative-sandbox-net-gateway-api-continuous
+    test_group_name: ci-knative-sandbox-net-gateway-api-continuous-beta-prow-tests
+    base_options: "sort-by-failures="
   - name: ci-knative-sandbox-net-http01-continuous
     test_group_name: ci-knative-sandbox-net-http01-continuous-beta-prow-tests
     base_options: "sort-by-failures="
@@ -3565,6 +3592,7 @@ dashboard_groups:
   - "sample-source"
   - "net-certmanager"
   - "net-contour"
+  - "net-gateway-api"
   - "net-http01"
   - "net-istio"
   - "net-kourier"

--- a/config/prod/prow/testgrid/testgrid.yaml
+++ b/config/prod/prow/testgrid/testgrid.yaml
@@ -705,6 +705,11 @@ test_groups:
   alert_options:
     alert_mail_to_addresses: "serverless-engprod-sea@google.com"
   num_failures_to_alert: 1
+- name: ci-knative-sandbox-net-gateway-api-auto-release
+  gcs_prefix: knative-prow/logs/ci-knative-sandbox-net-gateway-api-auto-release
+  alert_options:
+    alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+  num_failures_to_alert: 1
 - name: ci-knative-sandbox-net-http01-continuous
   gcs_prefix: knative-prow/logs/ci-knative-sandbox-net-http01-continuous
   alert_stale_results_hours: 3
@@ -2186,6 +2191,12 @@ dashboards:
     num_failures_to_alert: 3
   - name: nightly
     test_group_name: ci-knative-sandbox-net-gateway-api-nightly-release
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 1
+  - name: auto-release
+    test_group_name: ci-knative-sandbox-net-gateway-api-auto-release
     base_options: "sort-by-name="
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"


### PR DESCRIPTION
This patch adds continuous, nigthly, auto-released and test-grid for gateway-api.

/cc @chizhg @markusthoemmes @dprotaso 