### PR TITLE
Add net-gateway-api job to serving CI

### DIFF
--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -218,6 +218,18 @@ presubmits:
         memory: 12Gi
       limits:
         memory: 16Gi
+  - custom-test: gateway-api-latest
+    needs-monitor: true
+    always-run: false
+    run-if-changed: ^third_party/gateway-api-latest/*
+    args:
+    - --run-test
+    - ./test/e2e-tests.sh --gateway-api-version latest
+    resources:
+      requests:
+        memory: 12Gi
+      limits:
+        memory: 16Gi
   - custom-test: https
     always-run: false
     run-if-changed: ^third_party/cert-manager-latest/*
@@ -668,6 +680,12 @@ periodics:
     - ./test/e2e-tests.sh --contour-version latest
     - --run-test
     - ./test/e2e-auto-tls-tests.sh --contour-version latest --run-http01-auto-tls-tests
+  - custom-job: gateway-api-latest
+    command:
+    - ./test/presubmit-tests.sh
+    args:
+    - --run-test
+    - ./test/e2e-tests.sh --gateway-api-version latest
   - custom-job: https
     command:
     - ./test/presubmit-tests.sh

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -825,6 +825,49 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
+  - name: pull-knative-serving-gateway-api-latest
+    agent: kubernetes
+    labels:
+      prow.k8s.io/pubsub.project: knative-tests
+      prow.k8s.io/pubsub.topic: knative-monitoring
+      prow.k8s.io/pubsub.runID: pull-knative-serving-gateway-api-latest
+    context: pull-knative-serving-gateway-api-latest
+    always_run: false
+    optional: false
+    run_if_changed: "^third_party/gateway-api-latest/*"
+    rerun_command: "/test pull-knative-serving-gateway-api-latest"
+    trigger: "(?m)^/test (all|pull-knative-serving-gateway-api-latest),?(\\s+|$)"
+    decorate: true
+    path_alias: knative.dev/serving
+    cluster: "build-knative"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-tests.sh --gateway-api-version latest"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+        resources:
+          requests:
+            memory: 12Gi
+          limits:
+            memory: 16Gi
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
   - name: pull-knative-serving-https
     agent: kubernetes
     context: pull-knative-serving-https
@@ -7036,6 +7079,45 @@ periodics:
       - "./test/e2e-tests.sh --contour-version latest"
       - "--run-test"
       - "./test/e2e-auto-tls-tests.sh --contour-version latest --run-http01-auto-tls-tests"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
+- cron: "32 */3 * * *"
+  name: ci-knative-serving-gateway-api-latest
+  agent: kubernetes
+  decorate: true
+  decoration_config:
+    timeout: 120m
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative
+    repo: serving
+    path_alias: knative.dev/serving
+    base_ref: main
+  annotations:
+    testgrid-dashboards: serving
+    testgrid-tab-name: gateway-api-latest
+    testgrid-alert-stale-results-hours: "3"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./test/presubmit-tests.sh"
+      - "--run-test"
+      - "./test/e2e-tests.sh --gateway-api-version latest"
       volumeMounts:
       - name: test-account
         mountPath: /etc/test-account

--- a/config/prod/prow/testgrid/testgrid.yaml
+++ b/config/prod/prow/testgrid/testgrid.yaml
@@ -82,6 +82,9 @@ test_groups:
 - name: ci-knative-serving-contour-latest
   gcs_prefix: knative-prow/logs/ci-knative-serving-contour-latest
   alert_stale_results_hours: 3
+- name: ci-knative-serving-gateway-api-latest
+  gcs_prefix: knative-prow/logs/ci-knative-serving-gateway-api-latest
+  alert_stale_results_hours: 3
 - name: ci-knative-serving-https
   gcs_prefix: knative-prow/logs/ci-knative-serving-https
   alert_stale_results_hours: 3
@@ -1616,6 +1619,9 @@ dashboards:
     base_options: "sort-by-name="
   - name: contour-latest
     test_group_name: ci-knative-serving-contour-latest
+    base_options: "sort-by-name="
+  - name: gateway-api-latest
+    test_group_name: ci-knative-serving-gateway-api-latest
     base_options: "sort-by-name="
   - name: https
     test_group_name: ci-knative-serving-https

--- a/pkg/testgrid/testgrid.go
+++ b/pkg/testgrid/testgrid.go
@@ -34,6 +34,7 @@ var jobNameTestgridURLMap = map[string]string{
 	"ci-knative-serving-istio-stable-no-mesh": "serving#istio-stable-no-mesh",
 	"ci-knative-serving-kourier-stable":       "serving#kourier-stable",
 	"ci-knative-serving-contour-latest":       "serving#contour-latest",
+	"ci-knative-serving-gateway-api-latest":   "serving#gateway-api-latest",
 }
 
 // GetTestgridTabURL gets Testgrid URL for giving job and filters for Testgrid


### PR DESCRIPTION
This patch adds a job:
- to run gateway-api test by `/test pull-knative-serving-gateway-api-latest`
- to run automatically when `third_party/gateway-api-latest/` was changed.

`tls` is not added as net-gateway-api does not support it yet.

/cc @chizhg @markusthoemmes 

