### PR TITLE
Update s390x custom-jobs to release-1.0 and 1.1

### DIFF
--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -617,7 +617,7 @@ periodics:
     external_cluster:
       secret: s390x-cluster1
   - custom-job: s390x-kourier-tests
-    release: "0.23"
+    release: "1.0"
     cron: 0 15 * * *
     command:
     - bash
@@ -636,7 +636,7 @@ periodics:
     external_cluster:
       secret: s390x-cluster1
   - custom-job: s390x-kourier-tests
-    release: "0.24"
+    release: "1.1"
     cron: 0 4 * * *
     command:
     - bash
@@ -711,7 +711,7 @@ periodics:
     external_cluster:
       secret: s390x-cluster1
   - custom-job: s390x-contour-tests
-    release: "0.23"
+    release: "1.0"
     cron: 0 21 * * *
     command:
     - bash
@@ -730,7 +730,7 @@ periodics:
     external_cluster:
       secret: s390x-cluster1
   - custom-job: s390x-contour-tests
-    release: "0.24"
+    release: "1.1"
     cron: 0 12 * * *
     command:
     - bash
@@ -872,7 +872,7 @@ periodics:
     external_cluster:
       secret: s390x-cluster1
   - custom-job: s390x-e2e-tests
-    release: "0.23"
+    release: "1.0"
     cron: 0 23 * * *
     command:
     - bash
@@ -889,7 +889,7 @@ periodics:
     external_cluster:
       secret: s390x-cluster1
   - custom-job: s390x-e2e-tests
-    release: "0.24"
+    release: "1.1"
     cron: 0 10 * * *
     command:
     - bash
@@ -1070,7 +1070,7 @@ periodics:
     external_cluster:
       secret: s390x-cluster1
   - custom-job: s390x-e2e-tests
-    release: "0.23"
+    release: "1.0"
     cron: 0 19 * * *
     command:
     - bash
@@ -1088,7 +1088,7 @@ periodics:
     external_cluster:
       secret: s390x-cluster1
   - custom-job: s390x-e2e-tests
-    release: "0.24"
+    release: "1.1"
     cron: 0 6 * * *
     command:
     - bash
@@ -1556,7 +1556,7 @@ periodics:
     external_cluster:
       secret: s390x-cluster1
   - custom-job: s390x-e2e-tests
-    release: "0.23"
+    release: "1.0"
     cron: 0 17 * * *
     command:
     - bash
@@ -1573,7 +1573,7 @@ periodics:
     external_cluster:
       secret: s390x-cluster1
   - custom-job: s390x-e2e-tests
-    release: "0.24"
+    release: "1.1"
     cron: 0 8 * * *
     command:
     - bash

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -6870,7 +6870,7 @@ periodics:
       secret:
         secretName: test-account
 - cron: "0 15 * * *"
-  name: ci-knative-serving-0.23-s390x-kourier-tests
+  name: ci-knative-serving-1.0-s390x-kourier-tests
   agent: kubernetes
   decorate: true
   decoration_config:
@@ -6880,9 +6880,9 @@ periodics:
   - org: knative
     repo: serving
     path_alias: knative.dev/serving
-    base_ref: release-0.23
+    base_ref: release-1.0
   annotations:
-    testgrid-dashboards: knative-0.23
+    testgrid-dashboards: knative-1.0
     testgrid-tab-name: serving-s390x-kourier-tests
     testgrid-alert-stale-results-hours: "3"
   spec:
@@ -6929,7 +6929,7 @@ periodics:
       - name: E2E_CLUSTER_REGION
         value: us-central1
       - name: PULL_BASE_REF
-        value: release-0.23
+        value: release-1.0
     volumes:
     - name: s390x-cluster1
       secret:
@@ -6939,7 +6939,7 @@ periodics:
       secret:
         secretName: test-account
 - cron: "0 4 * * *"
-  name: ci-knative-serving-0.24-s390x-kourier-tests
+  name: ci-knative-serving-1.1-s390x-kourier-tests
   agent: kubernetes
   decorate: true
   decoration_config:
@@ -6949,9 +6949,9 @@ periodics:
   - org: knative
     repo: serving
     path_alias: knative.dev/serving
-    base_ref: release-0.24
+    base_ref: release-1.1
   annotations:
-    testgrid-dashboards: knative-0.24
+    testgrid-dashboards: knative-1.1
     testgrid-tab-name: serving-s390x-kourier-tests
     testgrid-alert-stale-results-hours: "3"
   spec:
@@ -6998,7 +6998,7 @@ periodics:
       - name: E2E_CLUSTER_REGION
         value: us-central1
       - name: PULL_BASE_REF
-        value: release-0.24
+        value: release-1.1
     volumes:
     - name: s390x-cluster1
       secret:
@@ -7213,7 +7213,7 @@ periodics:
       secret:
         secretName: test-account
 - cron: "0 21 * * *"
-  name: ci-knative-serving-0.23-s390x-contour-tests
+  name: ci-knative-serving-1.0-s390x-contour-tests
   agent: kubernetes
   decorate: true
   decoration_config:
@@ -7223,9 +7223,9 @@ periodics:
   - org: knative
     repo: serving
     path_alias: knative.dev/serving
-    base_ref: release-0.23
+    base_ref: release-1.0
   annotations:
-    testgrid-dashboards: knative-0.23
+    testgrid-dashboards: knative-1.0
     testgrid-tab-name: serving-s390x-contour-tests
     testgrid-alert-stale-results-hours: "3"
   spec:
@@ -7272,7 +7272,7 @@ periodics:
       - name: E2E_CLUSTER_REGION
         value: us-central1
       - name: PULL_BASE_REF
-        value: release-0.23
+        value: release-1.0
     volumes:
     - name: s390x-cluster1
       secret:
@@ -7282,7 +7282,7 @@ periodics:
       secret:
         secretName: test-account
 - cron: "0 12 * * *"
-  name: ci-knative-serving-0.24-s390x-contour-tests
+  name: ci-knative-serving-1.1-s390x-contour-tests
   agent: kubernetes
   decorate: true
   decoration_config:
@@ -7292,9 +7292,9 @@ periodics:
   - org: knative
     repo: serving
     path_alias: knative.dev/serving
-    base_ref: release-0.24
+    base_ref: release-1.1
   annotations:
-    testgrid-dashboards: knative-0.24
+    testgrid-dashboards: knative-1.1
     testgrid-tab-name: serving-s390x-contour-tests
     testgrid-alert-stale-results-hours: "3"
   spec:
@@ -7341,7 +7341,7 @@ periodics:
       - name: E2E_CLUSTER_REGION
         value: us-central1
       - name: PULL_BASE_REF
-        value: release-0.24
+        value: release-1.1
     volumes:
     - name: s390x-cluster1
       secret:
@@ -8803,7 +8803,7 @@ periodics:
       secret:
         secretName: test-account
 - cron: "0 23 * * *"
-  name: ci-knative-client-0.23-s390x-e2e-tests
+  name: ci-knative-client-1.0-s390x-e2e-tests
   agent: kubernetes
   decorate: true
   decoration_config:
@@ -8813,9 +8813,9 @@ periodics:
   - org: knative
     repo: client
     path_alias: knative.dev/client
-    base_ref: release-0.23
+    base_ref: release-1.0
   annotations:
-    testgrid-dashboards: knative-0.23
+    testgrid-dashboards: knative-1.0
     testgrid-tab-name: client-s390x-e2e-tests
     testgrid-alert-stale-results-hours: "3"
   spec:
@@ -8858,7 +8858,7 @@ periodics:
       - name: E2E_CLUSTER_REGION
         value: us-central1
       - name: PULL_BASE_REF
-        value: release-0.23
+        value: release-1.0
     volumes:
     - name: s390x-cluster1
       secret:
@@ -8868,7 +8868,7 @@ periodics:
       secret:
         secretName: test-account
 - cron: "0 10 * * *"
-  name: ci-knative-client-0.24-s390x-e2e-tests
+  name: ci-knative-client-1.1-s390x-e2e-tests
   agent: kubernetes
   decorate: true
   decoration_config:
@@ -8878,9 +8878,9 @@ periodics:
   - org: knative
     repo: client
     path_alias: knative.dev/client
-    base_ref: release-0.24
+    base_ref: release-1.1
   annotations:
-    testgrid-dashboards: knative-0.24
+    testgrid-dashboards: knative-1.1
     testgrid-tab-name: client-s390x-e2e-tests
     testgrid-alert-stale-results-hours: "3"
   spec:
@@ -8923,7 +8923,7 @@ periodics:
       - name: E2E_CLUSTER_REGION
         value: us-central1
       - name: PULL_BASE_REF
-        value: release-0.24
+        value: release-1.1
     volumes:
     - name: s390x-cluster1
       secret:
@@ -12244,7 +12244,7 @@ periodics:
       secret:
         secretName: test-account
 - cron: "0 19 * * *"
-  name: ci-knative-eventing-0.23-s390x-e2e-tests
+  name: ci-knative-eventing-1.0-s390x-e2e-tests
   agent: kubernetes
   decorate: true
   decoration_config:
@@ -12254,9 +12254,9 @@ periodics:
   - org: knative
     repo: eventing
     path_alias: knative.dev/eventing
-    base_ref: release-0.23
+    base_ref: release-1.0
   annotations:
-    testgrid-dashboards: knative-0.23
+    testgrid-dashboards: knative-1.0
     testgrid-tab-name: eventing-s390x-e2e-tests
     testgrid-alert-stale-results-hours: "3"
   spec:
@@ -12301,7 +12301,7 @@ periodics:
       - name: E2E_CLUSTER_REGION
         value: us-central1
       - name: PULL_BASE_REF
-        value: release-0.23
+        value: release-1.0
     volumes:
     - name: s390x-cluster1
       secret:
@@ -12311,7 +12311,7 @@ periodics:
       secret:
         secretName: test-account
 - cron: "0 6 * * *"
-  name: ci-knative-eventing-0.24-s390x-e2e-tests
+  name: ci-knative-eventing-1.1-s390x-e2e-tests
   agent: kubernetes
   decorate: true
   decoration_config:
@@ -12321,9 +12321,9 @@ periodics:
   - org: knative
     repo: eventing
     path_alias: knative.dev/eventing
-    base_ref: release-0.24
+    base_ref: release-1.1
   annotations:
-    testgrid-dashboards: knative-0.24
+    testgrid-dashboards: knative-1.1
     testgrid-tab-name: eventing-s390x-e2e-tests
     testgrid-alert-stale-results-hours: "3"
   spec:
@@ -12368,7 +12368,7 @@ periodics:
       - name: E2E_CLUSTER_REGION
         value: us-central1
       - name: PULL_BASE_REF
-        value: release-0.24
+        value: release-1.1
     volumes:
     - name: s390x-cluster1
       secret:
@@ -20089,7 +20089,7 @@ periodics:
       secret:
         secretName: test-account
 - cron: "0 17 * * *"
-  name: ci-knative-operator-0.23-s390x-e2e-tests
+  name: ci-knative-operator-1.0-s390x-e2e-tests
   agent: kubernetes
   decorate: true
   decoration_config:
@@ -20099,9 +20099,9 @@ periodics:
   - org: knative
     repo: operator
     path_alias: knative.dev/operator
-    base_ref: release-0.23
+    base_ref: release-1.0
   annotations:
-    testgrid-dashboards: knative-0.23
+    testgrid-dashboards: knative-1.0
     testgrid-tab-name: operator-s390x-e2e-tests
     testgrid-alert-stale-results-hours: "3"
   spec:
@@ -20144,7 +20144,7 @@ periodics:
       - name: E2E_CLUSTER_REGION
         value: us-central1
       - name: PULL_BASE_REF
-        value: release-0.23
+        value: release-1.0
     volumes:
     - name: s390x-cluster1
       secret:
@@ -20154,7 +20154,7 @@ periodics:
       secret:
         secretName: test-account
 - cron: "0 8 * * *"
-  name: ci-knative-operator-0.24-s390x-e2e-tests
+  name: ci-knative-operator-1.1-s390x-e2e-tests
   agent: kubernetes
   decorate: true
   decoration_config:
@@ -20164,9 +20164,9 @@ periodics:
   - org: knative
     repo: operator
     path_alias: knative.dev/operator
-    base_ref: release-0.24
+    base_ref: release-1.1
   annotations:
-    testgrid-dashboards: knative-0.24
+    testgrid-dashboards: knative-1.1
     testgrid-tab-name: operator-s390x-e2e-tests
     testgrid-alert-stale-results-hours: "3"
   spec:
@@ -20209,7 +20209,7 @@ periodics:
       - name: E2E_CLUSTER_REGION
         value: us-central1
       - name: PULL_BASE_REF
-        value: release-0.24
+        value: release-1.1
     volumes:
     - name: s390x-cluster1
       secret:

--- a/config/prod/prow/k8s-testgrid/k8s-testgrid.yaml
+++ b/config/prod/prow/k8s-testgrid/k8s-testgrid.yaml
@@ -57,8 +57,6 @@ dashboards:
 - name: kn-plugin-service-log
 - name: kn-plugin-source-kafka
 - name: kn-plugin-source-kamelet
-- name: knative-0.23
-- name: knative-0.24
 - name: knative-0.25
 - name: knative-0.26
 - name: knative-1.0

--- a/config/prod/prow/testgrid/testgrid.yaml
+++ b/config/prod/prow/testgrid/testgrid.yaml
@@ -312,6 +312,12 @@ test_groups:
   alert_options:
     alert_mail_to_addresses: "serverless-engprod-sea@google.com"
   num_failures_to_alert: 3
+- name: ci-knative-serving-1.0-s390x-kourier-tests
+  gcs_prefix: knative-prow/logs/ci-knative-serving-1.0-s390x-kourier-tests
+  alert_stale_results_hours: 3
+- name: ci-knative-serving-1.0-s390x-contour-tests
+  gcs_prefix: knative-prow/logs/ci-knative-serving-1.0-s390x-contour-tests
+  alert_stale_results_hours: 3
 - name: ci-knative-serving-1.0-dot-release
   gcs_prefix: knative-prow/logs/ci-knative-serving-1.0-dot-release
   alert_options:
@@ -329,6 +335,9 @@ test_groups:
     alert_mail_to_addresses: "serverless-engprod-sea@google.com"
   alert_stale_results_hours: 170
   num_failures_to_alert: 1
+- name: ci-knative-client-1.0-s390x-e2e-tests
+  gcs_prefix: knative-prow/logs/ci-knative-client-1.0-s390x-e2e-tests
+  alert_stale_results_hours: 3
 - name: ci-knative-eventing-1.0-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-1.0-continuous
   alert_options:
@@ -340,6 +349,9 @@ test_groups:
     alert_mail_to_addresses: "serverless-engprod-sea@google.com"
   alert_stale_results_hours: 170
   num_failures_to_alert: 1
+- name: ci-knative-eventing-1.0-s390x-e2e-tests
+  gcs_prefix: knative-prow/logs/ci-knative-eventing-1.0-s390x-e2e-tests
+  alert_stale_results_hours: 3
 - name: ci-knative-operator-1.0-continuous
   gcs_prefix: knative-prow/logs/ci-knative-operator-1.0-continuous
   alert_options:
@@ -351,11 +363,20 @@ test_groups:
     alert_mail_to_addresses: "serverless-engprod-sea@google.com"
   alert_stale_results_hours: 170
   num_failures_to_alert: 1
+- name: ci-knative-operator-1.0-s390x-e2e-tests
+  gcs_prefix: knative-prow/logs/ci-knative-operator-1.0-s390x-e2e-tests
+  alert_stale_results_hours: 3
 - name: ci-knative-serving-1.1-continuous
   gcs_prefix: knative-prow/logs/ci-knative-serving-1.1-continuous
   alert_options:
     alert_mail_to_addresses: "serverless-engprod-sea@google.com"
   num_failures_to_alert: 3
+- name: ci-knative-serving-1.1-s390x-kourier-tests
+  gcs_prefix: knative-prow/logs/ci-knative-serving-1.1-s390x-kourier-tests
+  alert_stale_results_hours: 3
+- name: ci-knative-serving-1.1-s390x-contour-tests
+  gcs_prefix: knative-prow/logs/ci-knative-serving-1.1-s390x-contour-tests
+  alert_stale_results_hours: 3
 - name: ci-knative-serving-1.1-dot-release
   gcs_prefix: knative-prow/logs/ci-knative-serving-1.1-dot-release
   alert_options:
@@ -373,6 +394,9 @@ test_groups:
     alert_mail_to_addresses: "serverless-engprod-sea@google.com"
   alert_stale_results_hours: 170
   num_failures_to_alert: 1
+- name: ci-knative-client-1.1-s390x-e2e-tests
+  gcs_prefix: knative-prow/logs/ci-knative-client-1.1-s390x-e2e-tests
+  alert_stale_results_hours: 3
 - name: ci-knative-eventing-1.1-continuous
   gcs_prefix: knative-prow/logs/ci-knative-eventing-1.1-continuous
   alert_options:
@@ -384,6 +408,9 @@ test_groups:
     alert_mail_to_addresses: "serverless-engprod-sea@google.com"
   alert_stale_results_hours: 170
   num_failures_to_alert: 1
+- name: ci-knative-eventing-1.1-s390x-e2e-tests
+  gcs_prefix: knative-prow/logs/ci-knative-eventing-1.1-s390x-e2e-tests
+  alert_stale_results_hours: 3
 - name: ci-knative-operator-1.1-continuous
   gcs_prefix: knative-prow/logs/ci-knative-operator-1.1-continuous
   alert_options:
@@ -395,35 +422,8 @@ test_groups:
     alert_mail_to_addresses: "serverless-engprod-sea@google.com"
   alert_stale_results_hours: 170
   num_failures_to_alert: 1
-- name: ci-knative-serving-0.23-s390x-kourier-tests
-  gcs_prefix: knative-prow/logs/ci-knative-serving-0.23-s390x-kourier-tests
-  alert_stale_results_hours: 3
-- name: ci-knative-serving-0.23-s390x-contour-tests
-  gcs_prefix: knative-prow/logs/ci-knative-serving-0.23-s390x-contour-tests
-  alert_stale_results_hours: 3
-- name: ci-knative-client-0.23-s390x-e2e-tests
-  gcs_prefix: knative-prow/logs/ci-knative-client-0.23-s390x-e2e-tests
-  alert_stale_results_hours: 3
-- name: ci-knative-eventing-0.23-s390x-e2e-tests
-  gcs_prefix: knative-prow/logs/ci-knative-eventing-0.23-s390x-e2e-tests
-  alert_stale_results_hours: 3
-- name: ci-knative-operator-0.23-s390x-e2e-tests
-  gcs_prefix: knative-prow/logs/ci-knative-operator-0.23-s390x-e2e-tests
-  alert_stale_results_hours: 3
-- name: ci-knative-serving-0.24-s390x-kourier-tests
-  gcs_prefix: knative-prow/logs/ci-knative-serving-0.24-s390x-kourier-tests
-  alert_stale_results_hours: 3
-- name: ci-knative-serving-0.24-s390x-contour-tests
-  gcs_prefix: knative-prow/logs/ci-knative-serving-0.24-s390x-contour-tests
-  alert_stale_results_hours: 3
-- name: ci-knative-client-0.24-s390x-e2e-tests
-  gcs_prefix: knative-prow/logs/ci-knative-client-0.24-s390x-e2e-tests
-  alert_stale_results_hours: 3
-- name: ci-knative-eventing-0.24-s390x-e2e-tests
-  gcs_prefix: knative-prow/logs/ci-knative-eventing-0.24-s390x-e2e-tests
-  alert_stale_results_hours: 3
-- name: ci-knative-operator-0.24-s390x-e2e-tests
-  gcs_prefix: knative-prow/logs/ci-knative-operator-0.24-s390x-e2e-tests
+- name: ci-knative-operator-1.1-s390x-e2e-tests
+  gcs_prefix: knative-prow/logs/ci-knative-operator-1.1-s390x-e2e-tests
   alert_stale_results_hours: 3
 - name: ci-knative-sandbox-kn-plugin-diag-continuous
   gcs_prefix: knative-prow/logs/ci-knative-sandbox-kn-plugin-diag-continuous
@@ -2718,6 +2718,18 @@ dashboards:
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
     num_failures_to_alert: 3
+  - name: serving-s390x-kourier-tests
+    test_group_name: ci-knative-serving-1.0-s390x-kourier-tests
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
+  - name: serving-s390x-contour-tests
+    test_group_name: ci-knative-serving-1.0-s390x-contour-tests
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
   - name: serving-dot-release
     test_group_name: ci-knative-serving-1.0-dot-release
     base_options: "sort-by-name="
@@ -2736,6 +2748,12 @@ dashboards:
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
     num_failures_to_alert: 3
+  - name: client-s390x-e2e-tests
+    test_group_name: ci-knative-client-1.0-s390x-e2e-tests
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
   - name: eventing-continuous
     test_group_name: ci-knative-eventing-1.0-continuous
     base_options: "sort-by-name="
@@ -2744,6 +2762,12 @@ dashboards:
     num_failures_to_alert: 3
   - name: eventing-dot-release
     test_group_name: ci-knative-eventing-1.0-dot-release
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
+  - name: eventing-s390x-e2e-tests
+    test_group_name: ci-knative-eventing-1.0-s390x-e2e-tests
     base_options: "sort-by-name="
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
@@ -2760,10 +2784,28 @@ dashboards:
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
     num_failures_to_alert: 3
+  - name: operator-s390x-e2e-tests
+    test_group_name: ci-knative-operator-1.0-s390x-e2e-tests
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
 - name: knative-1.1
   dashboard_tab:
   - name: serving-continuous
     test_group_name: ci-knative-serving-1.1-continuous
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
+  - name: serving-s390x-kourier-tests
+    test_group_name: ci-knative-serving-1.1-s390x-kourier-tests
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
+  - name: serving-s390x-contour-tests
+    test_group_name: ci-knative-serving-1.1-s390x-contour-tests
     base_options: "sort-by-name="
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
@@ -2786,6 +2828,12 @@ dashboards:
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
     num_failures_to_alert: 3
+  - name: client-s390x-e2e-tests
+    test_group_name: ci-knative-client-1.1-s390x-e2e-tests
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
   - name: eventing-continuous
     test_group_name: ci-knative-eventing-1.1-continuous
     base_options: "sort-by-name="
@@ -2794,6 +2842,12 @@ dashboards:
     num_failures_to_alert: 3
   - name: eventing-dot-release
     test_group_name: ci-knative-eventing-1.1-dot-release
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
+  - name: eventing-s390x-e2e-tests
+    test_group_name: ci-knative-eventing-1.1-s390x-e2e-tests
     base_options: "sort-by-name="
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
@@ -2810,66 +2864,8 @@ dashboards:
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
     num_failures_to_alert: 3
-- name: knative-0.23
-  dashboard_tab:
-  - name: serving-s390x-kourier-tests
-    test_group_name: ci-knative-serving-0.23-s390x-kourier-tests
-    base_options: "sort-by-name="
-    alert_options:
-      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
-    num_failures_to_alert: 3
-  - name: serving-s390x-contour-tests
-    test_group_name: ci-knative-serving-0.23-s390x-contour-tests
-    base_options: "sort-by-name="
-    alert_options:
-      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
-    num_failures_to_alert: 3
-  - name: client-s390x-e2e-tests
-    test_group_name: ci-knative-client-0.23-s390x-e2e-tests
-    base_options: "sort-by-name="
-    alert_options:
-      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
-    num_failures_to_alert: 3
-  - name: eventing-s390x-e2e-tests
-    test_group_name: ci-knative-eventing-0.23-s390x-e2e-tests
-    base_options: "sort-by-name="
-    alert_options:
-      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
-    num_failures_to_alert: 3
   - name: operator-s390x-e2e-tests
-    test_group_name: ci-knative-operator-0.23-s390x-e2e-tests
-    base_options: "sort-by-name="
-    alert_options:
-      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
-    num_failures_to_alert: 3
-- name: knative-0.24
-  dashboard_tab:
-  - name: serving-s390x-kourier-tests
-    test_group_name: ci-knative-serving-0.24-s390x-kourier-tests
-    base_options: "sort-by-name="
-    alert_options:
-      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
-    num_failures_to_alert: 3
-  - name: serving-s390x-contour-tests
-    test_group_name: ci-knative-serving-0.24-s390x-contour-tests
-    base_options: "sort-by-name="
-    alert_options:
-      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
-    num_failures_to_alert: 3
-  - name: client-s390x-e2e-tests
-    test_group_name: ci-knative-client-0.24-s390x-e2e-tests
-    base_options: "sort-by-name="
-    alert_options:
-      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
-    num_failures_to_alert: 3
-  - name: eventing-s390x-e2e-tests
-    test_group_name: ci-knative-eventing-0.24-s390x-e2e-tests
-    base_options: "sort-by-name="
-    alert_options:
-      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
-    num_failures_to_alert: 3
-  - name: operator-s390x-e2e-tests
-    test_group_name: ci-knative-operator-0.24-s390x-e2e-tests
+    test_group_name: ci-knative-operator-1.1-s390x-e2e-tests
     base_options: "sort-by-name="
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
This PR is to update the existing 10 custom jobs for s390x from release-0.23 and 0.24 to 1.0 and 1.1, respectively. This functions as an indicator of how the corresponding release of the downstream product works on Z.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #

**Special notes to reviewers**:

**User-visible changes in this PR**:

