### PR TITLE
Add reconciler-tests job for eventing-kafka-broker

### DIFF
--- a/config/prod/prow/config_knative.yaml
+++ b/config/prod/prow/config_knative.yaml
@@ -493,7 +493,12 @@ presubmits:
     needs-dind: true
     args:
     - --run-test
-    - ./test/e2e-upgrade-tests.sh
+    - ./test/upgrade-tests.sh
+  - custom-test: reconciler-tests
+    needs-dind: true
+    args:
+      - --run-test
+      - ./test/reconciler-tests.sh
   - go-coverage: true
   knative-sandbox/eventing-rabbitmq:
   - build-tests: false

--- a/config/prod/prow/jobs/config.yaml
+++ b/config/prod/prow/jobs/config.yaml
@@ -5530,7 +5530,60 @@ presubmits:
         args:
         - "./test/presubmit-tests.sh"
         - "--run-test"
-        - "./test/e2e-upgrade-tests.sh"
+        - "./test/upgrade-tests.sh"
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: docker-graph
+          mountPath: /docker-graph
+        - name: modules
+          mountPath: /lib/modules
+        - name: cgroup
+          mountPath: /sys/fs/cgroup
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: "true"
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: docker-graph
+        emptyDir: {}
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-sandbox-eventing-kafka-broker-reconciler-tests
+    agent: kubernetes
+    context: pull-knative-sandbox-eventing-kafka-broker-reconciler-tests
+    always_run: true
+    optional: false
+    rerun_command: "/test pull-knative-sandbox-eventing-kafka-broker-reconciler-tests"
+    trigger: "(?m)^/test (all|pull-knative-sandbox-eventing-kafka-broker-reconciler-tests),?(\\s+|$)"
+    decorate: true
+    path_alias: knative.dev/eventing-kafka-broker
+    cluster: "build-knative"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/reconciler-tests.sh"
         securityContext:
           privileged: true
         volumeMounts:


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:

The E2E tests job takes ~1h to complete since we execute tests
for every Kafka component (Broker, Sink, Source, and soon Channel).
Splitting the execution of these tests in multiple jobs will reduce the time to merge
a PR or getting CI feedback on a PR.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:

Part of https://github.com/knative-sandbox/eventing-kafka-broker/issues/1677


