### PR TITLE
Install the cred helper properly

### DIFF
--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -15,7 +15,7 @@
 FROM gcr.io/k8s-testimages/kubekins-e2e:v20210113-cc576af-master AS stable-stuff
 
 ENV DEBIAN_FRONTEND noninteractive
-ARG GCLOUD_VERSION=317.0.0
+ARG GCLOUD_VERSION=368.0.0
 ARG KUBECTL_VERSION=v1.21.4
 
 # If we don't run update, the apt-get install below don't work
@@ -30,8 +30,7 @@ RUN rm -f "$(which kubectl)" && \
     chmod +x /usr/local/bin/kubectl
 
 # Docker
-RUN gcloud components install docker-credential-gcr
-RUN docker-credential-gcr configure-docker
+RUN gcloud auth configure-docker -q
 
 # Extra tools through apt-get
 RUN apt-get install -y uuid-runtime   # for uuidgen

--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -30,7 +30,8 @@ RUN rm -f "$(which kubectl)" && \
     chmod +x /usr/local/bin/kubectl
 
 # Docker
-RUN gcloud auth configure-docker -q
+RUN gcloud components install docker-credential-gcr
+RUN docker-credential-gcr configure-docker --registries=gcr.io,us-docker.pkg.dev
 
 # Extra tools through apt-get
 RUN apt-get install -y uuid-runtime   # for uuidgen

--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -30,7 +30,7 @@ RUN rm -f "$(which kubectl)" && \
     chmod +x /usr/local/bin/kubectl
 
 # Docker
-RUN gcloud components install docker-credential-gcr
+RUN go get -u github.com/GoogleCloudPlatform/docker-credential-gcr@v2.0.5
 RUN docker-credential-gcr configure-docker --registries=gcr.io,us-docker.pkg.dev
 
 # Extra tools through apt-get


### PR DESCRIPTION
gcloud bundles an old credential helper. The cred helper is installed directly now.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #

**Special notes to reviewers**:

**User-visible changes in this PR**:

