### PR TITLE
Configure Docker-in-Docker for prow-tests image build presubmit job

### DIFF
--- a/config/prod/prow/jobs/custom/test-infra.yaml
+++ b/config/prod/prow/jobs/custom/test-infra.yaml
@@ -91,14 +91,20 @@ presubmits:
         - "-C"
         - "images/prow-tests"
         - "build"
+        securityContext:
+          privileged: true
+        env:
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: "true"
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
         volumeMounts:
         - name: test-account
           mountPath: /etc/test-account
           readOnly: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/test-account/service-account.json
       volumes:
+      - name: docker-graph
+        emptyDir: {}
       - name: test-account
         secret:
           secretName: test-account


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
The job is using `docker` command to build the image, so we need to configure Docker-in-Docker for it.

