### PR TITLE
Use cloudbuild to validate the image build in presubmit

### DIFF
--- a/config/prod/prow/jobs/custom/test-infra.yaml
+++ b/config/prod/prow/jobs/custom/test-infra.yaml
@@ -90,12 +90,8 @@ presubmits:
         - "make"
         - "-C"
         - "images/prow-tests"
-        - "build"
-        securityContext:
-          privileged: true
+        - "build-ci-test"
         env:
-        - name: DOCKER_IN_DOCKER_ENABLED
-          value: "true"
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         volumeMounts:
@@ -103,8 +99,6 @@ presubmits:
           mountPath: /etc/test-account
           readOnly: true
       volumes:
-      - name: docker-graph
-        emptyDir: {}
       - name: test-account
         secret:
           secretName: test-account

--- a/images/prow-tests/cloudbuild-test.yaml
+++ b/images/prow-tests/cloudbuild-test.yaml
@@ -1,4 +1,4 @@
-# Copyright 2019 The Knative Authors
+# Copyright 2022 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,16 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-IMAGE_NAME = prow-tests
-include ../simple-image.mk
-
-push: confirm-main
-	gcloud builds submit --config=./cloudbuild.yaml --substitutions=_TAG=$(TAG),_IMG=$(IMG) \
-		--machine-type=n1-highcpu-8 \
-		--project=$(PROJECT) --timeout=1h ./../..
-
-# Build target for validating prow-tests image build in presubmit.
-build-ci-test:
-	gcloud builds submit --config=./cloudbuild-test.yaml --substitutions=_TAG=$(TAG),_IMG=$(IMG) \
-		--machine-type=n1-highcpu-8 \
-		--project=$(PROJECT) --timeout=1h ./../..
+steps:
+- name: gcr.io/cloud-builders/docker
+  args:
+  - 'build'
+  - '--no-cache'
+  - '--pull'
+  - '-t'
+  - '${_IMG}:${_TAG}'
+  - '-f'
+  - 'images/prow-tests/Dockerfile'
+  - '.'


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
I forgot that we tried building prow-tests image in presubmit before, but it had some issues with memory limit so we dropped it (see https://prow.knative.dev/view/gs/knative-prow/pr-logs/pull/knative_test-infra/2960/pull-knative-test-infra-prow-tests-image-build/1481787082845196288). 

This PR is a workaround to also verify the image build with Google cloud build. We may be able to switch back to `docker build` if https://github.com/knative/test-infra/issues/2957 is done.
