### PR TITLE
Build Prow Image from Scratch

### DIFF
--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -26,11 +26,54 @@ ARG DOCKER_VERSION=5:20.10.9~3-0~debian-buster
 RUN curl -fsSL "https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl && \
     chmod +x /usr/local/bin/kubectl
 
-# Docker including docker-ce, docker-ce-cli,
-RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
-    echo "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list && \
-    apt-get update && \
-    apt-get -y install --no-install-recommends docker-ce="${DOCKER_VERSION}" docker-ce-cli="${DOCKER_VERSION}"
+#
+# BEGIN: DOCKER IN DOCKER SETUP
+#
+
+# Install Docker deps, some of these are already installed in the image but
+# that's fine since they won't re-install and we can reuse the code below
+# for another image someday.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    gnupg2 \
+    software-properties-common \
+    lsb-release && \
+    rm -rf /var/lib/apt/lists/*
+
+# Add the Docker apt-repository
+RUN curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg \
+    | apt-key add - && \
+    add-apt-repository \
+    "deb [arch=amd64] https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") \
+    $(lsb_release -cs) stable"
+
+# Install Docker
+# TODO: the `sed` is a bit of a hack, look into alternatives.
+# Why this exists: `docker service start` on debian runs a `cgroupfs_mount` method,
+# We're already inside docker though so we can be sure these are already mounted.
+# Trying to remount these makes for a very noisy error block in the beginning of
+# the pod logs, so we just comment out the call to it... :shrug:
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends docker-ce="${DOCKER_VERSION}" && \
+    rm -rf /var/lib/apt/lists/* && \
+    sed -i 's/cgroupfs_mount$/#cgroupfs_mount\n/' /etc/init.d/docker \
+    && update-alternatives --set iptables /usr/sbin/iptables-legacy \
+    && update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+
+
+
+# Move Docker's storage location
+RUN echo 'DOCKER_OPTS="${DOCKER_OPTS} --data-root=/docker-graph"' | \
+    tee --append /etc/default/docker
+# NOTE this should be mounted and persisted as a volume ideally (!)
+# We will make a fallback one now just in case
+RUN mkdir /docker-graph
+
+#
+# END: DOCKER IN DOCKER SETUP
+#
 
 # Setup adoptopenjdk
 ARG JAVA_VERSION=16
@@ -54,7 +97,7 @@ RUN java -version && \
 
 # Install go 1.13, 1.14, and 1.15 using https://github.com/moovweb/gvm
 # Missing prerequisite:
-RUN apt-get install -y bison uuid-runtime shellcheck unzip
+RUN apt-get install -y bison uuid-runtime shellcheck unzip wget
 # GVM_NO_UPDATE_PROFILE=true means do not alter /root/.bashrc to automatically source gvm config, so when not using runner.sh, image works normally
 # Install the tool:
 RUN curl -fsSL https://raw.githubusercontent.com/moovweb/gvm/master/binscripts/gvm-installer | GVM_NO_UPDATE_PROFILE=true bash
@@ -80,7 +123,6 @@ RUN curl -fsSL "https://github.com/protocolbuffers/protobuf/releases/download/v$
 
 # Note, it's pointless to run `source-gvm-and-run.sh use go1.13` in this Dockerfile because the PATH changes it makes won't stay in effect
 # We wrap the runner with our own which will run `gvm use $GO_VERSION` for us.
-RUN mv "$(which runner.sh)" "$(dirname "$(which runner.sh)")/kubekins-runner.sh"
 COPY images/prow-tests/runner.sh /usr/local/bin
 
 # Used if you want to install different programs for different versions of Go
@@ -99,15 +141,14 @@ ARG KIND_VERSION=v0.11.1
 ARG KO_VERSION=v0.8.2
 ARG PROTOC_GEN_GO_VERSION=v1.26.0
 ARG PROTOC_GEN_GOGOFASTER_VERSION=v1.3.1
-ARG KIND_VERSION=v0.11.1
 ARG GOTESTSUM_VERSION=v1.7.0
 ARG KAIL_VERSION=v0.15.0
-ARG LICHE_VERSION=v0.0.0-20200229003944-f57a5d1c5be4 
+ARG LICHE_VERSION=v0.0.0-20200229003944-f57a5d1c5be4
 ARG GO_LICENSES_VERSION=v1.0.0
 ARG JUNIT_HELPER=release-0.17
 ARG DOCKER_CREDENTIAL_GCR_VERSION=v2.0.5
 
-# Extra tools through go get
+# Extra tools through go install/get
 # These run using the golang image version of Go, not any defined by `gvm`
 RUN go install github.com/google/ko@${KO_VERSION}
 RUN go get github.com/boz/kail/cmd/kail@${KAIL_VERSION}

--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -83,7 +83,7 @@ RUN apt-get update
 RUN apt-get install -y adoptopenjdk-${JAVA_VERSION}-hotspot
 ENV JAVA_HOME=/usr/lib/jvm/adoptopenjdk-${JAVA_VERSION}-hotspot-amd64
 
-ARG MAVEN_VERSION=3.8.3
+ARG MAVEN_VERSION=3.8.4
 ENV MAVEN_HOME=/usr/local/maven
 ENV M2_HOME=$MAVEN_HOME
 ENV PATH=${M2_HOME}/bin:${PATH}
@@ -175,28 +175,26 @@ RUN go get knative.dev/pkg/testutils/junithelper@${JUNIT_HELPER}
 # Docker
 RUN go install github.com/GoogleCloudPlatform/docker-credential-gcr@${DOCKER_CREDENTIAL_GCR_VERSION}
 
-############################################################
-FROM stable-stuff AS test-infra-builds
-
 # We do this instead of `go get` so the tools are locked to the Dockerfile's commit
 COPY . /go/src/knative.dev/test-infra
 
 # Build custom tools in the container
 
-RUN go install knative.dev/test-infra/tools/coverage
-RUN go install knative.dev/test-infra/kntest/cmd/kntest
+RUN go install knative.dev/test-infra/tools/coverage@latest
+RUN go install knative.dev/test-infra/kntest/cmd/kntest@latest
 
 # TODO(chizhg): maybe also move perf-tests tool to be part of kntest?
-RUN go install knative.dev/test-infra/pkg/clustermanager/perf-tests
+RUN go install knative.dev/test-infra/pkg/clustermanager/perf-tests@latest
 
 ############################################################
 FROM stable-stuff
 
 COPY --from=external-go-gets /go/bin/* /go/bin/
-COPY --from=test-infra-builds /go/bin/* /go/bin/
 
 # Only needed in this Dockerfile
 RUN rm -f /usr/local/bin/source-gvm-and-run.sh
+
+ENV PATH /go/bin:$PATH
 
 # Extract versions
 RUN ko version > /ko_version

--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -12,15 +12,60 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Starting from the gcloud debian image https://github.com/GoogleCloudPlatform/cloud-sdk-docker/blob/master/debian_slim/Dockerfile
-ARG GCLOUD_VERSION=368.0.0
+FROM debian:bullseye-slim AS base
 
-FROM google/cloud-sdk:${GCLOUD_VERSION}-slim AS stable-stuff
+# Pinned versions of stuff we pull in
+ARG CLOUD_SDK_VERSION=368.0.0
+ARG KUBECTL_VERSION=v1.21.4
+ARG DOCKER_VERSION=5:20.10.9~3-0~debian-bullseye
+ARG MAVEN_VERSION=3.8.4
+ARG JAVA_VERSION=16
+ARG PROTOC_VERSION=3.17.0
 
+WORKDIR /workspace
+RUN mkdir -p /workspace
+ENV WORKSPACE=/workspace \
+    TERM=xterm
 ENV DEBIAN_FRONTEND noninteractive
 
-ARG KUBECTL_VERSION=v1.21.4
-ARG DOCKER_VERSION=5:20.10.9~3-0~debian-buster
+#
+# BEGIN: GCLOUD SETUP from https://dockgithub.com/GoogleCloudPlatform/cloud-sdk-docker/blob/master/debian_slim/Dockerfile 
+#
+
+ENV PATH=/google-cloud-sdk/bin:/workspace:${PATH} \
+    CLOUDSDK_CORE_DISABLE_PROMPTS=1
+
+RUN apt-get update -qqy && apt-get install -qqy \
+        curl \
+        gcc \
+        python3-dev \
+        python3-pip \
+        apt-transport-https \
+        lsb-release \
+        openssh-client \
+        ca-certificates \
+        git \
+        software-properties-common \
+        bison \
+        uuid-runtime \
+        shellcheck \
+        unzip \
+        wget \
+        gnupg
+
+RUN pip3 install -U crcmod==1.7
+RUN curl -fsSLO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz
+RUN tar xzf google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz -C /
+RUN rm google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz
+RUN gcloud config set core/disable_usage_reporting true && \
+    gcloud config set component_manager/disable_update_check true && \
+    gcloud config set metrics/environment github_docker_image && \
+    gcloud components install alpha beta && \
+    gcloud --version 
+
+#
+# END: GCLOUD SETUP
+#
 
 # kubectl
 RUN curl -fsSL "https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl && \
@@ -30,24 +75,11 @@ RUN curl -fsSL "https://storage.googleapis.com/kubernetes-release/release/${KUBE
 # BEGIN: DOCKER IN DOCKER SETUP
 #
 
-# Install Docker deps, some of these are already installed in the image but
-# that's fine since they won't re-install and we can reuse the code below
-# for another image someday.
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    apt-transport-https \
-    ca-certificates \
-    curl \
-    gnupg2 \
-    software-properties-common \
-    lsb-release && \
-    rm -rf /var/lib/apt/lists/*
-
 # Add the Docker apt-repository
-RUN curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg \
-    | apt-key add - && \
-    add-apt-repository \
-    "deb [arch=amd64] https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") \
-    $(lsb_release -cs) stable"
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg && \
+    echo \
+    "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian \
+    $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
 
 # Install Docker
 # TODO: the `sed` is a bit of a hack, look into alternatives.
@@ -55,14 +87,11 @@ RUN curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID"
 # We're already inside docker though so we can be sure these are already mounted.
 # Trying to remount these makes for a very noisy error block in the beginning of
 # the pod logs, so we just comment out the call to it... :shrug:
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends docker-ce="${DOCKER_VERSION}" && \
-    rm -rf /var/lib/apt/lists/* && \
+RUN apt-get update -qqy && \
+    apt-get install -qqy --no-install-recommends docker-ce="${DOCKER_VERSION}" && \
     sed -i 's/cgroupfs_mount$/#cgroupfs_mount\n/' /etc/init.d/docker \
     && update-alternatives --set iptables /usr/sbin/iptables-legacy \
     && update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
-
-
 
 # Move Docker's storage location
 RUN echo 'DOCKER_OPTS="${DOCKER_OPTS} --data-root=/docker-graph"' | \
@@ -75,15 +104,19 @@ RUN mkdir /docker-graph
 # END: DOCKER IN DOCKER SETUP
 #
 
-# Setup adoptopenjdk
-ARG JAVA_VERSION=16
-RUN curl -fsSL https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add -
-RUN echo "deb https://adoptopenjdk.jfrog.io/adoptopenjdk/deb buster main" | tee /etc/apt/sources.list.d/adoptopenjdk.list
-RUN apt-get update
-RUN apt-get install -y adoptopenjdk-${JAVA_VERSION}-hotspot
+#
+# BEGIN: JAVA SETUP
+#
+
+RUN curl -fsSL https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | gpg --dearmor -o /usr/share/keyrings/adoptopenjdk-archive-keyring.gpg && \
+    echo \
+    "deb [signed-by=/usr/share/keyrings/adoptopenjdk-archive-keyring.gpg] https://adoptopenjdk.jfrog.io/adoptopenjdk/deb \
+    $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/adoptopenjdk.list
+RUN apt-get update -qqy && \
+    apt-get install -qqy adoptopenjdk-${JAVA_VERSION}-hotspot && \
+    rm -rf /var/lib/apt/lists/* 
 ENV JAVA_HOME=/usr/lib/jvm/adoptopenjdk-${JAVA_VERSION}-hotspot-amd64
 
-ARG MAVEN_VERSION=3.8.4
 ENV MAVEN_HOME=/usr/local/maven
 ENV M2_HOME=$MAVEN_HOME
 ENV PATH=${M2_HOME}/bin:${PATH}
@@ -95,9 +128,11 @@ RUN curl -fsSL https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/bi
 RUN java -version && \
     mvn -v
 
-# Install go 1.13, 1.14, and 1.15 using https://github.com/moovweb/gvm
-# Missing prerequisite:
-RUN apt-get install -y bison uuid-runtime shellcheck unzip wget
+#
+# END: JAVA SETUP
+#
+
+# Install go 1.15, 1.16, and 1.17 using https://github.com/moovweb/gvm
 # GVM_NO_UPDATE_PROFILE=true means do not alter /root/.bashrc to automatically source gvm config, so when not using runner.sh, image works normally
 # Install the tool:
 RUN curl -fsSL https://raw.githubusercontent.com/moovweb/gvm/master/binscripts/gvm-installer | GVM_NO_UPDATE_PROFILE=true bash
@@ -114,7 +149,6 @@ RUN source-gvm-and-run.sh install go1.17.6 --prefer-binary
 RUN source-gvm-and-run.sh use go1.17 --default
 
 # protoc and required golang tooling
-ARG PROTOC_VERSION=3.17.0
 RUN curl -fsSL "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip" -o protoc.zip \
     && unzip -p protoc.zip bin/protoc > /usr/local/bin/protoc \
     && chmod +x /usr/local/bin/protoc \
@@ -131,7 +165,7 @@ COPY images/prow-tests/in-gvm-env.sh /usr/local/bin
 #  you could do it like:
 #  RUN GO_VERSION=go1.13 in-gvm-env.sh go install knative.dev/test-infra/tools/coverage
 #  RUN GO_VERSION=go1.14 in-gvm-env.sh go install knative.dev/test-infra/tools/coverage
-# But it must be done in stable-stuff or the last FROM, because it does not install to /go/bin
+# But it must be done in base or the last FROM, because it does not install to /go/bin
 
 ############################################################
 FROM golang:1.17 AS external-go-gets
@@ -175,14 +209,14 @@ COPY . /go/src/knative.dev/test-infra
 
 # Build custom tools in the container
 
-RUN go install knative.dev/test-infra/tools/coverage@latest
-RUN go install knative.dev/test-infra/kntest/cmd/kntest@latest
+RUN cd /go/src/knative.dev/test-infra && go install ./tools/coverage
+RUN cd /go/src/knative.dev/test-infra && go install ./kntest/cmd/kntest
 
 # TODO(chizhg): maybe also move perf-tests tool to be part of kntest?
-RUN go install knative.dev/test-infra/pkg/clustermanager/perf-tests@latest
+RUN cd /go/src/knative.dev/test-infra && go install ./pkg/clustermanager/perf-tests
 
 ############################################################
-FROM stable-stuff
+FROM base
 
 COPY --from=external-go-gets /go/bin/* /go/bin/
 

--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -12,42 +12,61 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/k8s-testimages/kubekins-e2e:v20210113-cc576af-master AS stable-stuff
+# Starting from the gcloud debian image https://github.com/GoogleCloudPlatform/cloud-sdk-docker/blob/master/debian_slim/Dockerfile
+ARG GCLOUD_VERSION=368.0.0
+
+FROM google/cloud-sdk:${GCLOUD_VERSION}-slim AS stable-stuff
 
 ENV DEBIAN_FRONTEND noninteractive
-ARG GCLOUD_VERSION=368.0.0
+
 ARG KUBECTL_VERSION=v1.21.4
-
-# If we don't run update, the apt-get install below don't work
-RUN apt-get update
-
-# gcloud
-RUN gcloud components update --version=${GCLOUD_VERSION}
+ARG BAZELISK_VERSION=v1.11.0
+ARG DOCKER_VERSION=5:20.10.9~3-0~debian-buster
 
 # kubectl
-RUN rm -f "$(which kubectl)" && \
-    wget "https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" -O /usr/local/bin/kubectl && \
+RUN curl -fsSL "https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl && \
     chmod +x /usr/local/bin/kubectl
 
-# Extra tools through apt-get
-RUN apt-get install -y uuid-runtime   # for uuidgen
-RUN apt-get install -y shellcheck     # for shellcheck presubmit
+# bazel
+RUN curl -fsSL "https://github.com/bazelbuild/bazelisk/releases/download/${BAZELISK_VERSION}/bazelisk-linux-amd64" -o /usr/local/bin/bazel && \
+    chmod +x /usr/local/bin/bazel
+
+# Docker including docker-ce, docker-ce-cli, and containerd.io
+RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
+    echo "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list && \
+    apt-get update && \
+    apt-get -y install --no-install-recommends docker-ce="${DOCKER_VERSION}" docker-ce-cli="${DOCKER_VERSION}"
+
+# # Install gcloud command line tool
+# # Install gcloud beta component
+# RUN set -eux; \
+#     \
+#     case $(uname -m) in \
+#         x86_64)  export GCLOUD_TAR_FILE="google-cloud-sdk-${GCLOUD_VERSION}-linux-x86_64.tar.gz" ;; \
+#         aarch64) export GCLOUD_TAR_FILE="google-cloud-sdk-${GCLOUD_VERSION}-linux-arm.tar.gz" ;; \
+#         *) echo "unsupported architecture"; exit 1 ;; \
+#     esac; \
+#     \
+#     wget -nv "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/${GCLOUD_TAR_FILE}"; \
+#     tar -xzvf ."/${GCLOUD_TAR_FILE}" -C "${OUTDIR}/usr/local" && rm "${GCLOUD_TAR_FILE}"; \
+#     ${OUTDIR}/usr/local/google-cloud-sdk/bin/gcloud components install beta --quiet; \
+#     ${OUTDIR}/usr/local/google-cloud-sdk/bin/gcloud components install alpha --quiet; \
+#     rm -rf /usr/local/google-cloud-sdk/.install/.backup
 
 # Setup adoptopenjdk
 ARG JAVA_VERSION=16
-RUN apt-get install -y wget apt-transport-https gnupg
-RUN wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add -
+RUN curl -sf https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add -
 RUN echo "deb https://adoptopenjdk.jfrog.io/adoptopenjdk/deb buster main" | tee /etc/apt/sources.list.d/adoptopenjdk.list
 RUN apt-get update
 RUN apt-get install -y adoptopenjdk-${JAVA_VERSION}-hotspot
 ENV JAVA_HOME=/usr/lib/jvm/adoptopenjdk-${JAVA_VERSION}-hotspot-amd64
 
-# Download maven from https://archive.apache.org/dist/maven/maven-3/ instead of dlcdn.apache.org to guarantee reproducible builds
-ARG MAVEN_VERSION=3.8.4
+ARG MAVEN_VERSION=3.8.3
 ENV MAVEN_HOME=/usr/local/maven
 ENV M2_HOME=$MAVEN_HOME
 ENV PATH=${M2_HOME}/bin:${PATH}
-RUN wget -q https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz -P /tmp && \
+
+RUN curl -fsSL https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz -o /tmp/apache-maven-${MAVEN_VERSION}-bin.tar.gz && \
     tar xf /tmp/apache-maven-${MAVEN_VERSION}-bin.tar.gz -C /tmp && \
     mv /tmp/apache-maven-${MAVEN_VERSION} $MAVEN_HOME
 
@@ -56,7 +75,7 @@ RUN java -version && \
 
 # Install go 1.13, 1.14, and 1.15 using https://github.com/moovweb/gvm
 # Missing prerequisite:
-RUN apt-get install -y bison
+RUN apt-get install -y bison uuid-runtime shellcheck unzip
 # GVM_NO_UPDATE_PROFILE=true means do not alter /root/.bashrc to automatically source gvm config, so when not using runner.sh, image works normally
 # Install the tool:
 RUN curl -s -S -L https://raw.githubusercontent.com/moovweb/gvm/master/binscripts/gvm-installer | GVM_NO_UPDATE_PROFILE=true bash
@@ -68,13 +87,13 @@ COPY images/prow-tests/source-gvm-and-run.sh /usr/local/bin
 # We only install the latest 3 versions of Go which should be enough for
 # all Knative repositories.
 RUN source-gvm-and-run.sh install go1.15.15 --prefer-binary
-RUN source-gvm-and-run.sh install go1.16.13 --prefer-binary
-RUN source-gvm-and-run.sh install go1.17.6 --prefer-binary
+RUN source-gvm-and-run.sh install go1.16.9 --prefer-binary
+RUN source-gvm-and-run.sh install go1.17.2 --prefer-binary
 RUN source-gvm-and-run.sh use go1.17 --default
 
 # protoc and required golang tooling
 ARG PROTOC_VERSION=3.17.0
-RUN wget "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip" -O protoc.zip \
+RUN curl -fsSL "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip" -o protoc.zip \
     && unzip -p protoc.zip bin/protoc > /usr/local/bin/protoc \
     && chmod +x /usr/local/bin/protoc \
     && rm protoc.zip
@@ -100,20 +119,23 @@ ARG KUBETEST2_VERSION=ea3c260668075a29dd2b7f3ba4ddf1fe78bdf898
 ARG KIND_VERSION=v0.11.1
 ARG KO_VERSION=v0.8.2
 ARG PROTOC_GEN_GO_VERSION=v1.26.0
+ARG KIND_VERSION=v0.11.1
 
 # Extra tools through go get
 # These run using the golang image version of Go, not any defined by `gvm`
-RUN go get github.com/google/ko@${KO_VERSION}
+RUN go install github.com/google/ko@${KO_VERSION}
 RUN go get github.com/boz/kail/cmd/kail
-RUN go get gotest.tools/gotestsum
-RUN go get github.com/raviqqe/liche@v0.0.0-20200229003944-f57a5d1c5be4  # stable liche version for checking md links
-RUN go get sigs.k8s.io/kind@${KIND_VERSION}
-RUN go get sigs.k8s.io/kubetest2@${KUBETEST2_VERSION}
-RUN go get sigs.k8s.io/kubetest2/kubetest2-gke@${KUBETEST2_VERSION}
-RUN go get sigs.k8s.io/kubetest2/kubetest2-kind@${KUBETEST2_VERSION}
-RUN go get sigs.k8s.io/kubetest2/kubetest2-tester-exec@${KUBETEST2_VERSION}
-RUN go get google.golang.org/protobuf/cmd/protoc-gen-go@${PROTOC_GEN_GO_VERSION}
-RUN go get github.com/google/go-licenses
+RUN go install gotest.tools/gotestsum
+RUN go install github.com/raviqqe/liche@v0.0.0-20200229003944-f57a5d1c5be4  # stable liche version for checking md links
+RUN go install sigs.k8s.io/kind@${KIND_VERSION}
+RUN go install sigs.k8s.io/kubetest2@${KUBETEST2_VERSION}
+RUN go install sigs.k8s.io/kubetest2/kubetest2-gke@${KUBETEST2_VERSION}
+RUN go install sigs.k8s.io/kubetest2/kubetest2-kind@${KUBETEST2_VERSION}
+RUN go install sigs.k8s.io/kubetest2/kubetest2-tester-exec@${KUBETEST2_VERSION}
+RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@${PROTOC_GEN_GO_VERSION}
+RUN go install github.com/google/go-licenses
+RUN go install sigs.k8s.io/kind@${KIND_VERSION}
+
 
 # According to https://github.com/knative/test-infra/pull/2762 protoc-gen-gogofaster is unsupported (and shouldn't be used?)
 # Not sure when it can be removed, maybe knative-0.26?
@@ -124,7 +146,7 @@ RUN go get github.com/gogo/protobuf/protoc-gen-gogofaster@v1.3.1
 RUN go get knative.dev/pkg/testutils/junithelper@release-0.17
 
 # Docker
-RUN go get -u github.com/GoogleCloudPlatform/docker-credential-gcr@v2.0.5
+RUN go install github.com/GoogleCloudPlatform/docker-credential-gcr@v2.0.5
 RUN docker-credential-gcr configure-docker --registries=gcr.io,us-docker.pkg.dev
 
 ############################################################

--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -29,7 +29,7 @@ ENV WORKSPACE=/workspace \
 ENV DEBIAN_FRONTEND noninteractive
 
 #
-# BEGIN: GCLOUD SETUP from https://dockgithub.com/GoogleCloudPlatform/cloud-sdk-docker/blob/master/debian_slim/Dockerfile 
+# BEGIN: GCLOUD SETUP
 #
 
 ENV PATH=/google-cloud-sdk/bin:/workspace:${PATH} \
@@ -61,7 +61,7 @@ RUN gcloud config set core/disable_usage_reporting true && \
     gcloud config set component_manager/disable_update_check true && \
     gcloud config set metrics/environment github_docker_image && \
     gcloud components install alpha beta && \
-    gcloud --version 
+    gcloud --version
 
 #
 # END: GCLOUD SETUP
@@ -114,7 +114,7 @@ RUN curl -fsSL https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | g
     $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/adoptopenjdk.list
 RUN apt-get update -qqy && \
     apt-get install -qqy adoptopenjdk-${JAVA_VERSION}-hotspot && \
-    rm -rf /var/lib/apt/lists/* 
+    rm -rf /var/lib/apt/lists/*
 ENV JAVA_HOME=/usr/lib/jvm/adoptopenjdk-${JAVA_VERSION}-hotspot-amd64
 
 ENV MAVEN_HOME=/usr/local/maven

--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -77,7 +77,7 @@ RUN mkdir /docker-graph
 
 # Setup adoptopenjdk
 ARG JAVA_VERSION=16
-RUN curl -sf https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add -
+RUN curl -fsSL https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add -
 RUN echo "deb https://adoptopenjdk.jfrog.io/adoptopenjdk/deb buster main" | tee /etc/apt/sources.list.d/adoptopenjdk.list
 RUN apt-get update
 RUN apt-get install -y adoptopenjdk-${JAVA_VERSION}-hotspot
@@ -151,7 +151,7 @@ ARG DOCKER_CREDENTIAL_GCR_VERSION=v2.0.5
 # Extra tools through go install/get
 # These run using the golang image version of Go, not any defined by `gvm`
 RUN go install github.com/google/ko@${KO_VERSION}
-RUN go get github.com/boz/kail/cmd/kail@${KAIL_VERSION}
+RUN go install github.com/boz/kail/cmd/kail@${KAIL_VERSION}
 RUN go install gotest.tools/gotestsum@${GOTESTSUM_VERSION}
 RUN go install github.com/raviqqe/liche@${LICHE_VERSION}  # stable liche version for checking md links
 RUN go install sigs.k8s.io/kind@${KIND_VERSION}
@@ -166,14 +166,14 @@ RUN go install sigs.k8s.io/kind@${KIND_VERSION}
 
 # According to https://github.com/knative/test-infra/pull/2762 protoc-gen-gogofaster is unsupported (and shouldn't be used?)
 # Not sure when it can be removed, maybe knative-0.26?
-RUN go get github.com/gogo/protobuf/protoc-gen-gogofaster@${PROTOC_GEN_GOGOFASTER_VERSION}}
+RUN go install github.com/gogo/protobuf/protoc-gen-gogofaster@${PROTOC_GEN_GOGOFASTER_VERSION}
 
 # TODO(chizhg): remove it once we replace with kntest in the places where this tool is used
 # Install our own tools
-RUN go get knative.dev/pkg/testutils/junithelper@{JUNIT_HELPER}
+RUN go get knative.dev/pkg/testutils/junithelper@${JUNIT_HELPER}
 
 # Docker
-RUN go get -u github.com/GoogleCloudPlatform/docker-credential-gcr@${DOCKER_CREDENTIAL_GCR_VERSION}
+RUN go install github.com/GoogleCloudPlatform/docker-credential-gcr@${DOCKER_CREDENTIAL_GCR_VERSION}
 
 ############################################################
 FROM stable-stuff AS test-infra-builds

--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -145,10 +145,9 @@ ARG GOTESTSUM_VERSION=v1.7.0
 ARG KAIL_VERSION=v0.15.0
 ARG LICHE_VERSION=v0.0.0-20200229003944-f57a5d1c5be4
 ARG GO_LICENSES_VERSION=v1.0.0
-ARG JUNIT_HELPER=release-0.17
 ARG DOCKER_CREDENTIAL_GCR_VERSION=v2.0.5
 
-# Extra tools through go install/get
+# Extra tools through go install
 # These run using the golang image version of Go, not any defined by `gvm`
 RUN go install github.com/google/ko@${KO_VERSION}
 RUN go install github.com/boz/kail/cmd/kail@${KAIL_VERSION}
@@ -167,10 +166,6 @@ RUN go install sigs.k8s.io/kind@${KIND_VERSION}
 # According to https://github.com/knative/test-infra/pull/2762 protoc-gen-gogofaster is unsupported (and shouldn't be used?)
 # Not sure when it can be removed, maybe knative-0.26?
 RUN go install github.com/gogo/protobuf/protoc-gen-gogofaster@${PROTOC_GEN_GOGOFASTER_VERSION}
-
-# TODO(chizhg): remove it once we replace with kntest in the places where this tool is used
-# Install our own tools
-RUN go get knative.dev/pkg/testutils/junithelper@${JUNIT_HELPER}
 
 # Docker
 RUN go install github.com/GoogleCloudPlatform/docker-credential-gcr@${DOCKER_CREDENTIAL_GCR_VERSION}

--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -37,22 +37,6 @@ RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
     apt-get update && \
     apt-get -y install --no-install-recommends docker-ce="${DOCKER_VERSION}" docker-ce-cli="${DOCKER_VERSION}"
 
-# # Install gcloud command line tool
-# # Install gcloud beta component
-# RUN set -eux; \
-#     \
-#     case $(uname -m) in \
-#         x86_64)  export GCLOUD_TAR_FILE="google-cloud-sdk-${GCLOUD_VERSION}-linux-x86_64.tar.gz" ;; \
-#         aarch64) export GCLOUD_TAR_FILE="google-cloud-sdk-${GCLOUD_VERSION}-linux-arm.tar.gz" ;; \
-#         *) echo "unsupported architecture"; exit 1 ;; \
-#     esac; \
-#     \
-#     wget -nv "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/${GCLOUD_TAR_FILE}"; \
-#     tar -xzvf ."/${GCLOUD_TAR_FILE}" -C "${OUTDIR}/usr/local" && rm "${GCLOUD_TAR_FILE}"; \
-#     ${OUTDIR}/usr/local/google-cloud-sdk/bin/gcloud components install beta --quiet; \
-#     ${OUTDIR}/usr/local/google-cloud-sdk/bin/gcloud components install alpha --quiet; \
-#     rm -rf /usr/local/google-cloud-sdk/.install/.backup
-
 # Setup adoptopenjdk
 ARG JAVA_VERSION=16
 RUN curl -sf https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add -
@@ -66,7 +50,7 @@ ENV MAVEN_HOME=/usr/local/maven
 ENV M2_HOME=$MAVEN_HOME
 ENV PATH=${M2_HOME}/bin:${PATH}
 
-RUN curl -fsSL https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz -o /tmp/apache-maven-${MAVEN_VERSION}-bin.tar.gz && \
+RUN curl -fsSL https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz -o /tmp/apache-maven-${MAVEN_VERSION}-bin.tar.gz && \
     tar xf /tmp/apache-maven-${MAVEN_VERSION}-bin.tar.gz -C /tmp && \
     mv /tmp/apache-maven-${MAVEN_VERSION} $MAVEN_HOME
 
@@ -87,8 +71,8 @@ COPY images/prow-tests/source-gvm-and-run.sh /usr/local/bin
 # We only install the latest 3 versions of Go which should be enough for
 # all Knative repositories.
 RUN source-gvm-and-run.sh install go1.15.15 --prefer-binary
-RUN source-gvm-and-run.sh install go1.16.9 --prefer-binary
-RUN source-gvm-and-run.sh install go1.17.2 --prefer-binary
+RUN source-gvm-and-run.sh install go1.16.13 --prefer-binary
+RUN source-gvm-and-run.sh install go1.17.6 --prefer-binary
 RUN source-gvm-and-run.sh use go1.17 --default
 
 # protoc and required golang tooling
@@ -124,8 +108,8 @@ ARG KIND_VERSION=v0.11.1
 # Extra tools through go get
 # These run using the golang image version of Go, not any defined by `gvm`
 RUN go install github.com/google/ko@${KO_VERSION}
-RUN go get github.com/boz/kail/cmd/kail
-RUN go install gotest.tools/gotestsum
+RUN go get github.com/boz/kail/cmd/kail@v0.15.0
+RUN go install gotest.tools/gotestsum@v1.7.0
 RUN go install github.com/raviqqe/liche@v0.0.0-20200229003944-f57a5d1c5be4  # stable liche version for checking md links
 RUN go install sigs.k8s.io/kind@${KIND_VERSION}
 RUN go install sigs.k8s.io/kubetest2@${KUBETEST2_VERSION}
@@ -133,7 +117,7 @@ RUN go install sigs.k8s.io/kubetest2/kubetest2-gke@${KUBETEST2_VERSION}
 RUN go install sigs.k8s.io/kubetest2/kubetest2-kind@${KUBETEST2_VERSION}
 RUN go install sigs.k8s.io/kubetest2/kubetest2-tester-exec@${KUBETEST2_VERSION}
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@${PROTOC_GEN_GO_VERSION}
-RUN go install github.com/google/go-licenses
+RUN go install github.com/google/go-licenses@v1.0.0
 RUN go install sigs.k8s.io/kind@${KIND_VERSION}
 
 

--- a/images/prow-tests/runner.sh
+++ b/images/prow-tests/runner.sh
@@ -14,6 +14,114 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+bootstrap () {
+  # From https://github.com/kubernetes/test-infra/blob/master/images/bootstrap/runner.sh
+  cleanup_dind() {
+      if [[ "${DOCKER_IN_DOCKER_ENABLED:-false}" == "true" ]]; then
+          echo "Cleaning up after docker"
+          docker ps -aq | xargs -r docker rm -f || true
+          service docker stop || true
+      fi
+  }
+
+  early_exit_handler() {
+      if [ -n "${WRAPPED_COMMAND_PID:-}" ]; then
+          kill -TERM "$WRAPPED_COMMAND_PID" || true
+      fi
+      cleanup_dind
+  }
+
+  # optionally enable ipv6 docker
+  export DOCKER_IN_DOCKER_IPV6_ENABLED=${DOCKER_IN_DOCKER_IPV6_ENABLED:-false}
+  if [[ "${DOCKER_IN_DOCKER_IPV6_ENABLED}" == "true" ]]; then
+      echo "Enabling IPV6 for Docker."
+      # configure the daemon with ipv6
+      mkdir -p /etc/docker/
+      cat <<EOF >/etc/docker/daemon.json
+  {
+    "ipv6": true,
+    "fixed-cidr-v6": "fc00:db8:1::/64"
+  }
+EOF
+      # enable ipv6
+      sysctl net.ipv6.conf.all.disable_ipv6=0
+      sysctl net.ipv6.conf.all.forwarding=1
+      # enable ipv6 iptables
+      modprobe -v ip6table_nat
+  fi
+  # Check if the job has opted-in to docker-in-docker availability.
+  export DOCKER_IN_DOCKER_ENABLED=${DOCKER_IN_DOCKER_ENABLED:-false}
+  if [[ "${DOCKER_IN_DOCKER_ENABLED}" == "true" ]]; then
+      echo "Docker in Docker enabled, initializing..."
+      printf '=%.0s' {1..80}; echo
+      # If we have opted in to docker in docker, start the docker daemon,
+      service docker start
+      # the service can be started but the docker socket not ready, wait for ready
+      WAIT_N=0
+      MAX_WAIT=5
+      while true; do
+          # docker ps -q should only work if the daemon is ready
+          docker ps -q > /dev/null 2>&1 && break
+          if [[ ${WAIT_N} -lt ${MAX_WAIT} ]]; then
+              WAIT_N=$((WAIT_N+1))
+              echo "Waiting for docker to be ready, sleeping for ${WAIT_N} seconds."
+              sleep ${WAIT_N}
+          else
+              echo "Reached maximum attempts, not waiting any longer..."
+              break
+          fi
+      done
+      printf '=%.0s' {1..80}; echo
+      echo "Done setting up docker in docker."
+
+      # Workaround for https://github.com/kubernetes/test-infra/issues/23741
+      # Instead of removing, disabled by default in case we need to address again
+      if [[ "${BOOTSTRAP_MTU_WORKAROUND:-"false"}" == "true" ]]; then
+          echo "configure iptables to set MTU"
+          iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
+      fi
+  fi
+
+  trap early_exit_handler INT TERM
+
+  # disable error exit so we can run post-command cleanup
+  set +o errexit
+
+  # add $GOPATH/bin to $PATH
+  export PATH="${GOPATH}/bin:${PATH}"
+  mkdir -p "${GOPATH}/bin"
+  # Authenticate gcloud, allow failures
+  if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
+    gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}" || true
+  fi
+
+  # Use a reproducible build date based on the most recent git commit timestamp.
+  SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct || true)
+  export SOURCE_DATE_EPOCH
+
+  # actually start bootstrap and the job
+  set -o xtrace
+  "$@" &
+  WRAPPED_COMMAND_PID=$!
+  wait $WRAPPED_COMMAND_PID
+  EXIT_VALUE=$?
+  set +o xtrace
+
+  # cleanup after job
+  if [[ "${DOCKER_IN_DOCKER_ENABLED}" == "true" ]]; then
+      echo "Cleaning up after docker in docker."
+      printf '=%.0s' {1..80}; echo
+      cleanup_dind
+      printf '=%.0s' {1..80}; echo
+      echo "Done cleaning up after docker in docker."
+  fi
+
+  # preserve exit value from job / bootstrap
+  exit ${EXIT_VALUE}
+
+}
+
+
 ORIGINAL_GOPATH="/home/prow/go"
 
 source "${HOME}/.gvm/scripts/gvm"
@@ -43,4 +151,4 @@ fi
 echo "Resetting GOPATH to '${ORIGINAL_GOPATH}'"
 export GOPATH="${ORIGINAL_GOPATH}"
 
-kubekins-runner.sh "$@"
+bootstrap "$@"


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:

The upstream prow image from kubernetes/test-infra is deprecated so we need to build our image from scratch.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #2957
Closes: #3012

**Special notes to reviewers**:

**User-visible changes in this PR**:

