### PR TITLE
Add the label for cncf-infra migration, so we can use it across all Knative repos

### DIFF
--- a/config/label_sync/labels.yaml
+++ b/config/label_sync/labels.yaml
@@ -89,6 +89,14 @@ default:
       target: both
       prowPlugin: label
       addedBy: humans
+    - color: 2596be
+      # (maybe) temporary label for CNCF migration, we'll
+      # decide if we still want to keep it after all issues under
+      # https://github.com/orgs/knative/projects/40/views/11 are addressed
+      name: kind/cncf-infra
+      target: both
+      prowPlugin: label
+      addedBy: humans
 
     # Specific labels for issue triage
     # See https://apenwarr.ca/log/20171213#slide32 for why we want to have these labels


### PR DESCRIPTION
/cc @upodroid 