### PR TITLE
Install jq in the prow-tests image

### DIFF
--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -54,7 +54,8 @@ RUN apt-get update -qqy && apt-get install -qqy \
         shellcheck \
         unzip \
         wget \
-        gnupg
+        gnupg \
+        jq
 
 RUN pip3 install -U crcmod==1.7
 RUN curl -fsSLO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz


### PR DESCRIPTION
https://prow.knative.dev/view/gs/knative-prow/logs/ci-knative-serving-continuous-beta-prow-tests/1483712020875317248#1:build-log.txt%3A7942 is failing because of missing `jq` command in the image

/cc @upodroid 