### PR TITLE
Run kubetest2 --down directly to save some costs

### DIFF
--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -174,7 +174,7 @@ COPY images/prow-tests/in-gvm-env.sh /usr/local/bin
 ############################################################
 FROM golang:1.17 AS external-go-gets
 
-ARG KUBETEST2_VERSION=ea3c260668075a29dd2b7f3ba4ddf1fe78bdf898
+ARG KUBETEST2_VERSION=beddb79392d0eeee3b87c3cd12b6aa3ad907e355
 ARG KIND_VERSION=v0.11.1
 ARG KO_VERSION=v0.8.2
 ARG PROTOC_GEN_GO_VERSION=v1.26.0

--- a/kntest/pkg/cluster/commands.go
+++ b/kntest/pkg/cluster/commands.go
@@ -25,7 +25,7 @@ import (
 func AddCommands(topLevel *cobra.Command) {
 	var clusterCmd = &cobra.Command{
 		Use:   "cluster",
-		Short: "Cluster related commands.",
+		Short: "Cluster related commands. Currently not used in Knative CI. Use kubetest2 subcommand instead.",
 	}
 
 	gke.AddCommands(clusterCmd)

--- a/pkg/clustermanager/kubetest2/gke.go
+++ b/pkg/clustermanager/kubetest2/gke.go
@@ -40,7 +40,7 @@ const (
 )
 
 var (
-	baseKubetest2Flags = []string{"gke", "--ignore-gcp-ssh-key=true", "--up", "-v=1"}
+	baseKubetest2Flags = []string{"gke", "--ignore-gcp-ssh-key=true", "--up", "-v=1", "--down"}
 
 	// If one of the error patterns below is matched, it would be recommended to
 	// retry creating the cluster in a different region.


### PR DESCRIPTION
Update kubetest2 to the latest version, and run it with `--down` flag to directly release GCP projects after the test flows are finished, instead of the relying on the heartbeat timeout to automatically release projects. This'll help save some compute time thus reducing some costs.

/cc @upodroid 