### PR TITLE
Revert "Run kubetest2 --down directly to save some costs"

### DIFF
--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -175,7 +175,7 @@ COPY images/prow-tests/in-gvm-env.sh /usr/local/bin
 ############################################################
 FROM golang:1.17 AS external-go-gets
 
-ARG KUBETEST2_VERSION=beddb79392d0eeee3b87c3cd12b6aa3ad907e355
+ARG KUBETEST2_VERSION=ea3c260668075a29dd2b7f3ba4ddf1fe78bdf898
 ARG KIND_VERSION=v0.11.1
 ARG KO_VERSION=v0.8.2
 ARG PROTOC_GEN_GO_VERSION=v1.26.0

--- a/kntest/pkg/cluster/commands.go
+++ b/kntest/pkg/cluster/commands.go
@@ -25,7 +25,7 @@ import (
 func AddCommands(topLevel *cobra.Command) {
 	var clusterCmd = &cobra.Command{
 		Use:   "cluster",
-		Short: "Cluster related commands. Currently not used in Knative CI. Use kubetest2 subcommand instead.",
+		Short: "Cluster related commands.",
 	}
 
 	gke.AddCommands(clusterCmd)

--- a/pkg/clustermanager/kubetest2/gke.go
+++ b/pkg/clustermanager/kubetest2/gke.go
@@ -40,7 +40,7 @@ const (
 )
 
 var (
-	baseKubetest2Flags = []string{"gke", "--ignore-gcp-ssh-key=true", "--up", "-v=1", "--down"}
+	baseKubetest2Flags = []string{"gke", "--ignore-gcp-ssh-key=true", "--up", "-v=1"}
 
 	// If one of the error patterns below is matched, it would be recommended to
 	// retry creating the cluster in a different region.


### PR DESCRIPTION
Reverts knative/test-infra#3032

See conversations in https://knative.slack.com/archives/CCSNR4FCH/p1643378939999349

/cc @upodroid @dprotaso 