### PR TITLE
Additional jobs to run KafkaChannel tests with auth cases

### DIFF
--- a/config/prow/config_knative.yaml
+++ b/config/prow/config_knative.yaml
@@ -504,6 +504,36 @@ presubmits:
     - --run-test
     - ./test/reconciler-tests.sh
   - go-coverage: true
+  - custom-test: channel-integration-tests-tls
+    needs-dind: true
+    args:
+    - --run-test
+    - ./test/e2e-tests.sh --channel-tls
+  - custom-test: channel-integration-tests-sasl-ssl
+    needs-dind: true
+    args:
+    - --run-test
+    - ./test/e2e-tests.sh --channel-sasl-ssl
+  - custom-test: channel-integration-tests-sasl-plain
+    needs-dind: true
+    args:
+    - --run-test
+    - ./test/e2e-tests.sh --channel-sasl-plain
+  - custom-test: channel-reconciler-tests-tls
+    needs-dind: true
+    args:
+    - --run-test
+    - ./test/reconciler-tests.sh channel-tls
+  - custom-test: channel-reconciler-tests-sasl-ssl
+    needs-dind: true
+    args:
+    - --run-test
+    - ./test/reconciler-tests.sh --channel-sasl-ssl
+  - custom-test: channel-reconciler-tests-sasl-plain
+    needs-dind: true
+    args:
+    - --run-test
+    - ./test/reconciler-tests.sh --channel-sasl-plain
   knative-sandbox/eventing-rabbitmq:
   - build-tests: false
   - unit-tests: false

--- a/config/prow/jobs/config.yaml
+++ b/config/prow/jobs/config.yaml
@@ -5762,6 +5762,324 @@ presubmits:
       - name: covbot-token
         secret:
           secretName: covbot-token
+  - name: pull-knative-sandbox-eventing-kafka-broker-channel-integration-tests-tls
+    agent: kubernetes
+    context: pull-knative-sandbox-eventing-kafka-broker-channel-integration-tests-tls
+    always_run: true
+    optional: false
+    rerun_command: "/test pull-knative-sandbox-eventing-kafka-broker-channel-integration-tests-tls"
+    trigger: "(?m)^/test (all|pull-knative-sandbox-eventing-kafka-broker-channel-integration-tests-tls),?(\\s+|$)"
+    decorate: true
+    path_alias: knative.dev/eventing-kafka-broker
+    cluster: "build-knative"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-tests.sh --channel-tls"
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: docker-graph
+          mountPath: /docker-graph
+        - name: modules
+          mountPath: /lib/modules
+        - name: cgroup
+          mountPath: /sys/fs/cgroup
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: "true"
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: docker-graph
+        emptyDir: {}
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-sandbox-eventing-kafka-broker-channel-integration-tests-sasl-ssl
+    agent: kubernetes
+    context: pull-knative-sandbox-eventing-kafka-broker-channel-integration-tests-sasl-ssl
+    always_run: true
+    optional: false
+    rerun_command: "/test pull-knative-sandbox-eventing-kafka-broker-channel-integration-tests-sasl-ssl"
+    trigger: "(?m)^/test (all|pull-knative-sandbox-eventing-kafka-broker-channel-integration-tests-sasl-ssl),?(\\s+|$)"
+    decorate: true
+    path_alias: knative.dev/eventing-kafka-broker
+    cluster: "build-knative"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-tests.sh --channel-sasl-ssl"
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: docker-graph
+          mountPath: /docker-graph
+        - name: modules
+          mountPath: /lib/modules
+        - name: cgroup
+          mountPath: /sys/fs/cgroup
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: "true"
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: docker-graph
+        emptyDir: {}
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-sandbox-eventing-kafka-broker-channel-integration-tests-sasl-plain
+    agent: kubernetes
+    context: pull-knative-sandbox-eventing-kafka-broker-channel-integration-tests-sasl-plain
+    always_run: true
+    optional: false
+    rerun_command: "/test pull-knative-sandbox-eventing-kafka-broker-channel-integration-tests-sasl-plain"
+    trigger: "(?m)^/test (all|pull-knative-sandbox-eventing-kafka-broker-channel-integration-tests-sasl-plain),?(\\s+|$)"
+    decorate: true
+    path_alias: knative.dev/eventing-kafka-broker
+    cluster: "build-knative"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/e2e-tests.sh --channel-sasl-plain"
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: docker-graph
+          mountPath: /docker-graph
+        - name: modules
+          mountPath: /lib/modules
+        - name: cgroup
+          mountPath: /sys/fs/cgroup
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: "true"
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: docker-graph
+        emptyDir: {}
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-sandbox-eventing-kafka-broker-channel-reconciler-tests-tls
+    agent: kubernetes
+    context: pull-knative-sandbox-eventing-kafka-broker-channel-reconciler-tests-tls
+    always_run: true
+    optional: false
+    rerun_command: "/test pull-knative-sandbox-eventing-kafka-broker-channel-reconciler-tests-tls"
+    trigger: "(?m)^/test (all|pull-knative-sandbox-eventing-kafka-broker-channel-reconciler-tests-tls),?(\\s+|$)"
+    decorate: true
+    path_alias: knative.dev/eventing-kafka-broker
+    cluster: "build-knative"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/reconciler-tests.sh channel-tls"
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: docker-graph
+          mountPath: /docker-graph
+        - name: modules
+          mountPath: /lib/modules
+        - name: cgroup
+          mountPath: /sys/fs/cgroup
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: "true"
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: docker-graph
+        emptyDir: {}
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-sandbox-eventing-kafka-broker-channel-reconciler-tests-sasl-ssl
+    agent: kubernetes
+    context: pull-knative-sandbox-eventing-kafka-broker-channel-reconciler-tests-sasl-ssl
+    always_run: true
+    optional: false
+    rerun_command: "/test pull-knative-sandbox-eventing-kafka-broker-channel-reconciler-tests-sasl-ssl"
+    trigger: "(?m)^/test (all|pull-knative-sandbox-eventing-kafka-broker-channel-reconciler-tests-sasl-ssl),?(\\s+|$)"
+    decorate: true
+    path_alias: knative.dev/eventing-kafka-broker
+    cluster: "build-knative"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/reconciler-tests.sh --channel-sasl-ssl"
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: docker-graph
+          mountPath: /docker-graph
+        - name: modules
+          mountPath: /lib/modules
+        - name: cgroup
+          mountPath: /sys/fs/cgroup
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: "true"
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: docker-graph
+        emptyDir: {}
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-knative-sandbox-eventing-kafka-broker-channel-reconciler-tests-sasl-plain
+    agent: kubernetes
+    context: pull-knative-sandbox-eventing-kafka-broker-channel-reconciler-tests-sasl-plain
+    always_run: true
+    optional: false
+    rerun_command: "/test pull-knative-sandbox-eventing-kafka-broker-channel-reconciler-tests-sasl-plain"
+    trigger: "(?m)^/test (all|pull-knative-sandbox-eventing-kafka-broker-channel-reconciler-tests-sasl-plain),?(\\s+|$)"
+    decorate: true
+    path_alias: knative.dev/eventing-kafka-broker
+    cluster: "build-knative"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - "./test/presubmit-tests.sh"
+        - "--run-test"
+        - "./test/reconciler-tests.sh --channel-sasl-plain"
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: docker-graph
+          mountPath: /docker-graph
+        - name: modules
+          mountPath: /lib/modules
+        - name: cgroup
+          mountPath: /sys/fs/cgroup
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: "true"
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: docker-graph
+        emptyDir: {}
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      - name: test-account
+        secret:
+          secretName: test-account
   knative-sandbox/kperf:
   - name: pull-knative-sandbox-kperf-build-tests
     agent: kubernetes


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
- With https://github.com/knative-sandbox/eventing-kafka-broker/pull/1816, we introduce capability to run e2e and reconciler tests of KafkaChannel with auth cases.
- We would like to run the entire test suites for KafkaChannel with different auth scenarios (TLS, SASL_SSL, SASL_PLAIN)
- As I wrote in the comment https://github.com/knative-sandbox/eventing-kafka-broker/pull/1816#issuecomment-1027993010, this PR won't cause any job failures with the HEAD at https://github.com/knative-sandbox/eventing-kafka-broker because it just adds new jobs with new command line arguments. Those arguments are currently ignored. So, the only "bad" thing will be that same thing (no auth) is tested multiple times.
- I want to merge https://github.com/knative-sandbox/eventing-kafka-broker/pull/1816 after this one is merged to see if my scripting changes there are actually good.


<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:
Fixes #

**Special notes to reviewers**:

**User-visible changes in this PR**:

