### PR TITLE
Don't set SOURCE_DATE_EPOCH

### DIFF
--- a/images/prow-tests/runner.sh
+++ b/images/prow-tests/runner.sh
@@ -95,10 +95,6 @@ EOF
     gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}" || true
   fi
 
-  # Use a reproducible build date based on the most recent git commit timestamp.
-  SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct || true)
-  export SOURCE_DATE_EPOCH
-
   # actually start bootstrap and the job
   set -o xtrace
   "$@" &


### PR DESCRIPTION
Since we're bumping community files and go.mod deps across our project it's
creating new nightlies with no actual code changes.

In serving this produces at least 5 PRs a day which bump the nightlies which take forever to
get through the merge pool.

This is unnecessary so this drops the use of `SOURCE_DATE_EPOCH` and
ko will now just zero out the timestamps.

