### PR TITLE
Wrap `runner.sh` for k8s groups sync jobs

### DIFF
--- a/config/prow/check_config.sh
+++ b/config/prow/check_config.sh
@@ -17,7 +17,7 @@
 # This script checks for consistency among prow core config, plugins, and job
 # configs
 
-source $(dirname "${BASH_SOURCE[0]}")/../../../vendor/knative.dev/hack/library.sh
+source $(dirname "${BASH_SOURCE[0]}")/../../vendor/knative.dev/hack/library.sh
 
 set -e
 

--- a/config/prow/jobs/custom/test-infra.yaml
+++ b/config/prow/jobs/custom/test-infra.yaml
@@ -112,8 +112,9 @@ presubmits:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         command:
-        - make
+        - runner.sh
         args:
+        - make
         - -C
         - ./groups
         - test
@@ -496,9 +497,10 @@ periodics:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:stable
       command:
-      - make
+      - runner.sh
       args:
-      - -C
+      - make
+      - C
       - groups
       - run
       - --
@@ -724,8 +726,9 @@ knative/community:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable
         command:
-        - make
+        - runner.sh
         args:
+        - make
         - -C
         - groups
         - run


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:
Forgot to wrap the job with runner.sh, seeing missing gopaths etc
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Which issue(s) this PR fixes**:

**Special notes to reviewers**:

**User-visible changes in this PR**:

/cc @chizhg
