### PR TITLE
Fix paths to point to the new prow/* layout

### DIFF
--- a/config/Makefile
+++ b/config/Makefile
@@ -42,7 +42,7 @@ PROW_JOB_CONFIG                 ?= prow/jobs
 PROW_GCS                        ?= knative-prow
 PROW_CONFIG_GCS                 ?= gs://$(PROW_GCS)/configs
 
-BOSKOS_RESOURCES                ?= prow/build-cluster/boskos/boskos_resources.yaml
+BOSKOS_RESOURCES                ?= prow/cluster/boskos/boskos_resources.yaml
 
 # Useful shortcuts.
 

--- a/prow/jobs/custom/test-infra.yaml
+++ b/prow/jobs/custom/test-infra.yaml
@@ -513,7 +513,7 @@ postsubmits:
     path_alias: knative.dev/test-infra
     max_concurrency: 1
     cluster: "prow-trusted"
-    run_if_changed: "^config/(prow/build-cluster/boskos/.*.yaml|prow/testgrid/testgrid.yaml)$"
+    run_if_changed: "^(prow/cluster/boskos/.*.yaml|config/prow/testgrid/testgrid.yaml)$"
     branches:
     - "main"
     annotations:
@@ -667,7 +667,7 @@ postsubmits:
           secretName: test-account
   - name: post-test-infra-update-testgrid-proto
     decorate: true
-    run_if_changed: "^config/prow/(jobs|k8s-testgrid)/.*.yaml"
+    run_if_changed: "^(config/prow/k8s-testgrid/|prow/jobs/).*.yaml"
     branches:
     - "main"
     cluster: "build-knative"


### PR DESCRIPTION
I don't know where this is getting picked up at https://prow.knative.dev/view/gs/knative-prow/logs/post-test-infra-update-testgrid-proto/1486710033059155968 (maybe cached yaml?)

https://prow.knative.dev/prowjob?prowjob=5806a02a-8ab8-11ec-b898-e2b391fd279d Below path fix should enable makefile to run