### PR TITLE
Fix the config check Prow job

### DIFF
--- a/prow/jobs/custom/test-infra.yaml
+++ b/prow/jobs/custom/test-infra.yaml
@@ -29,7 +29,8 @@ presubmits:
         command:
         - "runner.sh"
         args:
-        - "./prow/config.sh check"
+        - "./prow/config.sh"
+        - "check"
         - "$(REPO_OWNER)/$(REPO_NAME)"
         securityContext:
           privileged: true


### PR DESCRIPTION
Prow job args consider the first line as the whole command, see one failing example at https://prow.knative.dev/view/gs/knative-prow/pr-logs/pull/knative_test-infra/3077/pull-test-infra-validate-prow-yaml/1492296679313903616. Splitting them into separate lines to fix the job.

/cc @kvmware 