### PR TITLE
Add security and cncf-blocked labels

### DIFF
--- a/config/label_sync/labels.yaml
+++ b/config/label_sync/labels.yaml
@@ -95,11 +95,22 @@ default:
       target: issues
       prowPlugin: label
       addedBy: humans
+    - color: d4522c
+      description: Issues or PRs related to security or CVEs.
+      name: kind/security
+      target: both
+      prowPlugin: label
+      addedBy: humans
     - color: 2596be
       # (maybe) temporary label for CNCF migration, we'll
       # decide if we still want to keep it after all issues under
       # https://github.com/orgs/knative/projects/40/views/11 are addressed
       name: kind/cncf-infra
+      target: both
+      prowPlugin: label
+      addedBy: humans
+    - color: be4d25
+      name: kind/cncf-blocked
       target: both
       prowPlugin: label
       addedBy: humans


### PR DESCRIPTION
cncf-blocked is a temporary label that complements cncf-infra while we track work for CNCF adoption.
security label is for us to prioritize security related issues/PRs
