### PR TITLE
Change cncf-blocked to cncf-after

### DIFF
--- a/config/label_sync/labels.yaml
+++ b/config/label_sync/labels.yaml
@@ -110,7 +110,7 @@ default:
       prowPlugin: label
       addedBy: humans
     - color: be4d25
-      name: kind/cncf-blocked
+      name: kind/cncf-after
       target: both
       prowPlugin: label
       addedBy: humans


### PR DESCRIPTION

**What this PR does, why we need it**:<br>
Blocked sounds like CNCF is stopping us when really this label is meant to capture the fact we can't do anything until **after** we are adopted.

<!--
  If there is any golang code in this PR please uncomment the 
  `/lint` statement below to have Prow automatically lint it.
-->
<!--
  /lint
-->
