### PR TITLE
Use kubetest2 to retry on GKE cluster creations

### DIFF
--- a/pkg/clustermanager/kubetest2/gke.go
+++ b/pkg/clustermanager/kubetest2/gke.go
@@ -21,8 +21,8 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"os"
 	"os/exec"
-	"regexp"
 	"strconv"
 	"strings"
 
@@ -45,10 +45,9 @@ var (
 	// If one of the error patterns below is matched, it would be recommended to
 	// retry creating the cluster in a different region.
 	// - stockout (https://github.com/knative/test-infra/issues/592)
-	retryableCreationErrors = []*regexp.Regexp{
-		regexp.MustCompile(`.*does not have enough resources available to fulfill.*`),
-		regexp.MustCompile(`.*only \d+ nodes out of \d+ have registered; this is likely due to Nodes failing to start correctly.*`),
-	}
+	retryableErrorPatterns = `.*does not have enough resources available to fulfill.*` +
+		`,.*only \d+ nodes out of \d+ have registered; this is likely due to Nodes failing to start correctly.*` +
+		`,.*All cluster resources were brought up.+ but: component .+ from endpoint .+ is unhealthy.*`
 )
 
 // GKEClusterConfig are the supported configurations for creating a GKE cluster.
@@ -75,8 +74,7 @@ type GKEClusterConfig struct {
 	ImageType                         string
 	EnableWorkloadIdentity            bool
 	PrivateClusterAccessLevel         string
-	PrivateClusterMasterIPSubnetRange string
-	PrivateClusterMasterIPSubnetMask  string
+	PrivateClusterMasterIPSubnetRange []string
 
 	ExtraGcloudFlags string
 }
@@ -128,69 +126,45 @@ func Run(opts *Options, cc *GKEClusterConfig) error {
 		kubetest2Flags = append(kubetest2Flags, "--project="+cc.GCPProjectID)
 	}
 
-	return createGKEClusterWithRetries(kubetest2Flags, opts, cc)
-}
+	if cc.PrivateClusterAccessLevel != "" {
+		kubetest2Flags = append(kubetest2Flags, "--private-cluster-access-level="+cc.PrivateClusterAccessLevel)
+		kubetest2Flags = append(kubetest2Flags, "--private-cluster-master-ip-range="+strings.Join(cc.PrivateClusterMasterIPSubnetRange, ","))
+	}
 
-func createGKEClusterWithRetries(kubetest2Flags []string, opts *Options, cc *GKEClusterConfig) error {
-	var err error
+	if opts.TestCommand != "" {
+		kubetest2Flags = append(kubetest2Flags, "--test=exec", "--")
+		kubetest2Flags = append(kubetest2Flags, strings.Split(opts.TestCommand, " ")...)
+	}
+
 	regions := append([]string{cc.Region}, cc.BackupRegions...)
-	for i, region := range regions {
-		flags := append(kubetest2Flags, "--region="+region)
-		if cc.PrivateClusterAccessLevel != "" {
-			flags = append(flags, "--private-cluster-access-level="+cc.PrivateClusterAccessLevel)
-			masterIPRange := fmt.Sprintf("%s.%d/%s", cc.PrivateClusterMasterIPSubnetRange, i, cc.PrivateClusterMasterIPSubnetMask)
-			flags = append(flags, "--private-cluster-master-ip-range="+masterIPRange)
-		}
+	kubetest2Flags = append(kubetest2Flags, "--region="+strings.Join(regions, ","))
+	kubetest2Flags = append(kubetest2Flags, "--retryable-error-patterns='"+retryableErrorPatterns+"'")
 
-		if opts.TestCommand != "" {
-			flags = append(flags, "--test=exec", "--")
-			flags = append(flags, strings.Split(opts.TestCommand, " ")...)
-		}
+	log.Printf("Running kubetest2 with flags: %q", kubetest2Flags)
 
-		log.Printf("Running kubetest2 with flags: %q", flags)
-		command := exec.Command("kubetest2", flags...)
-		var out string
-		out, err = runWithOutput(command)
-		if err != nil {
-			if isRetryableCreationError(out) {
-				log.Print("Cluster creation fails due to unpredictable reasons, will retry creating with different args")
-				continue
-			} else {
-				return err
-			}
-		} else {
-			// Only save the metadata if it's in CI environment and meta data is asked to be saved.
-			if prow.IsCI() && opts.SaveMetaData {
-				saveMetaData(cc, region)
-			}
-			break
-		}
+	command := exec.Command("kubetest2", kubetest2Flags...)
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
+	if err := command.Run(); err != nil {
+		return err
 	}
 
-	return err
-}
-
-// isRetryableCreationError determines if cluster creation should be retried based on the error message.
-func isRetryableCreationError(errMsg string) bool {
-	for _, regx := range retryableCreationErrors {
-		if regx.MatchString(errMsg) {
-			return true
-		}
+	// Only save the metadata if it's in CI environment and meta data is asked to be saved.
+	if prow.IsCI() && opts.SaveMetaData {
+		return saveMetaData(cc, strings.Join(regions, ","))
 	}
-	return false
+	return nil
 }
 
 // saveMetaData will save the metadata with best effort.
-func saveMetaData(cc *GKEClusterConfig, region string) {
+func saveMetaData(cc *GKEClusterConfig, region string) error {
 	cli, err := metautil.NewClient("")
 	if err != nil {
-		log.Printf("error creating the metautil client: %v", err)
-		return
+		return fmt.Errorf("error creating the metautil client: %w", err)
 	}
 	cv, err := cmd.RunCommand("kubectl version --short=true")
 	if err != nil {
-		log.Printf("error getting the cluster version: %v", err)
-		return
+		return fmt.Errorf("error getting the cluster version: %w", err)
 	}
 
 	// Set the metadata with best effort.
@@ -200,4 +174,5 @@ func saveMetaData(cc *GKEClusterConfig, region string) {
 	cli.Set("E2E:Version", cv)
 	cli.Set("E2E:MinNodes", strconv.Itoa(cc.MinNodes))
 	cli.Set("E2E:MaxNodes", strconv.Itoa(cc.MaxNodes))
+	return nil
 }

--- a/tools/kntest/pkg/kubetest2/gke/options.go
+++ b/tools/kntest/pkg/kubetest2/gke/options.go
@@ -44,8 +44,7 @@ func addOptions(gkeCmd *cobra.Command, cfg *kubetest2.GKEClusterConfig) {
 	f.StringVar(&cfg.Addons, "addons", "", "Addons for the GKE cluster, should be comma-separated.")
 	f.BoolVar(&cfg.EnableWorkloadIdentity, "enable-workload-identity", false, "Whether to enable workload identity for this cluster or not.")
 	f.StringVar(&cfg.PrivateClusterAccessLevel, "private-cluster-access-level", "", "Private cluster access level, if not empty, must be one of 'no', 'limited' or 'unrestricted'")
-	f.StringVar(&cfg.PrivateClusterMasterIPSubnetRange, "private-cluster-master-ip-subnet-range", "172.16.0", "The master IP subnet range for the private cluster. The last digit must be left empty to allow retrying cluster creation in the backup regions.")
-	f.StringVar(&cfg.PrivateClusterMasterIPSubnetMask, "private-cluster-master-ip-subnet-mask", "28", "The master IP subnet mask for the private cluster.")
+	f.StringSliceVar(&cfg.PrivateClusterMasterIPSubnetRange, "private-cluster-master-ip-subnet-range", []string{"172.16.0.32/28", "173.16.0.32/28", "174.16.0.32/28"}, "The master IP subnet range for the private cluster. Its length must be the same as the number of clusters if private cluster is requested.")
 
 	f.StringVar(&cfg.ExtraGcloudFlags, "extra-gcloud-flags", "", "The extra gcloud flags that will be used for cluster creation.")
 }


### PR DESCRIPTION
**Which issue(s) this PR fixes**:<br>
Fixes #3096 

<!--
  If there is any golang code in this PR please uncomment the 
  `/lint` statement below to have Prow automatically lint it.
-->
<!--
  /lint
-->
