### PR TITLE
Only run auto-bump job once per week

### DIFF
--- a/config/prow/testgrid/testgrid.yaml
+++ b/config/prow/testgrid/testgrid.yaml
@@ -1499,11 +1499,6 @@ test_groups:
   alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"
   num_failures_to_alert: 1
-- name: ci-knative-prow-auto-bumper
-  gcs_prefix: knative-prow/logs/ci-knative-prow-auto-bumper
-  alert_options:
-      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
-  num_failures_to_alert: 1
 - name: ci-knative-prow-jobs-syncer
   gcs_prefix: knative-prow/logs/ci-knative-prow-jobs-syncer
   alert_options:
@@ -3433,9 +3428,6 @@ dashboards:
     base_options: ""
   - name: ci-knative-flakes-resultsrecorder
     test_group_name: ci-knative-flakes-resultsrecorder
-    base_options: ""
-  - name: ci-knative-prow-auto-bumper
-    test_group_name: ci-knative-prow-auto-bumper
     base_options: ""
   - name: ci-knative-prow-jobs-syncer
     test_group_name: ci-knative-prow-jobs-syncer

--- a/prow/jobs/custom/autobump-prow.yaml
+++ b/prow/jobs/custom/autobump-prow.yaml
@@ -1,5 +1,5 @@
 periodics:
-- cron: "15 15-23 * * 1"  # Bump with label `skip-review`. Run at 7:15-15:15 PST (15:15 UTC) each Monday.
+- cron: "15 15 * * 1"  # Bump with label `skip-review`. Run at 7:15 PST (15:15 UTC) each Monday.
   name: ci-knative-prow-auto-bumper-for-auto-deploy
   cluster: "build-knative"
   decorate: true
@@ -21,41 +21,6 @@ periodics:
       args:
       - --config=prow/knative-autobump-config.yaml
       - --labels-override=skip-review # This label is used by tide for identifying trusted PR
-      volumeMounts:
-      - name: prow-auto-bumper-github-token
-        mountPath: /etc/prow-auto-bumper-github-token
-        readOnly: true
-      - name: ssh
-        mountPath: /root/.ssh
-    volumes:
-    - name: prow-auto-bumper-github-token
-      secret:
-        secretName: prow-auto-bumper-github-token
-    - name: ssh
-      secret:
-        secretName: prow-updater-robot-ssh-key
-        defaultMode: 0400
-- cron: "30 * * * 1-5"  # Bump don't label `skip-review`. Run at :30 past every hour Mon-Fri
-  name: ci-knative-prow-auto-bumper
-  cluster: "build-knative"
-  decorate: true
-  extra_refs:
-  - org: knative
-    repo: test-infra
-    base_ref: main
-    path_alias: knative.dev/test-infra
-  annotations:
-    testgrid-dashboards: utilities
-    testgrid-tab-name: ci-knative-prow-auto-bumper
-    testgrid-alert-email: "serverless-engprod-sea@google.com"
-    testgrid-num-failures-to-alert: "1"
-  spec:
-    containers:
-    - image: gcr.io/k8s-prow/generic-autobumper:v20220219-6289bdf4c9
-      command:
-      - /app/prow/cmd/generic-autobumper/app.binary
-      args:
-      - --config=prow/knative-autobump-config.yaml
       volumeMounts:
       - name: prow-auto-bumper-github-token
         mountPath: /etc/prow-auto-bumper-github-token

--- a/tools/config-generator/customjobs.go
+++ b/tools/config-generator/customjobs.go
@@ -25,7 +25,6 @@ var (
 		"ci-knative-cleanup",
 		"ci-knative-flakes-reporter",
 		"ci-knative-flakes-resultsrecorder",
-		"ci-knative-prow-auto-bumper",
 		"ci-knative-prow-jobs-syncer",
 		"post-knative-test-infra-image-push",
 		"post-knative-sandbox-peribolos",


### PR DESCRIPTION
**What this PR does, why we need it**:<br>
--> There is no need to run auto-bump job more frequently than once per week

<!--
  If there is any golang code in this PR please uncomment the 
  `/lint` statement below to have Prow automatically lint it.
-->
<!--
  /lint
-->
