### PR TITLE
Fix the kubetest2 command

### DIFF
--- a/pkg/clustermanager/kubetest2/gke.go
+++ b/pkg/clustermanager/kubetest2/gke.go
@@ -131,14 +131,15 @@ func Run(opts *Options, cc *GKEClusterConfig) error {
 		kubetest2Flags = append(kubetest2Flags, "--private-cluster-master-ip-range="+strings.Join(cc.PrivateClusterMasterIPSubnetRange, ","))
 	}
 
+	regions := append([]string{cc.Region}, cc.BackupRegions...)
+	kubetest2Flags = append(kubetest2Flags, "--region="+strings.Join(regions, ","))
+	kubetest2Flags = append(kubetest2Flags, "--retryable-error-patterns='"+retryableErrorPatterns+"'")
+
+	// Test command args must come last.
 	if opts.TestCommand != "" {
 		kubetest2Flags = append(kubetest2Flags, "--test=exec", "--")
 		kubetest2Flags = append(kubetest2Flags, strings.Split(opts.TestCommand, " ")...)
 	}
-
-	regions := append([]string{cc.Region}, cc.BackupRegions...)
-	kubetest2Flags = append(kubetest2Flags, "--region="+strings.Join(regions, ","))
-	kubetest2Flags = append(kubetest2Flags, "--retryable-error-patterns='"+retryableErrorPatterns+"'")
 
 	log.Printf("Running kubetest2 with flags: %q", kubetest2Flags)
 


### PR DESCRIPTION
Beta Prow jobs are failing - https://prow.knative.dev/view/gs/knative-prow/logs/ci-knative-client-continuous-beta-prow-tests/1496609183930257408, the reason is the test command args must come last. This PR fixes it.

/cc @kvmware @upodroid 