### PR TITLE
Run kubetest2 with --down arg

### DIFF
--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -175,7 +175,7 @@ COPY images/prow-tests/in-gvm-env.sh /usr/local/bin
 ############################################################
 FROM golang:1.17 AS external-go-gets
 
-ARG KUBETEST2_VERSION=cc0c36d0693ec17451a39a1bf2fff706beb06150
+ARG KUBETEST2_VERSION=5e5d3e9eebc6a609aa428bd3e2a1c0c3566d5baf
 ARG KIND_VERSION=v0.11.1
 ARG KO_VERSION=v0.8.2
 ARG PROTOC_GEN_GO_VERSION=v1.26.0

--- a/pkg/clustermanager/kubetest2/gke.go
+++ b/pkg/clustermanager/kubetest2/gke.go
@@ -40,7 +40,7 @@ const (
 )
 
 var (
-	baseKubetest2Flags = []string{"gke", "--ignore-gcp-ssh-key=true", "--up", "-v=1"}
+	baseKubetest2Flags = []string{"gke", "--ignore-gcp-ssh-key=true", "--up", "--down", "-v=1"}
 
 	// If one of the error patterns below is matched, it would be recommended to
 	// retry creating the cluster in a different region.

--- a/tools/kntest/pkg/cluster/commands.go
+++ b/tools/kntest/pkg/cluster/commands.go
@@ -25,7 +25,7 @@ import (
 func AddCommands(topLevel *cobra.Command) {
 	var clusterCmd = &cobra.Command{
 		Use:   "cluster",
-		Short: "Cluster related commands.",
+		Short: "Cluster related commands. Currently not used in Knative CI. Use kubetest2 subcommand instead.",
 	}
 
 	gke.AddCommands(clusterCmd)


### PR DESCRIPTION
**Which issue(s) this PR fixes**:<br>
Fixes #3117 

Update kubetest2 to the latest version, and run it with --down arg to directly release GCP projects after the test flows are finished, instead of the relying on the heartbeat timeout to automatically release projects. This'll help save some compute time thus reducing some costs.

Previously attempt failed due to one bug in kubetest2, now the bug has been fixed by https://github.com/kubernetes-sigs/kubetest2/pull/180 so trying this again.

/cc @upodroid @kvmware 