### PR TITLE
make  pull-knative-eventing-reconciler-tests prow job optional

### DIFF
--- a/prow/config_knative.yaml
+++ b/prow/config_knative.yaml
@@ -244,6 +244,7 @@ presubmits:
     - ./test/e2e-tests.sh
   - custom-test: reconciler-tests
     needs-monitor: true
+    optional: true
     args:
     - --run-test
     - ./test/e2e-rekt-tests.sh

--- a/prow/jobs/config.yaml
+++ b/prow/jobs/config.yaml
@@ -2415,7 +2415,7 @@ presubmits:
       prow.k8s.io/pubsub.runID: pull-knative-eventing-reconciler-tests
     context: pull-knative-eventing-reconciler-tests
     always_run: true
-    optional: false
+    optional: true
     rerun_command: "/test pull-knative-eventing-reconciler-tests"
     trigger: "(?m)^/test (all|pull-knative-eventing-reconciler-tests),?(\\s+|$)"
     decorate: true


### PR DESCRIPTION
Temporarily make reconciler-test optional to be able to make incremental progress on fixing it.