### PR TITLE
Remove --output arg from the validate-own-testgrid job

### DIFF
--- a/prow/jobs/custom/test-infra.yaml
+++ b/prow/jobs/custom/test-infra.yaml
@@ -71,7 +71,8 @@ presubmits:
         - --default=config/prow/k8s-testgrid/testgrid-common-settings.yaml
         - --yaml=config/prow/k8s-testgrid/k8s-testgrid.yaml
         - --oneshot
-        - --output=./config.pb
+        - --validate-config-file
+
   - name: pull-knative-test-infra-prow-tests-image-build
     agent: kubernetes
     optional: false


### PR DESCRIPTION
After the image was updated to the new images built with `ko`, it will run binary as user instead of root which does not have write permission to the folders except `/tmp`. While it doesn't really matter to write the file, removing `--output` arg from `pull-test-infra-validate-own-testgrid-yaml` to fix the job.

/cc @chaodaiG 