### PR TITLE
Change max_pod_age to 30m and max_prowjob_age to 24h for Prow

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -130,8 +130,8 @@ log_level: debug
 
 sinker:
   resync_period: 1m
-  max_prowjob_age: 48h
-  max_pod_age: 48h
+  max_prowjob_age: 24h
+  max_pod_age: 30m
   terminated_pod_ttl: 30m
 
 tide:


### PR DESCRIPTION
It's not quite useful to keep the Prow job Pods for such long time, since most contributors don't have the access and needs to check them from the Prow build cluster, but these Pods will block Node Autoscaler to scale down. Updating `max_pod_age` for Prow to 30m and max_prowjob_age to 24h to potentially save more compute resource.