### PR TITLE
Eventing Kafka and RabbitMQ slack reporter for nightlies

### DIFF
--- a/prow/config_knative.yaml
+++ b/prow/config_knative.yaml
@@ -1617,6 +1617,12 @@ periodics:
     needs-dind: true
   - nightly: true
     needs-dind: true
+    reporter_config:
+      slack:
+        channel: eventing-kafka
+        job_states_to_report:
+        - failure
+        report_template: '"The nightly release job for eventing-kafka failed, check the log: <{{.Status.URL}}|View logs>"'
   - dot-release: true
     release: "0.26"
     needs-dind: true
@@ -1635,6 +1641,12 @@ periodics:
   - continuous: true
     needs-dind: true
   - nightly: true
+    reporter_config:
+      slack:
+        channel: eventing-kafka
+        job_states_to_report:
+        - failure
+        report_template: '"The nightly release job for eventing-kafka-broker failed, check the log: <{{.Status.URL}}|View logs>"'
     needs-dind: true
   - dot-release: true
     release: "0.26"
@@ -1654,7 +1666,7 @@ periodics:
   - nightly: true
     reporter_config:
       slack:
-        channel: eventing
+        channel: eventing-rabbitmq
         job_states_to_report:
         - failure
         report_template: '"The nightly release job for eventing-rabbitmq failed, check the log: <{{.Status.URL}}|View logs>"'

--- a/prow/jobs/config.yaml
+++ b/prow/jobs/config.yaml
@@ -21128,6 +21128,12 @@ periodics:
   name: ci-knative-sandbox-eventing-kafka-nightly-release
   agent: kubernetes
   decorate: true
+  reporter_config:
+    slack:
+      channel: eventing-kafka
+      report_template: "The nightly release job for eventing-kafka failed, check the log: <{{.Status.URL}}|View logs>"
+      job_states_to_report:
+      - "failure"
   decoration_config:
     timeout: 180m
   cluster: "build-knative"
@@ -21735,6 +21741,12 @@ periodics:
   name: ci-knative-sandbox-eventing-kafka-broker-nightly-release
   agent: kubernetes
   decorate: true
+  reporter_config:
+    slack:
+      channel: eventing-kafka
+      report_template: "The nightly release job for eventing-kafka-broker failed, check the log: <{{.Status.URL}}|View logs>"
+      job_states_to_report:
+      - "failure"
   decoration_config:
     timeout: 180m
   cluster: "build-knative"
@@ -22228,7 +22240,7 @@ periodics:
   decorate: true
   reporter_config:
     slack:
-      channel: eventing
+      channel: eventing-rabbitmq
       report_template: "The nightly release job for eventing-rabbitmq failed, check the log: <{{.Status.URL}}|View logs>"
       job_states_to_report:
       - "failure"


### PR DESCRIPTION
- Add eventing-kafka and eventing-kafka-broker slack reporter
  config
- Update eventing-rabbitmq slack reporter to use eventing-rabbitmq
  channel

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>