### PR TITLE
Increase resources for eventing-kafka auto-release

### DIFF
--- a/prow/config_knative.yaml
+++ b/prow/config_knative.yaml
@@ -1636,6 +1636,11 @@ periodics:
     release: "1.3"
     needs-dind: true
   - auto-release: true
+    resources:
+      requests:
+        memory: 12Gi
+      limits:
+        memory: 16Gi
     needs-dind: true
   knative-sandbox/eventing-kafka-broker:
   - continuous: true

--- a/prow/jobs/config.yaml
+++ b/prow/jobs/config.yaml
@@ -18735,6 +18735,11 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
+      resources:
+        requests:
+          memory: 12Gi
+        limits:
+          memory: 16Gi
     volumes:
     - name: hub-token
       secret:


### PR DESCRIPTION
It seems that the [auto-release job](https://prow.knative.dev/job-history/gs/knative-prow/logs/ci-knative-sandbox-eventing-kafka-auto-release) for eventing-kafka gets killed by the end of the job randomly, which might be due to resources  starvation. This PR sets the resources similar to serving and other repos resources. 

<!-- 
  Use `Fixes #<issue number>`, or `Fixes (paste link of issue)`
  to automatically close linked issue when the PR is merged.
  Uncomment and fill below if the PR does not close any issues.
-->
<!--
**What this PR does, why we need it**:<br>
-->

<!--
  If there is any golang code in this PR please uncomment the 
  `/lint` statement below to have Prow automatically lint it.
-->
<!--
  /lint
-->
