### PR TITLE
Add 1.2 dot release job for knaitve/eventing

### DIFF
--- a/config/prow/testgrid/testgrid.yaml
+++ b/config/prow/testgrid/testgrid.yaml
@@ -374,6 +374,12 @@ test_groups:
   alert_options:
     alert_mail_to_addresses: "serverless-engprod-sea@google.com"
   num_failures_to_alert: 3
+- name: ci-knative-eventing-1.2-dot-release
+  gcs_prefix: knative-prow/logs/ci-knative-eventing-1.2-dot-release
+  alert_options:
+    alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+  alert_stale_results_hours: 170
+  num_failures_to_alert: 1
 - name: ci-knative-eventing-1.2-s390x-e2e-tests
   gcs_prefix: knative-prow/logs/ci-knative-eventing-1.2-s390x-e2e-tests
   alert_stale_results_hours: 3
@@ -2603,6 +2609,12 @@ dashboards:
     num_failures_to_alert: 3
   - name: eventing-continuous
     test_group_name: ci-knative-eventing-1.2-continuous
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
+  - name: eventing-dot-release
+    test_group_name: ci-knative-eventing-1.2-dot-release
     base_options: "sort-by-name="
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"

--- a/config/prow/testgrid/testgrid.yaml
+++ b/config/prow/testgrid/testgrid.yaml
@@ -369,6 +369,11 @@ test_groups:
 - name: ci-knative-client-1.2-s390x-e2e-tests
   gcs_prefix: knative-prow/logs/ci-knative-client-1.2-s390x-e2e-tests
   alert_stale_results_hours: 3
+- name: ci-knative-eventing-1.2-continuous
+  gcs_prefix: knative-prow/logs/ci-knative-eventing-1.2-continuous
+  alert_options:
+    alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+  num_failures_to_alert: 3
 - name: ci-knative-eventing-1.2-s390x-e2e-tests
   gcs_prefix: knative-prow/logs/ci-knative-eventing-1.2-s390x-e2e-tests
   alert_stale_results_hours: 3
@@ -2592,6 +2597,12 @@ dashboards:
     num_failures_to_alert: 3
   - name: client-s390x-e2e-tests
     test_group_name: ci-knative-client-1.2-s390x-e2e-tests
+    base_options: "sort-by-name="
+    alert_options:
+      alert_mail_to_addresses: "serverless-engprod-sea@google.com"
+    num_failures_to_alert: 3
+  - name: eventing-continuous
+    test_group_name: ci-knative-eventing-1.2-continuous
     base_options: "sort-by-name="
     alert_options:
       alert_mail_to_addresses: "serverless-engprod-sea@google.com"

--- a/prow/config_knative.yaml
+++ b/prow/config_knative.yaml
@@ -1064,6 +1064,8 @@ periodics:
   - branch-ci: true
     release: "1.1"
   - branch-ci: true
+    release: "1.2"
+  - branch-ci: true
     release: "1.3"
   - nightly: true
     reporter_config:

--- a/prow/config_knative.yaml
+++ b/prow/config_knative.yaml
@@ -1101,6 +1101,13 @@ periodics:
       limits:
         memory: 16Gi
   - dot-release: true
+    release: "1.2"
+    resources:
+      requests:
+        memory: 12Gi
+      limits:
+        memory: 16Gi
+  - dot-release: true
     release: "1.3"
     resources:
       requests:

--- a/prow/jobs/config.yaml
+++ b/prow/jobs/config.yaml
@@ -11008,6 +11008,67 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
+- cron: "0 8 * * *"
+  name: ci-knative-eventing-1.2-continuous
+  agent: kubernetes
+  decorate: true
+  decoration_config:
+    timeout: 180m
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative
+    repo: eventing
+    path_alias: knative.dev/eventing
+    base_ref: release-1.2
+  annotations:
+    testgrid-dashboards: knative-1.2
+    testgrid-tab-name: eventing-continuous
+    testgrid-alert-stale-results-hours: "3"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--nopublish"
+      - "--notag-release"
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - name: docker-graph
+        mountPath: /docker-graph
+      - name: modules
+        mountPath: /lib/modules
+      - name: cgroup
+        mountPath: /sys/fs/cgroup
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-1.2
+    volumes:
+    - name: docker-graph
+      emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+    - name: test-account
+      secret:
+        secretName: test-account
 - cron: "45 8 * * *"
   name: ci-knative-eventing-1.3-continuous
   agent: kubernetes

--- a/prow/jobs/config.yaml
+++ b/prow/jobs/config.yaml
@@ -11358,6 +11358,65 @@ periodics:
     - name: release-account
       secret:
         secretName: release-account
+- cron: "58 9 * * 2"
+  name: ci-knative-eventing-1.2-dot-release
+  agent: kubernetes
+  decorate: true
+  decoration_config:
+    timeout: 180m
+  cluster: "build-knative"
+  extra_refs:
+  - org: knative
+    repo: eventing
+    path_alias: knative.dev/eventing
+    base_ref: release-1.2
+  annotations:
+    testgrid-dashboards: knative-1.2
+    testgrid-tab-name: eventing-dot-release
+    testgrid-alert-stale-results-hours: "3"
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - "./hack/release.sh"
+      - "--dot-release"
+      - "--release-gcs"
+      - "knative-releases/eventing"
+      - "--release-gcr"
+      - "gcr.io/knative-releases"
+      - "--github-token"
+      - "/etc/hub-token/token"
+      - "--branch"
+      - "release-1.2"
+      volumeMounts:
+      - name: hub-token
+        mountPath: /etc/hub-token
+        readOnly: true
+      - name: release-account
+        mountPath: /etc/release-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: PULL_BASE_REF
+        value: release-1.2
+      resources:
+        requests:
+          memory: 12Gi
+        limits:
+          memory: 16Gi
+    volumes:
+    - name: hub-token
+      secret:
+        secretName: hub-token
+    - name: release-account
+      secret:
+        secretName: release-account
 - cron: "1 9 * * 2"
   name: ci-knative-eventing-1.3-dot-release
   agent: kubernetes


### PR DESCRIPTION
**Which issue(s) this PR fixes**:<br>

we aren't getting dot releases for eventing release-1.2 branch
since there is no job for 1.2.

See individual commits for details.

<!-- 
  Use `Fixes #<issue number>`, or `Fixes (paste link of issue)`
  to automatically close linked issue when the PR is merged.
  Uncomment and fill below if the PR does not close any issues.
-->
<!--
**What this PR does, why we need it**:<br>
-->

<!--
  If there is any golang code in this PR please uncomment the 
  `/lint` statement below to have Prow automatically lint it.
-->
<!--
  /lint
-->
