### PR TITLE
Fix path_alias for knative-sandbox repos

### DIFF
--- a/prow/jobs/generated/knative-sandbox/async-component-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/async-component-main.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/async-component
     repo: async-component
   name: continuous_async-component_main_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/async-component
     repo: async-component
   name: nightly_async-component_main_periodic
   spec:
@@ -88,6 +90,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/async-component
     repo: async-component
   name: release_async-component_main_periodic
   spec:
@@ -138,6 +141,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_async-component_main
+    path_alias: knative.dev/async-component
     spec:
       containers:
       - command:
@@ -157,6 +161,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_async-component_main
+    path_alias: knative.dev/async-component
     spec:
       containers:
       - command:
@@ -176,6 +181,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_async-component_main
+    path_alias: knative.dev/async-component
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/container-freezer-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/container-freezer-main.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/container-freezer
     repo: container-freezer
   name: continuous_container-freezer_main_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/container-freezer
     repo: container-freezer
   name: nightly_container-freezer_main_periodic
   spec:
@@ -88,6 +90,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/container-freezer
     repo: container-freezer
   name: release_container-freezer_main_periodic
   spec:
@@ -138,6 +141,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_container-freezer_main
+    path_alias: knative.dev/container-freezer
     spec:
       containers:
       - command:
@@ -157,6 +161,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_container-freezer_main
+    path_alias: knative.dev/container-freezer
     spec:
       containers:
       - command:
@@ -176,6 +181,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_container-freezer_main
+    path_alias: knative.dev/container-freezer
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/discovery-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/discovery-main.gen.yaml
@@ -13,6 +13,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_discovery_main
+    path_alias: knative.dev/discovery
     spec:
       containers:
       - command:
@@ -32,6 +33,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_discovery_main
+    path_alias: knative.dev/discovery
     spec:
       containers:
       - command:
@@ -51,6 +53,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_discovery_main
+    path_alias: knative.dev/discovery
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/eventing-autoscaler-keda-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-autoscaler-keda-main.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/eventing-autoscaler-keda
     repo: eventing-autoscaler-keda
   name: continuous_eventing-autoscaler-keda_main_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/eventing-autoscaler-keda
     repo: eventing-autoscaler-keda
   name: nightly_eventing-autoscaler-keda_main_periodic
   spec:
@@ -88,6 +90,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/eventing-autoscaler-keda
     repo: eventing-autoscaler-keda
   name: release_eventing-autoscaler-keda_main_periodic
   spec:
@@ -139,6 +142,7 @@ presubmits:
     decorate: true
     name: integration-test-kafka-source_eventing-autoscaler-keda_main
     optional: true
+    path_alias: knative.dev/eventing-autoscaler-keda
     spec:
       containers:
       - command:
@@ -173,6 +177,7 @@ presubmits:
     decorate: true
     name: integration-test-kafka-mt-source_eventing-autoscaler-keda_main
     optional: true
+    path_alias: knative.dev/eventing-autoscaler-keda
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/eventing-autoscaler-keda-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-autoscaler-keda-release-1.0.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.0
     org: knative-sandbox
+    path_alias: knative.dev/eventing-autoscaler-keda
     repo: eventing-autoscaler-keda
   name: continuous_eventing-autoscaler-keda_release-1.0_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.0
     org: knative-sandbox
+    path_alias: knative.dev/eventing-autoscaler-keda
     repo: eventing-autoscaler-keda
   name: release_eventing-autoscaler-keda_release-1.0_periodic
   spec:
@@ -105,6 +107,7 @@ presubmits:
     decorate: true
     name: integration-test-kafka-source_eventing-autoscaler-keda_release-1.0
     optional: true
+    path_alias: knative.dev/eventing-autoscaler-keda
     spec:
       containers:
       - command:
@@ -139,6 +142,7 @@ presubmits:
     decorate: true
     name: integration-test-kafka-mt-source_eventing-autoscaler-keda_release-1.0
     optional: true
+    path_alias: knative.dev/eventing-autoscaler-keda
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/eventing-autoscaler-keda-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-autoscaler-keda-release-1.1.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.1
     org: knative-sandbox
+    path_alias: knative.dev/eventing-autoscaler-keda
     repo: eventing-autoscaler-keda
   name: continuous_eventing-autoscaler-keda_release-1.1_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.1
     org: knative-sandbox
+    path_alias: knative.dev/eventing-autoscaler-keda
     repo: eventing-autoscaler-keda
   name: release_eventing-autoscaler-keda_release-1.1_periodic
   spec:
@@ -105,6 +107,7 @@ presubmits:
     decorate: true
     name: integration-test-kafka-source_eventing-autoscaler-keda_release-1.1
     optional: true
+    path_alias: knative.dev/eventing-autoscaler-keda
     spec:
       containers:
       - command:
@@ -139,6 +142,7 @@ presubmits:
     decorate: true
     name: integration-test-kafka-mt-source_eventing-autoscaler-keda_release-1.1
     optional: true
+    path_alias: knative.dev/eventing-autoscaler-keda
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/eventing-autoscaler-keda-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-autoscaler-keda-release-1.2.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.2
     org: knative-sandbox
+    path_alias: knative.dev/eventing-autoscaler-keda
     repo: eventing-autoscaler-keda
   name: continuous_eventing-autoscaler-keda_release-1.2_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.2
     org: knative-sandbox
+    path_alias: knative.dev/eventing-autoscaler-keda
     repo: eventing-autoscaler-keda
   name: release_eventing-autoscaler-keda_release-1.2_periodic
   spec:
@@ -105,6 +107,7 @@ presubmits:
     decorate: true
     name: integration-test-kafka-source_eventing-autoscaler-keda_release-1.2
     optional: true
+    path_alias: knative.dev/eventing-autoscaler-keda
     spec:
       containers:
       - command:
@@ -139,6 +142,7 @@ presubmits:
     decorate: true
     name: integration-test-kafka-mt-source_eventing-autoscaler-keda_release-1.2
     optional: true
+    path_alias: knative.dev/eventing-autoscaler-keda
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/eventing-autoscaler-keda-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-autoscaler-keda-release-1.3.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.3
     org: knative-sandbox
+    path_alias: knative.dev/eventing-autoscaler-keda
     repo: eventing-autoscaler-keda
   name: continuous_eventing-autoscaler-keda_release-1.3_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.3
     org: knative-sandbox
+    path_alias: knative.dev/eventing-autoscaler-keda
     repo: eventing-autoscaler-keda
   name: release_eventing-autoscaler-keda_release-1.3_periodic
   spec:
@@ -105,6 +107,7 @@ presubmits:
     decorate: true
     name: integration-test-kafka-source_eventing-autoscaler-keda_release-1.3
     optional: true
+    path_alias: knative.dev/eventing-autoscaler-keda
     spec:
       containers:
       - command:
@@ -139,6 +142,7 @@ presubmits:
     decorate: true
     name: integration-test-kafka-mt-source_eventing-autoscaler-keda_release-1.3
     optional: true
+    path_alias: knative.dev/eventing-autoscaler-keda
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/eventing-awssqs-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-awssqs-main.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/eventing-awssqs
     repo: eventing-awssqs
   name: continuous_eventing-awssqs_main_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/eventing-awssqs
     repo: eventing-awssqs
   name: nightly_eventing-awssqs_main_periodic
   spec:
@@ -88,6 +90,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/eventing-awssqs
     repo: eventing-awssqs
   name: release_eventing-awssqs_main_periodic
   spec:

--- a/prow/jobs/generated/knative-sandbox/eventing-awssqs-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-awssqs-release-1.0.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.0
     org: knative-sandbox
+    path_alias: knative.dev/eventing-awssqs
     repo: eventing-awssqs
   name: continuous_eventing-awssqs_release-1.0_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.0
     org: knative-sandbox
+    path_alias: knative.dev/eventing-awssqs
     repo: eventing-awssqs
   name: release_eventing-awssqs_release-1.0_periodic
   spec:

--- a/prow/jobs/generated/knative-sandbox/eventing-awssqs-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-awssqs-release-1.1.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.1
     org: knative-sandbox
+    path_alias: knative.dev/eventing-awssqs
     repo: eventing-awssqs
   name: continuous_eventing-awssqs_release-1.1_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.1
     org: knative-sandbox
+    path_alias: knative.dev/eventing-awssqs
     repo: eventing-awssqs
   name: release_eventing-awssqs_release-1.1_periodic
   spec:

--- a/prow/jobs/generated/knative-sandbox/eventing-awssqs-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-awssqs-release-1.2.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.2
     org: knative-sandbox
+    path_alias: knative.dev/eventing-awssqs
     repo: eventing-awssqs
   name: continuous_eventing-awssqs_release-1.2_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.2
     org: knative-sandbox
+    path_alias: knative.dev/eventing-awssqs
     repo: eventing-awssqs
   name: release_eventing-awssqs_release-1.2_periodic
   spec:

--- a/prow/jobs/generated/knative-sandbox/eventing-ceph-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-ceph-main.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/eventing-ceph
     repo: eventing-ceph
   name: continuous_eventing-ceph_main_periodic
   spec:
@@ -70,6 +71,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/eventing-ceph
     repo: eventing-ceph
   name: nightly_eventing-ceph_main_periodic
   spec:
@@ -124,6 +126,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/eventing-ceph
     repo: eventing-ceph
   name: release_eventing-ceph_main_periodic
   spec:

--- a/prow/jobs/generated/knative-sandbox/eventing-ceph-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-ceph-release-1.0.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.0
     org: knative-sandbox
+    path_alias: knative.dev/eventing-ceph
     repo: eventing-ceph
   name: continuous_eventing-ceph_release-1.0_periodic
   spec:
@@ -70,6 +71,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.0
     org: knative-sandbox
+    path_alias: knative.dev/eventing-ceph
     repo: eventing-ceph
   name: release_eventing-ceph_release-1.0_periodic
   spec:

--- a/prow/jobs/generated/knative-sandbox/eventing-ceph-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-ceph-release-1.1.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.1
     org: knative-sandbox
+    path_alias: knative.dev/eventing-ceph
     repo: eventing-ceph
   name: continuous_eventing-ceph_release-1.1_periodic
   spec:
@@ -70,6 +71,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.1
     org: knative-sandbox
+    path_alias: knative.dev/eventing-ceph
     repo: eventing-ceph
   name: release_eventing-ceph_release-1.1_periodic
   spec:

--- a/prow/jobs/generated/knative-sandbox/eventing-ceph-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-ceph-release-1.2.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.2
     org: knative-sandbox
+    path_alias: knative.dev/eventing-ceph
     repo: eventing-ceph
   name: continuous_eventing-ceph_release-1.2_periodic
   spec:
@@ -70,6 +71,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.2
     org: knative-sandbox
+    path_alias: knative.dev/eventing-ceph
     repo: eventing-ceph
   name: release_eventing-ceph_release-1.2_periodic
   spec:

--- a/prow/jobs/generated/knative-sandbox/eventing-ceph-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-ceph-release-1.3.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.3
     org: knative-sandbox
+    path_alias: knative.dev/eventing-ceph
     repo: eventing-ceph
   name: continuous_eventing-ceph_release-1.3_periodic
   spec:
@@ -70,6 +71,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.3
     org: knative-sandbox
+    path_alias: knative.dev/eventing-ceph
     repo: eventing-ceph
   name: release_eventing-ceph_release-1.3_periodic
   spec:

--- a/prow/jobs/generated/knative-sandbox/eventing-couchdb-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-couchdb-main.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/eventing-couchdb
     repo: eventing-couchdb
   name: continuous_eventing-couchdb_main_periodic
   spec:
@@ -70,6 +71,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/eventing-couchdb
     repo: eventing-couchdb
   name: nightly_eventing-couchdb_main_periodic
   spec:
@@ -124,6 +126,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/eventing-couchdb
     repo: eventing-couchdb
   name: release_eventing-couchdb_main_periodic
   spec:

--- a/prow/jobs/generated/knative-sandbox/eventing-couchdb-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-couchdb-release-1.0.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.0
     org: knative-sandbox
+    path_alias: knative.dev/eventing-couchdb
     repo: eventing-couchdb
   name: continuous_eventing-couchdb_release-1.0_periodic
   spec:
@@ -70,6 +71,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.0
     org: knative-sandbox
+    path_alias: knative.dev/eventing-couchdb
     repo: eventing-couchdb
   name: release_eventing-couchdb_release-1.0_periodic
   spec:

--- a/prow/jobs/generated/knative-sandbox/eventing-couchdb-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-couchdb-release-1.1.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.1
     org: knative-sandbox
+    path_alias: knative.dev/eventing-couchdb
     repo: eventing-couchdb
   name: continuous_eventing-couchdb_release-1.1_periodic
   spec:
@@ -70,6 +71,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.1
     org: knative-sandbox
+    path_alias: knative.dev/eventing-couchdb
     repo: eventing-couchdb
   name: release_eventing-couchdb_release-1.1_periodic
   spec:

--- a/prow/jobs/generated/knative-sandbox/eventing-github-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-github-main.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/eventing-github
     repo: eventing-github
   name: continuous_eventing-github_main_periodic
   spec:
@@ -70,6 +71,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/eventing-github
     repo: eventing-github
   name: nightly_eventing-github_main_periodic
   spec:
@@ -124,6 +126,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/eventing-github
     repo: eventing-github
   name: release_eventing-github_main_periodic
   spec:

--- a/prow/jobs/generated/knative-sandbox/eventing-github-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-github-release-1.0.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.0
     org: knative-sandbox
+    path_alias: knative.dev/eventing-github
     repo: eventing-github
   name: continuous_eventing-github_release-1.0_periodic
   spec:
@@ -70,6 +71,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.0
     org: knative-sandbox
+    path_alias: knative.dev/eventing-github
     repo: eventing-github
   name: release_eventing-github_release-1.0_periodic
   spec:

--- a/prow/jobs/generated/knative-sandbox/eventing-github-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-github-release-1.1.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.1
     org: knative-sandbox
+    path_alias: knative.dev/eventing-github
     repo: eventing-github
   name: continuous_eventing-github_release-1.1_periodic
   spec:
@@ -70,6 +71,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.1
     org: knative-sandbox
+    path_alias: knative.dev/eventing-github
     repo: eventing-github
   name: release_eventing-github_release-1.1_periodic
   spec:

--- a/prow/jobs/generated/knative-sandbox/eventing-github-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-github-release-1.2.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.2
     org: knative-sandbox
+    path_alias: knative.dev/eventing-github
     repo: eventing-github
   name: continuous_eventing-github_release-1.2_periodic
   spec:
@@ -70,6 +71,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.2
     org: knative-sandbox
+    path_alias: knative.dev/eventing-github
     repo: eventing-github
   name: release_eventing-github_release-1.2_periodic
   spec:

--- a/prow/jobs/generated/knative-sandbox/eventing-github-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-github-release-1.3.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.3
     org: knative-sandbox
+    path_alias: knative.dev/eventing-github
     repo: eventing-github
   name: continuous_eventing-github_release-1.3_periodic
   spec:
@@ -70,6 +71,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.3
     org: knative-sandbox
+    path_alias: knative.dev/eventing-github
     repo: eventing-github
   name: release_eventing-github_release-1.3_periodic
   spec:

--- a/prow/jobs/generated/knative-sandbox/eventing-gitlab-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-gitlab-main.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/eventing-gitlab
     repo: eventing-gitlab
   name: continuous_eventing-gitlab_main_periodic
   spec:
@@ -74,6 +75,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/eventing-gitlab
     repo: eventing-gitlab
   name: nightly_eventing-gitlab_main_periodic
   spec:
@@ -132,6 +134,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/eventing-gitlab
     repo: eventing-gitlab
   name: release_eventing-gitlab_main_periodic
   spec:

--- a/prow/jobs/generated/knative-sandbox/eventing-gitlab-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-gitlab-release-1.0.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.0
     org: knative-sandbox
+    path_alias: knative.dev/eventing-gitlab
     repo: eventing-gitlab
   name: continuous_eventing-gitlab_release-1.0_periodic
   spec:
@@ -74,6 +75,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.0
     org: knative-sandbox
+    path_alias: knative.dev/eventing-gitlab
     repo: eventing-gitlab
   name: release_eventing-gitlab_release-1.0_periodic
   spec:

--- a/prow/jobs/generated/knative-sandbox/eventing-gitlab-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-gitlab-release-1.1.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.1
     org: knative-sandbox
+    path_alias: knative.dev/eventing-gitlab
     repo: eventing-gitlab
   name: continuous_eventing-gitlab_release-1.1_periodic
   spec:
@@ -74,6 +75,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.1
     org: knative-sandbox
+    path_alias: knative.dev/eventing-gitlab
     repo: eventing-gitlab
   name: release_eventing-gitlab_release-1.1_periodic
   spec:

--- a/prow/jobs/generated/knative-sandbox/eventing-gitlab-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-gitlab-release-1.2.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.2
     org: knative-sandbox
+    path_alias: knative.dev/eventing-gitlab
     repo: eventing-gitlab
   name: continuous_eventing-gitlab_release-1.2_periodic
   spec:
@@ -74,6 +75,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.2
     org: knative-sandbox
+    path_alias: knative.dev/eventing-gitlab
     repo: eventing-gitlab
   name: release_eventing-gitlab_release-1.2_periodic
   spec:

--- a/prow/jobs/generated/knative-sandbox/eventing-gitlab-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-gitlab-release-1.3.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.3
     org: knative-sandbox
+    path_alias: knative.dev/eventing-gitlab
     repo: eventing-gitlab
   name: continuous_eventing-gitlab_release-1.3_periodic
   spec:
@@ -74,6 +75,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.3
     org: knative-sandbox
+    path_alias: knative.dev/eventing-gitlab
     repo: eventing-gitlab
   name: release_eventing-gitlab_release-1.3_periodic
   spec:

--- a/prow/jobs/generated/knative-sandbox/eventing-kafka-broker-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kafka-broker-main.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/eventing-kafka-broker
     repo: eventing-kafka-broker
   name: continuous_eventing-kafka-broker_main_periodic
   spec:
@@ -70,6 +71,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/eventing-kafka-broker
     repo: eventing-kafka-broker
   name: nightly_eventing-kafka-broker_main_periodic
   reporter_config:
@@ -131,6 +133,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/eventing-kafka-broker
     repo: eventing-kafka-broker
   name: release_eventing-kafka-broker_main_periodic
   spec:
@@ -199,6 +202,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_eventing-kafka-broker_main
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:
@@ -218,6 +222,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_eventing-kafka-broker_main
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:
@@ -237,6 +242,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_eventing-kafka-broker_main
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:
@@ -287,6 +293,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: upgrade-tests_eventing-kafka-broker_main
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:
@@ -338,6 +345,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: reconciler-tests_eventing-kafka-broker_main
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:
@@ -389,6 +397,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: channel-integration-tests-ssl_eventing-kafka-broker_main
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:
@@ -442,6 +451,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: channel-integration-tests-sasl-ssl_eventing-kafka-broker_main
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:
@@ -495,6 +505,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: channel-integration-tests-sasl-plain_eventing-kafka-broker_main
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:
@@ -548,6 +559,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: channel-reconciler-tests-ssl_eventing-kafka-broker_main
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:
@@ -601,6 +613,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: channel-reconciler-tests-sasl-ssl_eventing-kafka-broker_main
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:
@@ -654,6 +667,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: channel-reconciler-tests-sasl-plain_eventing-kafka-broker_main
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/eventing-kafka-broker-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kafka-broker-release-1.0.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.0
     org: knative-sandbox
+    path_alias: knative.dev/eventing-kafka-broker
     repo: eventing-kafka-broker
   name: continuous_eventing-kafka-broker_release-1.0_periodic
   spec:
@@ -70,6 +71,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.0
     org: knative-sandbox
+    path_alias: knative.dev/eventing-kafka-broker
     repo: eventing-kafka-broker
   name: release_eventing-kafka-broker_release-1.0_periodic
   spec:
@@ -122,6 +124,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_eventing-kafka-broker_release-1.0
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:
@@ -141,6 +144,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_eventing-kafka-broker_release-1.0
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:
@@ -160,6 +164,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_eventing-kafka-broker_release-1.0
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:
@@ -210,6 +215,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: upgrade-tests_eventing-kafka-broker_release-1.0
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:
@@ -261,6 +267,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: reconciler-tests_eventing-kafka-broker_release-1.0
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:
@@ -312,6 +319,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: channel-integration-tests-ssl_eventing-kafka-broker_release-1.0
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:
@@ -365,6 +373,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: channel-integration-tests-sasl-ssl_eventing-kafka-broker_release-1.0
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:
@@ -418,6 +427,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: channel-integration-tests-sasl-plain_eventing-kafka-broker_release-1.0
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:
@@ -471,6 +481,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: channel-reconciler-tests-ssl_eventing-kafka-broker_release-1.0
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:
@@ -524,6 +535,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: channel-reconciler-tests-sasl-ssl_eventing-kafka-broker_release-1.0
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:
@@ -577,6 +589,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: channel-reconciler-tests-sasl-plain_eventing-kafka-broker_release-1.0
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/eventing-kafka-broker-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kafka-broker-release-1.1.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.1
     org: knative-sandbox
+    path_alias: knative.dev/eventing-kafka-broker
     repo: eventing-kafka-broker
   name: continuous_eventing-kafka-broker_release-1.1_periodic
   spec:
@@ -70,6 +71,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.1
     org: knative-sandbox
+    path_alias: knative.dev/eventing-kafka-broker
     repo: eventing-kafka-broker
   name: release_eventing-kafka-broker_release-1.1_periodic
   spec:
@@ -122,6 +124,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_eventing-kafka-broker_release-1.1
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:
@@ -141,6 +144,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_eventing-kafka-broker_release-1.1
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:
@@ -160,6 +164,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_eventing-kafka-broker_release-1.1
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:
@@ -210,6 +215,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: upgrade-tests_eventing-kafka-broker_release-1.1
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:
@@ -261,6 +267,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: reconciler-tests_eventing-kafka-broker_release-1.1
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:
@@ -312,6 +319,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: channel-integration-tests-ssl_eventing-kafka-broker_release-1.1
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:
@@ -365,6 +373,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: channel-integration-tests-sasl-ssl_eventing-kafka-broker_release-1.1
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:
@@ -418,6 +427,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: channel-integration-tests-sasl-plain_eventing-kafka-broker_release-1.1
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:
@@ -471,6 +481,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: channel-reconciler-tests-ssl_eventing-kafka-broker_release-1.1
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:
@@ -524,6 +535,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: channel-reconciler-tests-sasl-ssl_eventing-kafka-broker_release-1.1
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:
@@ -577,6 +589,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: channel-reconciler-tests-sasl-plain_eventing-kafka-broker_release-1.1
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/eventing-kafka-broker-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kafka-broker-release-1.2.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.2
     org: knative-sandbox
+    path_alias: knative.dev/eventing-kafka-broker
     repo: eventing-kafka-broker
   name: continuous_eventing-kafka-broker_release-1.2_periodic
   spec:
@@ -70,6 +71,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.2
     org: knative-sandbox
+    path_alias: knative.dev/eventing-kafka-broker
     repo: eventing-kafka-broker
   name: release_eventing-kafka-broker_release-1.2_periodic
   spec:
@@ -122,6 +124,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_eventing-kafka-broker_release-1.2
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:
@@ -141,6 +144,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_eventing-kafka-broker_release-1.2
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:
@@ -160,6 +164,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_eventing-kafka-broker_release-1.2
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:
@@ -210,6 +215,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: upgrade-tests_eventing-kafka-broker_release-1.2
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:
@@ -261,6 +267,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: reconciler-tests_eventing-kafka-broker_release-1.2
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:
@@ -312,6 +319,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: channel-integration-tests-ssl_eventing-kafka-broker_release-1.2
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:
@@ -365,6 +373,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: channel-integration-tests-sasl-ssl_eventing-kafka-broker_release-1.2
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:
@@ -418,6 +427,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: channel-integration-tests-sasl-plain_eventing-kafka-broker_release-1.2
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:
@@ -471,6 +481,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: channel-reconciler-tests-ssl_eventing-kafka-broker_release-1.2
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:
@@ -524,6 +535,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: channel-reconciler-tests-sasl-ssl_eventing-kafka-broker_release-1.2
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:
@@ -577,6 +589,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: channel-reconciler-tests-sasl-plain_eventing-kafka-broker_release-1.2
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/eventing-kafka-broker-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kafka-broker-release-1.3.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.3
     org: knative-sandbox
+    path_alias: knative.dev/eventing-kafka-broker
     repo: eventing-kafka-broker
   name: continuous_eventing-kafka-broker_release-1.3_periodic
   spec:
@@ -70,6 +71,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.3
     org: knative-sandbox
+    path_alias: knative.dev/eventing-kafka-broker
     repo: eventing-kafka-broker
   name: release_eventing-kafka-broker_release-1.3_periodic
   spec:
@@ -122,6 +124,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_eventing-kafka-broker_release-1.3
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:
@@ -141,6 +144,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_eventing-kafka-broker_release-1.3
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:
@@ -160,6 +164,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_eventing-kafka-broker_release-1.3
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:
@@ -210,6 +215,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: upgrade-tests_eventing-kafka-broker_release-1.3
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:
@@ -261,6 +267,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: reconciler-tests_eventing-kafka-broker_release-1.3
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:
@@ -312,6 +319,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: channel-integration-tests-ssl_eventing-kafka-broker_release-1.3
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:
@@ -365,6 +373,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: channel-integration-tests-sasl-ssl_eventing-kafka-broker_release-1.3
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:
@@ -418,6 +427,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: channel-integration-tests-sasl-plain_eventing-kafka-broker_release-1.3
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:
@@ -471,6 +481,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: channel-reconciler-tests-ssl_eventing-kafka-broker_release-1.3
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:
@@ -524,6 +535,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: channel-reconciler-tests-sasl-ssl_eventing-kafka-broker_release-1.3
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:
@@ -577,6 +589,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: channel-reconciler-tests-sasl-plain_eventing-kafka-broker_release-1.3
+    path_alias: knative.dev/eventing-kafka-broker
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/eventing-kafka-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kafka-main.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/eventing-kafka
     repo: eventing-kafka
   name: continuous_eventing-kafka_main_periodic
   spec:
@@ -70,6 +71,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/eventing-kafka
     repo: eventing-kafka
   name: nightly_eventing-kafka_main_periodic
   reporter_config:
@@ -131,6 +133,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/eventing-kafka
     repo: eventing-kafka
   name: release_eventing-kafka_main_periodic
   spec:
@@ -199,6 +202,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_eventing-kafka_main
+    path_alias: knative.dev/eventing-kafka
     spec:
       containers:
       - command:
@@ -239,6 +243,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_eventing-kafka_main
+    path_alias: knative.dev/eventing-kafka
     spec:
       containers:
       - command:
@@ -279,6 +284,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-test-channel-consolidated_eventing-kafka_main
+    path_alias: knative.dev/eventing-kafka
     spec:
       containers:
       - command:
@@ -312,6 +318,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-test-channel-consolidated-tls_eventing-kafka_main
+    path_alias: knative.dev/eventing-kafka
     spec:
       containers:
       - command:
@@ -345,6 +352,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-test-channel-consolidated-sasl_eventing-kafka_main
+    path_alias: knative.dev/eventing-kafka
     spec:
       containers:
       - command:
@@ -378,6 +386,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-test-channel-distributed_eventing-kafka_main
+    path_alias: knative.dev/eventing-kafka
     spec:
       containers:
       - command:
@@ -412,6 +421,7 @@ presubmits:
     decorate: true
     name: integration-test-mt-source_eventing-kafka_main
     optional: true
+    path_alias: knative.dev/eventing-kafka
     spec:
       containers:
       - command:
@@ -445,6 +455,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: upgrade-tests_eventing-kafka_main
+    path_alias: knative.dev/eventing-kafka
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/eventing-kafka-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kafka-release-1.0.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.0
     org: knative-sandbox
+    path_alias: knative.dev/eventing-kafka
     repo: eventing-kafka
   name: continuous_eventing-kafka_release-1.0_periodic
   spec:
@@ -70,6 +71,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.0
     org: knative-sandbox
+    path_alias: knative.dev/eventing-kafka
     repo: eventing-kafka
   name: release_eventing-kafka_release-1.0_periodic
   spec:
@@ -122,6 +124,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_eventing-kafka_release-1.0
+    path_alias: knative.dev/eventing-kafka
     spec:
       containers:
       - command:
@@ -162,6 +165,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_eventing-kafka_release-1.0
+    path_alias: knative.dev/eventing-kafka
     spec:
       containers:
       - command:
@@ -202,6 +206,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-test-channel-consolidated_eventing-kafka_release-1.0
+    path_alias: knative.dev/eventing-kafka
     spec:
       containers:
       - command:
@@ -235,6 +240,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-test-channel-consolidated-tls_eventing-kafka_release-1.0
+    path_alias: knative.dev/eventing-kafka
     spec:
       containers:
       - command:
@@ -268,6 +274,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-test-channel-consolidated-sasl_eventing-kafka_release-1.0
+    path_alias: knative.dev/eventing-kafka
     spec:
       containers:
       - command:
@@ -301,6 +308,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-test-channel-distributed_eventing-kafka_release-1.0
+    path_alias: knative.dev/eventing-kafka
     spec:
       containers:
       - command:
@@ -335,6 +343,7 @@ presubmits:
     decorate: true
     name: integration-test-mt-source_eventing-kafka_release-1.0
     optional: true
+    path_alias: knative.dev/eventing-kafka
     spec:
       containers:
       - command:
@@ -368,6 +377,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: upgrade-tests_eventing-kafka_release-1.0
+    path_alias: knative.dev/eventing-kafka
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/eventing-kafka-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kafka-release-1.1.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.1
     org: knative-sandbox
+    path_alias: knative.dev/eventing-kafka
     repo: eventing-kafka
   name: continuous_eventing-kafka_release-1.1_periodic
   spec:
@@ -70,6 +71,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.1
     org: knative-sandbox
+    path_alias: knative.dev/eventing-kafka
     repo: eventing-kafka
   name: release_eventing-kafka_release-1.1_periodic
   spec:
@@ -122,6 +124,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_eventing-kafka_release-1.1
+    path_alias: knative.dev/eventing-kafka
     spec:
       containers:
       - command:
@@ -162,6 +165,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_eventing-kafka_release-1.1
+    path_alias: knative.dev/eventing-kafka
     spec:
       containers:
       - command:
@@ -202,6 +206,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-test-channel-consolidated_eventing-kafka_release-1.1
+    path_alias: knative.dev/eventing-kafka
     spec:
       containers:
       - command:
@@ -235,6 +240,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-test-channel-consolidated-tls_eventing-kafka_release-1.1
+    path_alias: knative.dev/eventing-kafka
     spec:
       containers:
       - command:
@@ -268,6 +274,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-test-channel-consolidated-sasl_eventing-kafka_release-1.1
+    path_alias: knative.dev/eventing-kafka
     spec:
       containers:
       - command:
@@ -301,6 +308,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-test-channel-distributed_eventing-kafka_release-1.1
+    path_alias: knative.dev/eventing-kafka
     spec:
       containers:
       - command:
@@ -335,6 +343,7 @@ presubmits:
     decorate: true
     name: integration-test-mt-source_eventing-kafka_release-1.1
     optional: true
+    path_alias: knative.dev/eventing-kafka
     spec:
       containers:
       - command:
@@ -368,6 +377,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: upgrade-tests_eventing-kafka_release-1.1
+    path_alias: knative.dev/eventing-kafka
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/eventing-kafka-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kafka-release-1.2.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.2
     org: knative-sandbox
+    path_alias: knative.dev/eventing-kafka
     repo: eventing-kafka
   name: continuous_eventing-kafka_release-1.2_periodic
   spec:
@@ -70,6 +71,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.2
     org: knative-sandbox
+    path_alias: knative.dev/eventing-kafka
     repo: eventing-kafka
   name: release_eventing-kafka_release-1.2_periodic
   spec:
@@ -122,6 +124,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_eventing-kafka_release-1.2
+    path_alias: knative.dev/eventing-kafka
     spec:
       containers:
       - command:
@@ -162,6 +165,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_eventing-kafka_release-1.2
+    path_alias: knative.dev/eventing-kafka
     spec:
       containers:
       - command:
@@ -202,6 +206,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-test-channel-consolidated_eventing-kafka_release-1.2
+    path_alias: knative.dev/eventing-kafka
     spec:
       containers:
       - command:
@@ -235,6 +240,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-test-channel-consolidated-tls_eventing-kafka_release-1.2
+    path_alias: knative.dev/eventing-kafka
     spec:
       containers:
       - command:
@@ -268,6 +274,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-test-channel-consolidated-sasl_eventing-kafka_release-1.2
+    path_alias: knative.dev/eventing-kafka
     spec:
       containers:
       - command:
@@ -301,6 +308,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-test-channel-distributed_eventing-kafka_release-1.2
+    path_alias: knative.dev/eventing-kafka
     spec:
       containers:
       - command:
@@ -335,6 +343,7 @@ presubmits:
     decorate: true
     name: integration-test-mt-source_eventing-kafka_release-1.2
     optional: true
+    path_alias: knative.dev/eventing-kafka
     spec:
       containers:
       - command:
@@ -368,6 +377,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: upgrade-tests_eventing-kafka_release-1.2
+    path_alias: knative.dev/eventing-kafka
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/eventing-kafka-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kafka-release-1.3.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.3
     org: knative-sandbox
+    path_alias: knative.dev/eventing-kafka
     repo: eventing-kafka
   name: continuous_eventing-kafka_release-1.3_periodic
   spec:
@@ -70,6 +71,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.3
     org: knative-sandbox
+    path_alias: knative.dev/eventing-kafka
     repo: eventing-kafka
   name: release_eventing-kafka_release-1.3_periodic
   spec:
@@ -122,6 +124,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_eventing-kafka_release-1.3
+    path_alias: knative.dev/eventing-kafka
     spec:
       containers:
       - command:
@@ -162,6 +165,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_eventing-kafka_release-1.3
+    path_alias: knative.dev/eventing-kafka
     spec:
       containers:
       - command:
@@ -202,6 +206,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-test-channel-consolidated_eventing-kafka_release-1.3
+    path_alias: knative.dev/eventing-kafka
     spec:
       containers:
       - command:
@@ -235,6 +240,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-test-channel-consolidated-tls_eventing-kafka_release-1.3
+    path_alias: knative.dev/eventing-kafka
     spec:
       containers:
       - command:
@@ -268,6 +274,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-test-channel-consolidated-sasl_eventing-kafka_release-1.3
+    path_alias: knative.dev/eventing-kafka
     spec:
       containers:
       - command:
@@ -301,6 +308,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-test-channel-distributed_eventing-kafka_release-1.3
+    path_alias: knative.dev/eventing-kafka
     spec:
       containers:
       - command:
@@ -335,6 +343,7 @@ presubmits:
     decorate: true
     name: integration-test-mt-source_eventing-kafka_release-1.3
     optional: true
+    path_alias: knative.dev/eventing-kafka
     spec:
       containers:
       - command:
@@ -368,6 +377,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: upgrade-tests_eventing-kafka_release-1.3
+    path_alias: knative.dev/eventing-kafka
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/eventing-kogito-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kogito-main.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/eventing-kogito
     repo: eventing-kogito
   name: continuous_eventing-kogito_main_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/eventing-kogito
     repo: eventing-kogito
   name: nightly_eventing-kogito_main_periodic
   reporter_config:
@@ -95,6 +97,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/eventing-kogito
     repo: eventing-kogito
   name: release_eventing-kogito_main_periodic
   spec:
@@ -145,6 +148,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_eventing-kogito_main
+    path_alias: knative.dev/eventing-kogito
     spec:
       containers:
       - command:
@@ -164,6 +168,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_eventing-kogito_main
+    path_alias: knative.dev/eventing-kogito
     spec:
       containers:
       - command:
@@ -183,6 +188,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_eventing-kogito_main
+    path_alias: knative.dev/eventing-kogito
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/eventing-kogito-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kogito-release-1.0.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.0
     org: knative-sandbox
+    path_alias: knative.dev/eventing-kogito
     repo: eventing-kogito
   name: continuous_eventing-kogito_release-1.0_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.0
     org: knative-sandbox
+    path_alias: knative.dev/eventing-kogito
     repo: eventing-kogito
   name: release_eventing-kogito_release-1.0_periodic
   spec:
@@ -104,6 +106,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_eventing-kogito_release-1.0
+    path_alias: knative.dev/eventing-kogito
     spec:
       containers:
       - command:
@@ -123,6 +126,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_eventing-kogito_release-1.0
+    path_alias: knative.dev/eventing-kogito
     spec:
       containers:
       - command:
@@ -142,6 +146,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_eventing-kogito_release-1.0
+    path_alias: knative.dev/eventing-kogito
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/eventing-kogito-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kogito-release-1.1.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.1
     org: knative-sandbox
+    path_alias: knative.dev/eventing-kogito
     repo: eventing-kogito
   name: continuous_eventing-kogito_release-1.1_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.1
     org: knative-sandbox
+    path_alias: knative.dev/eventing-kogito
     repo: eventing-kogito
   name: release_eventing-kogito_release-1.1_periodic
   spec:
@@ -104,6 +106,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_eventing-kogito_release-1.1
+    path_alias: knative.dev/eventing-kogito
     spec:
       containers:
       - command:
@@ -123,6 +126,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_eventing-kogito_release-1.1
+    path_alias: knative.dev/eventing-kogito
     spec:
       containers:
       - command:
@@ -142,6 +146,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_eventing-kogito_release-1.1
+    path_alias: knative.dev/eventing-kogito
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/eventing-kogito-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kogito-release-1.2.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.2
     org: knative-sandbox
+    path_alias: knative.dev/eventing-kogito
     repo: eventing-kogito
   name: continuous_eventing-kogito_release-1.2_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.2
     org: knative-sandbox
+    path_alias: knative.dev/eventing-kogito
     repo: eventing-kogito
   name: release_eventing-kogito_release-1.2_periodic
   spec:
@@ -104,6 +106,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_eventing-kogito_release-1.2
+    path_alias: knative.dev/eventing-kogito
     spec:
       containers:
       - command:
@@ -123,6 +126,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_eventing-kogito_release-1.2
+    path_alias: knative.dev/eventing-kogito
     spec:
       containers:
       - command:
@@ -142,6 +146,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_eventing-kogito_release-1.2
+    path_alias: knative.dev/eventing-kogito
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/eventing-kogito-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kogito-release-1.3.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.3
     org: knative-sandbox
+    path_alias: knative.dev/eventing-kogito
     repo: eventing-kogito
   name: continuous_eventing-kogito_release-1.3_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.3
     org: knative-sandbox
+    path_alias: knative.dev/eventing-kogito
     repo: eventing-kogito
   name: release_eventing-kogito_release-1.3_periodic
   spec:
@@ -104,6 +106,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_eventing-kogito_release-1.3
+    path_alias: knative.dev/eventing-kogito
     spec:
       containers:
       - command:
@@ -123,6 +126,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_eventing-kogito_release-1.3
+    path_alias: knative.dev/eventing-kogito
     spec:
       containers:
       - command:
@@ -142,6 +146,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_eventing-kogito_release-1.3
+    path_alias: knative.dev/eventing-kogito
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/eventing-natss-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-natss-main.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/eventing-natss
     repo: eventing-natss
   name: continuous_eventing-natss_main_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/eventing-natss
     repo: eventing-natss
   name: nightly_eventing-natss_main_periodic
   reporter_config:
@@ -95,6 +97,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/eventing-natss
     repo: eventing-natss
   name: release_eventing-natss_main_periodic
   spec:

--- a/prow/jobs/generated/knative-sandbox/eventing-natss-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-natss-release-1.0.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.0
     org: knative-sandbox
+    path_alias: knative.dev/eventing-natss
     repo: eventing-natss
   name: continuous_eventing-natss_release-1.0_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.0
     org: knative-sandbox
+    path_alias: knative.dev/eventing-natss
     repo: eventing-natss
   name: release_eventing-natss_release-1.0_periodic
   spec:

--- a/prow/jobs/generated/knative-sandbox/eventing-natss-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-natss-release-1.1.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.1
     org: knative-sandbox
+    path_alias: knative.dev/eventing-natss
     repo: eventing-natss
   name: continuous_eventing-natss_release-1.1_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.1
     org: knative-sandbox
+    path_alias: knative.dev/eventing-natss
     repo: eventing-natss
   name: release_eventing-natss_release-1.1_periodic
   spec:

--- a/prow/jobs/generated/knative-sandbox/eventing-natss-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-natss-release-1.2.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.2
     org: knative-sandbox
+    path_alias: knative.dev/eventing-natss
     repo: eventing-natss
   name: continuous_eventing-natss_release-1.2_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.2
     org: knative-sandbox
+    path_alias: knative.dev/eventing-natss
     repo: eventing-natss
   name: release_eventing-natss_release-1.2_periodic
   spec:

--- a/prow/jobs/generated/knative-sandbox/eventing-natss-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-natss-release-1.3.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.3
     org: knative-sandbox
+    path_alias: knative.dev/eventing-natss
     repo: eventing-natss
   name: continuous_eventing-natss_release-1.3_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.3
     org: knative-sandbox
+    path_alias: knative.dev/eventing-natss
     repo: eventing-natss
   name: release_eventing-natss_release-1.3_periodic
   spec:

--- a/prow/jobs/generated/knative-sandbox/eventing-rabbitmq-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-rabbitmq-main.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/eventing-rabbitmq
     repo: eventing-rabbitmq
   name: continuous_eventing-rabbitmq_main_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/eventing-rabbitmq
     repo: eventing-rabbitmq
   name: nightly_eventing-rabbitmq_main_periodic
   reporter_config:
@@ -95,6 +97,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/eventing-rabbitmq
     repo: eventing-rabbitmq
   name: release_eventing-rabbitmq_main_periodic
   spec:

--- a/prow/jobs/generated/knative-sandbox/eventing-rabbitmq-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-rabbitmq-release-1.0.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.0
     org: knative-sandbox
+    path_alias: knative.dev/eventing-rabbitmq
     repo: eventing-rabbitmq
   name: continuous_eventing-rabbitmq_release-1.0_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.0
     org: knative-sandbox
+    path_alias: knative.dev/eventing-rabbitmq
     repo: eventing-rabbitmq
   name: release_eventing-rabbitmq_release-1.0_periodic
   spec:

--- a/prow/jobs/generated/knative-sandbox/eventing-rabbitmq-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-rabbitmq-release-1.1.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.1
     org: knative-sandbox
+    path_alias: knative.dev/eventing-rabbitmq
     repo: eventing-rabbitmq
   name: continuous_eventing-rabbitmq_release-1.1_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.1
     org: knative-sandbox
+    path_alias: knative.dev/eventing-rabbitmq
     repo: eventing-rabbitmq
   name: release_eventing-rabbitmq_release-1.1_periodic
   spec:

--- a/prow/jobs/generated/knative-sandbox/eventing-rabbitmq-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-rabbitmq-release-1.2.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.2
     org: knative-sandbox
+    path_alias: knative.dev/eventing-rabbitmq
     repo: eventing-rabbitmq
   name: continuous_eventing-rabbitmq_release-1.2_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.2
     org: knative-sandbox
+    path_alias: knative.dev/eventing-rabbitmq
     repo: eventing-rabbitmq
   name: release_eventing-rabbitmq_release-1.2_periodic
   spec:

--- a/prow/jobs/generated/knative-sandbox/eventing-rabbitmq-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-rabbitmq-release-1.3.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.3
     org: knative-sandbox
+    path_alias: knative.dev/eventing-rabbitmq
     repo: eventing-rabbitmq
   name: continuous_eventing-rabbitmq_release-1.3_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.3
     org: knative-sandbox
+    path_alias: knative.dev/eventing-rabbitmq
     repo: eventing-rabbitmq
   name: release_eventing-rabbitmq_release-1.3_periodic
   spec:

--- a/prow/jobs/generated/knative-sandbox/eventing-redis-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-redis-main.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/eventing-redis
     repo: eventing-redis
   name: continuous_eventing-redis_main_periodic
   spec:
@@ -70,6 +71,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/eventing-redis
     repo: eventing-redis
   name: nightly_eventing-redis_main_periodic
   spec:
@@ -124,6 +126,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/eventing-redis
     repo: eventing-redis
   name: release_eventing-redis_main_periodic
   spec:

--- a/prow/jobs/generated/knative-sandbox/eventing-redis-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-redis-release-1.0.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.0
     org: knative-sandbox
+    path_alias: knative.dev/eventing-redis
     repo: eventing-redis
   name: continuous_eventing-redis_release-1.0_periodic
   spec:
@@ -70,6 +71,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.0
     org: knative-sandbox
+    path_alias: knative.dev/eventing-redis
     repo: eventing-redis
   name: release_eventing-redis_release-1.0_periodic
   spec:

--- a/prow/jobs/generated/knative-sandbox/eventing-redis-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-redis-release-1.1.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.1
     org: knative-sandbox
+    path_alias: knative.dev/eventing-redis
     repo: eventing-redis
   name: continuous_eventing-redis_release-1.1_periodic
   spec:
@@ -70,6 +71,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.1
     org: knative-sandbox
+    path_alias: knative.dev/eventing-redis
     repo: eventing-redis
   name: release_eventing-redis_release-1.1_periodic
   spec:

--- a/prow/jobs/generated/knative-sandbox/eventing-redis-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-redis-release-1.2.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.2
     org: knative-sandbox
+    path_alias: knative.dev/eventing-redis
     repo: eventing-redis
   name: continuous_eventing-redis_release-1.2_periodic
   spec:
@@ -70,6 +71,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.2
     org: knative-sandbox
+    path_alias: knative.dev/eventing-redis
     repo: eventing-redis
   name: release_eventing-redis_release-1.2_periodic
   spec:

--- a/prow/jobs/generated/knative-sandbox/eventing-redis-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-redis-release-1.3.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.3
     org: knative-sandbox
+    path_alias: knative.dev/eventing-redis
     repo: eventing-redis
   name: continuous_eventing-redis_release-1.3_periodic
   spec:
@@ -70,6 +71,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.3
     org: knative-sandbox
+    path_alias: knative.dev/eventing-redis
     repo: eventing-redis
   name: release_eventing-redis_release-1.3_periodic
   spec:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-admin-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-admin-main.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-admin
     repo: kn-plugin-admin
   name: continuous_kn-plugin-admin_main_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-admin
     repo: kn-plugin-admin
   name: nightly_kn-plugin-admin_main_periodic
   spec:
@@ -88,6 +90,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-admin
     repo: kn-plugin-admin
   name: release_kn-plugin-admin_main_periodic
   spec:
@@ -138,6 +141,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_kn-plugin-admin_main
+    path_alias: knative.dev/kn-plugin-admin
     spec:
       containers:
       - command:
@@ -157,6 +161,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_kn-plugin-admin_main
+    path_alias: knative.dev/kn-plugin-admin
     spec:
       containers:
       - command:
@@ -176,6 +181,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_kn-plugin-admin_main
+    path_alias: knative.dev/kn-plugin-admin
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-admin-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-admin-release-1.0.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.0
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-admin
     repo: kn-plugin-admin
   name: continuous_kn-plugin-admin_release-1.0_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.0
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-admin
     repo: kn-plugin-admin
   name: release_kn-plugin-admin_release-1.0_periodic
   spec:
@@ -104,6 +106,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_kn-plugin-admin_release-1.0
+    path_alias: knative.dev/kn-plugin-admin
     spec:
       containers:
       - command:
@@ -123,6 +126,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_kn-plugin-admin_release-1.0
+    path_alias: knative.dev/kn-plugin-admin
     spec:
       containers:
       - command:
@@ -142,6 +146,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_kn-plugin-admin_release-1.0
+    path_alias: knative.dev/kn-plugin-admin
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-admin-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-admin-release-1.1.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.1
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-admin
     repo: kn-plugin-admin
   name: continuous_kn-plugin-admin_release-1.1_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.1
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-admin
     repo: kn-plugin-admin
   name: release_kn-plugin-admin_release-1.1_periodic
   spec:
@@ -104,6 +106,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_kn-plugin-admin_release-1.1
+    path_alias: knative.dev/kn-plugin-admin
     spec:
       containers:
       - command:
@@ -123,6 +126,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_kn-plugin-admin_release-1.1
+    path_alias: knative.dev/kn-plugin-admin
     spec:
       containers:
       - command:
@@ -142,6 +146,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_kn-plugin-admin_release-1.1
+    path_alias: knative.dev/kn-plugin-admin
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-admin-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-admin-release-1.2.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.2
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-admin
     repo: kn-plugin-admin
   name: continuous_kn-plugin-admin_release-1.2_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.2
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-admin
     repo: kn-plugin-admin
   name: release_kn-plugin-admin_release-1.2_periodic
   spec:
@@ -104,6 +106,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_kn-plugin-admin_release-1.2
+    path_alias: knative.dev/kn-plugin-admin
     spec:
       containers:
       - command:
@@ -123,6 +126,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_kn-plugin-admin_release-1.2
+    path_alias: knative.dev/kn-plugin-admin
     spec:
       containers:
       - command:
@@ -142,6 +146,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_kn-plugin-admin_release-1.2
+    path_alias: knative.dev/kn-plugin-admin
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-admin-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-admin-release-1.3.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.3
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-admin
     repo: kn-plugin-admin
   name: continuous_kn-plugin-admin_release-1.3_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.3
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-admin
     repo: kn-plugin-admin
   name: release_kn-plugin-admin_release-1.3_periodic
   spec:
@@ -104,6 +106,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_kn-plugin-admin_release-1.3
+    path_alias: knative.dev/kn-plugin-admin
     spec:
       containers:
       - command:
@@ -123,6 +126,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_kn-plugin-admin_release-1.3
+    path_alias: knative.dev/kn-plugin-admin
     spec:
       containers:
       - command:
@@ -142,6 +146,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_kn-plugin-admin_release-1.3
+    path_alias: knative.dev/kn-plugin-admin
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-diag-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-diag-main.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-diag
     repo: kn-plugin-diag
   name: continuous_kn-plugin-diag_main_periodic
   spec:
@@ -51,6 +52,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_kn-plugin-diag_main
+    path_alias: knative.dev/kn-plugin-diag
     spec:
       containers:
       - command:
@@ -70,6 +72,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_kn-plugin-diag_main
+    path_alias: knative.dev/kn-plugin-diag
     spec:
       containers:
       - command:
@@ -89,6 +92,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_kn-plugin-diag_main
+    path_alias: knative.dev/kn-plugin-diag
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-event-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-event-main.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-event
     repo: kn-plugin-event
   name: continuous_kn-plugin-event_main_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-event
     repo: kn-plugin-event
   name: nightly_kn-plugin-event_main_periodic
   spec:
@@ -88,6 +90,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-event
     repo: kn-plugin-event
   name: release_kn-plugin-event_main_periodic
   spec:
@@ -138,6 +141,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_kn-plugin-event_main
+    path_alias: knative.dev/kn-plugin-event
     spec:
       containers:
       - command:
@@ -157,6 +161,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_kn-plugin-event_main
+    path_alias: knative.dev/kn-plugin-event
     spec:
       containers:
       - command:
@@ -176,6 +181,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_kn-plugin-event_main
+    path_alias: knative.dev/kn-plugin-event
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-event-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-event-release-1.0.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.0
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-event
     repo: kn-plugin-event
   name: continuous_kn-plugin-event_release-1.0_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.0
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-event
     repo: kn-plugin-event
   name: release_kn-plugin-event_release-1.0_periodic
   spec:
@@ -104,6 +106,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_kn-plugin-event_release-1.0
+    path_alias: knative.dev/kn-plugin-event
     spec:
       containers:
       - command:
@@ -123,6 +126,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_kn-plugin-event_release-1.0
+    path_alias: knative.dev/kn-plugin-event
     spec:
       containers:
       - command:
@@ -142,6 +146,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_kn-plugin-event_release-1.0
+    path_alias: knative.dev/kn-plugin-event
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-event-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-event-release-1.1.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.1
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-event
     repo: kn-plugin-event
   name: continuous_kn-plugin-event_release-1.1_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.1
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-event
     repo: kn-plugin-event
   name: release_kn-plugin-event_release-1.1_periodic
   spec:
@@ -104,6 +106,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_kn-plugin-event_release-1.1
+    path_alias: knative.dev/kn-plugin-event
     spec:
       containers:
       - command:
@@ -123,6 +126,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_kn-plugin-event_release-1.1
+    path_alias: knative.dev/kn-plugin-event
     spec:
       containers:
       - command:
@@ -142,6 +146,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_kn-plugin-event_release-1.1
+    path_alias: knative.dev/kn-plugin-event
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-event-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-event-release-1.2.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.2
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-event
     repo: kn-plugin-event
   name: continuous_kn-plugin-event_release-1.2_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.2
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-event
     repo: kn-plugin-event
   name: release_kn-plugin-event_release-1.2_periodic
   spec:
@@ -104,6 +106,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_kn-plugin-event_release-1.2
+    path_alias: knative.dev/kn-plugin-event
     spec:
       containers:
       - command:
@@ -123,6 +126,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_kn-plugin-event_release-1.2
+    path_alias: knative.dev/kn-plugin-event
     spec:
       containers:
       - command:
@@ -142,6 +146,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_kn-plugin-event_release-1.2
+    path_alias: knative.dev/kn-plugin-event
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-event-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-event-release-1.3.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.3
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-event
     repo: kn-plugin-event
   name: continuous_kn-plugin-event_release-1.3_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.3
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-event
     repo: kn-plugin-event
   name: release_kn-plugin-event_release-1.3_periodic
   spec:
@@ -104,6 +106,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_kn-plugin-event_release-1.3
+    path_alias: knative.dev/kn-plugin-event
     spec:
       containers:
       - command:
@@ -123,6 +126,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_kn-plugin-event_release-1.3
+    path_alias: knative.dev/kn-plugin-event
     spec:
       containers:
       - command:
@@ -142,6 +146,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_kn-plugin-event_release-1.3
+    path_alias: knative.dev/kn-plugin-event
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-func-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-func-main.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-func
     repo: kn-plugin-func
   name: nightly_kn-plugin-func_main_periodic
   spec:
@@ -69,6 +70,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-func
     repo: kn-plugin-func
   name: release_kn-plugin-func_main_periodic
   spec:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-func-release-0.22.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-func-release-0.22.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-0.22
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-func
     repo: kn-plugin-func
   name: release_kn-plugin-func_release-0.22_periodic
   spec:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-migration-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-migration-main.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-migration
     repo: kn-plugin-migration
   name: continuous_kn-plugin-migration_main_periodic
   spec:
@@ -51,6 +52,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_kn-plugin-migration_main
+    path_alias: knative.dev/kn-plugin-migration
     spec:
       containers:
       - command:
@@ -70,6 +72,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_kn-plugin-migration_main
+    path_alias: knative.dev/kn-plugin-migration
     spec:
       containers:
       - command:
@@ -89,6 +92,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_kn-plugin-migration_main
+    path_alias: knative.dev/kn-plugin-migration
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-operator-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-operator-main.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-operator
     repo: kn-plugin-operator
   name: continuous_kn-plugin-operator_main_periodic
   spec:
@@ -51,6 +52,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_kn-plugin-operator_main
+    path_alias: knative.dev/kn-plugin-operator
     spec:
       containers:
       - command:
@@ -70,6 +72,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_kn-plugin-operator_main
+    path_alias: knative.dev/kn-plugin-operator
     spec:
       containers:
       - command:
@@ -89,6 +92,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_kn-plugin-operator_main
+    path_alias: knative.dev/kn-plugin-operator
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-quickstart-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-quickstart-main.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-quickstart
     repo: kn-plugin-quickstart
   name: continuous_kn-plugin-quickstart_main_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-quickstart
     repo: kn-plugin-quickstart
   name: nightly_kn-plugin-quickstart_main_periodic
   spec:
@@ -88,6 +90,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-quickstart
     repo: kn-plugin-quickstart
   name: release_kn-plugin-quickstart_main_periodic
   spec:
@@ -138,6 +141,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_kn-plugin-quickstart_main
+    path_alias: knative.dev/kn-plugin-quickstart
     spec:
       containers:
       - command:
@@ -157,6 +161,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_kn-plugin-quickstart_main
+    path_alias: knative.dev/kn-plugin-quickstart
     spec:
       containers:
       - command:
@@ -176,6 +181,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_kn-plugin-quickstart_main
+    path_alias: knative.dev/kn-plugin-quickstart
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-quickstart-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-quickstart-release-1.0.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.0
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-quickstart
     repo: kn-plugin-quickstart
   name: continuous_kn-plugin-quickstart_release-1.0_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.0
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-quickstart
     repo: kn-plugin-quickstart
   name: release_kn-plugin-quickstart_release-1.0_periodic
   spec:
@@ -104,6 +106,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_kn-plugin-quickstart_release-1.0
+    path_alias: knative.dev/kn-plugin-quickstart
     spec:
       containers:
       - command:
@@ -123,6 +126,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_kn-plugin-quickstart_release-1.0
+    path_alias: knative.dev/kn-plugin-quickstart
     spec:
       containers:
       - command:
@@ -142,6 +146,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_kn-plugin-quickstart_release-1.0
+    path_alias: knative.dev/kn-plugin-quickstart
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-quickstart-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-quickstart-release-1.1.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.1
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-quickstart
     repo: kn-plugin-quickstart
   name: continuous_kn-plugin-quickstart_release-1.1_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.1
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-quickstart
     repo: kn-plugin-quickstart
   name: release_kn-plugin-quickstart_release-1.1_periodic
   spec:
@@ -104,6 +106,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_kn-plugin-quickstart_release-1.1
+    path_alias: knative.dev/kn-plugin-quickstart
     spec:
       containers:
       - command:
@@ -123,6 +126,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_kn-plugin-quickstart_release-1.1
+    path_alias: knative.dev/kn-plugin-quickstart
     spec:
       containers:
       - command:
@@ -142,6 +146,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_kn-plugin-quickstart_release-1.1
+    path_alias: knative.dev/kn-plugin-quickstart
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-quickstart-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-quickstart-release-1.2.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.2
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-quickstart
     repo: kn-plugin-quickstart
   name: continuous_kn-plugin-quickstart_release-1.2_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.2
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-quickstart
     repo: kn-plugin-quickstart
   name: release_kn-plugin-quickstart_release-1.2_periodic
   spec:
@@ -104,6 +106,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_kn-plugin-quickstart_release-1.2
+    path_alias: knative.dev/kn-plugin-quickstart
     spec:
       containers:
       - command:
@@ -123,6 +126,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_kn-plugin-quickstart_release-1.2
+    path_alias: knative.dev/kn-plugin-quickstart
     spec:
       containers:
       - command:
@@ -142,6 +146,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_kn-plugin-quickstart_release-1.2
+    path_alias: knative.dev/kn-plugin-quickstart
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-quickstart-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-quickstart-release-1.3.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.3
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-quickstart
     repo: kn-plugin-quickstart
   name: continuous_kn-plugin-quickstart_release-1.3_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.3
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-quickstart
     repo: kn-plugin-quickstart
   name: release_kn-plugin-quickstart_release-1.3_periodic
   spec:
@@ -104,6 +106,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_kn-plugin-quickstart_release-1.3
+    path_alias: knative.dev/kn-plugin-quickstart
     spec:
       containers:
       - command:
@@ -123,6 +126,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_kn-plugin-quickstart_release-1.3
+    path_alias: knative.dev/kn-plugin-quickstart
     spec:
       containers:
       - command:
@@ -142,6 +146,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_kn-plugin-quickstart_release-1.3
+    path_alias: knative.dev/kn-plugin-quickstart
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-sample-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-sample-main.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-sample
     repo: kn-plugin-sample
   name: continuous_kn-plugin-sample_main_periodic
   spec:
@@ -51,6 +52,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_kn-plugin-sample_main
+    path_alias: knative.dev/kn-plugin-sample
     spec:
       containers:
       - command:
@@ -70,6 +72,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_kn-plugin-sample_main
+    path_alias: knative.dev/kn-plugin-sample
     spec:
       containers:
       - command:
@@ -89,6 +92,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_kn-plugin-sample_main
+    path_alias: knative.dev/kn-plugin-sample
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-service-log-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-service-log-main.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-service-log
     repo: kn-plugin-service-log
   name: continuous_kn-plugin-service-log_main_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-service-log
     repo: kn-plugin-service-log
   name: nightly_kn-plugin-service-log_main_periodic
   spec:
@@ -106,6 +108,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-service-log
     repo: kn-plugin-service-log
   name: release_kn-plugin-service-log_main_periodic
   spec:
@@ -174,6 +177,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_kn-plugin-service-log_main
+    path_alias: knative.dev/kn-plugin-service-log
     spec:
       containers:
       - command:
@@ -193,6 +197,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_kn-plugin-service-log_main
+    path_alias: knative.dev/kn-plugin-service-log
     spec:
       containers:
       - command:
@@ -212,6 +217,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_kn-plugin-service-log_main
+    path_alias: knative.dev/kn-plugin-service-log
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-source-kafka-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-source-kafka-main.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-source-kafka
     repo: kn-plugin-source-kafka
   name: continuous_kn-plugin-source-kafka_main_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-source-kafka
     repo: kn-plugin-source-kafka
   name: nightly_kn-plugin-source-kafka_main_periodic
   spec:
@@ -106,6 +108,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-source-kafka
     repo: kn-plugin-source-kafka
   name: release_kn-plugin-source-kafka_main_periodic
   spec:
@@ -174,6 +177,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_kn-plugin-source-kafka_main
+    path_alias: knative.dev/kn-plugin-source-kafka
     spec:
       containers:
       - command:
@@ -193,6 +197,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_kn-plugin-source-kafka_main
+    path_alias: knative.dev/kn-plugin-source-kafka
     spec:
       containers:
       - command:
@@ -212,6 +217,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_kn-plugin-source-kafka_main
+    path_alias: knative.dev/kn-plugin-source-kafka
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-source-kafka-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-source-kafka-release-1.0.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.0
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-source-kafka
     repo: kn-plugin-source-kafka
   name: continuous_kn-plugin-source-kafka_release-1.0_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.0
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-source-kafka
     repo: kn-plugin-source-kafka
   name: release_kn-plugin-source-kafka_release-1.0_periodic
   spec:
@@ -104,6 +106,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_kn-plugin-source-kafka_release-1.0
+    path_alias: knative.dev/kn-plugin-source-kafka
     spec:
       containers:
       - command:
@@ -123,6 +126,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_kn-plugin-source-kafka_release-1.0
+    path_alias: knative.dev/kn-plugin-source-kafka
     spec:
       containers:
       - command:
@@ -142,6 +146,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_kn-plugin-source-kafka_release-1.0
+    path_alias: knative.dev/kn-plugin-source-kafka
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-source-kafka-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-source-kafka-release-1.1.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.1
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-source-kafka
     repo: kn-plugin-source-kafka
   name: continuous_kn-plugin-source-kafka_release-1.1_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.1
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-source-kafka
     repo: kn-plugin-source-kafka
   name: release_kn-plugin-source-kafka_release-1.1_periodic
   spec:
@@ -104,6 +106,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_kn-plugin-source-kafka_release-1.1
+    path_alias: knative.dev/kn-plugin-source-kafka
     spec:
       containers:
       - command:
@@ -123,6 +126,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_kn-plugin-source-kafka_release-1.1
+    path_alias: knative.dev/kn-plugin-source-kafka
     spec:
       containers:
       - command:
@@ -142,6 +146,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_kn-plugin-source-kafka_release-1.1
+    path_alias: knative.dev/kn-plugin-source-kafka
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-source-kafka-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-source-kafka-release-1.2.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.2
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-source-kafka
     repo: kn-plugin-source-kafka
   name: continuous_kn-plugin-source-kafka_release-1.2_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.2
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-source-kafka
     repo: kn-plugin-source-kafka
   name: release_kn-plugin-source-kafka_release-1.2_periodic
   spec:
@@ -104,6 +106,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_kn-plugin-source-kafka_release-1.2
+    path_alias: knative.dev/kn-plugin-source-kafka
     spec:
       containers:
       - command:
@@ -123,6 +126,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_kn-plugin-source-kafka_release-1.2
+    path_alias: knative.dev/kn-plugin-source-kafka
     spec:
       containers:
       - command:
@@ -142,6 +146,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_kn-plugin-source-kafka_release-1.2
+    path_alias: knative.dev/kn-plugin-source-kafka
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-source-kafka-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-source-kafka-release-1.3.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.3
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-source-kafka
     repo: kn-plugin-source-kafka
   name: continuous_kn-plugin-source-kafka_release-1.3_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.3
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-source-kafka
     repo: kn-plugin-source-kafka
   name: release_kn-plugin-source-kafka_release-1.3_periodic
   spec:
@@ -104,6 +106,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_kn-plugin-source-kafka_release-1.3
+    path_alias: knative.dev/kn-plugin-source-kafka
     spec:
       containers:
       - command:
@@ -123,6 +126,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_kn-plugin-source-kafka_release-1.3
+    path_alias: knative.dev/kn-plugin-source-kafka
     spec:
       containers:
       - command:
@@ -142,6 +146,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_kn-plugin-source-kafka_release-1.3
+    path_alias: knative.dev/kn-plugin-source-kafka
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-source-kamelet-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-source-kamelet-main.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-source-kamelet
     repo: kn-plugin-source-kamelet
   name: continuous_kn-plugin-source-kamelet_main_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-source-kamelet
     repo: kn-plugin-source-kamelet
   name: nightly_kn-plugin-source-kamelet_main_periodic
   spec:
@@ -88,6 +90,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-source-kamelet
     repo: kn-plugin-source-kamelet
   name: release_kn-plugin-source-kamelet_main_periodic
   spec:
@@ -138,6 +141,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_kn-plugin-source-kamelet_main
+    path_alias: knative.dev/kn-plugin-source-kamelet
     spec:
       containers:
       - command:
@@ -157,6 +161,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_kn-plugin-source-kamelet_main
+    path_alias: knative.dev/kn-plugin-source-kamelet
     spec:
       containers:
       - command:
@@ -176,6 +181,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_kn-plugin-source-kamelet_main
+    path_alias: knative.dev/kn-plugin-source-kamelet
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-source-kamelet-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-source-kamelet-release-1.0.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.0
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-source-kamelet
     repo: kn-plugin-source-kamelet
   name: continuous_kn-plugin-source-kamelet_release-1.0_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.0
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-source-kamelet
     repo: kn-plugin-source-kamelet
   name: release_kn-plugin-source-kamelet_release-1.0_periodic
   spec:
@@ -104,6 +106,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_kn-plugin-source-kamelet_release-1.0
+    path_alias: knative.dev/kn-plugin-source-kamelet
     spec:
       containers:
       - command:
@@ -123,6 +126,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_kn-plugin-source-kamelet_release-1.0
+    path_alias: knative.dev/kn-plugin-source-kamelet
     spec:
       containers:
       - command:
@@ -142,6 +146,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_kn-plugin-source-kamelet_release-1.0
+    path_alias: knative.dev/kn-plugin-source-kamelet
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-source-kamelet-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-source-kamelet-release-1.1.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.1
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-source-kamelet
     repo: kn-plugin-source-kamelet
   name: continuous_kn-plugin-source-kamelet_release-1.1_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.1
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-source-kamelet
     repo: kn-plugin-source-kamelet
   name: release_kn-plugin-source-kamelet_release-1.1_periodic
   spec:
@@ -104,6 +106,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_kn-plugin-source-kamelet_release-1.1
+    path_alias: knative.dev/kn-plugin-source-kamelet
     spec:
       containers:
       - command:
@@ -123,6 +126,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_kn-plugin-source-kamelet_release-1.1
+    path_alias: knative.dev/kn-plugin-source-kamelet
     spec:
       containers:
       - command:
@@ -142,6 +146,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_kn-plugin-source-kamelet_release-1.1
+    path_alias: knative.dev/kn-plugin-source-kamelet
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-source-kamelet-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-source-kamelet-release-1.2.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.2
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-source-kamelet
     repo: kn-plugin-source-kamelet
   name: continuous_kn-plugin-source-kamelet_release-1.2_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.2
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-source-kamelet
     repo: kn-plugin-source-kamelet
   name: release_kn-plugin-source-kamelet_release-1.2_periodic
   spec:
@@ -104,6 +106,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_kn-plugin-source-kamelet_release-1.2
+    path_alias: knative.dev/kn-plugin-source-kamelet
     spec:
       containers:
       - command:
@@ -123,6 +126,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_kn-plugin-source-kamelet_release-1.2
+    path_alias: knative.dev/kn-plugin-source-kamelet
     spec:
       containers:
       - command:
@@ -142,6 +146,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_kn-plugin-source-kamelet_release-1.2
+    path_alias: knative.dev/kn-plugin-source-kamelet
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-source-kamelet-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-source-kamelet-release-1.3.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.3
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-source-kamelet
     repo: kn-plugin-source-kamelet
   name: continuous_kn-plugin-source-kamelet_release-1.3_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.3
     org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-source-kamelet
     repo: kn-plugin-source-kamelet
   name: release_kn-plugin-source-kamelet_release-1.3_periodic
   spec:
@@ -104,6 +106,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_kn-plugin-source-kamelet_release-1.3
+    path_alias: knative.dev/kn-plugin-source-kamelet
     spec:
       containers:
       - command:
@@ -123,6 +126,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_kn-plugin-source-kamelet_release-1.3
+    path_alias: knative.dev/kn-plugin-source-kamelet
     spec:
       containers:
       - command:
@@ -142,6 +146,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_kn-plugin-source-kamelet_release-1.3
+    path_alias: knative.dev/kn-plugin-source-kamelet
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/kperf-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kperf-main.gen.yaml
@@ -13,6 +13,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_kperf_main
+    path_alias: knative.dev/kperf
     spec:
       containers:
       - command:
@@ -32,6 +33,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_kperf_main
+    path_alias: knative.dev/kperf
     spec:
       containers:
       - command:
@@ -51,6 +53,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_kperf_main
+    path_alias: knative.dev/kperf
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/net-certmanager-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-certmanager-main.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/net-certmanager
     repo: net-certmanager
   name: continuous_net-certmanager_main_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/net-certmanager
     repo: net-certmanager
   name: nightly_net-certmanager_main_periodic
   reporter_config:
@@ -95,6 +97,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/net-certmanager
     repo: net-certmanager
   name: release_net-certmanager_main_periodic
   spec:
@@ -145,6 +148,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_net-certmanager_main
+    path_alias: knative.dev/net-certmanager
     spec:
       containers:
       - command:
@@ -164,6 +168,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_net-certmanager_main
+    path_alias: knative.dev/net-certmanager
     spec:
       containers:
       - command:
@@ -183,6 +188,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_net-certmanager_main
+    path_alias: knative.dev/net-certmanager
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/net-certmanager-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-certmanager-release-1.0.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.0
     org: knative-sandbox
+    path_alias: knative.dev/net-certmanager
     repo: net-certmanager
   name: continuous_net-certmanager_release-1.0_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.0
     org: knative-sandbox
+    path_alias: knative.dev/net-certmanager
     repo: net-certmanager
   name: release_net-certmanager_release-1.0_periodic
   spec:
@@ -104,6 +106,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_net-certmanager_release-1.0
+    path_alias: knative.dev/net-certmanager
     spec:
       containers:
       - command:
@@ -123,6 +126,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_net-certmanager_release-1.0
+    path_alias: knative.dev/net-certmanager
     spec:
       containers:
       - command:
@@ -142,6 +146,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_net-certmanager_release-1.0
+    path_alias: knative.dev/net-certmanager
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/net-certmanager-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-certmanager-release-1.1.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.1
     org: knative-sandbox
+    path_alias: knative.dev/net-certmanager
     repo: net-certmanager
   name: continuous_net-certmanager_release-1.1_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.1
     org: knative-sandbox
+    path_alias: knative.dev/net-certmanager
     repo: net-certmanager
   name: release_net-certmanager_release-1.1_periodic
   spec:
@@ -104,6 +106,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_net-certmanager_release-1.1
+    path_alias: knative.dev/net-certmanager
     spec:
       containers:
       - command:
@@ -123,6 +126,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_net-certmanager_release-1.1
+    path_alias: knative.dev/net-certmanager
     spec:
       containers:
       - command:
@@ -142,6 +146,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_net-certmanager_release-1.1
+    path_alias: knative.dev/net-certmanager
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/net-certmanager-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-certmanager-release-1.2.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.2
     org: knative-sandbox
+    path_alias: knative.dev/net-certmanager
     repo: net-certmanager
   name: continuous_net-certmanager_release-1.2_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.2
     org: knative-sandbox
+    path_alias: knative.dev/net-certmanager
     repo: net-certmanager
   name: release_net-certmanager_release-1.2_periodic
   spec:
@@ -104,6 +106,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_net-certmanager_release-1.2
+    path_alias: knative.dev/net-certmanager
     spec:
       containers:
       - command:
@@ -123,6 +126,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_net-certmanager_release-1.2
+    path_alias: knative.dev/net-certmanager
     spec:
       containers:
       - command:
@@ -142,6 +146,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_net-certmanager_release-1.2
+    path_alias: knative.dev/net-certmanager
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/net-certmanager-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-certmanager-release-1.3.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.3
     org: knative-sandbox
+    path_alias: knative.dev/net-certmanager
     repo: net-certmanager
   name: continuous_net-certmanager_release-1.3_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.3
     org: knative-sandbox
+    path_alias: knative.dev/net-certmanager
     repo: net-certmanager
   name: release_net-certmanager_release-1.3_periodic
   spec:
@@ -104,6 +106,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_net-certmanager_release-1.3
+    path_alias: knative.dev/net-certmanager
     spec:
       containers:
       - command:
@@ -123,6 +126,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_net-certmanager_release-1.3
+    path_alias: knative.dev/net-certmanager
     spec:
       containers:
       - command:
@@ -142,6 +146,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_net-certmanager_release-1.3
+    path_alias: knative.dev/net-certmanager
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/net-contour-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-contour-main.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/net-contour
     repo: net-contour
   name: continuous_net-contour_main_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/net-contour
     repo: net-contour
   name: nightly_net-contour_main_periodic
   reporter_config:
@@ -95,6 +97,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/net-contour
     repo: net-contour
   name: release_net-contour_main_periodic
   spec:
@@ -145,6 +148,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_net-contour_main
+    path_alias: knative.dev/net-contour
     spec:
       containers:
       - command:
@@ -164,6 +168,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_net-contour_main
+    path_alias: knative.dev/net-contour
     spec:
       containers:
       - command:
@@ -183,6 +188,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_net-contour_main
+    path_alias: knative.dev/net-contour
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/net-contour-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-contour-release-1.0.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.0
     org: knative-sandbox
+    path_alias: knative.dev/net-contour
     repo: net-contour
   name: continuous_net-contour_release-1.0_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.0
     org: knative-sandbox
+    path_alias: knative.dev/net-contour
     repo: net-contour
   name: release_net-contour_release-1.0_periodic
   spec:
@@ -104,6 +106,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_net-contour_release-1.0
+    path_alias: knative.dev/net-contour
     spec:
       containers:
       - command:
@@ -123,6 +126,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_net-contour_release-1.0
+    path_alias: knative.dev/net-contour
     spec:
       containers:
       - command:
@@ -142,6 +146,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_net-contour_release-1.0
+    path_alias: knative.dev/net-contour
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/net-contour-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-contour-release-1.1.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.1
     org: knative-sandbox
+    path_alias: knative.dev/net-contour
     repo: net-contour
   name: continuous_net-contour_release-1.1_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.1
     org: knative-sandbox
+    path_alias: knative.dev/net-contour
     repo: net-contour
   name: release_net-contour_release-1.1_periodic
   spec:
@@ -104,6 +106,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_net-contour_release-1.1
+    path_alias: knative.dev/net-contour
     spec:
       containers:
       - command:
@@ -123,6 +126,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_net-contour_release-1.1
+    path_alias: knative.dev/net-contour
     spec:
       containers:
       - command:
@@ -142,6 +146,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_net-contour_release-1.1
+    path_alias: knative.dev/net-contour
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/net-contour-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-contour-release-1.2.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.2
     org: knative-sandbox
+    path_alias: knative.dev/net-contour
     repo: net-contour
   name: continuous_net-contour_release-1.2_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.2
     org: knative-sandbox
+    path_alias: knative.dev/net-contour
     repo: net-contour
   name: release_net-contour_release-1.2_periodic
   spec:
@@ -104,6 +106,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_net-contour_release-1.2
+    path_alias: knative.dev/net-contour
     spec:
       containers:
       - command:
@@ -123,6 +126,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_net-contour_release-1.2
+    path_alias: knative.dev/net-contour
     spec:
       containers:
       - command:
@@ -142,6 +146,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_net-contour_release-1.2
+    path_alias: knative.dev/net-contour
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/net-contour-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-contour-release-1.3.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.3
     org: knative-sandbox
+    path_alias: knative.dev/net-contour
     repo: net-contour
   name: continuous_net-contour_release-1.3_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.3
     org: knative-sandbox
+    path_alias: knative.dev/net-contour
     repo: net-contour
   name: release_net-contour_release-1.3_periodic
   spec:
@@ -104,6 +106,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_net-contour_release-1.3
+    path_alias: knative.dev/net-contour
     spec:
       containers:
       - command:
@@ -123,6 +126,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_net-contour_release-1.3
+    path_alias: knative.dev/net-contour
     spec:
       containers:
       - command:
@@ -142,6 +146,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_net-contour_release-1.3
+    path_alias: knative.dev/net-contour
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/net-gateway-api-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-gateway-api-main.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/net-gateway-api
     repo: net-gateway-api
   name: continuous_net-gateway-api_main_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/net-gateway-api
     repo: net-gateway-api
   name: nightly_net-gateway-api_main_periodic
   reporter_config:
@@ -95,6 +97,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/net-gateway-api
     repo: net-gateway-api
   name: release_net-gateway-api_main_periodic
   spec:
@@ -145,6 +148,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_net-gateway-api_main
+    path_alias: knative.dev/net-gateway-api
     spec:
       containers:
       - command:
@@ -164,6 +168,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_net-gateway-api_main
+    path_alias: knative.dev/net-gateway-api
     spec:
       containers:
       - command:
@@ -183,6 +188,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_net-gateway-api_main
+    path_alias: knative.dev/net-gateway-api
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/net-gateway-api-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-gateway-api-release-1.1.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.1
     org: knative-sandbox
+    path_alias: knative.dev/net-gateway-api
     repo: net-gateway-api
   name: continuous_net-gateway-api_release-1.1_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.1
     org: knative-sandbox
+    path_alias: knative.dev/net-gateway-api
     repo: net-gateway-api
   name: release_net-gateway-api_release-1.1_periodic
   spec:
@@ -104,6 +106,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_net-gateway-api_release-1.1
+    path_alias: knative.dev/net-gateway-api
     spec:
       containers:
       - command:
@@ -123,6 +126,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_net-gateway-api_release-1.1
+    path_alias: knative.dev/net-gateway-api
     spec:
       containers:
       - command:
@@ -142,6 +146,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_net-gateway-api_release-1.1
+    path_alias: knative.dev/net-gateway-api
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/net-gateway-api-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-gateway-api-release-1.2.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.2
     org: knative-sandbox
+    path_alias: knative.dev/net-gateway-api
     repo: net-gateway-api
   name: continuous_net-gateway-api_release-1.2_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.2
     org: knative-sandbox
+    path_alias: knative.dev/net-gateway-api
     repo: net-gateway-api
   name: release_net-gateway-api_release-1.2_periodic
   spec:
@@ -104,6 +106,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_net-gateway-api_release-1.2
+    path_alias: knative.dev/net-gateway-api
     spec:
       containers:
       - command:
@@ -123,6 +126,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_net-gateway-api_release-1.2
+    path_alias: knative.dev/net-gateway-api
     spec:
       containers:
       - command:
@@ -142,6 +146,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_net-gateway-api_release-1.2
+    path_alias: knative.dev/net-gateway-api
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/net-gateway-api-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-gateway-api-release-1.3.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.3
     org: knative-sandbox
+    path_alias: knative.dev/net-gateway-api
     repo: net-gateway-api
   name: continuous_net-gateway-api_release-1.3_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.3
     org: knative-sandbox
+    path_alias: knative.dev/net-gateway-api
     repo: net-gateway-api
   name: release_net-gateway-api_release-1.3_periodic
   spec:
@@ -104,6 +106,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_net-gateway-api_release-1.3
+    path_alias: knative.dev/net-gateway-api
     spec:
       containers:
       - command:
@@ -123,6 +126,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_net-gateway-api_release-1.3
+    path_alias: knative.dev/net-gateway-api
     spec:
       containers:
       - command:
@@ -142,6 +146,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_net-gateway-api_release-1.3
+    path_alias: knative.dev/net-gateway-api
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/net-http01-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-http01-main.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/net-http01
     repo: net-http01
   name: continuous_net-http01_main_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/net-http01
     repo: net-http01
   name: nightly_net-http01_main_periodic
   reporter_config:
@@ -95,6 +97,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/net-http01
     repo: net-http01
   name: release_net-http01_main_periodic
   spec:
@@ -145,6 +148,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_net-http01_main
+    path_alias: knative.dev/net-http01
     spec:
       containers:
       - command:
@@ -164,6 +168,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_net-http01_main
+    path_alias: knative.dev/net-http01
     spec:
       containers:
       - command:
@@ -183,6 +188,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_net-http01_main
+    path_alias: knative.dev/net-http01
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/net-http01-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-http01-release-1.0.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.0
     org: knative-sandbox
+    path_alias: knative.dev/net-http01
     repo: net-http01
   name: continuous_net-http01_release-1.0_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.0
     org: knative-sandbox
+    path_alias: knative.dev/net-http01
     repo: net-http01
   name: release_net-http01_release-1.0_periodic
   spec:
@@ -104,6 +106,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_net-http01_release-1.0
+    path_alias: knative.dev/net-http01
     spec:
       containers:
       - command:
@@ -123,6 +126,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_net-http01_release-1.0
+    path_alias: knative.dev/net-http01
     spec:
       containers:
       - command:
@@ -142,6 +146,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_net-http01_release-1.0
+    path_alias: knative.dev/net-http01
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/net-http01-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-http01-release-1.1.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.1
     org: knative-sandbox
+    path_alias: knative.dev/net-http01
     repo: net-http01
   name: continuous_net-http01_release-1.1_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.1
     org: knative-sandbox
+    path_alias: knative.dev/net-http01
     repo: net-http01
   name: release_net-http01_release-1.1_periodic
   spec:
@@ -104,6 +106,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_net-http01_release-1.1
+    path_alias: knative.dev/net-http01
     spec:
       containers:
       - command:
@@ -123,6 +126,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_net-http01_release-1.1
+    path_alias: knative.dev/net-http01
     spec:
       containers:
       - command:
@@ -142,6 +146,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_net-http01_release-1.1
+    path_alias: knative.dev/net-http01
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/net-http01-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-http01-release-1.2.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.2
     org: knative-sandbox
+    path_alias: knative.dev/net-http01
     repo: net-http01
   name: continuous_net-http01_release-1.2_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.2
     org: knative-sandbox
+    path_alias: knative.dev/net-http01
     repo: net-http01
   name: release_net-http01_release-1.2_periodic
   spec:
@@ -104,6 +106,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_net-http01_release-1.2
+    path_alias: knative.dev/net-http01
     spec:
       containers:
       - command:
@@ -123,6 +126,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_net-http01_release-1.2
+    path_alias: knative.dev/net-http01
     spec:
       containers:
       - command:
@@ -142,6 +146,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_net-http01_release-1.2
+    path_alias: knative.dev/net-http01
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/net-http01-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-http01-release-1.3.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.3
     org: knative-sandbox
+    path_alias: knative.dev/net-http01
     repo: net-http01
   name: continuous_net-http01_release-1.3_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.3
     org: knative-sandbox
+    path_alias: knative.dev/net-http01
     repo: net-http01
   name: release_net-http01_release-1.3_periodic
   spec:
@@ -104,6 +106,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_net-http01_release-1.3
+    path_alias: knative.dev/net-http01
     spec:
       containers:
       - command:
@@ -123,6 +126,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_net-http01_release-1.3
+    path_alias: knative.dev/net-http01
     spec:
       containers:
       - command:
@@ -142,6 +146,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_net-http01_release-1.3
+    path_alias: knative.dev/net-http01
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/net-istio-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-istio-main.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/net-istio
     repo: net-istio
   name: continuous_net-istio_main_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/net-istio
     repo: net-istio
   name: nightly_net-istio_main_periodic
   reporter_config:
@@ -95,6 +97,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/net-istio
     repo: net-istio
   name: release_net-istio_main_periodic
   spec:
@@ -145,6 +148,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_net-istio_main
+    path_alias: knative.dev/net-istio
     spec:
       containers:
       - command:
@@ -164,6 +168,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_net-istio_main
+    path_alias: knative.dev/net-istio
     spec:
       containers:
       - command:
@@ -183,6 +188,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_net-istio_main
+    path_alias: knative.dev/net-istio
     spec:
       containers:
       - command:
@@ -215,6 +221,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: latest_net-istio_main
+    path_alias: knative.dev/net-istio
     spec:
       containers:
       - command:
@@ -248,6 +255,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: latest-mesh_net-istio_main
+    path_alias: knative.dev/net-istio
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/net-istio-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-istio-release-1.0.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.0
     org: knative-sandbox
+    path_alias: knative.dev/net-istio
     repo: net-istio
   name: continuous_net-istio_release-1.0_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.0
     org: knative-sandbox
+    path_alias: knative.dev/net-istio
     repo: net-istio
   name: release_net-istio_release-1.0_periodic
   spec:
@@ -104,6 +106,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_net-istio_release-1.0
+    path_alias: knative.dev/net-istio
     spec:
       containers:
       - command:
@@ -123,6 +126,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_net-istio_release-1.0
+    path_alias: knative.dev/net-istio
     spec:
       containers:
       - command:
@@ -142,6 +146,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_net-istio_release-1.0
+    path_alias: knative.dev/net-istio
     spec:
       containers:
       - command:
@@ -174,6 +179,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: latest_net-istio_release-1.0
+    path_alias: knative.dev/net-istio
     spec:
       containers:
       - command:
@@ -207,6 +213,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: latest-mesh_net-istio_release-1.0
+    path_alias: knative.dev/net-istio
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/net-istio-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-istio-release-1.1.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.1
     org: knative-sandbox
+    path_alias: knative.dev/net-istio
     repo: net-istio
   name: continuous_net-istio_release-1.1_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.1
     org: knative-sandbox
+    path_alias: knative.dev/net-istio
     repo: net-istio
   name: release_net-istio_release-1.1_periodic
   spec:
@@ -104,6 +106,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_net-istio_release-1.1
+    path_alias: knative.dev/net-istio
     spec:
       containers:
       - command:
@@ -123,6 +126,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_net-istio_release-1.1
+    path_alias: knative.dev/net-istio
     spec:
       containers:
       - command:
@@ -142,6 +146,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_net-istio_release-1.1
+    path_alias: knative.dev/net-istio
     spec:
       containers:
       - command:
@@ -174,6 +179,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: latest_net-istio_release-1.1
+    path_alias: knative.dev/net-istio
     spec:
       containers:
       - command:
@@ -207,6 +213,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: latest-mesh_net-istio_release-1.1
+    path_alias: knative.dev/net-istio
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/net-istio-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-istio-release-1.2.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.2
     org: knative-sandbox
+    path_alias: knative.dev/net-istio
     repo: net-istio
   name: continuous_net-istio_release-1.2_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.2
     org: knative-sandbox
+    path_alias: knative.dev/net-istio
     repo: net-istio
   name: release_net-istio_release-1.2_periodic
   spec:
@@ -104,6 +106,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_net-istio_release-1.2
+    path_alias: knative.dev/net-istio
     spec:
       containers:
       - command:
@@ -123,6 +126,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_net-istio_release-1.2
+    path_alias: knative.dev/net-istio
     spec:
       containers:
       - command:
@@ -142,6 +146,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_net-istio_release-1.2
+    path_alias: knative.dev/net-istio
     spec:
       containers:
       - command:
@@ -174,6 +179,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: latest_net-istio_release-1.2
+    path_alias: knative.dev/net-istio
     spec:
       containers:
       - command:
@@ -207,6 +213,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: latest-mesh_net-istio_release-1.2
+    path_alias: knative.dev/net-istio
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/net-istio-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-istio-release-1.3.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.3
     org: knative-sandbox
+    path_alias: knative.dev/net-istio
     repo: net-istio
   name: continuous_net-istio_release-1.3_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.3
     org: knative-sandbox
+    path_alias: knative.dev/net-istio
     repo: net-istio
   name: release_net-istio_release-1.3_periodic
   spec:
@@ -104,6 +106,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_net-istio_release-1.3
+    path_alias: knative.dev/net-istio
     spec:
       containers:
       - command:
@@ -123,6 +126,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_net-istio_release-1.3
+    path_alias: knative.dev/net-istio
     spec:
       containers:
       - command:
@@ -142,6 +146,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_net-istio_release-1.3
+    path_alias: knative.dev/net-istio
     spec:
       containers:
       - command:
@@ -174,6 +179,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: latest_net-istio_release-1.3
+    path_alias: knative.dev/net-istio
     spec:
       containers:
       - command:
@@ -207,6 +213,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: latest-mesh_net-istio_release-1.3
+    path_alias: knative.dev/net-istio
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/net-kourier-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-kourier-main.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/net-kourier
     repo: net-kourier
   name: continuous_net-kourier_main_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/net-kourier
     repo: net-kourier
   name: nightly_net-kourier_main_periodic
   reporter_config:
@@ -95,6 +97,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/net-kourier
     repo: net-kourier
   name: release_net-kourier_main_periodic
   spec:
@@ -145,6 +148,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_net-kourier_main
+    path_alias: knative.dev/net-kourier
     spec:
       containers:
       - command:
@@ -164,6 +168,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_net-kourier_main
+    path_alias: knative.dev/net-kourier
     spec:
       containers:
       - command:
@@ -183,6 +188,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_net-kourier_main
+    path_alias: knative.dev/net-kourier
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/net-kourier-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-kourier-release-1.0.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.0
     org: knative-sandbox
+    path_alias: knative.dev/net-kourier
     repo: net-kourier
   name: continuous_net-kourier_release-1.0_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.0
     org: knative-sandbox
+    path_alias: knative.dev/net-kourier
     repo: net-kourier
   name: release_net-kourier_release-1.0_periodic
   spec:
@@ -104,6 +106,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_net-kourier_release-1.0
+    path_alias: knative.dev/net-kourier
     spec:
       containers:
       - command:
@@ -123,6 +126,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_net-kourier_release-1.0
+    path_alias: knative.dev/net-kourier
     spec:
       containers:
       - command:
@@ -142,6 +146,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_net-kourier_release-1.0
+    path_alias: knative.dev/net-kourier
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/net-kourier-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-kourier-release-1.1.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.1
     org: knative-sandbox
+    path_alias: knative.dev/net-kourier
     repo: net-kourier
   name: continuous_net-kourier_release-1.1_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.1
     org: knative-sandbox
+    path_alias: knative.dev/net-kourier
     repo: net-kourier
   name: release_net-kourier_release-1.1_periodic
   spec:
@@ -104,6 +106,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_net-kourier_release-1.1
+    path_alias: knative.dev/net-kourier
     spec:
       containers:
       - command:
@@ -123,6 +126,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_net-kourier_release-1.1
+    path_alias: knative.dev/net-kourier
     spec:
       containers:
       - command:
@@ -142,6 +146,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_net-kourier_release-1.1
+    path_alias: knative.dev/net-kourier
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/net-kourier-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-kourier-release-1.2.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.2
     org: knative-sandbox
+    path_alias: knative.dev/net-kourier
     repo: net-kourier
   name: continuous_net-kourier_release-1.2_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.2
     org: knative-sandbox
+    path_alias: knative.dev/net-kourier
     repo: net-kourier
   name: release_net-kourier_release-1.2_periodic
   spec:
@@ -104,6 +106,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_net-kourier_release-1.2
+    path_alias: knative.dev/net-kourier
     spec:
       containers:
       - command:
@@ -123,6 +126,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_net-kourier_release-1.2
+    path_alias: knative.dev/net-kourier
     spec:
       containers:
       - command:
@@ -142,6 +146,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_net-kourier_release-1.2
+    path_alias: knative.dev/net-kourier
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/net-kourier-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-kourier-release-1.3.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.3
     org: knative-sandbox
+    path_alias: knative.dev/net-kourier
     repo: net-kourier
   name: continuous_net-kourier_release-1.3_periodic
   spec:
@@ -52,6 +53,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.3
     org: knative-sandbox
+    path_alias: knative.dev/net-kourier
     repo: net-kourier
   name: release_net-kourier_release-1.3_periodic
   spec:
@@ -104,6 +106,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_net-kourier_release-1.3
+    path_alias: knative.dev/net-kourier
     spec:
       containers:
       - command:
@@ -123,6 +126,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_net-kourier_release-1.3
+    path_alias: knative.dev/net-kourier
     spec:
       containers:
       - command:
@@ -142,6 +146,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_net-kourier_release-1.3
+    path_alias: knative.dev/net-kourier
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/reconciler-test-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/reconciler-test-main.gen.yaml
@@ -13,6 +13,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_reconciler-test_main
+    path_alias: knative.dev/reconciler-test
     spec:
       containers:
       - command:
@@ -32,6 +33,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_reconciler-test_main
+    path_alias: knative.dev/reconciler-test
     spec:
       containers:
       - command:
@@ -51,6 +53,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: integration-tests_reconciler-test_main
+    path_alias: knative.dev/reconciler-test
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/sample-controller-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/sample-controller-main.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/sample-controller
     repo: sample-controller
   name: nightly_sample-controller_main_periodic
   spec:
@@ -51,6 +52,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/sample-controller
     repo: sample-controller
   name: release_sample-controller_main_periodic
   spec:
@@ -101,6 +103,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_sample-controller_main
+    path_alias: knative.dev/sample-controller
     spec:
       containers:
       - command:
@@ -120,6 +123,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_sample-controller_main
+    path_alias: knative.dev/sample-controller
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/sample-controller-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/sample-controller-release-1.0.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.0
     org: knative-sandbox
+    path_alias: knative.dev/sample-controller
     repo: sample-controller
   name: release_sample-controller_release-1.0_periodic
   spec:
@@ -67,6 +68,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_sample-controller_release-1.0
+    path_alias: knative.dev/sample-controller
     spec:
       containers:
       - command:
@@ -86,6 +88,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_sample-controller_release-1.0
+    path_alias: knative.dev/sample-controller
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/sample-controller-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/sample-controller-release-1.1.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.1
     org: knative-sandbox
+    path_alias: knative.dev/sample-controller
     repo: sample-controller
   name: release_sample-controller_release-1.1_periodic
   spec:
@@ -67,6 +68,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_sample-controller_release-1.1
+    path_alias: knative.dev/sample-controller
     spec:
       containers:
       - command:
@@ -86,6 +88,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_sample-controller_release-1.1
+    path_alias: knative.dev/sample-controller
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/sample-controller-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/sample-controller-release-1.2.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.2
     org: knative-sandbox
+    path_alias: knative.dev/sample-controller
     repo: sample-controller
   name: release_sample-controller_release-1.2_periodic
   spec:
@@ -67,6 +68,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_sample-controller_release-1.2
+    path_alias: knative.dev/sample-controller
     spec:
       containers:
       - command:
@@ -86,6 +88,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_sample-controller_release-1.2
+    path_alias: knative.dev/sample-controller
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/sample-controller-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/sample-controller-release-1.3.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.3
     org: knative-sandbox
+    path_alias: knative.dev/sample-controller
     repo: sample-controller
   name: release_sample-controller_release-1.3_periodic
   spec:
@@ -67,6 +68,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_sample-controller_release-1.3
+    path_alias: knative.dev/sample-controller
     spec:
       containers:
       - command:
@@ -86,6 +88,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_sample-controller_release-1.3
+    path_alias: knative.dev/sample-controller
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/sample-source-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/sample-source-main.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/sample-source
     repo: sample-source
   name: nightly_sample-source_main_periodic
   spec:
@@ -51,6 +52,7 @@ periodics:
   extra_refs:
   - base_ref: main
     org: knative-sandbox
+    path_alias: knative.dev/sample-source
     repo: sample-source
   name: release_sample-source_main_periodic
   spec:
@@ -101,6 +103,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_sample-source_main
+    path_alias: knative.dev/sample-source
     spec:
       containers:
       - command:
@@ -120,6 +123,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_sample-source_main
+    path_alias: knative.dev/sample-source
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/sample-source-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/sample-source-release-1.0.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.0
     org: knative-sandbox
+    path_alias: knative.dev/sample-source
     repo: sample-source
   name: release_sample-source_release-1.0_periodic
   spec:
@@ -67,6 +68,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_sample-source_release-1.0
+    path_alias: knative.dev/sample-source
     spec:
       containers:
       - command:
@@ -86,6 +88,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_sample-source_release-1.0
+    path_alias: knative.dev/sample-source
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/sample-source-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/sample-source-release-1.1.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.1
     org: knative-sandbox
+    path_alias: knative.dev/sample-source
     repo: sample-source
   name: release_sample-source_release-1.1_periodic
   spec:
@@ -67,6 +68,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_sample-source_release-1.1
+    path_alias: knative.dev/sample-source
     spec:
       containers:
       - command:
@@ -86,6 +88,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_sample-source_release-1.1
+    path_alias: knative.dev/sample-source
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/sample-source-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/sample-source-release-1.2.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.2
     org: knative-sandbox
+    path_alias: knative.dev/sample-source
     repo: sample-source
   name: release_sample-source_release-1.2_periodic
   spec:
@@ -67,6 +68,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_sample-source_release-1.2
+    path_alias: knative.dev/sample-source
     spec:
       containers:
       - command:
@@ -86,6 +88,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_sample-source_release-1.2
+    path_alias: knative.dev/sample-source
     spec:
       containers:
       - command:

--- a/prow/jobs/generated/knative-sandbox/sample-source-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/sample-source-release-1.3.gen.yaml
@@ -15,6 +15,7 @@ periodics:
   extra_refs:
   - base_ref: release-1.3
     org: knative-sandbox
+    path_alias: knative.dev/sample-source
     repo: sample-source
   name: release_sample-source_release-1.3_periodic
   spec:
@@ -67,6 +68,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: build-tests_sample-source_release-1.3
+    path_alias: knative.dev/sample-source
     spec:
       containers:
       - command:
@@ -86,6 +88,7 @@ presubmits:
     cluster: build-knative
     decorate: true
     name: unit-tests_sample-source_release-1.3
+    path_alias: knative.dev/sample-source
     spec:
       containers:
       - command:

--- a/prow/jobs_config/.base.yaml
+++ b/prow/jobs_config/.base.yaml
@@ -8,6 +8,7 @@ autogen_header: |
 
 path_aliases:
   knative: knative.dev
+  knative-sandbox: knative.dev
 
 node_selector:
   type: testing


### PR DESCRIPTION
This doesn't really matter much now since all the projects are on Go module, but it's still better to keep the config for `knative` and `knative-sandbox` to be consistent.

The only manual change in the PR is adding one line in `prow/jobs_config/.base.yaml`, other changes are all generated by running `/hack/generate-configs.sh`