### PR TITLE
Update timeout for eventing continuous and release Prow jobs to 3h

### DIFF
--- a/prow/jobs/generated/knative/eventing-main.gen.yaml
+++ b/prow/jobs/generated/knative/eventing-main.gen.yaml
@@ -10,8 +10,10 @@ periodics:
     testgrid-dashboards: eventing
     testgrid-tab-name: continuous
   cluster: build-knative
-  cron: 59 */9 * * *
+  cron: 59 */12 * * *
   decorate: true
+  decoration_config:
+    timeout: 3h0m0s
   extra_refs:
   - base_ref: main
     org: knative
@@ -132,6 +134,8 @@ periodics:
   cluster: build-knative
   cron: 9 9 * * *
   decorate: true
+  decoration_config:
+    timeout: 3h0m0s
   extra_refs:
   - base_ref: main
     org: knative
@@ -178,8 +182,10 @@ periodics:
     testgrid-dashboards: eventing
     testgrid-tab-name: release
   cluster: build-knative
-  cron: 41 */9 * * *
+  cron: 41 */12 * * *
   decorate: true
+  decoration_config:
+    timeout: 3h0m0s
   extra_refs:
   - base_ref: main
     org: knative

--- a/prow/jobs/generated/knative/eventing-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative/eventing-release-1.0.gen.yaml
@@ -12,6 +12,8 @@ periodics:
   cluster: build-knative
   cron: 45 4 * * *
   decorate: true
+  decoration_config:
+    timeout: 3h0m0s
   extra_refs:
   - base_ref: release-1.0
     org: knative
@@ -132,6 +134,8 @@ periodics:
   cluster: build-knative
   cron: 15 9 * * 2
   decorate: true
+  decoration_config:
+    timeout: 3h0m0s
   extra_refs:
   - base_ref: release-1.0
     org: knative

--- a/prow/jobs/generated/knative/eventing-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative/eventing-release-1.1.gen.yaml
@@ -12,6 +12,8 @@ periodics:
   cluster: build-knative
   cron: 14 9 * * *
   decorate: true
+  decoration_config:
+    timeout: 3h0m0s
   extra_refs:
   - base_ref: release-1.1
     org: knative
@@ -132,6 +134,8 @@ periodics:
   cluster: build-knative
   cron: 10 9 * * 2
   decorate: true
+  decoration_config:
+    timeout: 3h0m0s
   extra_refs:
   - base_ref: release-1.1
     org: knative

--- a/prow/jobs/generated/knative/eventing-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative/eventing-release-1.2.gen.yaml
@@ -12,6 +12,8 @@ periodics:
   cluster: build-knative
   cron: 47 6 * * *
   decorate: true
+  decoration_config:
+    timeout: 3h0m0s
   extra_refs:
   - base_ref: release-1.2
     org: knative
@@ -132,6 +134,8 @@ periodics:
   cluster: build-knative
   cron: 5 9 * * 2
   decorate: true
+  decoration_config:
+    timeout: 3h0m0s
   extra_refs:
   - base_ref: release-1.2
     org: knative

--- a/prow/jobs/generated/knative/eventing-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative/eventing-release-1.3.gen.yaml
@@ -12,6 +12,8 @@ periodics:
   cluster: build-knative
   cron: 52 11 * * *
   decorate: true
+  decoration_config:
+    timeout: 3h0m0s
   extra_refs:
   - base_ref: release-1.3
     org: knative
@@ -132,6 +134,8 @@ periodics:
   cluster: build-knative
   cron: 16 9 * * 2
   decorate: true
+  decoration_config:
+    timeout: 3h0m0s
   extra_refs:
   - base_ref: release-1.3
     org: knative

--- a/prow/jobs_config/knative/eventing-release-1.0.yaml
+++ b/prow/jobs_config/knative/eventing-release-1.0.yaml
@@ -58,6 +58,7 @@ jobs:
   - ./test/presubmit-tests.sh
   - --all-tests
   name: continuous
+  timeout: 3h
   types:
   - periodic
 - args:
@@ -98,6 +99,7 @@ jobs:
   - --branch
   - release-1.0
   name: release
+  timeout: 3h
   requirements:
   - release
   excluded_requirements:

--- a/prow/jobs_config/knative/eventing-release-1.1.yaml
+++ b/prow/jobs_config/knative/eventing-release-1.1.yaml
@@ -58,6 +58,7 @@ jobs:
   - ./test/presubmit-tests.sh
   - --all-tests
   name: continuous
+  timeout: 3h
   types:
   - periodic
 - args:
@@ -98,6 +99,7 @@ jobs:
   - --branch
   - release-1.1
   name: release
+  timeout: 3h
   requirements:
   - release
   excluded_requirements:

--- a/prow/jobs_config/knative/eventing-release-1.2.yaml
+++ b/prow/jobs_config/knative/eventing-release-1.2.yaml
@@ -58,6 +58,7 @@ jobs:
   - ./test/presubmit-tests.sh
   - --all-tests
   name: continuous
+  timeout: 3h
   types:
   - periodic
 - args:
@@ -98,6 +99,7 @@ jobs:
   - --branch
   - release-1.2
   name: release
+  timeout: 3h
   requirements:
   - release
   excluded_requirements:

--- a/prow/jobs_config/knative/eventing-release-1.3.yaml
+++ b/prow/jobs_config/knative/eventing-release-1.3.yaml
@@ -58,6 +58,7 @@ jobs:
   - ./test/presubmit-tests.sh
   - --all-tests
   name: continuous
+  timeout: 3h
   types:
   - periodic
 - args:
@@ -98,6 +99,7 @@ jobs:
   - --branch
   - release-1.3
   name: release
+  timeout: 3h
   requirements:
   - release
   excluded_requirements:

--- a/prow/jobs_config/knative/eventing.yaml
+++ b/prow/jobs_config/knative/eventing.yaml
@@ -31,6 +31,7 @@ jobs:
 
   - name: continuous
     types: [periodic]
+    timeout: 3h
     command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
 
   - name: s390x-e2e-tests
@@ -58,6 +59,7 @@ jobs:
 
   - name: nightly
     types: [periodic]
+    timeout: 3h
     command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
     requirements: [nightly]
     excluded_requirements: [gcp]
@@ -71,6 +73,7 @@ jobs:
 
   - name: release
     types: [periodic]
+    timeout: 3h
     command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/eventing, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
     requirements: [release]
     excluded_requirements: [gcp]


### PR DESCRIPTION
This config got mistakenly deleted when I migrated to the new config generation flow.

/cc @lionelvillard 