### PR TITLE
Remove knative-gcp config from Knative Prow

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -162,7 +162,6 @@ tide:
     - do-not-merge/invalid-owners-file
     - needs-rebase
   - repos:
-    - "google/knative-gcp"
     - "knative-prow-robot/test-infra"
     labels:
     - lgtm
@@ -179,7 +178,6 @@ tide:
   merge_method:
     knative: squash
     knative-sandbox: squash
-    google/knative-gcp: squash
   target_url: https://prow.knative.dev/tide
   pr_status_base_urls:
     '*': https://prow.knative.dev/pr
@@ -229,15 +227,3 @@ branch-protection:
       repos:
         .github:
           protect: false
-
-    google:
-      repos:
-        # Protect all branches in google/knative-gcp
-        knative-gcp:
-          protect: true
-          required_status_checks:
-            contexts:
-            - cla/google
-            - tide
-          # Enforce all configured restrictions above for administrators.
-          enforce_admins: true

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -17,7 +17,6 @@ approve:
 - repos:
   - "knative"
   - "knative-sandbox"
-  - "google/knative-gcp"
   - "knative-prow-robot/test-infra"
   ignore_review_state: false
 
@@ -26,7 +25,6 @@ lgtm:
 - repos:
   - "knative-sandbox"
   - "knative"
-  - "google/knative-gcp"
   review_acts_as_lgtm: true
 
 # Settings for the "heart" plugin.
@@ -156,33 +154,6 @@ plugins:
     - welcome
     - wip
     - yuks
-  google/knative-gcp:
-    plugins:
-    - approve
-    - assign
-    - blunderbuss
-    - buildifier
-    - cat
-    - dog
-    - golint
-    - heart
-    - help
-    - hold
-    - label
-    - lgtm
-    - lifecycle
-    - milestone
-    - override
-    - owners-label
-    - project
-    - shrug
-    - size
-    - skip
-    - trigger
-    - verify-owners
-    - welcome
-    - wip
-    - yuks
   knative-prow-robot/test-infra:
     plugins:
     - approve
@@ -224,15 +195,6 @@ external_plugins:
       - issue_comment
       - pull_request
   knative-sandbox:
-  - name: needs-rebase
-    events:
-      - issue_comment
-      - pull_request
-  - name: cherrypicker
-    events:
-      - issue_comment
-      - pull_request
-  google/knative-gcp:
   - name: needs-rebase
     events:
       - issue_comment


### PR DESCRIPTION
This was already removed from https://github.com/GoogleCloudPlatform/oss-test-infra/pull/1554

/cc @kvmware @upodroid 