### PR TITLE
Move a few Prow jobs to run on the build clusters

### DIFF
--- a/prow/jobs/custom/knativeteam-groups.yaml
+++ b/prow/jobs/custom/knativeteam-groups.yaml
@@ -5,6 +5,7 @@ presubmits:
     run_if_changed: "^groups/"
     branches:
     - ^main$
+    cluster: prow-trusted
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable

--- a/prow/jobs/custom/test-infra.yaml
+++ b/prow/jobs/custom/test-infra.yaml
@@ -22,6 +22,7 @@ presubmits:
   - name: pull-test-infra-validate-prow-yaml
     decorate: true
     run_if_changed: '^prow/((config|plugins)\.yaml$|jobs/)'
+    cluster: "build-knative"
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:stable


### PR DESCRIPTION
I've seen flakes with running the Prow jobs on the default Prow cluster - the job Pod frequently got deleted in the middle. Probably it's worth to investigate in the future, but the best practice should be scheduling the Prow job pods on the build clusters. This PR moves these Prow jobs to the corresponding build cluster.

/cc @kvmware @upodroid 