### PR TITLE
Update heartbeat interval for holding Boskos resources to a shorter time

### DIFF
--- a/pkg/clustermanager/kubetest2/gke.go
+++ b/pkg/clustermanager/kubetest2/gke.go
@@ -40,7 +40,14 @@ const (
 )
 
 var (
-	baseKubetest2Flags = []string{"gke", "--ignore-gcp-ssh-key=true", "--up", "--down", "-v=1"}
+	baseKubetest2Flags = []string{
+		"gke",
+		"--up",
+		"--down",
+		"--ignore-gcp-ssh-key=true",
+		"--boskos-heartbeat-interval-seconds=60",
+		"-v=1",
+	}
 
 	// If one of the error patterns below is matched, it would be recommended to
 	// retry creating the cluster in a different region.

--- a/prow/cluster/build/400-boskos-reaper.yaml
+++ b/prow/cluster/build/400-boskos-reaper.yaml
@@ -37,7 +37,7 @@ spec:
         image: gcr.io/k8s-staging-boskos/reaper:v20200819-984516e
         args:
         - --resource-type=gke-project
-        - --expire=11m
+        - --expire=3m
         resources:
           requests:
             cpu: 200m


### PR DESCRIPTION
kubetest2 can already run `--down` to stop the heartbeat requests to Boskos when the Prow job is interrupted, but it's not guaranteed to run for a number of reasons.

This PR updates heartbeat interval for holding Boskos resources to a shorter time, to make sure the Boskos resources can be released as soon as possible they are not used, thus saving more compute resource.

/cc @kvmware 