### PR TITLE
Pin prow-tests image to a version label and configure autobump to update it

### DIFF
--- a/prow/jobs/custom/autobump-prow-tests.yaml
+++ b/prow/jobs/custom/autobump-prow-tests.yaml
@@ -1,0 +1,37 @@
+periodics:
+- cron: "15 15 * * 1-5"  # Bump with label `skip-review`. Run at 7:15 PST (15:15 UTC) each weekday.
+  name: ci-knative-prow-tests-auto-bumper
+  cluster: "build-knative"
+  decorate: true
+  extra_refs:
+  - org: knative
+    repo: test-infra
+    base_ref: main
+    path_alias: knative.dev/test-infra
+  annotations:
+    testgrid-dashboards: utilities
+    testgrid-tab-name: ci-knative-prow-tests-auto-bumper
+    testgrid-alert-email: "serverless-engprod-sea@google.com"
+    testgrid-num-failures-to-alert: "1"
+  spec:
+    containers:
+    - image: gcr.io/k8s-prow/generic-autobumper:v20220323-9b8611d021
+      command:
+      - generic-autobumper
+      args:
+      - --config=prow/knative-prow-tests-autobump-config.yaml
+      - --labels-override=skip-review # This label is used by tide for identifying trusted PR
+      volumeMounts:
+      - name: prow-auto-bumper-github-token
+        mountPath: /etc/prow-auto-bumper-github-token
+        readOnly: true
+      - name: ssh
+        mountPath: /root/.ssh
+    volumes:
+    - name: prow-auto-bumper-github-token
+      secret:
+        secretName: prow-auto-bumper-github-token
+    - name: ssh
+      secret:
+        secretName: prow-updater-robot-ssh-key
+        defaultMode: 0400

--- a/prow/jobs/custom/knativeteam-groups.yaml
+++ b/prow/jobs/custom/knativeteam-groups.yaml
@@ -8,7 +8,7 @@ presubmits:
     cluster: prow-trusted
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         command:
         - runner.sh
         args:
@@ -41,7 +41,7 @@ periodics:
   spec:
     serviceAccountName: gsuite-groups-manager
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       command:
       - runner.sh
       args:
@@ -73,7 +73,7 @@ postsubmits:
     spec:
       serviceAccountName: gsuite-groups-manager
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         command:
         - runner.sh
         args:

--- a/prow/jobs/custom/test-infra.yaml
+++ b/prow/jobs/custom/test-infra.yaml
@@ -25,7 +25,7 @@ presubmits:
     cluster: "build-knative"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         command:
         - "runner.sh"
         args:
@@ -84,7 +84,7 @@ presubmits:
     - "main"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -124,7 +124,7 @@ periodics:
     testgrid-num-failures-to-alert: "1"
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       imagePullPolicy: Always
       command:
       - "runner.sh"
@@ -158,7 +158,7 @@ periodics:
     testgrid-num-failures-to-alert: "1"
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       imagePullPolicy: Always
       command:
       - "runner.sh"
@@ -285,7 +285,7 @@ periodics:
     testgrid-num-failures-to-alert: "1"
   spec:
     containers:
-    - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+    - image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       imagePullPolicy: Always
       command:
       - "runner.sh"
@@ -340,7 +340,7 @@ postsubmits:
       testgrid-num-failures-to-alert: "1"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -384,7 +384,7 @@ postsubmits:
       testgrid-num-failures-to-alert: "1"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -420,7 +420,7 @@ postsubmits:
       testgrid-num-failures-to-alert: "1"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         imagePullPolicy: Always
         command:
         - runner.sh

--- a/prow/jobs/generated/knative-sandbox/async-component-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/async-component-main.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -66,7 +66,7 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -112,7 +112,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -148,7 +148,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -168,7 +168,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -193,7 +193,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/container-freezer-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/container-freezer-main.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -66,7 +66,7 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -112,7 +112,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -148,7 +148,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -168,7 +168,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -193,7 +193,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/discovery-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/discovery-main.gen.yaml
@@ -20,7 +20,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -40,7 +40,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -65,7 +65,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/eventing-autoscaler-keda-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-autoscaler-keda-main.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -66,7 +66,7 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -112,7 +112,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -155,7 +155,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -190,7 +190,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/eventing-autoscaler-keda-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-autoscaler-keda-release-1.0.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -120,7 +120,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -155,7 +155,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/eventing-autoscaler-keda-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-autoscaler-keda-release-1.1.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -120,7 +120,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -155,7 +155,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/eventing-autoscaler-keda-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-autoscaler-keda-release-1.2.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -120,7 +120,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -155,7 +155,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/eventing-autoscaler-keda-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-autoscaler-keda-release-1.3.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -120,7 +120,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -155,7 +155,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/eventing-awssqs-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-awssqs-main.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -66,7 +66,7 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -112,7 +112,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:

--- a/prow/jobs/generated/knative-sandbox/eventing-awssqs-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-awssqs-release-1.0.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:

--- a/prow/jobs/generated/knative-sandbox/eventing-awssqs-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-awssqs-release-1.1.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:

--- a/prow/jobs/generated/knative-sandbox/eventing-awssqs-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-awssqs-release-1.2.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:

--- a/prow/jobs/generated/knative-sandbox/eventing-ceph-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-ceph-main.gen.yaml
@@ -31,7 +31,7 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -86,7 +86,7 @@ periodics:
         value: /etc/nightly-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -150,7 +150,7 @@ periodics:
         value: knative-sandbox
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:

--- a/prow/jobs/generated/knative-sandbox/eventing-ceph-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-ceph-release-1.0.gen.yaml
@@ -31,7 +31,7 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -95,7 +95,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:

--- a/prow/jobs/generated/knative-sandbox/eventing-ceph-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-ceph-release-1.1.gen.yaml
@@ -31,7 +31,7 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -95,7 +95,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:

--- a/prow/jobs/generated/knative-sandbox/eventing-ceph-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-ceph-release-1.2.gen.yaml
@@ -31,7 +31,7 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -95,7 +95,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:

--- a/prow/jobs/generated/knative-sandbox/eventing-ceph-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-ceph-release-1.3.gen.yaml
@@ -31,7 +31,7 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -95,7 +95,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:

--- a/prow/jobs/generated/knative-sandbox/eventing-couchdb-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-couchdb-main.gen.yaml
@@ -31,7 +31,7 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -86,7 +86,7 @@ periodics:
         value: /etc/nightly-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -150,7 +150,7 @@ periodics:
         value: knative-sandbox
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:

--- a/prow/jobs/generated/knative-sandbox/eventing-couchdb-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-couchdb-release-1.0.gen.yaml
@@ -31,7 +31,7 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -95,7 +95,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:

--- a/prow/jobs/generated/knative-sandbox/eventing-couchdb-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-couchdb-release-1.1.gen.yaml
@@ -31,7 +31,7 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -95,7 +95,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:

--- a/prow/jobs/generated/knative-sandbox/eventing-github-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-github-main.gen.yaml
@@ -31,7 +31,7 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -86,7 +86,7 @@ periodics:
         value: /etc/nightly-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -150,7 +150,7 @@ periodics:
         value: knative-sandbox
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:

--- a/prow/jobs/generated/knative-sandbox/eventing-github-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-github-release-1.0.gen.yaml
@@ -31,7 +31,7 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -95,7 +95,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:

--- a/prow/jobs/generated/knative-sandbox/eventing-github-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-github-release-1.1.gen.yaml
@@ -31,7 +31,7 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -95,7 +95,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:

--- a/prow/jobs/generated/knative-sandbox/eventing-github-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-github-release-1.2.gen.yaml
@@ -31,7 +31,7 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -95,7 +95,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:

--- a/prow/jobs/generated/knative-sandbox/eventing-github-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-github-release-1.3.gen.yaml
@@ -31,7 +31,7 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -95,7 +95,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:

--- a/prow/jobs/generated/knative-sandbox/eventing-gitlab-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-gitlab-main.gen.yaml
@@ -31,7 +31,7 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:
@@ -90,7 +90,7 @@ periodics:
         value: /etc/nightly-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:
@@ -158,7 +158,7 @@ periodics:
         value: knative-sandbox
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:

--- a/prow/jobs/generated/knative-sandbox/eventing-gitlab-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-gitlab-release-1.0.gen.yaml
@@ -31,7 +31,7 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:
@@ -99,7 +99,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:

--- a/prow/jobs/generated/knative-sandbox/eventing-gitlab-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-gitlab-release-1.1.gen.yaml
@@ -31,7 +31,7 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:
@@ -99,7 +99,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:

--- a/prow/jobs/generated/knative-sandbox/eventing-gitlab-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-gitlab-release-1.2.gen.yaml
@@ -31,7 +31,7 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:
@@ -99,7 +99,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:

--- a/prow/jobs/generated/knative-sandbox/eventing-gitlab-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-gitlab-release-1.3.gen.yaml
@@ -31,7 +31,7 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:
@@ -99,7 +99,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:

--- a/prow/jobs/generated/knative-sandbox/eventing-kafka-broker-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kafka-broker-main.gen.yaml
@@ -31,7 +31,7 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -93,7 +93,7 @@ periodics:
         value: /etc/nightly-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -157,7 +157,7 @@ periodics:
         value: knative-sandbox
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -209,7 +209,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -229,7 +229,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -256,7 +256,7 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -308,7 +308,7 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -360,7 +360,7 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -414,7 +414,7 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -468,7 +468,7 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -522,7 +522,7 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -576,7 +576,7 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -630,7 +630,7 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -684,7 +684,7 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/eventing-kafka-broker-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kafka-broker-release-1.0.gen.yaml
@@ -31,7 +31,7 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -95,7 +95,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -131,7 +131,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -151,7 +151,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -178,7 +178,7 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -230,7 +230,7 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -282,7 +282,7 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -336,7 +336,7 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -390,7 +390,7 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -444,7 +444,7 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -498,7 +498,7 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -552,7 +552,7 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -606,7 +606,7 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/eventing-kafka-broker-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kafka-broker-release-1.1.gen.yaml
@@ -31,7 +31,7 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -95,7 +95,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -131,7 +131,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -151,7 +151,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -178,7 +178,7 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -230,7 +230,7 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -282,7 +282,7 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -336,7 +336,7 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -390,7 +390,7 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -444,7 +444,7 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -498,7 +498,7 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -552,7 +552,7 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -606,7 +606,7 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/eventing-kafka-broker-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kafka-broker-release-1.2.gen.yaml
@@ -31,7 +31,7 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -95,7 +95,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -131,7 +131,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -151,7 +151,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -178,7 +178,7 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -230,7 +230,7 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -282,7 +282,7 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -336,7 +336,7 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -390,7 +390,7 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -444,7 +444,7 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -498,7 +498,7 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -552,7 +552,7 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -606,7 +606,7 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/eventing-kafka-broker-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kafka-broker-release-1.3.gen.yaml
@@ -31,7 +31,7 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -95,7 +95,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -131,7 +131,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -151,7 +151,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -178,7 +178,7 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -230,7 +230,7 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -282,7 +282,7 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -336,7 +336,7 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -390,7 +390,7 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -444,7 +444,7 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -498,7 +498,7 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -552,7 +552,7 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -606,7 +606,7 @@ presubmits:
           value: /etc/test-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/eventing-kafka-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kafka-main.gen.yaml
@@ -31,7 +31,7 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -93,7 +93,7 @@ periodics:
         value: /etc/nightly-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -157,7 +157,7 @@ periodics:
         value: knative-sandbox
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -212,7 +212,7 @@ presubmits:
         env:
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -253,7 +253,7 @@ presubmits:
         env:
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -297,7 +297,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -331,7 +331,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -365,7 +365,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -399,7 +399,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -434,7 +434,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -468,7 +468,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/eventing-kafka-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kafka-release-1.0.gen.yaml
@@ -31,7 +31,7 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -95,7 +95,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -134,7 +134,7 @@ presubmits:
         env:
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -175,7 +175,7 @@ presubmits:
         env:
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -219,7 +219,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -253,7 +253,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -287,7 +287,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -321,7 +321,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -356,7 +356,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -390,7 +390,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/eventing-kafka-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kafka-release-1.1.gen.yaml
@@ -31,7 +31,7 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -95,7 +95,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -134,7 +134,7 @@ presubmits:
         env:
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -175,7 +175,7 @@ presubmits:
         env:
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -219,7 +219,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -253,7 +253,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -287,7 +287,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -321,7 +321,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -356,7 +356,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -390,7 +390,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/eventing-kafka-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kafka-release-1.2.gen.yaml
@@ -31,7 +31,7 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -95,7 +95,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -134,7 +134,7 @@ presubmits:
         env:
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -175,7 +175,7 @@ presubmits:
         env:
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -219,7 +219,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -253,7 +253,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -287,7 +287,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -321,7 +321,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -356,7 +356,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -390,7 +390,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/eventing-kafka-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kafka-release-1.3.gen.yaml
@@ -31,7 +31,7 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -95,7 +95,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -134,7 +134,7 @@ presubmits:
         env:
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -175,7 +175,7 @@ presubmits:
         env:
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -219,7 +219,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -253,7 +253,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -287,7 +287,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -321,7 +321,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -356,7 +356,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -390,7 +390,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/eventing-kogito-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kogito-main.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -73,7 +73,7 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -119,7 +119,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -155,7 +155,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -175,7 +175,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -200,7 +200,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/eventing-kogito-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kogito-release-1.0.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -113,7 +113,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -133,7 +133,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -158,7 +158,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/eventing-kogito-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kogito-release-1.1.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -113,7 +113,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -133,7 +133,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -158,7 +158,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/eventing-kogito-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kogito-release-1.2.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -113,7 +113,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -133,7 +133,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -158,7 +158,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/eventing-kogito-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kogito-release-1.3.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -113,7 +113,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -133,7 +133,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -158,7 +158,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/eventing-natss-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-natss-main.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -73,7 +73,7 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -119,7 +119,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:

--- a/prow/jobs/generated/knative-sandbox/eventing-natss-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-natss-release-1.0.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:

--- a/prow/jobs/generated/knative-sandbox/eventing-natss-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-natss-release-1.1.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:

--- a/prow/jobs/generated/knative-sandbox/eventing-natss-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-natss-release-1.2.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:

--- a/prow/jobs/generated/knative-sandbox/eventing-natss-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-natss-release-1.3.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:

--- a/prow/jobs/generated/knative-sandbox/eventing-rabbitmq-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-rabbitmq-main.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -73,7 +73,7 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -119,7 +119,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:

--- a/prow/jobs/generated/knative-sandbox/eventing-rabbitmq-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-rabbitmq-release-1.0.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:

--- a/prow/jobs/generated/knative-sandbox/eventing-rabbitmq-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-rabbitmq-release-1.1.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:

--- a/prow/jobs/generated/knative-sandbox/eventing-rabbitmq-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-rabbitmq-release-1.2.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:

--- a/prow/jobs/generated/knative-sandbox/eventing-rabbitmq-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-rabbitmq-release-1.3.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:

--- a/prow/jobs/generated/knative-sandbox/eventing-redis-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-redis-main.gen.yaml
@@ -31,7 +31,7 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -86,7 +86,7 @@ periodics:
         value: /etc/nightly-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -150,7 +150,7 @@ periodics:
         value: knative-sandbox
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:

--- a/prow/jobs/generated/knative-sandbox/eventing-redis-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-redis-release-1.0.gen.yaml
@@ -31,7 +31,7 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -95,7 +95,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:

--- a/prow/jobs/generated/knative-sandbox/eventing-redis-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-redis-release-1.1.gen.yaml
@@ -31,7 +31,7 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -95,7 +95,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:

--- a/prow/jobs/generated/knative-sandbox/eventing-redis-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-redis-release-1.2.gen.yaml
@@ -31,7 +31,7 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -95,7 +95,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:

--- a/prow/jobs/generated/knative-sandbox/eventing-redis-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-redis-release-1.3.gen.yaml
@@ -31,7 +31,7 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -95,7 +95,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-admin-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-admin-main.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -66,7 +66,7 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -112,7 +112,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -148,7 +148,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -168,7 +168,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -193,7 +193,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-admin-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-admin-release-1.0.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -113,7 +113,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -133,7 +133,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -158,7 +158,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-admin-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-admin-release-1.1.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -113,7 +113,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -133,7 +133,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -158,7 +158,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-admin-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-admin-release-1.2.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -113,7 +113,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -133,7 +133,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -158,7 +158,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-admin-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-admin-release-1.3.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -113,7 +113,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -133,7 +133,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -158,7 +158,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-diag-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-diag-main.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -59,7 +59,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -79,7 +79,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -104,7 +104,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-event-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-event-main.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -66,7 +66,7 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -112,7 +112,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -148,7 +148,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -168,7 +168,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -193,7 +193,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-event-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-event-release-1.0.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -113,7 +113,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -133,7 +133,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -158,7 +158,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-event-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-event-release-1.1.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -113,7 +113,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -133,7 +133,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -158,7 +158,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-event-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-event-release-1.2.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -113,7 +113,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -133,7 +133,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -158,7 +158,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-event-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-event-release-1.3.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -113,7 +113,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -133,7 +133,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -158,7 +158,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-func-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-func-main.gen.yaml
@@ -30,7 +30,7 @@ periodics:
         value: /etc/nightly-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -94,7 +94,7 @@ periodics:
         value: knative-sandbox
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-func-release-0.22.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-func-release-0.22.gen.yaml
@@ -41,7 +41,7 @@ periodics:
         value: knative-sandbox
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-migration-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-migration-main.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -59,7 +59,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -79,7 +79,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -104,7 +104,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-operator-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-operator-main.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -59,7 +59,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -79,7 +79,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -104,7 +104,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-quickstart-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-quickstart-main.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -66,7 +66,7 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -112,7 +112,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -148,7 +148,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -168,7 +168,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -193,7 +193,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-quickstart-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-quickstart-release-1.0.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -113,7 +113,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -133,7 +133,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -158,7 +158,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-quickstart-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-quickstart-release-1.1.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -113,7 +113,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -133,7 +133,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -158,7 +158,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-quickstart-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-quickstart-release-1.2.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -113,7 +113,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -133,7 +133,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -158,7 +158,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-quickstart-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-quickstart-release-1.3.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -113,7 +113,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -133,7 +133,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -158,7 +158,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-sample-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-sample-main.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -59,7 +59,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -79,7 +79,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -104,7 +104,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-service-log-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-service-log-main.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -68,7 +68,7 @@ periodics:
         value: /etc/nightly-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -132,7 +132,7 @@ periodics:
         value: knative-sandbox
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -184,7 +184,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -204,7 +204,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -229,7 +229,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-source-kafka-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-source-kafka-main.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -68,7 +68,7 @@ periodics:
         value: /etc/nightly-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -132,7 +132,7 @@ periodics:
         value: knative-sandbox
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -184,7 +184,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -204,7 +204,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -229,7 +229,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-source-kafka-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-source-kafka-release-1.0.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -113,7 +113,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -133,7 +133,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -158,7 +158,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-source-kafka-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-source-kafka-release-1.1.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -113,7 +113,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -133,7 +133,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -158,7 +158,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-source-kafka-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-source-kafka-release-1.2.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -113,7 +113,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -133,7 +133,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -158,7 +158,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-source-kafka-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-source-kafka-release-1.3.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -113,7 +113,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -133,7 +133,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -158,7 +158,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-source-kamelet-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-source-kamelet-main.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -66,7 +66,7 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -112,7 +112,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -148,7 +148,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -168,7 +168,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -193,7 +193,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-source-kamelet-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-source-kamelet-release-1.0.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -113,7 +113,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -133,7 +133,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -158,7 +158,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-source-kamelet-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-source-kamelet-release-1.1.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -113,7 +113,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -133,7 +133,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -158,7 +158,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-source-kamelet-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-source-kamelet-release-1.2.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -113,7 +113,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -133,7 +133,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -158,7 +158,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-source-kamelet-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-source-kamelet-release-1.3.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -113,7 +113,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -133,7 +133,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -158,7 +158,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/kperf-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kperf-main.gen.yaml
@@ -20,7 +20,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -40,7 +40,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -65,7 +65,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/net-certmanager-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-certmanager-main.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -73,7 +73,7 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -119,7 +119,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -155,7 +155,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -175,7 +175,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -200,7 +200,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/net-certmanager-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-certmanager-release-1.0.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -113,7 +113,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -133,7 +133,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -158,7 +158,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/net-certmanager-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-certmanager-release-1.1.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -113,7 +113,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -133,7 +133,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -158,7 +158,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/net-certmanager-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-certmanager-release-1.2.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -113,7 +113,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -133,7 +133,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -158,7 +158,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/net-certmanager-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-certmanager-release-1.3.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -113,7 +113,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -133,7 +133,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -158,7 +158,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/net-contour-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-contour-main.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -73,7 +73,7 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -119,7 +119,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -155,7 +155,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -175,7 +175,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -200,7 +200,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/net-contour-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-contour-release-1.0.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -113,7 +113,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -133,7 +133,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -158,7 +158,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/net-contour-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-contour-release-1.1.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -113,7 +113,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -133,7 +133,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -158,7 +158,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/net-contour-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-contour-release-1.2.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -113,7 +113,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -133,7 +133,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -158,7 +158,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/net-contour-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-contour-release-1.3.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -113,7 +113,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -133,7 +133,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -158,7 +158,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/net-gateway-api-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-gateway-api-main.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -73,7 +73,7 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -119,7 +119,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -155,7 +155,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -175,7 +175,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -200,7 +200,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/net-gateway-api-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-gateway-api-release-1.1.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -113,7 +113,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -133,7 +133,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -158,7 +158,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/net-gateway-api-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-gateway-api-release-1.2.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -113,7 +113,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -133,7 +133,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -158,7 +158,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/net-gateway-api-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-gateway-api-release-1.3.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -113,7 +113,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -133,7 +133,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -158,7 +158,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/net-http01-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-http01-main.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -73,7 +73,7 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -119,7 +119,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -155,7 +155,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -175,7 +175,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -200,7 +200,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/net-http01-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-http01-release-1.0.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -113,7 +113,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -133,7 +133,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -158,7 +158,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/net-http01-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-http01-release-1.1.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -113,7 +113,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -133,7 +133,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -158,7 +158,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/net-http01-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-http01-release-1.2.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -113,7 +113,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -133,7 +133,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -158,7 +158,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/net-http01-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-http01-release-1.3.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -113,7 +113,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -133,7 +133,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -158,7 +158,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/net-istio-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-istio-main.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -73,7 +73,7 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -119,7 +119,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -155,7 +155,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -175,7 +175,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -200,7 +200,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -234,7 +234,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -268,7 +268,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/net-istio-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-istio-release-1.0.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -113,7 +113,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -133,7 +133,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -158,7 +158,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -192,7 +192,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -226,7 +226,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/net-istio-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-istio-release-1.1.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -113,7 +113,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -133,7 +133,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -158,7 +158,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -192,7 +192,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -226,7 +226,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/net-istio-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-istio-release-1.2.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -113,7 +113,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -133,7 +133,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -158,7 +158,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -192,7 +192,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -226,7 +226,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/net-istio-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-istio-release-1.3.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -113,7 +113,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -133,7 +133,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -158,7 +158,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -192,7 +192,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -226,7 +226,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/net-kourier-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-kourier-main.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -73,7 +73,7 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -119,7 +119,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -155,7 +155,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -175,7 +175,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -200,7 +200,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/net-kourier-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-kourier-release-1.0.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -113,7 +113,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -133,7 +133,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -158,7 +158,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/net-kourier-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-kourier-release-1.1.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -113,7 +113,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -133,7 +133,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -158,7 +158,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/net-kourier-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-kourier-release-1.2.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -113,7 +113,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -133,7 +133,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -158,7 +158,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/net-kourier-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-kourier-release-1.3.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -113,7 +113,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -133,7 +133,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -158,7 +158,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/reconciler-test-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/reconciler-test-main.gen.yaml
@@ -20,7 +20,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -40,7 +40,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -65,7 +65,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/sample-controller-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/sample-controller-main.gen.yaml
@@ -28,7 +28,7 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -74,7 +74,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -110,7 +110,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -130,7 +130,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/sample-controller-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/sample-controller-release-1.0.gen.yaml
@@ -39,7 +39,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -75,7 +75,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -95,7 +95,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/sample-controller-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/sample-controller-release-1.1.gen.yaml
@@ -39,7 +39,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -75,7 +75,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -95,7 +95,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/sample-controller-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/sample-controller-release-1.2.gen.yaml
@@ -39,7 +39,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -75,7 +75,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -95,7 +95,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/sample-controller-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/sample-controller-release-1.3.gen.yaml
@@ -39,7 +39,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -75,7 +75,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -95,7 +95,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/sample-source-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/sample-source-main.gen.yaml
@@ -28,7 +28,7 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -74,7 +74,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -110,7 +110,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -130,7 +130,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/sample-source-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/sample-source-release-1.0.gen.yaml
@@ -39,7 +39,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -75,7 +75,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -95,7 +95,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/sample-source-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/sample-source-release-1.1.gen.yaml
@@ -39,7 +39,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -75,7 +75,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -95,7 +95,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/sample-source-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/sample-source-release-1.2.gen.yaml
@@ -39,7 +39,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -75,7 +75,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -95,7 +95,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative-sandbox/sample-source-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/sample-source-release-1.3.gen.yaml
@@ -39,7 +39,7 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -75,7 +75,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -95,7 +95,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative/caching-main.gen.yaml
+++ b/prow/jobs/generated/knative/caching-main.gen.yaml
@@ -20,7 +20,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -40,7 +40,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -65,7 +65,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative/client-main.gen.yaml
+++ b/prow/jobs/generated/knative/client-main.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -66,7 +66,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -131,7 +131,7 @@ periodics:
         value: /root/.kube/config
       - name: DOCKER_CONFIG
         value: /opt/cluster
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -182,7 +182,7 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -226,7 +226,7 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -262,7 +262,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -282,7 +282,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -307,7 +307,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -339,7 +339,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative/client-pkg-main.gen.yaml
+++ b/prow/jobs/generated/knative/client-pkg-main.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -59,7 +59,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -79,7 +79,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative/client-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative/client-release-1.0.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -94,7 +94,7 @@ periodics:
         value: /root/.kube/config
       - name: DOCKER_CONFIG
         value: /opt/cluster
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -147,7 +147,7 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -183,7 +183,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -203,7 +203,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -228,7 +228,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -260,7 +260,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative/client-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative/client-release-1.1.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -94,7 +94,7 @@ periodics:
         value: /root/.kube/config
       - name: DOCKER_CONFIG
         value: /opt/cluster
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -147,7 +147,7 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -183,7 +183,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -203,7 +203,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -228,7 +228,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -260,7 +260,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative/client-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative/client-release-1.2.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -94,7 +94,7 @@ periodics:
         value: /root/.kube/config
       - name: DOCKER_CONFIG
         value: /opt/cluster
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -147,7 +147,7 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -183,7 +183,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -203,7 +203,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -228,7 +228,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -260,7 +260,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative/client-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative/client-release-1.3.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -94,7 +94,7 @@ periodics:
         value: /root/.kube/config
       - name: DOCKER_CONFIG
         value: /opt/cluster
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -147,7 +147,7 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -183,7 +183,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -203,7 +203,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -228,7 +228,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -260,7 +260,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative/docs-main.gen.yaml
+++ b/prow/jobs/generated/knative/docs-main.gen.yaml
@@ -31,7 +31,7 @@ periodics:
         value: /etc/test-account/service-account.json
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -77,7 +77,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -97,7 +97,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative/eventing-main.gen.yaml
+++ b/prow/jobs/generated/knative/eventing-main.gen.yaml
@@ -31,7 +31,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:
@@ -102,7 +102,7 @@ periodics:
         value: /root/.kube/config
       - name: DOCKER_CONFIG
         value: /opt/cluster
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:
@@ -159,7 +159,7 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:
@@ -209,7 +209,7 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:
@@ -249,7 +249,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -273,7 +273,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -303,7 +303,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -342,7 +342,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -380,7 +380,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:

--- a/prow/jobs/generated/knative/eventing-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative/eventing-release-1.0.gen.yaml
@@ -31,7 +31,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:
@@ -102,7 +102,7 @@ periodics:
         value: /root/.kube/config
       - name: DOCKER_CONFIG
         value: /opt/cluster
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:
@@ -161,7 +161,7 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:
@@ -201,7 +201,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -225,7 +225,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -255,7 +255,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -294,7 +294,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -332,7 +332,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:

--- a/prow/jobs/generated/knative/eventing-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative/eventing-release-1.1.gen.yaml
@@ -31,7 +31,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:
@@ -102,7 +102,7 @@ periodics:
         value: /root/.kube/config
       - name: DOCKER_CONFIG
         value: /opt/cluster
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:
@@ -161,7 +161,7 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:
@@ -201,7 +201,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -225,7 +225,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -255,7 +255,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -294,7 +294,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -332,7 +332,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:

--- a/prow/jobs/generated/knative/eventing-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative/eventing-release-1.2.gen.yaml
@@ -31,7 +31,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:
@@ -102,7 +102,7 @@ periodics:
         value: /root/.kube/config
       - name: DOCKER_CONFIG
         value: /opt/cluster
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:
@@ -161,7 +161,7 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:
@@ -201,7 +201,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -225,7 +225,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -255,7 +255,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -294,7 +294,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -332,7 +332,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:

--- a/prow/jobs/generated/knative/eventing-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative/eventing-release-1.3.gen.yaml
@@ -31,7 +31,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:
@@ -102,7 +102,7 @@ periodics:
         value: /root/.kube/config
       - name: DOCKER_CONFIG
         value: /opt/cluster
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:
@@ -161,7 +161,7 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:
@@ -201,7 +201,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -225,7 +225,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -255,7 +255,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -294,7 +294,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -332,7 +332,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:

--- a/prow/jobs/generated/knative/hack-main.gen.yaml
+++ b/prow/jobs/generated/knative/hack-main.gen.yaml
@@ -20,7 +20,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -40,7 +40,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -66,7 +66,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -100,7 +100,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative/networking-main.gen.yaml
+++ b/prow/jobs/generated/knative/networking-main.gen.yaml
@@ -20,7 +20,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -40,7 +40,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -65,7 +65,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative/operator-main.gen.yaml
+++ b/prow/jobs/generated/knative/operator-main.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -94,7 +94,7 @@ periodics:
         value: /root/.kube/config
       - name: DOCKER_CONFIG
         value: /opt/cluster
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -145,7 +145,7 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -189,7 +189,7 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -225,7 +225,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -245,7 +245,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -270,7 +270,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -304,7 +304,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -338,7 +338,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -372,7 +372,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative/operator-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative/operator-release-1.0.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -94,7 +94,7 @@ periodics:
         value: /root/.kube/config
       - name: DOCKER_CONFIG
         value: /opt/cluster
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -147,7 +147,7 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -183,7 +183,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -203,7 +203,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -228,7 +228,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -262,7 +262,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -296,7 +296,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -330,7 +330,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative/operator-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative/operator-release-1.1.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -94,7 +94,7 @@ periodics:
         value: /root/.kube/config
       - name: DOCKER_CONFIG
         value: /opt/cluster
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -147,7 +147,7 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -183,7 +183,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -203,7 +203,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -228,7 +228,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -262,7 +262,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -296,7 +296,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -330,7 +330,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative/operator-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative/operator-release-1.2.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -94,7 +94,7 @@ periodics:
         value: /root/.kube/config
       - name: DOCKER_CONFIG
         value: /opt/cluster
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -147,7 +147,7 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -183,7 +183,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -203,7 +203,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -228,7 +228,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -262,7 +262,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -296,7 +296,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -330,7 +330,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative/operator-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative/operator-release-1.3.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -94,7 +94,7 @@ periodics:
         value: /root/.kube/config
       - name: DOCKER_CONFIG
         value: /opt/cluster
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -147,7 +147,7 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources: {}
       securityContext:
@@ -183,7 +183,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -203,7 +203,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -228,7 +228,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -262,7 +262,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -296,7 +296,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -330,7 +330,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative/pkg-main.gen.yaml
+++ b/prow/jobs/generated/knative/pkg-main.gen.yaml
@@ -20,7 +20,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -40,7 +40,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -65,7 +65,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs/generated/knative/serving-main.gen.yaml
+++ b/prow/jobs/generated/knative/serving-main.gen.yaml
@@ -31,7 +31,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:
@@ -77,7 +77,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:
@@ -123,7 +123,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:
@@ -169,7 +169,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:
@@ -215,7 +215,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:
@@ -261,7 +261,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:
@@ -307,7 +307,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:
@@ -351,7 +351,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:
@@ -397,7 +397,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:
@@ -469,7 +469,7 @@ periodics:
         value: /root/.kube/config
       - name: DOCKER_CONFIG
         value: /opt/cluster
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:
@@ -548,7 +548,7 @@ periodics:
         value: /root/.kube/config
       - name: DOCKER_CONFIG
         value: /opt/cluster
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:
@@ -605,7 +605,7 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:
@@ -655,7 +655,7 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:
@@ -695,7 +695,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -719,7 +719,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -749,7 +749,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -787,7 +787,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -825,7 +825,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -864,7 +864,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -903,7 +903,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -942,7 +942,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -981,7 +981,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -1020,7 +1020,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -1059,7 +1059,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -1098,7 +1098,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -1137,7 +1137,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -1176,7 +1176,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -1219,7 +1219,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:

--- a/prow/jobs/generated/knative/serving-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative/serving-release-1.0.gen.yaml
@@ -31,7 +31,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:
@@ -103,7 +103,7 @@ periodics:
         value: /root/.kube/config
       - name: DOCKER_CONFIG
         value: /opt/cluster
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:
@@ -182,7 +182,7 @@ periodics:
         value: /root/.kube/config
       - name: DOCKER_CONFIG
         value: /opt/cluster
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:
@@ -241,7 +241,7 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:
@@ -281,7 +281,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -305,7 +305,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -335,7 +335,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -373,7 +373,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -411,7 +411,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -450,7 +450,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -489,7 +489,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -528,7 +528,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -567,7 +567,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -606,7 +606,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -645,7 +645,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -684,7 +684,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -723,7 +723,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -762,7 +762,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -805,7 +805,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:

--- a/prow/jobs/generated/knative/serving-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative/serving-release-1.1.gen.yaml
@@ -31,7 +31,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:
@@ -103,7 +103,7 @@ periodics:
         value: /root/.kube/config
       - name: DOCKER_CONFIG
         value: /opt/cluster
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:
@@ -182,7 +182,7 @@ periodics:
         value: /root/.kube/config
       - name: DOCKER_CONFIG
         value: /opt/cluster
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:
@@ -241,7 +241,7 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:
@@ -281,7 +281,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -305,7 +305,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -335,7 +335,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -373,7 +373,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -411,7 +411,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -450,7 +450,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -489,7 +489,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -528,7 +528,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -567,7 +567,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -606,7 +606,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -645,7 +645,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -684,7 +684,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -723,7 +723,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -762,7 +762,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -805,7 +805,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:

--- a/prow/jobs/generated/knative/serving-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative/serving-release-1.2.gen.yaml
@@ -31,7 +31,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:
@@ -103,7 +103,7 @@ periodics:
         value: /root/.kube/config
       - name: DOCKER_CONFIG
         value: /opt/cluster
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:
@@ -182,7 +182,7 @@ periodics:
         value: /root/.kube/config
       - name: DOCKER_CONFIG
         value: /opt/cluster
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:
@@ -241,7 +241,7 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:
@@ -281,7 +281,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -305,7 +305,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -335,7 +335,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -373,7 +373,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -411,7 +411,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -450,7 +450,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -489,7 +489,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -528,7 +528,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -567,7 +567,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -606,7 +606,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -645,7 +645,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -684,7 +684,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -723,7 +723,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -762,7 +762,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -805,7 +805,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:

--- a/prow/jobs/generated/knative/serving-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative/serving-release-1.3.gen.yaml
@@ -31,7 +31,7 @@ periodics:
         value: us-central1
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:
@@ -103,7 +103,7 @@ periodics:
         value: /root/.kube/config
       - name: DOCKER_CONFIG
         value: /opt/cluster
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:
@@ -182,7 +182,7 @@ periodics:
         value: /root/.kube/config
       - name: DOCKER_CONFIG
         value: /opt/cluster
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:
@@ -241,7 +241,7 @@ periodics:
         value: /etc/release-account/service-account.json
       - name: E2E_CLUSTER_REGION
         value: us-central1
-      image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
       name: ""
       resources:
         limits:
@@ -281,7 +281,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -305,7 +305,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -335,7 +335,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -373,7 +373,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -411,7 +411,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -450,7 +450,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -489,7 +489,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -528,7 +528,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -567,7 +567,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -606,7 +606,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -645,7 +645,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -684,7 +684,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -723,7 +723,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -762,7 +762,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:
@@ -805,7 +805,7 @@ presubmits:
           value: us-central1
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources:
           limits:

--- a/prow/jobs/generated/knative/test-infra-main.gen.yaml
+++ b/prow/jobs/generated/knative/test-infra-main.gen.yaml
@@ -20,7 +20,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --build-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:
@@ -40,7 +40,7 @@ presubmits:
         - runner.sh
         - ./test/presubmit-tests.sh
         - --unit-tests
-        image: gcr.io/knative-tests/test-infra/prow-tests:stable
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
         name: ""
         resources: {}
         securityContext:

--- a/prow/jobs_config/knative-sandbox/async-component.yaml
+++ b/prow/jobs_config/knative-sandbox/async-component.yaml
@@ -1,7 +1,7 @@
 org: knative-sandbox
 repo: async-component
 branches: [main]
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 imagePullPolicy: Always
 
 jobs:

--- a/prow/jobs_config/knative-sandbox/container-freezer.yaml
+++ b/prow/jobs_config/knative-sandbox/container-freezer.yaml
@@ -1,7 +1,7 @@
 org: knative-sandbox
 repo: container-freezer
 branches: [main]
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 imagePullPolicy: Always
 
 jobs:

--- a/prow/jobs_config/knative-sandbox/discovery.yaml
+++ b/prow/jobs_config/knative-sandbox/discovery.yaml
@@ -1,7 +1,7 @@
 org: knative-sandbox
 repo: discovery
 branches: [main]
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 imagePullPolicy: Always
 
 jobs:

--- a/prow/jobs_config/knative-sandbox/eventing-autoscaler-keda-release-1.0.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-autoscaler-keda-release-1.0.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.0
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/eventing-autoscaler-keda-release-1.1.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-autoscaler-keda-release-1.1.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.1
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/eventing-autoscaler-keda-release-1.2.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-autoscaler-keda-release-1.2.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.2
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/eventing-autoscaler-keda-release-1.3.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-autoscaler-keda-release-1.3.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.3
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/eventing-autoscaler-keda.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-autoscaler-keda.yaml
@@ -1,7 +1,7 @@
 org: knative-sandbox
 repo: eventing-autoscaler-keda
 branches: [main]
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 imagePullPolicy: Always
 
 jobs:

--- a/prow/jobs_config/knative-sandbox/eventing-awssqs-release-1.0.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-awssqs-release-1.0.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.0
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/eventing-awssqs-release-1.1.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-awssqs-release-1.1.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.1
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/eventing-awssqs-release-1.2.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-awssqs-release-1.2.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.2
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/eventing-awssqs.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-awssqs.yaml
@@ -1,7 +1,7 @@
 org: knative-sandbox
 repo: eventing-awssqs
 branches: [main]
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 imagePullPolicy: Always
 
 jobs:

--- a/prow/jobs_config/knative-sandbox/eventing-ceph-release-1.0.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-ceph-release-1.0.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.0
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/eventing-ceph-release-1.1.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-ceph-release-1.1.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.1
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/eventing-ceph-release-1.2.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-ceph-release-1.2.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.2
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/eventing-ceph-release-1.3.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-ceph-release-1.3.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.3
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/eventing-ceph.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-ceph.yaml
@@ -1,7 +1,7 @@
 org: knative-sandbox
 repo: eventing-ceph
 branches: [main]
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 imagePullPolicy: Always
 
 jobs:

--- a/prow/jobs_config/knative-sandbox/eventing-couchdb-release-1.0.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-couchdb-release-1.0.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.0
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/eventing-couchdb-release-1.1.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-couchdb-release-1.1.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.1
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/eventing-couchdb.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-couchdb.yaml
@@ -1,7 +1,7 @@
 org: knative-sandbox
 repo: eventing-couchdb
 branches: [main]
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 imagePullPolicy: Always
 
 jobs:

--- a/prow/jobs_config/knative-sandbox/eventing-github-release-1.0.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-github-release-1.0.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.0
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/eventing-github-release-1.1.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-github-release-1.1.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.1
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/eventing-github-release-1.2.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-github-release-1.2.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.2
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/eventing-github-release-1.3.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-github-release-1.3.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.3
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/eventing-github.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-github.yaml
@@ -1,7 +1,7 @@
 org: knative-sandbox
 repo: eventing-github
 branches: [main]
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 imagePullPolicy: Always
 
 jobs:

--- a/prow/jobs_config/knative-sandbox/eventing-gitlab-release-1.0.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-gitlab-release-1.0.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.0
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/eventing-gitlab-release-1.1.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-gitlab-release-1.1.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.1
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/eventing-gitlab-release-1.2.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-gitlab-release-1.2.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.2
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/eventing-gitlab-release-1.3.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-gitlab-release-1.3.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.3
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/eventing-gitlab.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-gitlab.yaml
@@ -1,7 +1,7 @@
 org: knative-sandbox
 repo: eventing-gitlab
 branches: [main]
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 imagePullPolicy: Always
 
 jobs:

--- a/prow/jobs_config/knative-sandbox/eventing-kafka-broker-release-1.0.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-kafka-broker-release-1.0.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.0
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/eventing-kafka-broker-release-1.1.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-kafka-broker-release-1.1.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.1
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/eventing-kafka-broker-release-1.2.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-kafka-broker-release-1.2.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.2
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/eventing-kafka-broker-release-1.3.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-kafka-broker-release-1.3.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.3
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/eventing-kafka-broker.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-kafka-broker.yaml
@@ -1,7 +1,7 @@
 org: knative-sandbox
 repo: eventing-kafka-broker
 branches: [main]
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 imagePullPolicy: Always
 
 jobs:

--- a/prow/jobs_config/knative-sandbox/eventing-kafka-release-1.0.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-kafka-release-1.0.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.0
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/eventing-kafka-release-1.1.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-kafka-release-1.1.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.1
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/eventing-kafka-release-1.2.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-kafka-release-1.2.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.2
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/eventing-kafka-release-1.3.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-kafka-release-1.3.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.3
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/eventing-kafka.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-kafka.yaml
@@ -1,7 +1,7 @@
 org: knative-sandbox
 repo: eventing-kafka
 branches: [main]
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 imagePullPolicy: Always
 
 jobs:

--- a/prow/jobs_config/knative-sandbox/eventing-kogito-release-1.0.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-kogito-release-1.0.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.0
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/eventing-kogito-release-1.1.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-kogito-release-1.1.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.1
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/eventing-kogito-release-1.2.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-kogito-release-1.2.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.2
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/eventing-kogito-release-1.3.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-kogito-release-1.3.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.3
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/eventing-kogito.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-kogito.yaml
@@ -1,7 +1,7 @@
 org: knative-sandbox
 repo: eventing-kogito
 branches: [main]
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 imagePullPolicy: Always
 
 jobs:

--- a/prow/jobs_config/knative-sandbox/eventing-natss-release-1.0.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-natss-release-1.0.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.0
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/eventing-natss-release-1.1.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-natss-release-1.1.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.1
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/eventing-natss-release-1.2.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-natss-release-1.2.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.2
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/eventing-natss-release-1.3.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-natss-release-1.3.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.3
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/eventing-natss.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-natss.yaml
@@ -1,7 +1,7 @@
 org: knative-sandbox
 repo: eventing-natss
 branches: [main]
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 imagePullPolicy: Always
 
 jobs:

--- a/prow/jobs_config/knative-sandbox/eventing-rabbitmq-release-1.0.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-rabbitmq-release-1.0.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.0
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/eventing-rabbitmq-release-1.1.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-rabbitmq-release-1.1.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.1
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/eventing-rabbitmq-release-1.2.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-rabbitmq-release-1.2.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.2
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/eventing-rabbitmq-release-1.3.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-rabbitmq-release-1.3.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.3
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/eventing-rabbitmq.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-rabbitmq.yaml
@@ -1,7 +1,7 @@
 org: knative-sandbox
 repo: eventing-rabbitmq
 branches: [main]
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 imagePullPolicy: Always
 
 jobs:

--- a/prow/jobs_config/knative-sandbox/eventing-redis-release-1.0.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-redis-release-1.0.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.0
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/eventing-redis-release-1.1.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-redis-release-1.1.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.1
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/eventing-redis-release-1.2.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-redis-release-1.2.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.2
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/eventing-redis-release-1.3.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-redis-release-1.3.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.3
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/eventing-redis.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-redis.yaml
@@ -1,7 +1,7 @@
 org: knative-sandbox
 repo: eventing-redis
 branches: [main]
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 imagePullPolicy: Always
 
 jobs:

--- a/prow/jobs_config/knative-sandbox/kn-plugin-admin-release-1.0.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-admin-release-1.0.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.0
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/kn-plugin-admin-release-1.1.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-admin-release-1.1.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.1
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/kn-plugin-admin-release-1.2.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-admin-release-1.2.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.2
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/kn-plugin-admin-release-1.3.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-admin-release-1.3.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.3
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/kn-plugin-admin.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-admin.yaml
@@ -1,7 +1,7 @@
 org: knative-sandbox
 repo: kn-plugin-admin
 branches: [main]
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 imagePullPolicy: Always
 
 jobs:

--- a/prow/jobs_config/knative-sandbox/kn-plugin-diag.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-diag.yaml
@@ -1,7 +1,7 @@
 org: knative-sandbox
 repo: kn-plugin-diag
 branches: [main]
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 imagePullPolicy: Always
 
 jobs:

--- a/prow/jobs_config/knative-sandbox/kn-plugin-event-release-1.0.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-event-release-1.0.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.0
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/kn-plugin-event-release-1.1.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-event-release-1.1.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.1
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/kn-plugin-event-release-1.2.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-event-release-1.2.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.2
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/kn-plugin-event-release-1.3.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-event-release-1.3.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.3
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/kn-plugin-event.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-event.yaml
@@ -1,7 +1,7 @@
 org: knative-sandbox
 repo: kn-plugin-event
 branches: [main]
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 imagePullPolicy: Always
 
 jobs:

--- a/prow/jobs_config/knative-sandbox/kn-plugin-func-release-0.22.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-func-release-0.22.yaml
@@ -6,7 +6,7 @@
 # #############################################################################
 branches:
 - release-0.22
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/kn-plugin-func.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-func.yaml
@@ -1,7 +1,7 @@
 org: knative-sandbox
 repo: kn-plugin-func
 branches: [main]
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 imagePullPolicy: Always
 
 jobs:

--- a/prow/jobs_config/knative-sandbox/kn-plugin-migration.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-migration.yaml
@@ -1,7 +1,7 @@
 org: knative-sandbox
 repo: kn-plugin-migration
 branches: [main]
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 imagePullPolicy: Always
 
 jobs:

--- a/prow/jobs_config/knative-sandbox/kn-plugin-operator.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-operator.yaml
@@ -1,7 +1,7 @@
 org: knative-sandbox
 repo: kn-plugin-operator
 branches: [main]
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 imagePullPolicy: Always
 
 jobs:

--- a/prow/jobs_config/knative-sandbox/kn-plugin-quickstart-release-1.0.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-quickstart-release-1.0.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.0
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/kn-plugin-quickstart-release-1.1.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-quickstart-release-1.1.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.1
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/kn-plugin-quickstart-release-1.2.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-quickstart-release-1.2.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.2
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/kn-plugin-quickstart-release-1.3.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-quickstart-release-1.3.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.3
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/kn-plugin-quickstart.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-quickstart.yaml
@@ -1,7 +1,7 @@
 org: knative-sandbox
 repo: kn-plugin-quickstart
 branches: [main]
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 imagePullPolicy: Always
 
 jobs:

--- a/prow/jobs_config/knative-sandbox/kn-plugin-sample.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-sample.yaml
@@ -1,7 +1,7 @@
 org: knative-sandbox
 repo: kn-plugin-sample
 branches: [main]
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 imagePullPolicy: Always
 
 jobs:

--- a/prow/jobs_config/knative-sandbox/kn-plugin-service-log.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-service-log.yaml
@@ -1,7 +1,7 @@
 org: knative-sandbox
 repo: kn-plugin-service-log
 branches: [main]
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 imagePullPolicy: Always
 
 jobs:

--- a/prow/jobs_config/knative-sandbox/kn-plugin-source-kafka-release-1.0.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-source-kafka-release-1.0.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.0
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/kn-plugin-source-kafka-release-1.1.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-source-kafka-release-1.1.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.1
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/kn-plugin-source-kafka-release-1.2.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-source-kafka-release-1.2.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.2
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/kn-plugin-source-kafka-release-1.3.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-source-kafka-release-1.3.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.3
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/kn-plugin-source-kafka.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-source-kafka.yaml
@@ -1,7 +1,7 @@
 org: knative-sandbox
 repo: kn-plugin-source-kafka
 branches: [main]
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 imagePullPolicy: Always
 
 jobs:

--- a/prow/jobs_config/knative-sandbox/kn-plugin-source-kamelet-release-1.0.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-source-kamelet-release-1.0.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.0
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/kn-plugin-source-kamelet-release-1.1.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-source-kamelet-release-1.1.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.1
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/kn-plugin-source-kamelet-release-1.2.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-source-kamelet-release-1.2.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.2
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/kn-plugin-source-kamelet-release-1.3.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-source-kamelet-release-1.3.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.3
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/kn-plugin-source-kamelet.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-source-kamelet.yaml
@@ -1,7 +1,7 @@
 org: knative-sandbox
 repo: kn-plugin-source-kamelet
 branches: [main]
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 imagePullPolicy: Always
 
 jobs:

--- a/prow/jobs_config/knative-sandbox/kperf.yaml
+++ b/prow/jobs_config/knative-sandbox/kperf.yaml
@@ -1,7 +1,7 @@
 org: knative-sandbox
 repo: kperf
 branches: [main]
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 imagePullPolicy: Always
 
 jobs:

--- a/prow/jobs_config/knative-sandbox/net-certmanager-release-1.0.yaml
+++ b/prow/jobs_config/knative-sandbox/net-certmanager-release-1.0.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.0
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/net-certmanager-release-1.1.yaml
+++ b/prow/jobs_config/knative-sandbox/net-certmanager-release-1.1.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.1
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/net-certmanager-release-1.2.yaml
+++ b/prow/jobs_config/knative-sandbox/net-certmanager-release-1.2.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.2
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/net-certmanager-release-1.3.yaml
+++ b/prow/jobs_config/knative-sandbox/net-certmanager-release-1.3.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.3
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/net-certmanager.yaml
+++ b/prow/jobs_config/knative-sandbox/net-certmanager.yaml
@@ -1,7 +1,7 @@
 org: knative-sandbox
 repo: net-certmanager
 branches: [main]
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 imagePullPolicy: Always
 
 jobs:

--- a/prow/jobs_config/knative-sandbox/net-contour-release-1.0.yaml
+++ b/prow/jobs_config/knative-sandbox/net-contour-release-1.0.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.0
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/net-contour-release-1.1.yaml
+++ b/prow/jobs_config/knative-sandbox/net-contour-release-1.1.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.1
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/net-contour-release-1.2.yaml
+++ b/prow/jobs_config/knative-sandbox/net-contour-release-1.2.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.2
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/net-contour-release-1.3.yaml
+++ b/prow/jobs_config/knative-sandbox/net-contour-release-1.3.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.3
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/net-contour.yaml
+++ b/prow/jobs_config/knative-sandbox/net-contour.yaml
@@ -1,7 +1,7 @@
 org: knative-sandbox
 repo: net-contour
 branches: [main]
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 imagePullPolicy: Always
 
 jobs:

--- a/prow/jobs_config/knative-sandbox/net-gateway-api-release-1.1.yaml
+++ b/prow/jobs_config/knative-sandbox/net-gateway-api-release-1.1.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.1
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/net-gateway-api-release-1.2.yaml
+++ b/prow/jobs_config/knative-sandbox/net-gateway-api-release-1.2.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.2
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/net-gateway-api-release-1.3.yaml
+++ b/prow/jobs_config/knative-sandbox/net-gateway-api-release-1.3.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.3
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/net-gateway-api.yaml
+++ b/prow/jobs_config/knative-sandbox/net-gateway-api.yaml
@@ -1,7 +1,7 @@
 org: knative-sandbox
 repo: net-gateway-api
 branches: [main]
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 imagePullPolicy: Always
 
 jobs:

--- a/prow/jobs_config/knative-sandbox/net-http01-release-1.0.yaml
+++ b/prow/jobs_config/knative-sandbox/net-http01-release-1.0.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.0
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/net-http01-release-1.1.yaml
+++ b/prow/jobs_config/knative-sandbox/net-http01-release-1.1.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.1
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/net-http01-release-1.2.yaml
+++ b/prow/jobs_config/knative-sandbox/net-http01-release-1.2.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.2
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/net-http01-release-1.3.yaml
+++ b/prow/jobs_config/knative-sandbox/net-http01-release-1.3.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.3
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/net-http01.yaml
+++ b/prow/jobs_config/knative-sandbox/net-http01.yaml
@@ -1,7 +1,7 @@
 org: knative-sandbox
 repo: net-http01
 branches: [main]
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 imagePullPolicy: Always
 
 jobs:

--- a/prow/jobs_config/knative-sandbox/net-istio-release-1.0.yaml
+++ b/prow/jobs_config/knative-sandbox/net-istio-release-1.0.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.0
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/net-istio-release-1.1.yaml
+++ b/prow/jobs_config/knative-sandbox/net-istio-release-1.1.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.1
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/net-istio-release-1.2.yaml
+++ b/prow/jobs_config/knative-sandbox/net-istio-release-1.2.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.2
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/net-istio-release-1.3.yaml
+++ b/prow/jobs_config/knative-sandbox/net-istio-release-1.3.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.3
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/net-istio.yaml
+++ b/prow/jobs_config/knative-sandbox/net-istio.yaml
@@ -1,7 +1,7 @@
 org: knative-sandbox
 repo: net-istio
 branches: [main]
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 imagePullPolicy: Always
 
 jobs:

--- a/prow/jobs_config/knative-sandbox/net-kourier-release-1.0.yaml
+++ b/prow/jobs_config/knative-sandbox/net-kourier-release-1.0.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.0
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/net-kourier-release-1.1.yaml
+++ b/prow/jobs_config/knative-sandbox/net-kourier-release-1.1.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.1
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/net-kourier-release-1.2.yaml
+++ b/prow/jobs_config/knative-sandbox/net-kourier-release-1.2.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.2
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/net-kourier-release-1.3.yaml
+++ b/prow/jobs_config/knative-sandbox/net-kourier-release-1.3.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.3
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/net-kourier.yaml
+++ b/prow/jobs_config/knative-sandbox/net-kourier.yaml
@@ -1,7 +1,7 @@
 org: knative-sandbox
 repo: net-kourier
 branches: [main]
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 imagePullPolicy: Always
 
 jobs:

--- a/prow/jobs_config/knative-sandbox/reconciler-test.yaml
+++ b/prow/jobs_config/knative-sandbox/reconciler-test.yaml
@@ -1,7 +1,7 @@
 org: knative-sandbox
 repo: reconciler-test
 branches: [main]
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 imagePullPolicy: Always
 
 jobs:

--- a/prow/jobs_config/knative-sandbox/sample-controller-release-1.0.yaml
+++ b/prow/jobs_config/knative-sandbox/sample-controller-release-1.0.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.0
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/sample-controller-release-1.1.yaml
+++ b/prow/jobs_config/knative-sandbox/sample-controller-release-1.1.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.1
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/sample-controller-release-1.2.yaml
+++ b/prow/jobs_config/knative-sandbox/sample-controller-release-1.2.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.2
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/sample-controller-release-1.3.yaml
+++ b/prow/jobs_config/knative-sandbox/sample-controller-release-1.3.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.3
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/sample-controller.yaml
+++ b/prow/jobs_config/knative-sandbox/sample-controller.yaml
@@ -1,7 +1,7 @@
 org: knative-sandbox
 repo: sample-controller
 branches: [main]
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 imagePullPolicy: Always
 
 jobs:

--- a/prow/jobs_config/knative-sandbox/sample-source-release-1.0.yaml
+++ b/prow/jobs_config/knative-sandbox/sample-source-release-1.0.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.0
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/sample-source-release-1.1.yaml
+++ b/prow/jobs_config/knative-sandbox/sample-source-release-1.1.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.1
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/sample-source-release-1.2.yaml
+++ b/prow/jobs_config/knative-sandbox/sample-source-release-1.2.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.2
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/sample-source-release-1.3.yaml
+++ b/prow/jobs_config/knative-sandbox/sample-source-release-1.3.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.3
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative-sandbox/sample-source.yaml
+++ b/prow/jobs_config/knative-sandbox/sample-source.yaml
@@ -1,7 +1,7 @@
 org: knative-sandbox
 repo: sample-source
 branches: [main]
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 imagePullPolicy: Always
 
 jobs:

--- a/prow/jobs_config/knative/caching.yaml
+++ b/prow/jobs_config/knative/caching.yaml
@@ -1,7 +1,7 @@
 org: knative
 repo: caching
 branches: [main]
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 imagePullPolicy: Always
 
 jobs:

--- a/prow/jobs_config/knative/client-pkg.yaml
+++ b/prow/jobs_config/knative/client-pkg.yaml
@@ -1,7 +1,7 @@
 org: knative
 repo: client-pkg
 branches: [main]
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 imagePullPolicy: Always
 
 jobs:

--- a/prow/jobs_config/knative/client-release-1.0.yaml
+++ b/prow/jobs_config/knative/client-release-1.0.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.0
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative/client-release-1.1.yaml
+++ b/prow/jobs_config/knative/client-release-1.1.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.1
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative/client-release-1.2.yaml
+++ b/prow/jobs_config/knative/client-release-1.2.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.2
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative/client-release-1.3.yaml
+++ b/prow/jobs_config/knative/client-release-1.3.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.3
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative/client.yaml
+++ b/prow/jobs_config/knative/client.yaml
@@ -1,7 +1,7 @@
 org: knative
 repo: client
 branches: [main]
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 imagePullPolicy: Always
 
 jobs:

--- a/prow/jobs_config/knative/docs.yaml
+++ b/prow/jobs_config/knative/docs.yaml
@@ -1,7 +1,7 @@
 org: knative
 repo: docs
 branches: [main]
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 imagePullPolicy: Always
 
 jobs:

--- a/prow/jobs_config/knative/eventing-release-1.0.yaml
+++ b/prow/jobs_config/knative/eventing-release-1.0.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.0
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative/eventing-release-1.1.yaml
+++ b/prow/jobs_config/knative/eventing-release-1.1.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.1
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative/eventing-release-1.2.yaml
+++ b/prow/jobs_config/knative/eventing-release-1.2.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.2
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative/eventing-release-1.3.yaml
+++ b/prow/jobs_config/knative/eventing-release-1.3.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.3
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative/eventing.yaml
+++ b/prow/jobs_config/knative/eventing.yaml
@@ -1,7 +1,7 @@
 org: knative
 repo: eventing
 branches: [main]
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 imagePullPolicy: Always
 
 jobs:

--- a/prow/jobs_config/knative/hack.yaml
+++ b/prow/jobs_config/knative/hack.yaml
@@ -1,7 +1,7 @@
 org: knative
 repo: hack
 branches: [main]
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 imagePullPolicy: Always
 
 jobs:

--- a/prow/jobs_config/knative/networking.yaml
+++ b/prow/jobs_config/knative/networking.yaml
@@ -1,7 +1,7 @@
 org: knative
 repo: networking
 branches: [main]
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 imagePullPolicy: Always
 
 jobs:

--- a/prow/jobs_config/knative/operator-release-1.0.yaml
+++ b/prow/jobs_config/knative/operator-release-1.0.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.0
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative/operator-release-1.1.yaml
+++ b/prow/jobs_config/knative/operator-release-1.1.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.1
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative/operator-release-1.2.yaml
+++ b/prow/jobs_config/knative/operator-release-1.2.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.2
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative/operator-release-1.3.yaml
+++ b/prow/jobs_config/knative/operator-release-1.3.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.3
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative/operator.yaml
+++ b/prow/jobs_config/knative/operator.yaml
@@ -1,7 +1,7 @@
 org: knative
 repo: operator
 branches: [main]
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 imagePullPolicy: Always
 
 jobs:

--- a/prow/jobs_config/knative/pkg.yaml
+++ b/prow/jobs_config/knative/pkg.yaml
@@ -1,7 +1,7 @@
 org: knative
 repo: pkg
 branches: [main]
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 imagePullPolicy: Always
 
 jobs:

--- a/prow/jobs_config/knative/serving-release-1.0.yaml
+++ b/prow/jobs_config/knative/serving-release-1.0.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.0
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative/serving-release-1.1.yaml
+++ b/prow/jobs_config/knative/serving-release-1.1.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.1
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative/serving-release-1.2.yaml
+++ b/prow/jobs_config/knative/serving-release-1.2.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.2
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative/serving-release-1.3.yaml
+++ b/prow/jobs_config/knative/serving-release-1.3.yaml
@@ -6,7 +6,7 @@
 # #######################################################################
 branches:
 - release-1.3
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 jobs:
 - command:
   - runner.sh

--- a/prow/jobs_config/knative/serving.yaml
+++ b/prow/jobs_config/knative/serving.yaml
@@ -1,7 +1,7 @@
 org: knative
 repo: serving
 branches: [main]
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 imagePullPolicy: Always
 
 jobs:

--- a/prow/jobs_config/knative/test-infra.yaml
+++ b/prow/jobs_config/knative/test-infra.yaml
@@ -1,7 +1,7 @@
 org: knative
 repo: test-infra
 branches: [main]
-image: gcr.io/knative-tests/test-infra/prow-tests:stable
+image: gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402
 imagePullPolicy: Always
 
 jobs:

--- a/prow/knative-prow-tests-autobump-config.yaml
+++ b/prow/knative-prow-tests-autobump-config.yaml
@@ -1,0 +1,19 @@
+---
+gitHubLogin: "knative-prow-updater-robot"
+gitHubToken: "/etc/prow-auto-bumper-github-token/token"
+skipPullRequest: false
+selfAssign: true # Commenting `/cc`, so that autobump PR is not assigned to anyone
+gitHubOrg: "knative"
+gitHubRepo: "test-infra"
+remoteName: "test-infra"
+headBranchName: "autobump-prow-tests-knative"
+targetVersion: "latest"
+includedConfigPaths:
+  - "prow/jobs"
+  - "prow/jobs_config"
+prefixes:
+  - name: "Knative prow-tests image"
+    prefix: "gcr.io/knative-tests/test-infra/prow-tests"
+    repo: "https://github.com/knative/test-infra"
+    summarise: false
+    consistentImages: true

--- a/tools/rundk/README.md
+++ b/tools/rundk/README.md
@@ -24,7 +24,7 @@ go get knative.dev/test-infra/rundk
 ```shell
 Usage of rundk:
   --image string
-      The image we use to run the test flow. (default "gcr.io/knative-tests/test-infra/prow-tests:stable")
+      The image we use to run the test flow. (default "gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402")
   --entrypoint string
       The entrypoint executable that runs the test commands. (default "runner.sh")
   --enable-docker-in-docker

--- a/tools/rundk/main.go
+++ b/tools/rundk/main.go
@@ -38,7 +38,7 @@ var (
 )
 
 func main() {
-	pflag.StringVar(&image, "image", "gcr.io/knative-tests/test-infra/prow-tests:stable", "The image we use to run the test flow.")
+	pflag.StringVar(&image, "image", "gcr.io/knative-tests/test-infra/prow-tests:v20220331-8ed73402", "The image we use to run the test flow.")
 	pflag.StringVar(&entrypoint, "entrypoint", "runner.sh", "The entrypoint executable that runs the test commands.")
 	pflag.BoolVar(&dindEnabled, "enable-docker-in-docker", false, "Enable running docker commands in the test flow. "+
 		"By enabling this the container will share the same docker daemon in the host machine, so be careful when using it.")


### PR DESCRIPTION
Fixes #3017

Note the Prow job is scheduled to run at 7:15 PST (15:15 UTC) each weekday.

/cc @kvmware @upodroid 