### PR TITLE
Add external secret for ppc64le cluster

### DIFF
--- a/prow/cluster/build/600-kubernetes_external_secrets.yaml
+++ b/prow/cluster/build/600-kubernetes_external_secrets.yaml
@@ -28,3 +28,19 @@ spec:
   - key: ci-script
     name: ci-script
     version: latest
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: ppc64le-cluster
+  namespace: test-pods
+spec:
+  backendType: gcpSecretsManager
+  projectId: hidden-bond-335716
+  data:
+  - key: knative-ssh
+    name: knative-ssh
+    version: latest
+  - key: ci-script
+    name: ci-script
+    version: latest


### PR DESCRIPTION
This PR is in reference to #2842 for adding `ppc64le-cluster` secret onto prow server for running tests on ppc64le hardware.

The ppc64le-cluster secret contains
  - `knative-ssh`: key to access remote ppc64le cluster
  - `ci-script`: script to connect and setup remote ppc64le environment

The secrets are created in GCP project and relevant permissions are provide to `kubernetes-external-secrets-sa@knative-tests.iam.gserviceaccount.com` service account as describe in [prow-secrets](https://github.com/knative/test-infra/tree/main/prow#prow-secrets) doc.

Signed-off-by: Siddhesh Ghadi <Siddhesh.Ghadi@ibm.com>

/cc @chizhg