### PR TITLE
Fix the command to install flaky-test-reporter in the Dockerfile

### DIFF
--- a/images/tool/Dockerfile
+++ b/images/tool/Dockerfile
@@ -25,7 +25,7 @@ COPY . /go/src/knative.dev/test-infra
 
 # TODO: jobs should not run `/command`, just `command`
 
-RUN go install "/go/src/knative.dev/test-infra/tools/${TOOLS_SUBDIR}${TOOL_NAME}"
+RUN cd "/go/src/knative.dev/test-infra" && go install "./tools/${TOOLS_SUBDIR}${TOOL_NAME}"
 RUN cp "$(which ${TOOL_NAME})" /
 
 RUN if [ "${TOOL_NAME}" = flaky-test-reporter ]; then mkdir -p /config && cp /go/src/knative.dev/test-infra/tools/flaky-test-reporter/config/config.yaml /config/config.yaml; fi


### PR DESCRIPTION
Go 1.17 requires running `go install` command under the project's folder.

/cc @upodroid 