### PR TITLE
Use Slack instead of email to alert on Prow job failures

### DIFF
--- a/prow/jobs/custom/autobump-flaky-test-reporter.yaml
+++ b/prow/jobs/custom/autobump-flaky-test-reporter.yaml
@@ -11,8 +11,6 @@ periodics:
   annotations:
     testgrid-dashboards: utilities
     testgrid-tab-name: ci-knative-flaky-test-reporter-auto-bumper
-    testgrid-alert-email: "serverless-engprod-sea@google.com"
-    testgrid-num-failures-to-alert: "1"
   spec:
     containers:
     - image: gcr.io/k8s-prow/generic-autobumper:v20220323-9b8611d021

--- a/prow/jobs/custom/autobump-prow-tests.yaml
+++ b/prow/jobs/custom/autobump-prow-tests.yaml
@@ -11,8 +11,6 @@ periodics:
   annotations:
     testgrid-dashboards: utilities
     testgrid-tab-name: ci-knative-prow-tests-auto-bumper
-    testgrid-alert-email: "serverless-engprod-sea@google.com"
-    testgrid-num-failures-to-alert: "1"
   spec:
     containers:
     - image: gcr.io/k8s-prow/generic-autobumper:v20220323-9b8611d021

--- a/prow/jobs/custom/autobump-prow.yaml
+++ b/prow/jobs/custom/autobump-prow.yaml
@@ -11,8 +11,6 @@ periodics:
   annotations:
     testgrid-dashboards: utilities
     testgrid-tab-name: ci-knative-prow-auto-bumper-for-auto-deploy
-    testgrid-alert-email: "serverless-engprod-sea@google.com"
-    testgrid-num-failures-to-alert: "1"
   spec:
     containers:
     - image: gcr.io/k8s-prow/generic-autobumper:v20220323-9b8611d021

--- a/prow/jobs/custom/autodeploy-prow.yaml
+++ b/prow/jobs/custom/autodeploy-prow.yaml
@@ -23,8 +23,6 @@ postsubmits:
     annotations:
       testgrid-dashboards: utilities
       testgrid-tab-name: ci-knative-prow-auto-deploy
-      testgrid-alert-email: "serverless-engprod-sea@google.com"
-      testgrid-num-failures-to-alert: "1"
     reporter_config:
       slack:
         channel: productivity
@@ -62,8 +60,6 @@ periodics:
   annotations:
     testgrid-dashboards: utilities
     testgrid-tab-name: ci-knative-test-infra-config-bootstrapper
-    testgrid-alert-email: "serverless-engprod-sea@google.com"
-    testgrid-num-failures-to-alert: "1"
   reporter_config:
     slack:
       channel: productivity

--- a/prow/jobs/custom/branchprotector.yaml
+++ b/prow/jobs/custom/branchprotector.yaml
@@ -38,8 +38,6 @@ periodics:
   annotations:
     testgrid-dashboards: utilities
     testgrid-tab-name: ci-knative-test-infra-branchprotector
-    testgrid-alert-email: "serverless-engprod-sea@google.com"
-    testgrid-num-failures-to-alert: "1"
   spec:
     containers:
     - name: branchprotector

--- a/prow/jobs/custom/knativeteam-groups.yaml
+++ b/prow/jobs/custom/knativeteam-groups.yaml
@@ -33,7 +33,6 @@ periodics:
   annotations:
       testgrid-dashboards: utilities
       testgrid-tab-name: ci-knativeteam-groups-jobs
-      testgrid-alert-email: "serverless-engprod-sea@google.com"
   rerun_auth_config:
     github_team_slugs:
     - org: knative
@@ -64,12 +63,16 @@ postsubmits:
     annotations:
       testgrid-dashboards: utilities
       testgrid-tab-name: post-knativeteam-groups-jobs
-      testgrid-alert-email: "serverless-engprod-sea@google.com"
-      testgrid-num-failures-to-alert: '1'
     rerun_auth_config:
       github_team_slugs:
       - org: knative
         slug: productivity-infra-admins
+    reporter_config:
+      slack:
+        channel: productivity
+        job_states_to_report:
+          - failure
+        report_template: '"The knativeteam-groups sync postsubmit job fails, check the log: <{{.Status.URL}}|View logs>"'
     spec:
       serviceAccountName: gsuite-groups-manager
       containers:

--- a/prow/jobs/custom/label-sync.yaml
+++ b/prow/jobs/custom/label-sync.yaml
@@ -71,8 +71,6 @@ periodics:
   annotations:
     testgrid-dashboards: utilities
     testgrid-tab-name: ci-knative-test-infra-label-sync
-    testgrid-alert-email: "serverless-engprod-sea@google.com"
-    testgrid-num-failures-to-alert: "1"
   spec:
     containers:
     - name: label-sync
@@ -123,8 +121,6 @@ postsubmits:
     annotations:
       testgrid-dashboards: utilities
       testgrid-tab-name: post-knative-test-infra-label-sync
-      testgrid-alert-email: "serverless-engprod-sea@google.com"
-      testgrid-num-failures-to-alert: "1"
     spec:
       containers:
       - name: label-sync

--- a/prow/jobs/custom/peribolos.yaml
+++ b/prow/jobs/custom/peribolos.yaml
@@ -120,8 +120,6 @@ postsubmits:
     annotations:
       testgrid-dashboards: utilities
       testgrid-tab-name: post-knative-peribolos
-      testgrid-alert-email: "serverless-engprod-sea@google.com"
-      testgrid-num-failures-to-alert: "1"
     spec:
       containers:
       - image: gcr.io/k8s-prow/peribolos:v20220323-9b8611d021
@@ -175,8 +173,6 @@ postsubmits:
     annotations:
       testgrid-dashboards: utilities
       testgrid-tab-name: post-knative-sandbox-peribolos
-      testgrid-alert-email: "serverless-engprod-sea@google.com"
-      testgrid-num-failures-to-alert: "1"
     spec:
       containers:
       - image: gcr.io/k8s-prow/peribolos:v20220323-9b8611d021
@@ -227,8 +223,6 @@ periodics:
   annotations:
     testgrid-dashboards: utilities
     testgrid-tab-name: ci-knative-peribolos
-    testgrid-alert-email: "serverless-engprod-sea@google.com"
-    testgrid-num-failures-to-alert: "1"
   spec:
     containers:
     - image: gcr.io/k8s-prow/peribolos:v20220323-9b8611d021
@@ -277,8 +271,6 @@ periodics:
   annotations:
     testgrid-dashboards: utilities
     testgrid-tab-name: ci-knative-sandbox-peribolos
-    testgrid-alert-email: "serverless-engprod-sea@google.com"
-    testgrid-num-failures-to-alert: "1"
   spec:
     containers:
     - image: gcr.io/k8s-prow/peribolos:v20220323-9b8611d021

--- a/prow/jobs/custom/test-infra.yaml
+++ b/prow/jobs/custom/test-infra.yaml
@@ -110,8 +110,6 @@ periodics:
   annotations:
     testgrid-dashboards: utilities
     testgrid-tab-name: ci-knative-heartbeat
-    testgrid-alert-email: "serverless-engprod-sea@google.com"
-    testgrid-num-failures-to-alert: "1"
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:v20220405-5a6cdbac
@@ -140,8 +138,6 @@ periodics:
   annotations:
     testgrid-dashboards: utilities
     testgrid-tab-name: ci-knative-cleanup
-    testgrid-alert-email: "serverless-engprod-sea@google.com"
-    testgrid-num-failures-to-alert: "1"
   reporter_config:
     slack:
       channel: productivity
@@ -179,8 +175,12 @@ periodics:
   annotations:
     testgrid-dashboards: utilities
     testgrid-tab-name: ci-knative-flakes-reporter
-    testgrid-alert-email: "serverless-engprod-sea@google.com"
-    testgrid-num-failures-to-alert: "1"
+  reporter_config:
+    slack:
+      channel: productivity
+      job_states_to_report:
+        - failure
+      report_template: '"The flakes-reporter periodic job fails, check the log: <{{.Status.URL}}|View logs>"'
   spec:
     serviceAccountName: flaky-test-reporter
     containers:
@@ -216,8 +216,12 @@ periodics:
   annotations:
     testgrid-dashboards: utilities
     testgrid-tab-name: ci-knative-flakes-resultsrecorder
-    testgrid-alert-email: "serverless-engprod-sea@google.com"
-    testgrid-num-failures-to-alert: "1"
+  reporter_config:
+    slack:
+      channel: productivity
+      job_states_to_report:
+        - failure
+      report_template: '"The flakes-resultsrecorder periodic job fails, check the log: <{{.Status.URL}}|View logs>"'
   spec:
     serviceAccountName: flaky-test-reporter
     containers:
@@ -256,8 +260,12 @@ periodics:
   annotations:
     testgrid-dashboards: utilities
     testgrid-tab-name: ci-knative-prow-jobs-syncer
-    testgrid-alert-email: "serverless-engprod-sea@google.com"
-    testgrid-num-failures-to-alert: "1"
+  reporter_config:
+    slack:
+      channel: productivity
+      job_states_to_report:
+        - failure
+      report_template: '"The prow-jobs-syncer periodic job fails, check the log: <{{.Status.URL}}|View logs>"'
   spec:
     containers:
     - image: gcr.io/knative-tests/test-infra/prow-tests:v20220405-5a6cdbac
@@ -311,8 +319,12 @@ postsubmits:
     annotations:
       testgrid-dashboards: utilities
       testgrid-tab-name: post-knative-test-infra-image-push
-      testgrid-alert-email: "serverless-engprod-sea@google.com"
-      testgrid-num-failures-to-alert: "1"
+    reporter_config:
+      slack:
+        channel: productivity
+        job_states_to_report:
+          - failure
+        report_template: '"The test-infra-tools-image-push postsubmit job fails, check the log: <{{.Status.URL}}|View logs>"'
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:v20220405-5a6cdbac
@@ -355,8 +367,12 @@ postsubmits:
     annotations:
       testgrid-dashboards: utilities
       testgrid-tab-name: post-knative-test-infra-prow-tests-image-push
-      testgrid-alert-email: "serverless-engprod-sea@google.com"
-      testgrid-num-failures-to-alert: "1"
+    reporter_config:
+      slack:
+        channel: productivity
+        job_states_to_report:
+          - failure
+        report_template: '"The prow-tests-image-push postsubmit job fails, check the log: <{{.Status.URL}}|View logs>"'
     spec:
       containers:
       - image: gcr.io/knative-tests/test-infra/prow-tests:v20220405-5a6cdbac
@@ -392,8 +408,12 @@ postsubmits:
     annotations:
       testgrid-dashboards: utilities
       testgrid-tab-name: post-test-infra-update-testgrid-proto
-      testgrid-alert-email: "serverless-engprod-sea@google.com"
-      testgrid-num-failures-to-alert: "1"
+    reporter_config:
+      slack:
+        channel: productivity
+        job_states_to_report:
+          - failure
+        report_template: '"The update-testgrid-proto postsubmit job fails, check the log: <{{.Status.URL}}|View logs>"'
     spec:
       containers:
       - image: gcr.io/k8s-prow/configurator:v20220323-9b8611d021


### PR DESCRIPTION
**Which issue(s) this PR fixes**:<br>
Fixes #3234
Fixes #3075