### PR TITLE
Remove the google group from the owner of the Boskos projects

### DIFF
--- a/infra/gcp/boskos/set_up_boskos_project.sh
+++ b/infra/gcp/boskos/set_up_boskos_project.sh
@@ -39,9 +39,6 @@ readonly PROJECT_NUMBER="$(gcloud projects describe ${PROJECT} --format="value(p
 #   - @googlegroups.com addresses are assumed to be groups.
 #   - @...gserviceaccount.com addresses are assumed to be service accounts.
 readonly RESOURCES=(
-    "roles/owner"
-    "serverless-engprod-sea-root@twosync.google.com"
-
     "roles/editor"
     "knative-productivity-admins@googlegroups.com"
     "knative-tests@appspot.gserviceaccount.com"


### PR DESCRIPTION
I have already manually run the script to remove it.

/cc @kvmware @upodroid 