### PR TITLE
Enable auto-merge for PRs created by knative-automation robot

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -141,7 +141,7 @@ tide:
   - orgs:
     - "knative"
     - "knative-sandbox"
-    excludedRepos:
+    excludedRepos: &knative_excluded_repos
     - knative/build
     - knative/build-templates
     - knative/eventing-operator
@@ -155,12 +155,15 @@ tide:
     - do-not-merge/work-in-progress
     - do-not-merge/invalid-owners-file
     - needs-rebase
-  - repos:
-    - "knative-prow-robot/test-infra"
+  - orgs:
+    - "knative"
+    - "knative-sandbox"
+    excludedRepos: *knative_excluded_repos
     labels:
-    - lgtm
-    - approved
+    - "skip-review"
     missingLabels: *knative_tide_missing_labels
+    author: knative-automation
+    reviewApprovedRequired: false
   - repos:
     # Allow PRs for test-infra to be automatically merged without manual approval
     - "knative/test-infra"


### PR DESCRIPTION
With this change, if a PR is created by `knative-automation` robot **and** it has `skip-review` label **and** all the required tests pass, it will be automatically merged without requiring manual approval.

Part of https://github.com/knative/test-infra/issues/2965