### PR TITLE
Move redirect app to the infra/gcp/dns folder

### DIFF
--- a/infra/gcp/dns/redirect/Makefile
+++ b/infra/gcp/dns/redirect/Makefile
@@ -1,0 +1,37 @@
+# Copyright 2022 The Knative Authors
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+PROJECT       ?= knative-dns
+OPTIONS       ?=
+
+all: default slack blog stats testgrid dispatch
+
+# For testing can deploy with --no-promote to avoid routing traffic to the new version
+# i.e. make OPTIONS=--no-promote slack
+
+default slack blog stats testgrid:
+	@declare -A REDIRS=( \
+	#### Redirection URLs for each subdomain #### \
+	["default"]="https://knative.dev" \
+	["testgrid"]="https://testgrid.k8s.io/r/knative-own-testgrid" \
+	["slack"]="https://join.slack.com/t/knative/shared_invite/zt-fzy43r2f-i4oJraPBHlBFp00v6NeI9w" \
+	["blog"]="https://knative.dev/blog" \
+	["stats"]="https://knative.teststats.cncf.io/" \
+	############################################## \
+	) ; sed -e 's/$$SERVICE_NAME/$@/' -e "s*\$$REDIR_TO*$${REDIRS[$@]}*" redir.yaml > app.yaml
+	gcloud app deploy --quiet --project="$(PROJECT)" $(OPTIONS) app.yaml
+	@rm app.yaml
+
+dispatch:
+	gcloud app deploy --quiet --project="$(PROJECT)" $(OPTIONS) dispatch.yaml

--- a/infra/gcp/dns/redirect/README.md
+++ b/infra/gcp/dns/redirect/README.md
@@ -1,0 +1,11 @@
+# knative.dev redirect app
+
+This is a simple redirection app for redirecting subdomains in `knative.dev`. It
+expects the destination URL to be set in the `REDIR_TO` environment variable.
+Each subdomain has its own `*subdomain*.knative.dev.yaml` deployment file.
+
+The `Makefile` contains ready-to-use rules to update the projects in the
+`knative-dns` GCP project.
+
+The `dispatch.yaml` file defines dispatching rules for all apps hosted in the
+`knative.dev` subdomain.

--- a/infra/gcp/dns/redirect/dispatch.yaml
+++ b/infra/gcp/dns/redirect/dispatch.yaml
@@ -1,0 +1,11 @@
+dispatch:
+- url: "testgrid.knative.dev/*"
+  service: testgrid
+- url: "slack.knative.dev/*"
+  service: slack
+- url: "blog.knative.dev/*"
+  service: blog
+- url: "stats.knative.dev/*"
+  service: stats
+- url: "knative.dev/*"
+  service: default

--- a/infra/gcp/dns/redirect/redir.py
+++ b/infra/gcp/dns/redirect/redir.py
@@ -1,0 +1,52 @@
+# Copyright 2022 The Knative Authors
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/usr/bin/env python
+"""Mostly simple redirection app for knative.dev subdomains."""
+
+import os
+import re
+import webapp2
+
+
+class RedirectHandler(webapp2.RequestHandler):
+  """Redirects URLs."""
+
+  def get(self):
+    original = self.request.uri
+    domain = 'knative.dev'
+    redirect_path = os.getenv('REDIR_TO', 'https://github.com/knative')
+    where = original.find(domain)
+    if where != -1:
+      # Increment to beginning of domain, then end of domain,
+      #  then one for the slash; okay if there is no slash,
+      #  python just gives empty string for slices past the end
+      extra_path = original[where+len(domain)+1:]
+    else:  # Probably only use this section when hitting app URL directly
+      match = re.match(r'https?://[^/]+/(.*)', original)
+      if not match:
+        # Failed to figure out the URL, redirect to the base page
+        self.redirect(redirect_path)
+        return
+      extra_path = match.groups()[0] or ''
+    # extra_path should never have a leading slash
+    if extra_path and redirect_path[-1] != '/':
+      self.redirect(redirect_path + '/' + extra_path)
+    else:
+      self.redirect(redirect_path + extra_path)
+
+
+app = webapp2.WSGIApplication([(r'/.*', RedirectHandler),],
+                              debug=True,
+                              config={})

--- a/infra/gcp/dns/redirect/redir.yaml
+++ b/infra/gcp/dns/redirect/redir.yaml
@@ -1,0 +1,15 @@
+runtime: python27
+service: $SERVICE_NAME
+api_version: 1
+threadsafe: false
+
+handlers:
+- url: .*
+  script: redir.app
+
+env_variables:
+  REDIR_TO: "$REDIR_TO"
+
+libraries:
+- name: webapp2
+  version: "2.5.2"


### PR DESCRIPTION
This is a simple redirection app for redirecting subdomains in `knative.dev`, which was deployed in the `knative-tests` project. This PR moves it from our internal codebase to knative/test-infra and configures it to deploy in the `knatve-dns` project.

I have manually deployed it with `make all` command and confirmed it's working.

Part of https://github.com/knative/test-infra/issues/3134

/cc @kvmware @upodroid 