### PR TITLE
Update Prow alerts recipient to kn-infra-gcp-org-admins@knative.team

### DIFF
--- a/prow/cluster/monitoring/secrets/alertmanager-prow_secret.yaml
+++ b/prow/cluster/monitoring/secrets/alertmanager-prow_secret.yaml
@@ -34,7 +34,7 @@ stringData:
     receivers:
     - name: 'email-alerts'
       email_configs:
-      - to: 'chizhg+prow-alert@google.com'
+      - to: 'kn-infra-gcp-org-admins@knative.team'
         text: '{{ template "custom_email_text" . }}'
         headers:
           subject: '[Knative prow] {{ template "email.default.subject" . }}'


### PR DESCRIPTION
I have confirmed the alerts are working well, so updating the recipient to the group that has access to the infra, which is kn-infra-gcp-org-admins@knative.team

In the future Knative Prow can make the switch to use the new monitoring stack, see https://github.com/knative/test-infra/issues/3253, with which alerts can be configured to send to the Productivity Slack channel.

/cc @kvmware @upodroid 