### PR TITLE
Add prow job for e2e eventing-main test on ppc64le

### DIFF
--- a/prow/jobs/generated/knative/eventing-main.gen.yaml
+++ b/prow/jobs/generated/knative/eventing-main.gen.yaml
@@ -208,6 +208,77 @@ periodics:
         secretName: s390x-cluster1
 - annotations:
     testgrid-dashboards: eventing
+    testgrid-tab-name: ppc64le-e2e-tests
+  cluster: build-knative
+  cron: 0 7 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative
+    path_alias: knative.dev/eventing
+    repo: eventing
+  name: ppc64le-e2e-tests_eventing_main_periodic
+  spec:
+    containers:
+    - args:
+      - bash
+      - -c
+      - |
+        cat /opt/cluster/ci-script > /tmp/connect.sh
+        chmod +x /tmp/connect.sh
+        . /tmp/connect.sh ${CI_JOB}
+        ./test/e2e-tests.sh --run-tests
+      command:
+      - runner.sh
+      env:
+      - name: SYSTEM_NAMESPACE
+        value: knative-eventing
+      - name: SCALE_CHAOSDUCK_TO_ZERO
+        value: "1"
+      - name: CI_JOB
+        value: eventing-main
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: KO_FLAGS
+        value: --platform=linux/ppc64le
+      - name: PLATFORM
+        value: linux/ppc64le
+      - name: KO_DOCKER_REPO
+        value: registry.ppc64le
+      - name: DISABLE_MD_LINTING
+        value: "1"
+      - name: KUBECONFIG
+        value: /root/.kube/config
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220405-5a6cdbac
+      name: ""
+      resources:
+        limits:
+          memory: 16Gi
+        requests:
+          memory: 12Gi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+      - mountPath: /opt/cluster
+        name: ppc64le-cluster
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
+    - name: ppc64le-cluster
+      secret:
+        defaultMode: 384
+        secretName: ppc64le-cluster
+- annotations:
+    testgrid-dashboards: eventing
     testgrid-tab-name: nightly
   cluster: build-knative
   cron: 9 9 * * *

--- a/prow/jobs_config/.base.yaml
+++ b/prow/jobs_config/.base.yaml
@@ -115,3 +115,25 @@ requirement_presets:
         secret:
           secretName: s390x-cluster1
           defaultMode: 0600
+
+  ppc64le:
+    env:
+      - name: KO_FLAGS
+        value: "--platform=linux/ppc64le"
+      - name: PLATFORM
+        value: "linux/ppc64le"
+      - name: KO_DOCKER_REPO
+        value: "registry.ppc64le"
+      - name: DISABLE_MD_LINTING
+        value: "1"
+      - name: KUBECONFIG
+        value: /root/.kube/config
+    volumeMounts:
+      - name: ppc64le-cluster
+        mountPath: /opt/cluster
+        readOnly: true
+    volumes:
+      - name: ppc64le-cluster
+        secret:
+          secretName: ppc64le-cluster
+          defaultMode: 0600

--- a/prow/jobs_config/knative/eventing.yaml
+++ b/prow/jobs_config/knative/eventing.yaml
@@ -80,6 +80,27 @@ jobs:
       - name: SCALE_CHAOSDUCK_TO_ZERO
         value: "1"
 
+  - name: ppc64le-e2e-tests
+    cron: 0 7 * * *
+    types: [periodic]
+    requirements: [ppc64le]
+    command: [runner.sh]
+    args:
+      - bash
+      - -c
+      - |
+        cat /opt/cluster/ci-script > /tmp/connect.sh
+        chmod +x /tmp/connect.sh
+        . /tmp/connect.sh ${CI_JOB}
+        ./test/e2e-tests.sh --run-tests
+    env:
+      - name: SYSTEM_NAMESPACE
+        value: knative-eventing
+      - name: SCALE_CHAOSDUCK_TO_ZERO
+        value: "1"
+      - name: CI_JOB
+        value: "eventing-main"
+
   - name: nightly
     types: [periodic]
     timeout: 3h

--- a/tools/release-jobs-syncer/pkg/jobs_sync.go
+++ b/tools/release-jobs-syncer/pkg/jobs_sync.go
@@ -44,7 +44,7 @@ const (
 // the load with Prow.
 var extraPeriodicProwJobsToSync map[string]sets.String = map[string]sets.String{
 	"knative/serving":  sets.NewString("s390x-kourier-tests", "s390x-contour-tests"),
-	"knative/eventing": sets.NewString("s390x-e2e-tests", "s390x-e2e-reconciler-tests"),
+	"knative/eventing": sets.NewString("s390x-e2e-tests", "s390x-e2e-reconciler-tests", "ppc64le-e2e-tests"),
 	"knative/client":   sets.NewString("s390x-e2e-tests"),
 	"knative/operator": sets.NewString("s390x-e2e-tests"),
 }


### PR DESCRIPTION
Signed-off-by: Siddhesh Ghadi <Siddhesh.Ghadi@ibm.com>

**Which issue(s) this PR fixes**:<br>
This PR adds nightly testing job for eventing component on ppc64le hardware as describe in https://github.com/knative/test-infra/issues/2842#issue-948568936. The required secrets to access remote ppc64le hardware is added onto the prow server via #3224.

/cc @coryrc
<!-- 
  Use `Fixes #<issue number>`, or `Fixes (paste link of issue)`
  to automatically close linked issue when the PR is merged.
  Uncomment and fill below if the PR does not close any issues.
-->
<!--
**What this PR does, why we need it**:<br>
-->

<!--
  If there is any golang code in this PR please uncomment the 
  `/lint` statement below to have Prow automatically lint it.
-->
<!--
  /lint
-->
