### PR TITLE
Fix autobump-prow job and configure Slack alerts

### DIFF
--- a/prow/autobump-config/knative.yaml
+++ b/prow/autobump-config/knative.yaml
@@ -14,7 +14,6 @@ includedConfigPaths:
   - "prow/jobs"
 extraFiles:
   - "prow/config.yaml"
-  - "prow/config.sh"
   - "prow/jobs/run_job.sh"
 prefixes:
   - name: "Prow"

--- a/prow/jobs/custom/autobump-flaky-test-reporter.yaml
+++ b/prow/jobs/custom/autobump-flaky-test-reporter.yaml
@@ -11,6 +11,12 @@ periodics:
   annotations:
     testgrid-dashboards: utilities
     testgrid-tab-name: ci-knative-flaky-test-reporter-auto-bumper
+  reporter_config:
+    slack:
+      channel: productivity
+      job_states_to_report:
+        - failure
+      report_template: '"The autobump-flaky-test-reporter periodic job fails, check the log: <{{.Status.URL}}|View logs>"'
   spec:
     containers:
     - image: gcr.io/k8s-prow/generic-autobumper:v20220323-9b8611d021

--- a/prow/jobs/custom/autobump-prow-tests.yaml
+++ b/prow/jobs/custom/autobump-prow-tests.yaml
@@ -11,6 +11,12 @@ periodics:
   annotations:
     testgrid-dashboards: utilities
     testgrid-tab-name: ci-knative-prow-tests-auto-bumper
+  reporter_config:
+    slack:
+      channel: productivity
+      job_states_to_report:
+        - failure
+      report_template: '"The autobump-prow-tests periodic job fails, check the log: <{{.Status.URL}}|View logs>"'
   spec:
     containers:
     - image: gcr.io/k8s-prow/generic-autobumper:v20220323-9b8611d021

--- a/prow/jobs/custom/autobump-prow.yaml
+++ b/prow/jobs/custom/autobump-prow.yaml
@@ -11,6 +11,12 @@ periodics:
   annotations:
     testgrid-dashboards: utilities
     testgrid-tab-name: ci-knative-prow-auto-bumper-for-auto-deploy
+  reporter_config:
+    slack:
+      channel: productivity
+      job_states_to_report:
+        - failure
+      report_template: '"The autobump-prow periodic job fails, check the log: <{{.Status.URL}}|View logs>"'
   spec:
     containers:
     - image: gcr.io/k8s-prow/generic-autobumper:v20220323-9b8611d021


### PR DESCRIPTION
This was broken when I removed `config.sh`, see the error in https://prow.knative.dev/view/gs/knative-prow/logs/ci-knative-prow-auto-bumper-for-auto-deploy/1513536322394918912#1:build-log.txt%3A241

/cc @kvmware @upodroid 