### PR TITLE
Manage Prow Trusted Cluster in Terraform

### DIFF
--- a/infra/gcp/.terraform.lock.hcl
+++ b/infra/gcp/.terraform.lock.hcl
@@ -1,6 +1,25 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/external" {
+  version = "2.2.2"
+  hashes = [
+    "h1:VUkgcWvCliS0HO4kt7oEQhFD2gcx/59XpwMqxfCU1kE=",
+    "zh:0b84ab0af2e28606e9c0c1289343949339221c3ab126616b831ddb5aaef5f5ca",
+    "zh:10cf5c9b9524ca2e4302bf02368dc6aac29fb50aeaa6f7758cce9aa36ae87a28",
+    "zh:56a016ee871c8501acb3f2ee3b51592ad7c3871a1757b098838349b17762ba6b",
+    "zh:719d6ef39c50e4cffc67aa67d74d195adaf42afcf62beab132dafdb500347d39",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7fbfc4d37435ac2f717b0316f872f558f608596b389b895fcb549f118462d327",
+    "zh:8ac71408204db606ce63fe8f9aeaf1ddc7751d57d586ec421e62d440c402e955",
+    "zh:a4cacdb06f114454b6ed0033add28006afa3f65a0ea7a43befe45fc82e6809fb",
+    "zh:bb5ce3132b52ae32b6cc005bc9f7627b95259b9ffe556de4dad60d47d47f21f0",
+    "zh:bb60d2976f125ffd232a7ccb4b3f81e7109578b23c9c6179f13a11d125dca82a",
+    "zh:f9540ecd2e056d6e71b9ea5f5a5cf8f63dd5c25394b9db831083a9d4ea99b372",
+    "zh:ffd998b55b8a64d4335a090b6956b4bf8855b290f7554dd38db3302de9c41809",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/google" {
   version     = "4.15.0"
   constraints = ">= 3.43.0, >= 3.50.0, >= 3.53.0, ~> 4.5, 4.15.0, < 5.0.0"
@@ -36,6 +55,26 @@ provider "registry.terraform.io/hashicorp/google-beta" {
     "zh:d35511761e4a9ecc4b299085be4fb595fa7ecdc21d86a15f6fbddc4bf8120a43",
     "zh:ea932225bad48b18f674065f764d78dbf00060ff45ce01889b97fb2f891c0f89",
     "zh:fd8475b45292aa4e3a229d3cb66590cd58bd50a8f9876df40463cab2f3040746",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version     = "2.10.0"
+  constraints = "~> 2.0"
+  hashes = [
+    "h1:v+xmcw54lMETOlhKPO61AlbxGB0OU8BphMfOO62e0Uo=",
+    "zh:0b011e77f02bc05194062c0a39f321a4f1bea0bae61787b0c1f5808f6efb2a26",
+    "zh:288ad46e240c5d1218909a9100ca8bd2197c8615558bbe7b393ba35877d5e4f0",
+    "zh:3e5554791ed103b6190efebe332fd3722796e6a59cf081f87ef1debb4e0b6ae3",
+    "zh:98e42cb48624be7eb2e16b5d8fc5044d7207943b6d13905bc3d3c006aa231cc7",
+    "zh:b1c800fd3971051d9deb4824f933e506ae288458e425be8ea449c9d40c7b0663",
+    "zh:bca1802585ecbc36bfcc700b6fa7c6ff96b2b8c4aca23c58df939a5002a05b4d",
+    "zh:c2f6bf46cd95d00f2bb1634afff92eeb269d27d83eea80b8cfceca1afdcd3033",
+    "zh:d2ccfbf3a9bf2ede8be6242c023173efd85a882cd3956a941f140c5718047412",
+    "zh:da19cd4a124f4ffc092e19f5b7a10ac4cce98db40cf855ea0d4a682f3df83a1f",
+    "zh:e3a2020453a86f80ad2b3f792e91a35fe272b907485a59c02d19269a1bdfe2fd",
+    "zh:f0659ca86e0dc0dd76b7f4497db8e58144ee9f0943b6d14dc57193d25ee22ced",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }
 

--- a/infra/gcp/README.md
+++ b/infra/gcp/README.md
@@ -6,6 +6,10 @@ We use Terraform to manage our Google Cloud infrastructure.
 
   This is the knative-dns project. It holds the `knative.dev` and `knative.team` DNS Zones
 
+- [knative-tests](./tests)
+
+  This is the knative-tests project. It holds the Prow Clusters and associated infrastructure.
+
 - [knative-gsuite](./gsuite)
 
   This is the knative-gsuite project. It holds a service account that can access Google Workspace Admin API.

--- a/infra/gcp/main.tf
+++ b/infra/gcp/main.tf
@@ -18,3 +18,7 @@ module "dns" {
 module "gsuite" {
   source = "./gsuite"
 }
+
+module "tests" {
+  source = "./tests"
+}

--- a/infra/gcp/tests/README.md
+++ b/infra/gcp/tests/README.md
@@ -1,0 +1,9 @@
+# Knative Tests Project
+
+Please be careful when making changes to infrastructure in this folder. Pay *extra* attention when modifying GKE Clusters as Prow runs on it.
+
+Key Infrastructure:
+- prow cluster
+- prow build cluster
+- prow trusted cluster
+

--- a/infra/gcp/tests/gke.tf
+++ b/infra/gcp/tests/gke.tf
@@ -1,0 +1,51 @@
+// WARNING, MAKE SURE YOU DON"T DESTROY THESE CLUSTERS ACCIDENTALLY
+
+
+module "prow_trusted" {
+  source                     = "terraform-google-modules/kubernetes-engine/google"
+  project_id                 = module.project.project_id
+  name                       = "prow-trusted"
+  regional                   = false
+  zones                      = ["us-central1-a"]
+  release_channel            = "STABLE"
+  network                    = "default"
+  subnetwork                 = "default"
+  ip_range_pods              = "gke-prow-trusted-pods-f579223d"
+  ip_range_services          = "gke-prow-trusted-services-f579223d"
+  http_load_balancing        = true
+  network_policy             = false
+  horizontal_pod_autoscaling = true
+  filestore_csi_driver       = false
+  create_service_account     = false
+
+  node_pools = [
+    {
+      name               = "prod-v1"
+      machine_type       = "e2-medium"
+      node_locations     = "us-central1-f"
+      min_count          = 1
+      max_count          = 3
+      disk_size_gb       = 100
+      disk_type          = "pd-standard"
+      image_type         = "COS_CONTAINERD"
+      auto_repair        = true
+      auto_upgrade       = true
+      service_account    = google_service_account.gke_nodes.email
+      enable_secure_boot = true
+      initial_node_count = 1
+    },
+  ]
+
+  node_pools_oauth_scopes = {
+    prow-trusted = [
+      "https://www.googleapis.com/auth/cloud-platform"
+    ]
+  }
+
+  node_pools_labels = {
+    prow-trusted = {
+      cluster     = "prow-trusted"
+      environment = "production"
+    }
+  }
+}

--- a/infra/gcp/tests/iam.tf
+++ b/infra/gcp/tests/iam.tf
@@ -7,21 +7,7 @@ module "iam" {
   mode = "authoritative"
 
   bindings = {
-    "roles/storage.objectViewer" = [
-      "serviceAccount:${google_service_account.gke_nodes.email}",
-    ]
 
-    "roles/logging.logWriter" = [
-      "serviceAccount:${google_service_account.gke_nodes.email}",
-    ]
-
-    "roles/monitoring.metricWriter" = [
-      "serviceAccount:${google_service_account.gke_nodes.email}",
-    ]
-
-    "roles/stackdriver.resourceMetadata.writer" = [
-      "serviceAccount:${google_service_account.gke_nodes.email}",
-    ]
 
     "roles/artifactregistry.reader" = [
       "serviceAccount:${google_service_account.gke_nodes.email}",
@@ -32,8 +18,64 @@ module "iam" {
       "serviceAccount:pwg-admins@knative-tests.iam.gserviceaccount.com"
     ]
 
-    "roles/container.admin" : [
+    "roles/container.admin" = [
       "serviceAccount:prow-deployer@knative-tests.iam.gserviceaccount.com",
+      "serviceAccount:pwg-admins@knative-tests.iam.gserviceaccount.com"
+    ]
+
+    "roles/container.clusterAdmin" = [
+      "serviceAccount:workload-metrics-svc-acct@knative-tests.iam.gserviceaccount.com"
+    ],
+
+    "roles/iam.serviceAccountTokenCreator" = [
+      "serviceAccount:workload-metrics-svc-acct@knative-tests.iam.gserviceaccount.com"
+    ],
+
+    "roles/iam.serviceAccountUser" : [
+      "serviceAccount:workload-metrics-svc-acct@knative-tests.iam.gserviceaccount.com"
+    ],
+
+
+    "roles/logging.logWriter" = [
+      "serviceAccount:${google_service_account.gke_nodes.email}",
+    ]
+
+    "roles/monitoring.metricWriter" = [
+      "serviceAccount:${google_service_account.gke_nodes.email}",
+    ]
+
+    "roles/pubsub.editor" : [
+      "serviceAccount:prow-control-plane@knative-tests.iam.gserviceaccount.com"
+    ],
+
+    "roles/secretmanager.secretAccessor" : [
+      "serviceAccount:kubernetes-external-secrets-sa@knative-tests.iam.gserviceaccount.com",
+      "serviceAccount:prow-deployer@knative-tests.iam.gserviceaccount.com"
+    ],
+
+    "roles/secretmanager.viewer" : [
+      "serviceAccount:kubernetes-external-secrets-sa@knative-tests.iam.gserviceaccount.com"
+    ],
+
+    "roles/stackdriver.resourceMetadata.writer" = [
+      "serviceAccount:${google_service_account.gke_nodes.email}",
+    ]
+
+    "roles/storage.admin" = [
+      "serviceAccount:knative-tests@appspot.gserviceaccount.com",
+      "serviceAccount:prow-control-plane@knative-tests.iam.gserviceaccount.com",
+      "serviceAccount:prow-job@knative-nightly.iam.gserviceaccount.com",
+      "serviceAccount:prow-job@knative-releases.iam.gserviceaccount.com",
+      "serviceAccount:prow-job@knative-tests.iam.gserviceaccount.com",
+      "serviceAccount:pwg-admins@knative-tests.iam.gserviceaccount.com"
+    ],
+
+    "roles/storage.objectViewer" = [
+      "serviceAccount:${google_service_account.gke_nodes.email}",
+    ]
+
+    "roles/viewer" = [
+      "serviceAccount:prow-job@knative-tests.iam.gserviceaccount.com",
       "serviceAccount:pwg-admins@knative-tests.iam.gserviceaccount.com"
     ]
   }

--- a/infra/gcp/tests/iam.tf
+++ b/infra/gcp/tests/iam.tf
@@ -1,0 +1,46 @@
+module "iam" {
+  source  = "terraform-google-modules/iam/google//modules/projects_iam"
+  version = "~> 7"
+
+  projects = ["knative-tests"]
+
+  mode = "authoritative"
+
+  bindings = {
+    "roles/storage.objectViewer" = [
+      "serviceAccount:${google_service_account.gke_nodes.email}",
+    ]
+
+    "roles/logging.logWriter" = [
+      "serviceAccount:${google_service_account.gke_nodes.email}",
+    ]
+
+    "roles/monitoring.metricWriter" = [
+      "serviceAccount:${google_service_account.gke_nodes.email}",
+    ]
+
+    "roles/stackdriver.resourceMetadata.writer" = [
+      "serviceAccount:${google_service_account.gke_nodes.email}",
+    ]
+
+    "roles/artifactregistry.reader" = [
+      "serviceAccount:${google_service_account.gke_nodes.email}",
+    ]
+
+    "roles/cloudbuild.builds.editor" = [
+      "serviceAccount:prow-job@knative-tests.iam.gserviceaccount.com",
+      "serviceAccount:pwg-admins@knative-tests.iam.gserviceaccount.com"
+    ]
+
+    "roles/container.admin" : [
+      "serviceAccount:prow-deployer@knative-tests.iam.gserviceaccount.com",
+      "serviceAccount:pwg-admins@knative-tests.iam.gserviceaccount.com"
+    ]
+  }
+}
+
+resource "google_service_account" "gke_nodes" {
+  account_id   = "gke-nodes"
+  display_name = "GKE Nodes"
+  project      = module.project.project_id
+}

--- a/infra/gcp/tests/main.tf
+++ b/infra/gcp/tests/main.tf
@@ -1,0 +1,23 @@
+module "project" {
+  source  = "terraform-google-modules/project-factory/google"
+  version = "~> 12"
+
+  name            = "Knative Tests"
+  project_id      = "knative-tests"
+  folder_id       = "1055082993535"
+  org_id          = "22054930418"
+  billing_account = "014273-543CE9-58CE57"
+
+  # Sane project defaults
+  default_service_account     = "keep"
+  disable_services_on_destroy = false
+  create_project_sa           = false
+  random_project_id           = false
+  auto_create_network         = true
+
+
+  activate_apis = [
+    "secretmanager.googleapis.com",
+    "compute.googleapis.com"
+  ]
+}

--- a/infra/gcp/tests/prow-flaky-reporter.tf
+++ b/infra/gcp/tests/prow-flaky-reporter.tf
@@ -1,0 +1,14 @@
+resource "google_service_account_iam_binding" "flaky_test_reporter" {
+  service_account_id = google_service_account.flaky_test_reporter.name
+  role               = "roles/iam.workloadIdentityUser"
+
+  members = [
+    "serviceAccount:knative-tests.svc.id.goog[test-pods/flaky-test-reporter]",
+  ]
+}
+
+resource "google_service_account" "flaky_test_reporter" {
+  account_id   = "flaky-test-reporter"
+  display_name = "Flaky Test Reporter"
+  project      = "knative-tests"
+}


### PR DESCRIPTION
Started managing prow-tests in GKE.

I made a few modifications:
- new nodepool
- subscribed the cluster to a release channel (stable)
- nodepool now runs with a custom service account. This account has enough permissions to pull images, write logs, write metrics
- Start managing some IAM

/cc @kvmware @chizhg 
