### PR TITLE
Fix label-sync presumbit Prow job, when config on community repo

### DIFF
--- a/prow/jobs/custom/label-sync.yaml
+++ b/prow/jobs/custom/label-sync.yaml
@@ -36,25 +36,19 @@ presubmits:
         # Set --confirm=false to only validate the configuration file.
         - --confirm=false
         - --orgs=knative-sandbox,knative
-        - --github-app-id=$(GITHUB_APP_ID)
-        - --github-app-private-key-path=/etc/github/cert
-        - "--github-hourly-tokens=2000"
-        - "--github-allowed-burst=1000"
+        # We have to still use the GitHub oauth token for authentication, since
+        # https://github.com/knative/test-infra/pull/3198 change and having
+        # --confirm=false. This happens with peribolos as well.
+        - --token=/etc/github/oauth
         - --debug
         volumeMounts:
-        - name: github-token
+        - name: oauth
           mountPath: /etc/github
           readOnly: true
-        env:
-        - name: GITHUB_APP_ID
-          valueFrom:
-            secretKeyRef:
-              name: github-token
-              key: appid
       volumes:
-      - name: github-token
+      - name: oauth
         secret:
-          secretName: github-token
+          secretName: oauth-token
 
 periodics:
 # Run at 8AM PST.


### PR DESCRIPTION
**What this PR does, why we need it**:<br>
Since we moved `labels.yaml` to community the label_sync prow job is failing which seemed to happen to peribolos before as well. 

<!--
  If there is any golang code in this PR please uncomment the 
  `/lint` statement below to have Prow automatically lint it.
-->
<!--
  /lint
-->
