### PR TITLE
Fix prow-jobs-syncer-job by changing ssh key default mode to 0700

### DIFF
--- a/prow/jobs/custom/test-infra.yaml
+++ b/prow/jobs/custom/test-infra.yaml
@@ -304,7 +304,7 @@ periodics:
     - name: prow-updater-robot-ssh-key
       secret:
         secretName: prow-updater-robot-ssh-key
-        defaultMode: 0400
+        defaultMode: 0700
 postsubmits:
   knative/test-infra:
   - name: post-knative-test-infra-image-push


### PR DESCRIPTION
Reference: https://electrictoolbox.com/failed-to-add-host-to-known-hosts/

No idea why it worked before but suddenly stopped working though..

/cc @kvmware 