### PR TITLE
Updates flag when creating new cluster

### DIFF
--- a/pkg/clustermanager/kubetest2/gke.go
+++ b/pkg/clustermanager/kubetest2/gke.go
@@ -88,7 +88,7 @@ func Run(opts *Options, cc *GKEClusterConfig) error {
 	if cc.ReleaseChannel != "" {
 		createCommand += " --release-channel=" + cc.ReleaseChannel
 	}
-	kubetest2Flags = append(kubetest2Flags, "--version="+cc.Version)
+	kubetest2Flags = append(kubetest2Flags, "--cluster-version="+cc.Version)
 	if cc.Addons != "" {
 		createCommand += " --addons=" + cc.Addons
 	}


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paulschw@us.ibm.com>

GKE has deprecated the `--version` flag in favor of `--cluster-version` when creating a new cluster. This PR switches to the new flag.

Link to GKE docs for flag to use:
https://cloud.google.com/kubernetes-engine/versioning#specifying_cluster_version

Example of deprecation warning in Prow job:
https://prow.knative.dev/view/gs/knative-prow/pr-logs/pull/knative_serving/12889/istio-latest-no-mesh_serving_main/1519674948770074624#1:build-log.txt%3A330

