### PR TITLE
add optional job to run perf tests using mako stub

### DIFF
--- a/prow/jobs/generated/knative/serving-main.gen.yaml
+++ b/prow/jobs/generated/knative/serving-main.gen.yaml
@@ -942,6 +942,48 @@ presubmits:
     - ^main$
     cluster: prow-build
     decorate: true
+    name: performance-tests-mako_serving_main
+    optional: true
+    path_alias: knative.dev/serving
+    spec:
+      containers:
+      - command:
+        - runner.sh
+        - ./test/presubmit-tests.sh
+        - --run-test
+        - ./test/performance/performance-tests-mako.sh
+        env:
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        image: gcr.io/knative-tests/test-infra/prow-tests:v20220427-e617c7a7
+        name: ""
+        resources:
+          limits:
+            memory: 16Gi
+          requests:
+            memory: 12Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/test-account
+          name: test-account
+          readOnly: true
+      nodeSelector:
+        type: testing
+      volumes:
+      - name: test-account
+        secret:
+          items:
+          - key: service-account-key.json
+            path: service-account.json
+          secretName: prow-google-credentials
+  - always_run: false
+    branches:
+    - ^main$
+    cluster: prow-build
+    decorate: true
     name: istio-latest-mesh_serving_main
     optional: true
     path_alias: knative.dev/serving

--- a/prow/jobs_config/knative/serving.yaml
+++ b/prow/jobs_config/knative/serving.yaml
@@ -33,6 +33,11 @@ jobs:
     command: [runner.sh, ./test/presubmit-tests.sh, --run-test, ./test/performance/performance-tests.sh]
     modifiers: [presubmit_optional, presubmit_skipped]
 
+  - name: performance-tests-mako
+    types: [presubmit]
+    command: [runner.sh, ./test/presubmit-tests.sh, --run-test, ./test/performance/performance-tests-mako.sh]
+    modifiers: [presubmit_optional, presubmit_skipped]
+
   - name: istio-latest-mesh
     types: [presubmit]
     command: [runner.sh, ./test/presubmit-tests.sh, --run-test, "./test/e2e-tests.sh --istio-version latest --mesh"]


### PR DESCRIPTION
**Which issue(s) this PR fixes**:<br>


<!-- 
  Use `Fixes #<issue number>`, or `Fixes (paste link of issue)`
  to automatically close linked issue when the PR is merged.
  Uncomment and fill below if the PR does not close any issues.
-->
<!--
**What this PR does, why we need it**:<br>
-->

 - add optional job to run perf tests using mako stub in serving
<!--
  If there is any golang code in this PR please uncomment the 
  `/lint` statement below to have Prow automatically lint it.
-->
<!--
  /lint
-->
