### PR TITLE
Fix sandbox release tests

### DIFF
--- a/prow/jobs/generated/knative-sandbox/async-component-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/async-component-main.gen.yaml
@@ -135,10 +135,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/async-component:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/container-freezer-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/container-freezer-main.gen.yaml
@@ -135,10 +135,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/container-freezer:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/eventing-autoscaler-keda-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-autoscaler-keda-main.gen.yaml
@@ -135,10 +135,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/eventing-autoscaler-keda:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/eventing-autoscaler-keda-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-autoscaler-keda-release-1.1.gen.yaml
@@ -97,10 +97,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/eventing-autoscaler-keda:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/eventing-autoscaler-keda-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-autoscaler-keda-release-1.2.gen.yaml
@@ -97,10 +97,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/eventing-autoscaler-keda:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/eventing-autoscaler-keda-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-autoscaler-keda-release-1.3.gen.yaml
@@ -97,10 +97,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/eventing-autoscaler-keda:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/eventing-autoscaler-keda-release-1.4.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-autoscaler-keda-release-1.4.gen.yaml
@@ -97,10 +97,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/eventing-autoscaler-keda:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/eventing-awssqs-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-awssqs-main.gen.yaml
@@ -135,7 +135,13 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials

--- a/prow/jobs/generated/knative-sandbox/eventing-awssqs-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-awssqs-release-1.0.gen.yaml
@@ -97,7 +97,13 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials

--- a/prow/jobs/generated/knative-sandbox/eventing-awssqs-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-awssqs-release-1.1.gen.yaml
@@ -97,7 +97,13 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials

--- a/prow/jobs/generated/knative-sandbox/eventing-awssqs-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-awssqs-release-1.2.gen.yaml
@@ -97,7 +97,13 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials

--- a/prow/jobs/generated/knative-sandbox/eventing-ceph-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-ceph-main.gen.yaml
@@ -179,10 +179,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
     - emptyDir: {}
       name: docker-graph
     - hostPath:

--- a/prow/jobs/generated/knative-sandbox/eventing-ceph-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-ceph-release-1.1.gen.yaml
@@ -115,7 +115,13 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials

--- a/prow/jobs/generated/knative-sandbox/eventing-ceph-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-ceph-release-1.2.gen.yaml
@@ -115,7 +115,13 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials

--- a/prow/jobs/generated/knative-sandbox/eventing-ceph-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-ceph-release-1.3.gen.yaml
@@ -115,7 +115,13 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials

--- a/prow/jobs/generated/knative-sandbox/eventing-ceph-release-1.4.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-ceph-release-1.4.gen.yaml
@@ -123,10 +123,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
     - emptyDir: {}
       name: docker-graph
     - hostPath:

--- a/prow/jobs/generated/knative-sandbox/eventing-couchdb-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-couchdb-main.gen.yaml
@@ -179,10 +179,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
     - emptyDir: {}
       name: docker-graph
     - hostPath:

--- a/prow/jobs/generated/knative-sandbox/eventing-couchdb-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-couchdb-release-1.0.gen.yaml
@@ -115,7 +115,13 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials

--- a/prow/jobs/generated/knative-sandbox/eventing-couchdb-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-couchdb-release-1.1.gen.yaml
@@ -115,7 +115,13 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials

--- a/prow/jobs/generated/knative-sandbox/eventing-github-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-github-main.gen.yaml
@@ -179,10 +179,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
     - emptyDir: {}
       name: docker-graph
     - hostPath:

--- a/prow/jobs/generated/knative-sandbox/eventing-github-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-github-release-1.1.gen.yaml
@@ -115,7 +115,13 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials

--- a/prow/jobs/generated/knative-sandbox/eventing-github-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-github-release-1.2.gen.yaml
@@ -115,7 +115,13 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials

--- a/prow/jobs/generated/knative-sandbox/eventing-github-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-github-release-1.3.gen.yaml
@@ -115,7 +115,13 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials

--- a/prow/jobs/generated/knative-sandbox/eventing-github-release-1.4.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-github-release-1.4.gen.yaml
@@ -123,10 +123,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
     - emptyDir: {}
       name: docker-graph
     - hostPath:

--- a/prow/jobs/generated/knative-sandbox/eventing-gitlab-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-gitlab-main.gen.yaml
@@ -191,10 +191,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
     - emptyDir: {}
       name: docker-graph
     - hostPath:

--- a/prow/jobs/generated/knative-sandbox/eventing-gitlab-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-gitlab-release-1.1.gen.yaml
@@ -123,7 +123,13 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials

--- a/prow/jobs/generated/knative-sandbox/eventing-gitlab-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-gitlab-release-1.2.gen.yaml
@@ -123,7 +123,13 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials

--- a/prow/jobs/generated/knative-sandbox/eventing-gitlab-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-gitlab-release-1.3.gen.yaml
@@ -123,7 +123,13 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials

--- a/prow/jobs/generated/knative-sandbox/eventing-gitlab-release-1.4.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-gitlab-release-1.4.gen.yaml
@@ -131,10 +131,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
     - emptyDir: {}
       name: docker-graph
     - hostPath:

--- a/prow/jobs/generated/knative-sandbox/eventing-kafka-broker-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kafka-broker-main.gen.yaml
@@ -186,10 +186,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
     - emptyDir: {}
       name: docker-graph
     - hostPath:

--- a/prow/jobs/generated/knative-sandbox/eventing-kafka-broker-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kafka-broker-release-1.1.gen.yaml
@@ -115,10 +115,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/eventing-kafka-broker:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/eventing-kafka-broker-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kafka-broker-release-1.2.gen.yaml
@@ -115,10 +115,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/eventing-kafka-broker:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/eventing-kafka-broker-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kafka-broker-release-1.3.gen.yaml
@@ -115,10 +115,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/eventing-kafka-broker:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/eventing-kafka-broker-release-1.4.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kafka-broker-release-1.4.gen.yaml
@@ -123,10 +123,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
     - emptyDir: {}
       name: docker-graph
     - hostPath:

--- a/prow/jobs/generated/knative-sandbox/eventing-kafka-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kafka-main.gen.yaml
@@ -186,10 +186,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
     - emptyDir: {}
       name: docker-graph
     - hostPath:

--- a/prow/jobs/generated/knative-sandbox/eventing-kafka-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kafka-release-1.1.gen.yaml
@@ -115,10 +115,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/eventing-kafka:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/eventing-kafka-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kafka-release-1.2.gen.yaml
@@ -115,10 +115,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/eventing-kafka:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/eventing-kafka-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kafka-release-1.3.gen.yaml
@@ -115,10 +115,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/eventing-kafka:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/eventing-kafka-release-1.4.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kafka-release-1.4.gen.yaml
@@ -123,10 +123,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
     - emptyDir: {}
       name: docker-graph
     - hostPath:

--- a/prow/jobs/generated/knative-sandbox/eventing-kogito-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kogito-main.gen.yaml
@@ -142,10 +142,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/eventing-kogito:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/eventing-kogito-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kogito-release-1.1.gen.yaml
@@ -97,10 +97,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/eventing-kogito:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/eventing-kogito-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kogito-release-1.2.gen.yaml
@@ -97,10 +97,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/eventing-kogito:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/eventing-kogito-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kogito-release-1.3.gen.yaml
@@ -97,10 +97,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/eventing-kogito:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/eventing-kogito-release-1.4.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kogito-release-1.4.gen.yaml
@@ -97,10 +97,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/eventing-kogito:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/eventing-natss-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-natss-main.gen.yaml
@@ -142,7 +142,13 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials

--- a/prow/jobs/generated/knative-sandbox/eventing-natss-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-natss-release-1.1.gen.yaml
@@ -97,7 +97,13 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials

--- a/prow/jobs/generated/knative-sandbox/eventing-natss-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-natss-release-1.2.gen.yaml
@@ -97,7 +97,13 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials

--- a/prow/jobs/generated/knative-sandbox/eventing-natss-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-natss-release-1.3.gen.yaml
@@ -97,7 +97,13 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials

--- a/prow/jobs/generated/knative-sandbox/eventing-natss-release-1.4.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-natss-release-1.4.gen.yaml
@@ -97,7 +97,13 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials

--- a/prow/jobs/generated/knative-sandbox/eventing-rabbitmq-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-rabbitmq-main.gen.yaml
@@ -142,7 +142,13 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials

--- a/prow/jobs/generated/knative-sandbox/eventing-rabbitmq-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-rabbitmq-release-1.1.gen.yaml
@@ -97,7 +97,13 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials

--- a/prow/jobs/generated/knative-sandbox/eventing-rabbitmq-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-rabbitmq-release-1.2.gen.yaml
@@ -97,7 +97,13 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials

--- a/prow/jobs/generated/knative-sandbox/eventing-rabbitmq-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-rabbitmq-release-1.3.gen.yaml
@@ -97,7 +97,13 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials

--- a/prow/jobs/generated/knative-sandbox/eventing-rabbitmq-release-1.4.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-rabbitmq-release-1.4.gen.yaml
@@ -97,7 +97,13 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials

--- a/prow/jobs/generated/knative-sandbox/eventing-redis-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-redis-main.gen.yaml
@@ -179,10 +179,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
     - emptyDir: {}
       name: docker-graph
     - hostPath:

--- a/prow/jobs/generated/knative-sandbox/eventing-redis-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-redis-release-1.1.gen.yaml
@@ -115,7 +115,13 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials

--- a/prow/jobs/generated/knative-sandbox/eventing-redis-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-redis-release-1.2.gen.yaml
@@ -115,7 +115,13 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials

--- a/prow/jobs/generated/knative-sandbox/eventing-redis-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-redis-release-1.3.gen.yaml
@@ -115,7 +115,13 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials

--- a/prow/jobs/generated/knative-sandbox/eventing-redis-release-1.4.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-redis-release-1.4.gen.yaml
@@ -123,10 +123,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
     - emptyDir: {}
       name: docker-graph
     - hostPath:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-admin-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-admin-main.gen.yaml
@@ -135,10 +135,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/kn-plugin-admin:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-admin-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-admin-release-1.1.gen.yaml
@@ -97,10 +97,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/kn-plugin-admin:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-admin-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-admin-release-1.2.gen.yaml
@@ -97,10 +97,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/kn-plugin-admin:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-admin-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-admin-release-1.3.gen.yaml
@@ -97,10 +97,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/kn-plugin-admin:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-admin-release-1.4.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-admin-release-1.4.gen.yaml
@@ -97,10 +97,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/kn-plugin-admin:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-event-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-event-main.gen.yaml
@@ -135,10 +135,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/kn-plugin-event:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-event-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-event-release-1.1.gen.yaml
@@ -97,10 +97,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/kn-plugin-event:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-event-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-event-release-1.2.gen.yaml
@@ -97,10 +97,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/kn-plugin-event:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-event-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-event-release-1.3.gen.yaml
@@ -97,10 +97,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/kn-plugin-event:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-event-release-1.4.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-event-release-1.4.gen.yaml
@@ -97,10 +97,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/kn-plugin-event:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-func-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-func-main.gen.yaml
@@ -120,10 +120,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
     - emptyDir: {}
       name: docker-graph
     - hostPath:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-func-release-0.22.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-func-release-0.22.gen.yaml
@@ -64,10 +64,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
     - emptyDir: {}
       name: docker-graph
     - hostPath:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-func-release-0.23.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-func-release-0.23.gen.yaml
@@ -64,10 +64,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
     - emptyDir: {}
       name: docker-graph
     - hostPath:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-quickstart-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-quickstart-main.gen.yaml
@@ -135,10 +135,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/kn-plugin-quickstart:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-quickstart-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-quickstart-release-1.1.gen.yaml
@@ -97,10 +97,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/kn-plugin-quickstart:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-quickstart-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-quickstart-release-1.2.gen.yaml
@@ -97,10 +97,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/kn-plugin-quickstart:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-quickstart-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-quickstart-release-1.3.gen.yaml
@@ -97,10 +97,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/kn-plugin-quickstart:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-quickstart-release-1.4.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-quickstart-release-1.4.gen.yaml
@@ -97,10 +97,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/kn-plugin-quickstart:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-service-log-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-service-log-main.gen.yaml
@@ -161,10 +161,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
     - emptyDir: {}
       name: docker-graph
     - hostPath:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-service-log-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-service-log-release-1.1.gen.yaml
@@ -105,10 +105,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
     - emptyDir: {}
       name: docker-graph
     - hostPath:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-source-kafka-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-source-kafka-main.gen.yaml
@@ -161,10 +161,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
     - emptyDir: {}
       name: docker-graph
     - hostPath:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-source-kafka-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-source-kafka-release-1.1.gen.yaml
@@ -97,10 +97,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/kn-plugin-source-kafka:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-source-kafka-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-source-kafka-release-1.2.gen.yaml
@@ -97,10 +97,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/kn-plugin-source-kafka:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-source-kafka-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-source-kafka-release-1.3.gen.yaml
@@ -97,10 +97,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/kn-plugin-source-kafka:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-source-kafka-release-1.4.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-source-kafka-release-1.4.gen.yaml
@@ -105,10 +105,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
     - emptyDir: {}
       name: docker-graph
     - hostPath:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-source-kamelet-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-source-kamelet-main.gen.yaml
@@ -135,10 +135,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/kn-plugin-source-kamelet:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-source-kamelet-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-source-kamelet-release-1.1.gen.yaml
@@ -97,10 +97,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/kn-plugin-source-kamelet:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-source-kamelet-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-source-kamelet-release-1.2.gen.yaml
@@ -97,10 +97,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/kn-plugin-source-kamelet:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-source-kamelet-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-source-kamelet-release-1.3.gen.yaml
@@ -97,10 +97,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/kn-plugin-source-kamelet:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-source-kamelet-release-1.4.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-source-kamelet-release-1.4.gen.yaml
@@ -97,10 +97,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/kn-plugin-source-kamelet:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/net-certmanager-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-certmanager-main.gen.yaml
@@ -142,10 +142,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/net-certmanager:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/net-certmanager-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-certmanager-release-1.1.gen.yaml
@@ -97,10 +97,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/net-certmanager:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/net-certmanager-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-certmanager-release-1.2.gen.yaml
@@ -97,10 +97,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/net-certmanager:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/net-certmanager-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-certmanager-release-1.3.gen.yaml
@@ -97,10 +97,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/net-certmanager:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/net-certmanager-release-1.4.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-certmanager-release-1.4.gen.yaml
@@ -97,10 +97,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/net-certmanager:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/net-contour-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-contour-main.gen.yaml
@@ -142,10 +142,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/net-contour:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/net-contour-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-contour-release-1.1.gen.yaml
@@ -97,10 +97,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/net-contour:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/net-contour-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-contour-release-1.2.gen.yaml
@@ -97,10 +97,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/net-contour:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/net-contour-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-contour-release-1.3.gen.yaml
@@ -97,10 +97,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/net-contour:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/net-contour-release-1.4.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-contour-release-1.4.gen.yaml
@@ -97,10 +97,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/net-contour:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/net-gateway-api-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-gateway-api-main.gen.yaml
@@ -142,10 +142,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/net-gateway-api:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/net-gateway-api-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-gateway-api-release-1.1.gen.yaml
@@ -97,10 +97,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/net-gateway-api:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/net-gateway-api-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-gateway-api-release-1.2.gen.yaml
@@ -97,10 +97,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/net-gateway-api:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/net-gateway-api-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-gateway-api-release-1.3.gen.yaml
@@ -97,10 +97,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/net-gateway-api:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/net-gateway-api-release-1.4.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-gateway-api-release-1.4.gen.yaml
@@ -97,10 +97,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/net-gateway-api:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/net-http01-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-http01-main.gen.yaml
@@ -142,10 +142,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/net-http01:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/net-http01-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-http01-release-1.1.gen.yaml
@@ -97,10 +97,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/net-http01:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/net-http01-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-http01-release-1.2.gen.yaml
@@ -97,10 +97,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/net-http01:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/net-http01-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-http01-release-1.3.gen.yaml
@@ -97,10 +97,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/net-http01:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/net-http01-release-1.4.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-http01-release-1.4.gen.yaml
@@ -97,10 +97,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/net-http01:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/net-istio-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-istio-main.gen.yaml
@@ -142,10 +142,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/net-istio:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/net-istio-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-istio-release-1.1.gen.yaml
@@ -97,10 +97,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/net-istio:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/net-istio-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-istio-release-1.2.gen.yaml
@@ -97,10 +97,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/net-istio:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/net-istio-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-istio-release-1.3.gen.yaml
@@ -97,10 +97,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/net-istio:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/net-istio-release-1.4.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-istio-release-1.4.gen.yaml
@@ -97,10 +97,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/net-istio:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/net-kourier-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-kourier-main.gen.yaml
@@ -142,10 +142,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/net-kourier:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/net-kourier-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-kourier-release-1.1.gen.yaml
@@ -97,10 +97,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/net-kourier:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/net-kourier-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-kourier-release-1.2.gen.yaml
@@ -97,10 +97,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/net-kourier:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/net-kourier-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-kourier-release-1.3.gen.yaml
@@ -97,10 +97,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/net-kourier:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/net-kourier-release-1.4.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-kourier-release-1.4.gen.yaml
@@ -97,10 +97,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/net-kourier:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/sample-controller-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/sample-controller-main.gen.yaml
@@ -94,10 +94,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/sample-controller:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/sample-controller-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/sample-controller-release-1.1.gen.yaml
@@ -56,10 +56,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/sample-controller:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/sample-controller-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/sample-controller-release-1.2.gen.yaml
@@ -56,10 +56,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/sample-controller:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/sample-controller-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/sample-controller-release-1.3.gen.yaml
@@ -56,10 +56,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/sample-controller:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/sample-controller-release-1.4.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/sample-controller-release-1.4.gen.yaml
@@ -56,10 +56,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/sample-controller:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/sample-source-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/sample-source-main.gen.yaml
@@ -94,10 +94,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/sample-source:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/sample-source-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/sample-source-release-1.1.gen.yaml
@@ -56,10 +56,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/sample-source:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/sample-source-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/sample-source-release-1.2.gen.yaml
@@ -56,10 +56,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/sample-source:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/sample-source-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/sample-source-release-1.3.gen.yaml
@@ -56,10 +56,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/sample-source:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/sample-source-release-1.4.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/sample-source-release-1.4.gen.yaml
@@ -56,10 +56,16 @@ periodics:
     volumes:
     - name: hub-token
       secret:
-        secretName: hub-token
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
     - name: release-account
       secret:
-        secretName: release-account
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/sample-source:
   - always_run: true

--- a/prow/jobs_config/knative-sandbox/.base.yaml
+++ b/prow/jobs_config/knative-sandbox/.base.yaml
@@ -20,7 +20,13 @@ requirement_presets:
     volumes:
       - name: hub-token
         secret:
-          secretName: hub-token
+          items:
+          - key: hub_token
+            path: token
+          secretName: github-credentials
       - name: release-account
         secret:
-          secretName: release-account
+          items:
+          - key: release.json
+            path: service-account.json
+          secretName: prow-google-credentials


### PR DESCRIPTION
**Which issue(s) this PR fixes**:<br>
Forgot sandbox projects had an override when I moved all the jobs over. Saw a trail of 
```
51m         Warning   FailedMount            pod/d806adaf-d047-11ec-9e81-5e946e41b7df   Unable to attach or mount volumes: unmounted volumes=[hub-token release-account], unattached volumes=[gcs-credentials tools hub-token release-account logs code clonerefs-tmp]: timed out waiting for the condition
```

/cc @chizhg @kvmware @dprotaso 

<!-- 
  Use `Fixes #<issue number>`, or `Fixes (paste link of issue)`
  to automatically close linked issue when the PR is merged.
  Uncomment and fill below if the PR does not close any issues.
-->
<!--
**What this PR does, why we need it**:<br>
-->

<!--
  If there is any golang code in this PR please uncomment the 
  `/lint` statement below to have Prow automatically lint it.
-->
<!--
  /lint
-->
