### PR TITLE
install netstat which is used by serving tests

### DIFF
--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -39,6 +39,7 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV PATH=/google-cloud-sdk/bin:/workspace:${PATH} \
     CLOUDSDK_CORE_DISABLE_PROMPTS=1
 
+# net-tools is used by serving tests
 RUN apt-get update -qqy && apt-get install -qqy \
         curl \
         gcc \
@@ -57,7 +58,8 @@ RUN apt-get update -qqy && apt-get install -qqy \
         wget \
         gnupg \
         jq \
-        procps
+        procps \
+        net-tools
 
 RUN pip3 install -U crcmod==1.7
 RUN curl -fsSLO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz


### PR DESCRIPTION
**Which issue(s) this PR fixes**:<br>
Fixes #3323

<!-- 
  Use `Fixes #<issue number>`, or `Fixes (paste link of issue)`
  to automatically close linked issue when the PR is merged.
  Uncomment and fill below if the PR does not close any issues.
-->
<!--
**What this PR does, why we need it**:<br>
-->

- install netstat on the prow image used by tests
- the serving performance tests needs to use netstat

<!--
  If there is any golang code in this PR please uncomment the 
  `/lint` statement below to have Prow automatically lint it.
-->
<!--
  /lint
-->
