### PR TITLE
WG Leads can re-run prow jobs

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -141,11 +141,25 @@ deck:
     '*':
       github_team_slugs:
         - org: 'knative'
+          slug: 'productivity-writers'
+        - org: 'knative'
           slug: 'technical-oversight-committee'
         - org: 'knative'
           slug: 'knative-release-leads'
         - org: 'knative'
-          slug: 'productivity-writers'
+          slug: 'client-wg-leads'
+        - org: 'knative'
+          slug: 'docs-wg-leads'
+        - org: 'knative'
+          slug: 'eventing-wg-leads'
+        - org: 'knative'
+          slug: 'operations-wg-leads'
+        - org: 'knative'
+          slug: 'security-wg-leads'
+        - org: 'knative'
+          slug: 'serving-wg-leads'
+        - org: 'knative'
+          slug: 'ux-wg-leads'
 
 prowjob_namespace: default
 pod_namespace: test-pods


### PR DESCRIPTION
Fixes: https://github.com/knative/community/issues/897

cc @pierDipi 
/assign @kvmware @chizhg 

I'm assuming with the CNCF migrations this is the appropriate place to make this change - please confirm and `/unhold` 

/hold