### PR TITLE
Revert "Revert easy cla (#3340)"

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -231,7 +231,7 @@ branch-protection:
       protect: true
       required_status_checks:
         contexts:
-        - cla/google
+        - EasyCLA
         - tide
       exclude:
       - "^dependabot/" # don't protect branches created by dependabot
@@ -247,7 +247,7 @@ branch-protection:
       protect: true
       required_status_checks:
         contexts:
-        - cla/google
+        - EasyCLA
         - tide
       include:
       - "^main$"


### PR DESCRIPTION
This reverts commit 24664762dc3b25a93f120eda718264cad03b0309.

It appears as though EasyCLA is now active on all repos in both orgs. Reverting the reverting.

Fixes https://github.com/knative/test-infra/issues/2984