### PR TITLE
chore: remove easycla (again)

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -231,7 +231,7 @@ branch-protection:
       protect: true
       required_status_checks:
         contexts:
-        - EasyCLA
+        - cla/google
         - tide
       exclude:
       - "^dependabot/" # don't protect branches created by dependabot
@@ -248,7 +248,7 @@ branch-protection:
       protect: true
       required_status_checks:
         contexts:
-        - EasyCLA
+        - cla/google
         - tide
       exclude:
       - "^dependabot/" # don't protect branches created by dependabot


### PR DESCRIPTION
Reverts EasyCLA again in favor of Google CLA until we can get configuration setting from CNCF resolved.

Signed-off-by: Lance Ball <lball@redhat.com>

/hold until 3pm EDT May 27
