### PR TITLE
bump go version to 1.18

### DIFF
--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -155,10 +155,10 @@ COPY images/prow-tests/source-gvm-and-run.sh /usr/local/bin
 # Install our versions of Go.
 # We only install the latest 3 versions of Go which should be enough for
 # all Knative repositories.
-RUN source-gvm-and-run.sh install go1.15.15 --prefer-binary
 RUN source-gvm-and-run.sh install go1.16.15 --prefer-binary
-RUN source-gvm-and-run.sh install go1.17.9 --prefer-binary
-RUN source-gvm-and-run.sh use go1.17 --default
+RUN source-gvm-and-run.sh install go1.17.11 --prefer-binary
+RUN source-gvm-and-run.sh install go1.18.3 --prefer-binary
+RUN source-gvm-and-run.sh use go1.18 --default
 
 # protoc and required golang tooling
 RUN curl -fsSL "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip" -o protoc.zip \
@@ -180,7 +180,7 @@ COPY images/prow-tests/in-gvm-env.sh /usr/local/bin
 # But it must be done in base or the last FROM, because it does not install to /go/bin
 
 ############################################################
-FROM golang:1.17 AS external-go-gets
+FROM golang:1.18 AS external-go-gets
 
 ARG KUBETEST2_VERSION=5e5d3e9eebc6a609aa428bd3e2a1c0c3566d5baf
 ARG KIND_VERSION=v0.12.0


### PR DESCRIPTION
go1.18 has been out for a few months so I'm assuming all the major bugs have been shaken out.

Confirmed with some K8s folks that 1.18.3 is 👍 