### PR TITLE
Clean up Knative.Team mail sending DNS records

### DIFF
--- a/infra/gcp/dns/dns.tf
+++ b/infra/gcp/dns/dns.tf
@@ -123,6 +123,31 @@ module "knative_team" {
         "knative.netlify.com.",
       ]
     },
+    {
+      name = "google._domainkey"
+      type = "TXT"
+      ttl = 300
+      records = [
+        "\"v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAjLQ9stjzBzp1HIGdxFWKotUPNrFwh47vQV7lIi1ioABjjgFDpeUvxVKsitVYO1m2ufxocY/rLOIGQ4Ap1WDM0qVh2VIPy9hpYxM1rEhEoQm5xWtyNb2GL9OUqXJmmDDDJPi2VnuNnDBRcGcEng/xGmgwSO6rMsAZrZVZVc41DkGWlQaiO5BzA/HBQx5vwMzvKhqtgbfAtgj7V6g8qTYTdyljgSQPlelH63xYGJNaEqf1blg7aXwsZzXPxHbW8Vj16zcFBweo7X+Gg/ig2H3uFdgMzON6CnGG/dw/8sL/zVDr/2zRd7i5DS0S8XJpn7lomwWlNE8RIW27qI8aVOvrZwIDAQAB\""
+      ]
+    },
+    {
+      name = ""
+      type = "TXT"
+      ttl  = 300
+      records = [
+        "\"v=spf1 include:_spf.google.com ~all\"",
+        "google-site-verification=w5KR-YluNH94Htu_LcKidfaDfQhlyzRaCp4-_VI5yFY"
+      ]
+    },
+    {
+      name = ""
+      type = "TXT"
+      ttl  = 300
+      records = [
+        "\"v=DMARC1; p=none; pct=100; adkim=s; aspf=s\"",
+      ]
+    },
   ]
 }
 


### PR DESCRIPTION
Knative.Team: Add existing SPF and DKIM records. Create DMARC record.

See 
https://mxtoolbox.com/SuperTool.aspx?action=mx%3aknative.team&run=toolpage

Someone reported this via the `security` alias, though it's not a relevant security issue, I figured I'd fix it up.
