### PR TITLE
Revert "Disable Periodic Jobs during the maintenance window"

### DIFF
--- a/config/prow/k8s-testgrid/k8s-testgrid.yaml
+++ b/config/prow/k8s-testgrid/k8s-testgrid.yaml
@@ -8,11 +8,79 @@
 # A prow annotation will be invalid if it references a dashboard that doesn't exist
 dashboard_groups:
 - dashboard_names:
+  - client
   - client-pkg
+  - docs
+  - eventing
+  - operator
+  - serving
   - utilities
   name: knative
+- dashboard_names:
+  - async-component
+  - container-freezer
+  - eventing-autoscaler-keda
+  - eventing-awssqs
+  - eventing-ceph
+  - eventing-couchdb
+  - eventing-github
+  - eventing-gitlab
+  - eventing-kafka
+  - eventing-kafka-broker
+  - eventing-kogito
+  - eventing-natss
+  - eventing-rabbitmq
+  - eventing-redis
+  - kn-plugin-admin
+  - kn-plugin-diag
+  - kn-plugin-event
+  - kn-plugin-func
+  - kn-plugin-migration
+  - kn-plugin-operator
+  - kn-plugin-quickstart
+  - kn-plugin-sample
+  - kn-plugin-service-log
+  - kn-plugin-source-kafka
+  - kn-plugin-source-kamelet
+  - net-certmanager
+  - net-contour
+  - net-gateway-api
+  - net-http01
+  - net-istio
+  - net-kourier
+  - sample-controller
+  - sample-source
+  name: knative-sandbox
 dashboards:
+- name: async-component
+- name: client
 - name: client-pkg
+- name: container-freezer
+- name: docs
+- name: eventing
+- name: eventing-autoscaler-keda
+- name: eventing-awssqs
+- name: eventing-ceph
+- name: eventing-couchdb
+- name: eventing-github
+- name: eventing-gitlab
+- name: eventing-kafka
+- name: eventing-kafka-broker
+- name: eventing-kogito
+- name: eventing-natss
+- name: eventing-rabbitmq
+- name: eventing-redis
+- name: kn-plugin-admin
+- name: kn-plugin-diag
+- name: kn-plugin-event
+- name: kn-plugin-func
+- name: kn-plugin-migration
+- name: kn-plugin-operator
+- name: kn-plugin-quickstart
+- name: kn-plugin-sample
+- name: kn-plugin-service-log
+- name: kn-plugin-source-kafka
+- name: kn-plugin-source-kamelet
 - name: knative-release-1.2
 - name: knative-release-1.3
 - name: knative-release-1.4
@@ -26,4 +94,14 @@ dashboards:
 - name: knative-sandbox-release-1.3
 - name: knative-sandbox-release-1.4
 - name: knative-sandbox-release-1.5
+- name: net-certmanager
+- name: net-contour
+- name: net-gateway-api
+- name: net-http01
+- name: net-istio
+- name: net-kourier
+- name: operator
+- name: sample-controller
+- name: sample-source
+- name: serving
 - name: utilities

--- a/prow/jobs/custom/test-infra.yaml
+++ b/prow/jobs/custom/test-infra.yaml
@@ -104,32 +104,32 @@ presubmits:
 periodics:
 # ci-knative-heartbeat is used for prometheus, alert(s) will be sent
 # if this job hadn't been succeeded for some time
-# - cron: "*/3 * * * *" # Every 3 minutes
-#   name: ci-knative-heartbeat
-#   agent: kubernetes
-#   decorate: true
-#   cluster: "default"
-#   extra_refs:
-#   - org: knative
-#     repo: test-infra
-#     base_ref: main
-#     path_alias: knative.dev/test-infra
-#   annotations:
-#     testgrid-dashboards: utilities
-#     testgrid-tab-name: ci-knative-heartbeat
-#   spec:
-#     containers:
-#     - image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
-#       imagePullPolicy: Always
-#       command:
-#       - "runner.sh"
-#       args:
-#       - "echo"
-#       - "Everything is fine!"
-#       resources:
-#         requests:
-#           cpu: 100m
-#           memory: 1Gi
+- cron: "*/3 * * * *" # Every 3 minutes
+  name: ci-knative-heartbeat
+  agent: kubernetes
+  decorate: true
+  cluster: "default"
+  extra_refs:
+  - org: knative
+    repo: test-infra
+    base_ref: main
+    path_alias: knative.dev/test-infra
+  annotations:
+    testgrid-dashboards: utilities
+    testgrid-tab-name: ci-knative-heartbeat
+  spec:
+    containers:
+    - image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      imagePullPolicy: Always
+      command:
+      - "runner.sh"
+      args:
+      - "echo"
+      - "Everything is fine!"
+      resources:
+        requests:
+          cpu: 100m
+          memory: 1Gi
 - cron: "0 19 * * *"
   name: ci-knative-cleanup
   agent: kubernetes

--- a/prow/jobs/generated/knative-sandbox/async-component-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/async-component-main.gen.yaml
@@ -5,6 +5,146 @@
 # ####                                                               ####
 # #######################################################################
 
+periodics:
+- annotations:
+    testgrid-dashboards: async-component
+    testgrid-tab-name: continuous
+  cluster: prow-build
+  cron: 17 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/async-component
+    repo: async-component
+  name: continuous_async-component_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./test/presubmit-tests.sh
+      - --all-tests
+      env:
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: async-component
+    testgrid-tab-name: nightly
+  cluster: prow-build
+  cron: 3 9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/async-component
+    repo: async-component
+  name: nightly_async-component_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --publish
+      - --tag-release
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/nightly-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/nightly-account
+        name: nightly-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: nightly-account
+      secret:
+        items:
+        - key: nightly.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: async-component
+    testgrid-tab-name: release
+  cluster: prow-build
+  cron: 15 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/async-component
+    repo: async-component
+  name: release_async-component_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --auto-release
+      - --release-gcs
+      - knative-releases/async-component
+      - --release-gcr
+      - gcr.io/knative-releases
+      - --github-token
+      - /etc/hub-token/token
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: ORG_NAME
+        value: knative-sandbox
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/hub-token
+        name: hub-token
+        readOnly: true
+      - mountPath: /etc/release-account
+        name: release-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: hub-token
+      secret:
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
+    - name: release-account
+      secret:
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/async-component:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/container-freezer-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/container-freezer-main.gen.yaml
@@ -5,6 +5,146 @@
 # ####                                                               ####
 # #######################################################################
 
+periodics:
+- annotations:
+    testgrid-dashboards: container-freezer
+    testgrid-tab-name: continuous
+  cluster: prow-build
+  cron: 6 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/container-freezer
+    repo: container-freezer
+  name: continuous_container-freezer_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./test/presubmit-tests.sh
+      - --all-tests
+      env:
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: container-freezer
+    testgrid-tab-name: nightly
+  cluster: prow-build
+  cron: 2 9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/container-freezer
+    repo: container-freezer
+  name: nightly_container-freezer_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --publish
+      - --tag-release
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/nightly-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/nightly-account
+        name: nightly-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: nightly-account
+      secret:
+        items:
+        - key: nightly.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: container-freezer
+    testgrid-tab-name: release
+  cluster: prow-build
+  cron: 14 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/container-freezer
+    repo: container-freezer
+  name: release_container-freezer_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --auto-release
+      - --release-gcs
+      - knative-releases/container-freezer
+      - --release-gcr
+      - gcr.io/knative-releases
+      - --github-token
+      - /etc/hub-token/token
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: ORG_NAME
+        value: knative-sandbox
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/hub-token
+        name: hub-token
+        readOnly: true
+      - mountPath: /etc/release-account
+        name: release-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: hub-token
+      secret:
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
+    - name: release-account
+      secret:
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/container-freezer:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/eventing-autoscaler-keda-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-autoscaler-keda-main.gen.yaml
@@ -5,6 +5,146 @@
 # ####                                                               ####
 # #######################################################################
 
+periodics:
+- annotations:
+    testgrid-dashboards: eventing-autoscaler-keda
+    testgrid-tab-name: continuous
+  cluster: prow-build
+  cron: 49 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/eventing-autoscaler-keda
+    repo: eventing-autoscaler-keda
+  name: continuous_eventing-autoscaler-keda_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./test/presubmit-tests.sh
+      - --all-tests
+      env:
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: eventing-autoscaler-keda
+    testgrid-tab-name: nightly
+  cluster: prow-build
+  cron: 55 9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/eventing-autoscaler-keda
+    repo: eventing-autoscaler-keda
+  name: nightly_eventing-autoscaler-keda_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --publish
+      - --tag-release
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/nightly-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/nightly-account
+        name: nightly-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: nightly-account
+      secret:
+        items:
+        - key: nightly.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: eventing-autoscaler-keda
+    testgrid-tab-name: release
+  cluster: prow-build
+  cron: 51 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/eventing-autoscaler-keda
+    repo: eventing-autoscaler-keda
+  name: release_eventing-autoscaler-keda_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --auto-release
+      - --release-gcs
+      - knative-releases/eventing-autoscaler-keda
+      - --release-gcr
+      - gcr.io/knative-releases
+      - --github-token
+      - /etc/hub-token/token
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: ORG_NAME
+        value: knative-sandbox
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/hub-token
+        name: hub-token
+        readOnly: true
+      - mountPath: /etc/release-account
+        name: release-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: hub-token
+      secret:
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
+    - name: release-account
+      secret:
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/eventing-autoscaler-keda:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/eventing-awssqs-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-awssqs-main.gen.yaml
@@ -5,4 +5,143 @@
 # ####                                                               ####
 # #######################################################################
 
-{}
+periodics:
+- annotations:
+    testgrid-dashboards: eventing-awssqs
+    testgrid-tab-name: continuous
+  cluster: prow-build
+  cron: 42 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/eventing-awssqs
+    repo: eventing-awssqs
+  name: continuous_eventing-awssqs_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./test/presubmit-tests.sh
+      - --all-tests
+      env:
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: eventing-awssqs
+    testgrid-tab-name: nightly
+  cluster: prow-build
+  cron: 38 9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/eventing-awssqs
+    repo: eventing-awssqs
+  name: nightly_eventing-awssqs_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --publish
+      - --tag-release
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/nightly-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/nightly-account
+        name: nightly-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: nightly-account
+      secret:
+        items:
+        - key: nightly.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: eventing-awssqs
+    testgrid-tab-name: release
+  cluster: prow-build
+  cron: 18 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/eventing-awssqs
+    repo: eventing-awssqs
+  name: release_eventing-awssqs_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --auto-release
+      - --release-gcs
+      - knative-releases/eventing-awssqs
+      - --release-gcr
+      - gcr.io/knative-releases
+      - --github-token
+      - /etc/hub-token/token
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: ORG_NAME
+        value: knative-sandbox
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/hub-token
+        name: hub-token
+        readOnly: true
+      - mountPath: /etc/release-account
+        name: release-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: hub-token
+      secret:
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
+    - name: release-account
+      secret:
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials

--- a/prow/jobs/generated/knative-sandbox/eventing-ceph-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-ceph-main.gen.yaml
@@ -5,4 +5,197 @@
 # ####                                                               ####
 # #######################################################################
 
-{}
+periodics:
+- annotations:
+    testgrid-dashboards: eventing-ceph
+    testgrid-tab-name: continuous
+  cluster: prow-build
+  cron: 4 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/eventing-ceph
+    repo: eventing-ceph
+  name: continuous_eventing-ceph_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./test/presubmit-tests.sh
+      - --all-tests
+      env:
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+      - mountPath: /docker-graph
+        name: docker-graph
+      - mountPath: /lib/modules
+        name: modules
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - emptyDir: {}
+      name: docker-graph
+    - hostPath:
+        path: /lib/modules
+        type: Directory
+      name: modules
+    - hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+      name: cgroup
+- annotations:
+    testgrid-dashboards: eventing-ceph
+    testgrid-tab-name: nightly
+  cluster: prow-build
+  cron: 0 9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/eventing-ceph
+    repo: eventing-ceph
+  name: nightly_eventing-ceph_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --publish
+      - --tag-release
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/nightly-account/service-account.json
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/nightly-account
+        name: nightly-account
+        readOnly: true
+      - mountPath: /docker-graph
+        name: docker-graph
+      - mountPath: /lib/modules
+        name: modules
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: nightly-account
+      secret:
+        items:
+        - key: nightly.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - emptyDir: {}
+      name: docker-graph
+    - hostPath:
+        path: /lib/modules
+        type: Directory
+      name: modules
+    - hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+      name: cgroup
+- annotations:
+    testgrid-dashboards: eventing-ceph
+    testgrid-tab-name: release
+  cluster: prow-build
+  cron: 24 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/eventing-ceph
+    repo: eventing-ceph
+  name: release_eventing-ceph_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --auto-release
+      - --release-gcs
+      - knative-releases/eventing-ceph
+      - --release-gcr
+      - gcr.io/knative-releases
+      - --github-token
+      - /etc/hub-token/token
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: ORG_NAME
+        value: knative-sandbox
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/hub-token
+        name: hub-token
+        readOnly: true
+      - mountPath: /etc/release-account
+        name: release-account
+        readOnly: true
+      - mountPath: /docker-graph
+        name: docker-graph
+      - mountPath: /lib/modules
+        name: modules
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: hub-token
+      secret:
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
+    - name: release-account
+      secret:
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - emptyDir: {}
+      name: docker-graph
+    - hostPath:
+        path: /lib/modules
+        type: Directory
+      name: modules
+    - hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+      name: cgroup

--- a/prow/jobs/generated/knative-sandbox/eventing-couchdb-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-couchdb-main.gen.yaml
@@ -5,4 +5,197 @@
 # ####                                                               ####
 # #######################################################################
 
-{}
+periodics:
+- annotations:
+    testgrid-dashboards: eventing-couchdb
+    testgrid-tab-name: continuous
+  cluster: prow-build
+  cron: 52 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/eventing-couchdb
+    repo: eventing-couchdb
+  name: continuous_eventing-couchdb_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./test/presubmit-tests.sh
+      - --all-tests
+      env:
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+      - mountPath: /docker-graph
+        name: docker-graph
+      - mountPath: /lib/modules
+        name: modules
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - emptyDir: {}
+      name: docker-graph
+    - hostPath:
+        path: /lib/modules
+        type: Directory
+      name: modules
+    - hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+      name: cgroup
+- annotations:
+    testgrid-dashboards: eventing-couchdb
+    testgrid-tab-name: nightly
+  cluster: prow-build
+  cron: 56 9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/eventing-couchdb
+    repo: eventing-couchdb
+  name: nightly_eventing-couchdb_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --publish
+      - --tag-release
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/nightly-account/service-account.json
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/nightly-account
+        name: nightly-account
+        readOnly: true
+      - mountPath: /docker-graph
+        name: docker-graph
+      - mountPath: /lib/modules
+        name: modules
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: nightly-account
+      secret:
+        items:
+        - key: nightly.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - emptyDir: {}
+      name: docker-graph
+    - hostPath:
+        path: /lib/modules
+        type: Directory
+      name: modules
+    - hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+      name: cgroup
+- annotations:
+    testgrid-dashboards: eventing-couchdb
+    testgrid-tab-name: release
+  cluster: prow-build
+  cron: 8 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/eventing-couchdb
+    repo: eventing-couchdb
+  name: release_eventing-couchdb_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --auto-release
+      - --release-gcs
+      - knative-releases/eventing-couchdb
+      - --release-gcr
+      - gcr.io/knative-releases
+      - --github-token
+      - /etc/hub-token/token
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: ORG_NAME
+        value: knative-sandbox
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/hub-token
+        name: hub-token
+        readOnly: true
+      - mountPath: /etc/release-account
+        name: release-account
+        readOnly: true
+      - mountPath: /docker-graph
+        name: docker-graph
+      - mountPath: /lib/modules
+        name: modules
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: hub-token
+      secret:
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
+    - name: release-account
+      secret:
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - emptyDir: {}
+      name: docker-graph
+    - hostPath:
+        path: /lib/modules
+        type: Directory
+      name: modules
+    - hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+      name: cgroup

--- a/prow/jobs/generated/knative-sandbox/eventing-github-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-github-main.gen.yaml
@@ -5,4 +5,197 @@
 # ####                                                               ####
 # #######################################################################
 
-{}
+periodics:
+- annotations:
+    testgrid-dashboards: eventing-github
+    testgrid-tab-name: continuous
+  cluster: prow-build
+  cron: 43 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/eventing-github
+    repo: eventing-github
+  name: continuous_eventing-github_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./test/presubmit-tests.sh
+      - --all-tests
+      env:
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+      - mountPath: /docker-graph
+        name: docker-graph
+      - mountPath: /lib/modules
+        name: modules
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - emptyDir: {}
+      name: docker-graph
+    - hostPath:
+        path: /lib/modules
+        type: Directory
+      name: modules
+    - hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+      name: cgroup
+- annotations:
+    testgrid-dashboards: eventing-github
+    testgrid-tab-name: nightly
+  cluster: prow-build
+  cron: 53 9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/eventing-github
+    repo: eventing-github
+  name: nightly_eventing-github_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --publish
+      - --tag-release
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/nightly-account/service-account.json
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/nightly-account
+        name: nightly-account
+        readOnly: true
+      - mountPath: /docker-graph
+        name: docker-graph
+      - mountPath: /lib/modules
+        name: modules
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: nightly-account
+      secret:
+        items:
+        - key: nightly.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - emptyDir: {}
+      name: docker-graph
+    - hostPath:
+        path: /lib/modules
+        type: Directory
+      name: modules
+    - hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+      name: cgroup
+- annotations:
+    testgrid-dashboards: eventing-github
+    testgrid-tab-name: release
+  cluster: prow-build
+  cron: 33 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/eventing-github
+    repo: eventing-github
+  name: release_eventing-github_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --auto-release
+      - --release-gcs
+      - knative-releases/eventing-github
+      - --release-gcr
+      - gcr.io/knative-releases
+      - --github-token
+      - /etc/hub-token/token
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: ORG_NAME
+        value: knative-sandbox
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/hub-token
+        name: hub-token
+        readOnly: true
+      - mountPath: /etc/release-account
+        name: release-account
+        readOnly: true
+      - mountPath: /docker-graph
+        name: docker-graph
+      - mountPath: /lib/modules
+        name: modules
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: hub-token
+      secret:
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
+    - name: release-account
+      secret:
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - emptyDir: {}
+      name: docker-graph
+    - hostPath:
+        path: /lib/modules
+        type: Directory
+      name: modules
+    - hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+      name: cgroup

--- a/prow/jobs/generated/knative-sandbox/eventing-gitlab-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-gitlab-main.gen.yaml
@@ -5,4 +5,209 @@
 # ####                                                               ####
 # #######################################################################
 
-{}
+periodics:
+- annotations:
+    testgrid-dashboards: eventing-gitlab
+    testgrid-tab-name: continuous
+  cluster: prow-build
+  cron: 43 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/eventing-gitlab
+    repo: eventing-gitlab
+  name: continuous_eventing-gitlab_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./test/presubmit-tests.sh
+      - --all-tests
+      env:
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources:
+        limits:
+          memory: 16Gi
+        requests:
+          memory: 12Gi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+      - mountPath: /docker-graph
+        name: docker-graph
+      - mountPath: /lib/modules
+        name: modules
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - emptyDir: {}
+      name: docker-graph
+    - hostPath:
+        path: /lib/modules
+        type: Directory
+      name: modules
+    - hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+      name: cgroup
+- annotations:
+    testgrid-dashboards: eventing-gitlab
+    testgrid-tab-name: nightly
+  cluster: prow-build
+  cron: 33 9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/eventing-gitlab
+    repo: eventing-gitlab
+  name: nightly_eventing-gitlab_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --publish
+      - --tag-release
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/nightly-account/service-account.json
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources:
+        limits:
+          memory: 16Gi
+        requests:
+          memory: 12Gi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/nightly-account
+        name: nightly-account
+        readOnly: true
+      - mountPath: /docker-graph
+        name: docker-graph
+      - mountPath: /lib/modules
+        name: modules
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: nightly-account
+      secret:
+        items:
+        - key: nightly.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - emptyDir: {}
+      name: docker-graph
+    - hostPath:
+        path: /lib/modules
+        type: Directory
+      name: modules
+    - hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+      name: cgroup
+- annotations:
+    testgrid-dashboards: eventing-gitlab
+    testgrid-tab-name: release
+  cluster: prow-build
+  cron: 5 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/eventing-gitlab
+    repo: eventing-gitlab
+  name: release_eventing-gitlab_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --auto-release
+      - --release-gcs
+      - knative-releases/eventing-gitlab
+      - --release-gcr
+      - gcr.io/knative-releases
+      - --github-token
+      - /etc/hub-token/token
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: ORG_NAME
+        value: knative-sandbox
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources:
+        limits:
+          memory: 16Gi
+        requests:
+          memory: 12Gi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/hub-token
+        name: hub-token
+        readOnly: true
+      - mountPath: /etc/release-account
+        name: release-account
+        readOnly: true
+      - mountPath: /docker-graph
+        name: docker-graph
+      - mountPath: /lib/modules
+        name: modules
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: hub-token
+      secret:
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
+    - name: release-account
+      secret:
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - emptyDir: {}
+      name: docker-graph
+    - hostPath:
+        path: /lib/modules
+        type: Directory
+      name: modules
+    - hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+      name: cgroup

--- a/prow/jobs/generated/knative-sandbox/eventing-kafka-broker-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kafka-broker-main.gen.yaml
@@ -5,6 +5,207 @@
 # ####                                                               ####
 # #######################################################################
 
+periodics:
+- annotations:
+    testgrid-dashboards: eventing-kafka-broker
+    testgrid-tab-name: continuous
+  cluster: prow-build
+  cron: 52 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/eventing-kafka-broker
+    repo: eventing-kafka-broker
+  name: continuous_eventing-kafka-broker_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./test/presubmit-tests.sh
+      - --all-tests
+      env:
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+      - mountPath: /docker-graph
+        name: docker-graph
+      - mountPath: /lib/modules
+        name: modules
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - emptyDir: {}
+      name: docker-graph
+    - hostPath:
+        path: /lib/modules
+        type: Directory
+      name: modules
+    - hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+      name: cgroup
+- annotations:
+    testgrid-dashboards: eventing-kafka-broker
+    testgrid-tab-name: nightly
+  cluster: prow-build
+  cron: 28 9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/eventing-kafka-broker
+    repo: eventing-kafka-broker
+  name: nightly_eventing-kafka-broker_main_periodic
+  reporter_config:
+    slack:
+      channel: eventing-kafka
+      job_states_to_report:
+      - failure
+      report_template: |
+        "The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --publish
+      - --tag-release
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/nightly-account/service-account.json
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/nightly-account
+        name: nightly-account
+        readOnly: true
+      - mountPath: /docker-graph
+        name: docker-graph
+      - mountPath: /lib/modules
+        name: modules
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: nightly-account
+      secret:
+        items:
+        - key: nightly.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - emptyDir: {}
+      name: docker-graph
+    - hostPath:
+        path: /lib/modules
+        type: Directory
+      name: modules
+    - hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+      name: cgroup
+- annotations:
+    testgrid-dashboards: eventing-kafka-broker
+    testgrid-tab-name: release
+  cluster: prow-build
+  cron: 0 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/eventing-kafka-broker
+    repo: eventing-kafka-broker
+  name: release_eventing-kafka-broker_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --auto-release
+      - --release-gcs
+      - knative-releases/eventing-kafka-broker
+      - --release-gcr
+      - gcr.io/knative-releases
+      - --github-token
+      - /etc/hub-token/token
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: ORG_NAME
+        value: knative-sandbox
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/hub-token
+        name: hub-token
+        readOnly: true
+      - mountPath: /etc/release-account
+        name: release-account
+        readOnly: true
+      - mountPath: /docker-graph
+        name: docker-graph
+      - mountPath: /lib/modules
+        name: modules
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: hub-token
+      secret:
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
+    - name: release-account
+      secret:
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - emptyDir: {}
+      name: docker-graph
+    - hostPath:
+        path: /lib/modules
+        type: Directory
+      name: modules
+    - hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+      name: cgroup
 presubmits:
   knative-sandbox/eventing-kafka-broker:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/eventing-kafka-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kafka-main.gen.yaml
@@ -5,6 +5,286 @@
 # ####                                                               ####
 # #######################################################################
 
+periodics:
+- annotations:
+    testgrid-dashboards: eventing-kafka
+    testgrid-tab-name: continuous
+  cluster: prow-build
+  cron: 10 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/eventing-kafka
+    repo: eventing-kafka
+  name: continuous_eventing-kafka_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./test/presubmit-tests.sh
+      - --all-tests
+      env:
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+      - mountPath: /docker-graph
+        name: docker-graph
+      - mountPath: /lib/modules
+        name: modules
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - emptyDir: {}
+      name: docker-graph
+    - hostPath:
+        path: /lib/modules
+        type: Directory
+      name: modules
+    - hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+      name: cgroup
+- annotations:
+    testgrid-dashboards: eventing-kafka
+    testgrid-tab-name: nightly
+  cluster: prow-build
+  cron: 38 9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/eventing-kafka
+    repo: eventing-kafka
+  name: nightly_eventing-kafka_main_periodic
+  reporter_config:
+    slack:
+      channel: eventing-kafka
+      job_states_to_report:
+      - failure
+      report_template: |
+        "The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --publish
+      - --tag-release
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/nightly-account/service-account.json
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/nightly-account
+        name: nightly-account
+        readOnly: true
+      - mountPath: /docker-graph
+        name: docker-graph
+      - mountPath: /lib/modules
+        name: modules
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: nightly-account
+      secret:
+        items:
+        - key: nightly.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - emptyDir: {}
+      name: docker-graph
+    - hostPath:
+        path: /lib/modules
+        type: Directory
+      name: modules
+    - hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+      name: cgroup
+- annotations:
+    testgrid-dashboards: eventing-kafka
+    testgrid-tab-name: release
+  cluster: prow-build
+  cron: 26 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/eventing-kafka
+    repo: eventing-kafka
+  name: release_eventing-kafka_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --auto-release
+      - --release-gcs
+      - knative-releases/eventing-kafka
+      - --release-gcr
+      - gcr.io/knative-releases
+      - --github-token
+      - /etc/hub-token/token
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: ORG_NAME
+        value: knative-sandbox
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/hub-token
+        name: hub-token
+        readOnly: true
+      - mountPath: /etc/release-account
+        name: release-account
+        readOnly: true
+      - mountPath: /docker-graph
+        name: docker-graph
+      - mountPath: /lib/modules
+        name: modules
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: hub-token
+      secret:
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
+    - name: release-account
+      secret:
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - emptyDir: {}
+      name: docker-graph
+    - hostPath:
+        path: /lib/modules
+        type: Directory
+      name: modules
+    - hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+      name: cgroup
+- annotations:
+    testgrid-dashboards: eventing-kafka
+    testgrid-tab-name: s390x-e2e-tests
+  cluster: prow-build
+  cron: 0 14 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/eventing-kafka
+    repo: eventing-kafka
+  name: s390x-e2e-tests_eventing-kafka_main_periodic
+  spec:
+    containers:
+    - args:
+      - bash
+      - -c
+      - |
+        mkdir -p /root/.kube
+        cat /opt/cluster/ci-script > connect.sh
+        chmod +x connect.sh
+        ./connect.sh eventing_kafka-main
+        kubectl get cm s390x-config-eventing-kafka -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
+        chmod +x adjust.sh
+        ./adjust.sh
+        ./test/e2e-tests.sh --run-tests
+      command:
+      - runner.sh
+      env:
+      - name: SYSTEM_NAMESPACE
+        value: knative-eventing
+      - name: EVENTING_NAMESPACE
+        value: knative-eventing
+      - name: SCALE_CHAOSDUCK_TO_ZERO
+        value: "1"
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: KO_FLAGS
+        value: --platform=linux/s390x
+      - name: PLATFORM
+        value: linux/s390x
+      - name: KO_DOCKER_REPO
+        valueFrom:
+          secretKeyRef:
+            key: ko-docker-repo
+            name: s390x-cluster1
+      - name: DISABLE_MD_LINTING
+        value: "1"
+      - name: KUBECONFIG
+        value: /root/.kube/config
+      - name: DOCKER_CONFIG
+        value: /opt/cluster
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+      - mountPath: /opt/cluster
+        name: s390x-cluster1
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - name: s390x-cluster1
+      secret:
+        defaultMode: 384
+        secretName: s390x-cluster1
 presubmits:
   knative-sandbox/eventing-kafka:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/eventing-kogito-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kogito-main.gen.yaml
@@ -5,6 +5,153 @@
 # ####                                                               ####
 # #######################################################################
 
+periodics:
+- annotations:
+    testgrid-dashboards: eventing-kogito
+    testgrid-tab-name: continuous
+  cluster: prow-build
+  cron: 27 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/eventing-kogito
+    repo: eventing-kogito
+  name: continuous_eventing-kogito_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./test/presubmit-tests.sh
+      - --all-tests
+      env:
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: eventing-kogito
+    testgrid-tab-name: nightly
+  cluster: prow-build
+  cron: 37 9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/eventing-kogito
+    repo: eventing-kogito
+  name: nightly_eventing-kogito_main_periodic
+  reporter_config:
+    slack:
+      channel: eventing-sources
+      job_states_to_report:
+      - failure
+      report_template: |
+        "The nightly release job for Kogito failed, check the log: <{{.Status.URL}}|View logs>"
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --publish
+      - --tag-release
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/nightly-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/nightly-account
+        name: nightly-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: nightly-account
+      secret:
+        items:
+        - key: nightly.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: eventing-kogito
+    testgrid-tab-name: release
+  cluster: prow-build
+  cron: 41 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/eventing-kogito
+    repo: eventing-kogito
+  name: release_eventing-kogito_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --auto-release
+      - --release-gcs
+      - knative-releases/eventing-kogito
+      - --release-gcr
+      - gcr.io/knative-releases
+      - --github-token
+      - /etc/hub-token/token
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: ORG_NAME
+        value: knative-sandbox
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/hub-token
+        name: hub-token
+        readOnly: true
+      - mountPath: /etc/release-account
+        name: release-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: hub-token
+      secret:
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
+    - name: release-account
+      secret:
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/eventing-kogito:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/eventing-natss-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-natss-main.gen.yaml
@@ -5,4 +5,150 @@
 # ####                                                               ####
 # #######################################################################
 
-{}
+periodics:
+- annotations:
+    testgrid-dashboards: eventing-natss
+    testgrid-tab-name: continuous
+  cluster: prow-build
+  cron: 45 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/eventing-natss
+    repo: eventing-natss
+  name: continuous_eventing-natss_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./test/presubmit-tests.sh
+      - --all-tests
+      env:
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: eventing-natss
+    testgrid-tab-name: nightly
+  cluster: prow-build
+  cron: 59 9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/eventing-natss
+    repo: eventing-natss
+  name: nightly_eventing-natss_main_periodic
+  reporter_config:
+    slack:
+      channel: eventing
+      job_states_to_report:
+      - failure
+      report_template: |
+        "The nightly release job for eventing-natss failed, check the log: <{{.Status.URL}}|View logs>"
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --publish
+      - --tag-release
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/nightly-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/nightly-account
+        name: nightly-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: nightly-account
+      secret:
+        items:
+        - key: nightly.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: eventing-natss
+    testgrid-tab-name: release
+  cluster: prow-build
+  cron: 55 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/eventing-natss
+    repo: eventing-natss
+  name: release_eventing-natss_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --auto-release
+      - --release-gcs
+      - knative-releases/eventing-natss
+      - --release-gcr
+      - gcr.io/knative-releases
+      - --github-token
+      - /etc/hub-token/token
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: ORG_NAME
+        value: knative-sandbox
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/hub-token
+        name: hub-token
+        readOnly: true
+      - mountPath: /etc/release-account
+        name: release-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: hub-token
+      secret:
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
+    - name: release-account
+      secret:
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials

--- a/prow/jobs/generated/knative-sandbox/eventing-rabbitmq-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-rabbitmq-main.gen.yaml
@@ -5,4 +5,150 @@
 # ####                                                               ####
 # #######################################################################
 
-{}
+periodics:
+- annotations:
+    testgrid-dashboards: eventing-rabbitmq
+    testgrid-tab-name: continuous
+  cluster: prow-build
+  cron: 50 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/eventing-rabbitmq
+    repo: eventing-rabbitmq
+  name: continuous_eventing-rabbitmq_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./test/presubmit-tests.sh
+      - --all-tests
+      env:
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: eventing-rabbitmq
+    testgrid-tab-name: nightly
+  cluster: prow-build
+  cron: 30 9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/eventing-rabbitmq
+    repo: eventing-rabbitmq
+  name: nightly_eventing-rabbitmq_main_periodic
+  reporter_config:
+    slack:
+      channel: eventing-rabbitmq
+      job_states_to_report:
+      - failure
+      report_template: |
+        "The nightly release job for eventing-rabbitmq failed, check the log: <{{.Status.URL}}|View logs>"
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --publish
+      - --tag-release
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/nightly-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/nightly-account
+        name: nightly-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: nightly-account
+      secret:
+        items:
+        - key: nightly.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: eventing-rabbitmq
+    testgrid-tab-name: release
+  cluster: prow-build
+  cron: 34 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/eventing-rabbitmq
+    repo: eventing-rabbitmq
+  name: release_eventing-rabbitmq_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --auto-release
+      - --release-gcs
+      - knative-releases/eventing-rabbitmq
+      - --release-gcr
+      - gcr.io/knative-releases
+      - --github-token
+      - /etc/hub-token/token
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: ORG_NAME
+        value: knative-sandbox
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/hub-token
+        name: hub-token
+        readOnly: true
+      - mountPath: /etc/release-account
+        name: release-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: hub-token
+      secret:
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
+    - name: release-account
+      secret:
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials

--- a/prow/jobs/generated/knative-sandbox/eventing-redis-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-redis-main.gen.yaml
@@ -5,4 +5,197 @@
 # ####                                                               ####
 # #######################################################################
 
-{}
+periodics:
+- annotations:
+    testgrid-dashboards: eventing-redis
+    testgrid-tab-name: continuous
+  cluster: prow-build
+  cron: 55 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/eventing-redis
+    repo: eventing-redis
+  name: continuous_eventing-redis_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./test/presubmit-tests.sh
+      - --all-tests
+      env:
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+      - mountPath: /docker-graph
+        name: docker-graph
+      - mountPath: /lib/modules
+        name: modules
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - emptyDir: {}
+      name: docker-graph
+    - hostPath:
+        path: /lib/modules
+        type: Directory
+      name: modules
+    - hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+      name: cgroup
+- annotations:
+    testgrid-dashboards: eventing-redis
+    testgrid-tab-name: nightly
+  cluster: prow-build
+  cron: 1 9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/eventing-redis
+    repo: eventing-redis
+  name: nightly_eventing-redis_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --publish
+      - --tag-release
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/nightly-account/service-account.json
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/nightly-account
+        name: nightly-account
+        readOnly: true
+      - mountPath: /docker-graph
+        name: docker-graph
+      - mountPath: /lib/modules
+        name: modules
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: nightly-account
+      secret:
+        items:
+        - key: nightly.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - emptyDir: {}
+      name: docker-graph
+    - hostPath:
+        path: /lib/modules
+        type: Directory
+      name: modules
+    - hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+      name: cgroup
+- annotations:
+    testgrid-dashboards: eventing-redis
+    testgrid-tab-name: release
+  cluster: prow-build
+  cron: 33 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/eventing-redis
+    repo: eventing-redis
+  name: release_eventing-redis_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --auto-release
+      - --release-gcs
+      - knative-releases/eventing-redis
+      - --release-gcr
+      - gcr.io/knative-releases
+      - --github-token
+      - /etc/hub-token/token
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: ORG_NAME
+        value: knative-sandbox
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/hub-token
+        name: hub-token
+        readOnly: true
+      - mountPath: /etc/release-account
+        name: release-account
+        readOnly: true
+      - mountPath: /docker-graph
+        name: docker-graph
+      - mountPath: /lib/modules
+        name: modules
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: hub-token
+      secret:
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
+    - name: release-account
+      secret:
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - emptyDir: {}
+      name: docker-graph
+    - hostPath:
+        path: /lib/modules
+        type: Directory
+      name: modules
+    - hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+      name: cgroup

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-admin-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-admin-main.gen.yaml
@@ -5,6 +5,146 @@
 # ####                                                               ####
 # #######################################################################
 
+periodics:
+- annotations:
+    testgrid-dashboards: kn-plugin-admin
+    testgrid-tab-name: continuous
+  cluster: prow-build
+  cron: 14 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-admin
+    repo: kn-plugin-admin
+  name: continuous_kn-plugin-admin_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./test/presubmit-tests.sh
+      - --all-tests
+      env:
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: kn-plugin-admin
+    testgrid-tab-name: nightly
+  cluster: prow-build
+  cron: 42 9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-admin
+    repo: kn-plugin-admin
+  name: nightly_kn-plugin-admin_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --publish
+      - --tag-release
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/nightly-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/nightly-account
+        name: nightly-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: nightly-account
+      secret:
+        items:
+        - key: nightly.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: kn-plugin-admin
+    testgrid-tab-name: release
+  cluster: prow-build
+  cron: 18 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-admin
+    repo: kn-plugin-admin
+  name: release_kn-plugin-admin_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --auto-release
+      - --release-gcs
+      - knative-releases/kn-plugin-admin
+      - --release-gcr
+      - gcr.io/knative-releases
+      - --github-token
+      - /etc/hub-token/token
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: ORG_NAME
+        value: knative-sandbox
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/hub-token
+        name: hub-token
+        readOnly: true
+      - mountPath: /etc/release-account
+        name: release-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: hub-token
+      secret:
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
+    - name: release-account
+      secret:
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/kn-plugin-admin:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-diag-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-diag-main.gen.yaml
@@ -5,6 +5,48 @@
 # ####                                                               ####
 # #######################################################################
 
+periodics:
+- annotations:
+    testgrid-dashboards: kn-plugin-diag
+    testgrid-tab-name: continuous
+  cluster: prow-build
+  cron: 8 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-diag
+    repo: kn-plugin-diag
+  name: continuous_kn-plugin-diag_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./test/presubmit-tests.sh
+      - --all-tests
+      env:
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/kn-plugin-diag:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-event-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-event-main.gen.yaml
@@ -5,6 +5,146 @@
 # ####                                                               ####
 # #######################################################################
 
+periodics:
+- annotations:
+    testgrid-dashboards: kn-plugin-event
+    testgrid-tab-name: continuous
+  cluster: prow-build
+  cron: 5 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-event
+    repo: kn-plugin-event
+  name: continuous_kn-plugin-event_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./test/presubmit-tests.sh
+      - --all-tests
+      env:
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: kn-plugin-event
+    testgrid-tab-name: nightly
+  cluster: prow-build
+  cron: 27 9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-event
+    repo: kn-plugin-event
+  name: nightly_kn-plugin-event_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --publish
+      - --tag-release
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/nightly-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/nightly-account
+        name: nightly-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: nightly-account
+      secret:
+        items:
+        - key: nightly.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: kn-plugin-event
+    testgrid-tab-name: release
+  cluster: prow-build
+  cron: 39 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-event
+    repo: kn-plugin-event
+  name: release_kn-plugin-event_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --auto-release
+      - --release-gcs
+      - knative-releases/kn-plugin-event
+      - --release-gcr
+      - gcr.io/knative-releases
+      - --github-token
+      - /etc/hub-token/token
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: ORG_NAME
+        value: knative-sandbox
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/hub-token
+        name: hub-token
+        readOnly: true
+      - mountPath: /etc/release-account
+        name: release-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: hub-token
+      secret:
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
+    - name: release-account
+      secret:
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/kn-plugin-event:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-func-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-func-main.gen.yaml
@@ -5,4 +5,138 @@
 # ####                                                               ####
 # #######################################################################
 
-{}
+periodics:
+- annotations:
+    testgrid-dashboards: kn-plugin-func
+    testgrid-tab-name: nightly
+  cluster: prow-build
+  cron: 43 9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-func
+    repo: kn-plugin-func
+  name: nightly_kn-plugin-func_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --publish
+      - --tag-release
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/nightly-account/service-account.json
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/nightly-account
+        name: nightly-account
+        readOnly: true
+      - mountPath: /docker-graph
+        name: docker-graph
+      - mountPath: /lib/modules
+        name: modules
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: nightly-account
+      secret:
+        items:
+        - key: nightly.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - emptyDir: {}
+      name: docker-graph
+    - hostPath:
+        path: /lib/modules
+        type: Directory
+      name: modules
+    - hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+      name: cgroup
+- annotations:
+    testgrid-dashboards: kn-plugin-func
+    testgrid-tab-name: release
+  cluster: prow-build
+  cron: 19 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-func
+    repo: kn-plugin-func
+  name: release_kn-plugin-func_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --auto-release
+      - --release-gcs
+      - knative-releases/kn-plugin-func
+      - --release-gcr
+      - gcr.io/knative-releases
+      - --github-token
+      - /etc/hub-token/token
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: ORG_NAME
+        value: knative-sandbox
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/hub-token
+        name: hub-token
+        readOnly: true
+      - mountPath: /etc/release-account
+        name: release-account
+        readOnly: true
+      - mountPath: /docker-graph
+        name: docker-graph
+      - mountPath: /lib/modules
+        name: modules
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: hub-token
+      secret:
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
+    - name: release-account
+      secret:
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - emptyDir: {}
+      name: docker-graph
+    - hostPath:
+        path: /lib/modules
+        type: Directory
+      name: modules
+    - hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+      name: cgroup

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-migration-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-migration-main.gen.yaml
@@ -5,6 +5,48 @@
 # ####                                                               ####
 # #######################################################################
 
+periodics:
+- annotations:
+    testgrid-dashboards: kn-plugin-migration
+    testgrid-tab-name: continuous
+  cluster: prow-build
+  cron: 53 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-migration
+    repo: kn-plugin-migration
+  name: continuous_kn-plugin-migration_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./test/presubmit-tests.sh
+      - --all-tests
+      env:
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/kn-plugin-migration:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-operator-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-operator-main.gen.yaml
@@ -5,6 +5,48 @@
 # ####                                                               ####
 # #######################################################################
 
+periodics:
+- annotations:
+    testgrid-dashboards: kn-plugin-operator
+    testgrid-tab-name: continuous
+  cluster: prow-build
+  cron: 47 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-operator
+    repo: kn-plugin-operator
+  name: continuous_kn-plugin-operator_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./test/presubmit-tests.sh
+      - --all-tests
+      env:
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/kn-plugin-operator:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-quickstart-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-quickstart-main.gen.yaml
@@ -5,6 +5,146 @@
 # ####                                                               ####
 # #######################################################################
 
+periodics:
+- annotations:
+    testgrid-dashboards: kn-plugin-quickstart
+    testgrid-tab-name: continuous
+  cluster: prow-build
+  cron: 42 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-quickstart
+    repo: kn-plugin-quickstart
+  name: continuous_kn-plugin-quickstart_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./test/presubmit-tests.sh
+      - --all-tests
+      env:
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: kn-plugin-quickstart
+    testgrid-tab-name: nightly
+  cluster: prow-build
+  cron: 22 9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-quickstart
+    repo: kn-plugin-quickstart
+  name: nightly_kn-plugin-quickstart_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --publish
+      - --tag-release
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/nightly-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/nightly-account
+        name: nightly-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: nightly-account
+      secret:
+        items:
+        - key: nightly.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: kn-plugin-quickstart
+    testgrid-tab-name: release
+  cluster: prow-build
+  cron: 26 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-quickstart
+    repo: kn-plugin-quickstart
+  name: release_kn-plugin-quickstart_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --auto-release
+      - --release-gcs
+      - knative-releases/kn-plugin-quickstart
+      - --release-gcr
+      - gcr.io/knative-releases
+      - --github-token
+      - /etc/hub-token/token
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: ORG_NAME
+        value: knative-sandbox
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/hub-token
+        name: hub-token
+        readOnly: true
+      - mountPath: /etc/release-account
+        name: release-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: hub-token
+      secret:
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
+    - name: release-account
+      secret:
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/kn-plugin-quickstart:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-sample-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-sample-main.gen.yaml
@@ -5,6 +5,48 @@
 # ####                                                               ####
 # #######################################################################
 
+periodics:
+- annotations:
+    testgrid-dashboards: kn-plugin-sample
+    testgrid-tab-name: continuous
+  cluster: prow-build
+  cron: 13 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-sample
+    repo: kn-plugin-sample
+  name: continuous_kn-plugin-sample_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./test/presubmit-tests.sh
+      - --all-tests
+      env:
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/kn-plugin-sample:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-service-log-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-service-log-main.gen.yaml
@@ -5,6 +5,182 @@
 # ####                                                               ####
 # #######################################################################
 
+periodics:
+- annotations:
+    testgrid-dashboards: kn-plugin-service-log
+    testgrid-tab-name: continuous
+  cluster: prow-build
+  cron: 13 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-service-log
+    repo: kn-plugin-service-log
+  name: continuous_kn-plugin-service-log_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./test/presubmit-tests.sh
+      - --all-tests
+      env:
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: kn-plugin-service-log
+    testgrid-tab-name: nightly
+  cluster: prow-build
+  cron: 35 9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-service-log
+    repo: kn-plugin-service-log
+  name: nightly_kn-plugin-service-log_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --publish
+      - --tag-release
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/nightly-account/service-account.json
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/nightly-account
+        name: nightly-account
+        readOnly: true
+      - mountPath: /docker-graph
+        name: docker-graph
+      - mountPath: /lib/modules
+        name: modules
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: nightly-account
+      secret:
+        items:
+        - key: nightly.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - emptyDir: {}
+      name: docker-graph
+    - hostPath:
+        path: /lib/modules
+        type: Directory
+      name: modules
+    - hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+      name: cgroup
+- annotations:
+    testgrid-dashboards: kn-plugin-service-log
+    testgrid-tab-name: release
+  cluster: prow-build
+  cron: 15 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-service-log
+    repo: kn-plugin-service-log
+  name: release_kn-plugin-service-log_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --auto-release
+      - --release-gcs
+      - knative-releases/kn-plugin-service-log
+      - --release-gcr
+      - gcr.io/knative-releases
+      - --github-token
+      - /etc/hub-token/token
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: ORG_NAME
+        value: knative-sandbox
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/hub-token
+        name: hub-token
+        readOnly: true
+      - mountPath: /etc/release-account
+        name: release-account
+        readOnly: true
+      - mountPath: /docker-graph
+        name: docker-graph
+      - mountPath: /lib/modules
+        name: modules
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: hub-token
+      secret:
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
+    - name: release-account
+      secret:
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - emptyDir: {}
+      name: docker-graph
+    - hostPath:
+        path: /lib/modules
+        type: Directory
+      name: modules
+    - hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+      name: cgroup
 presubmits:
   knative-sandbox/kn-plugin-service-log:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-source-kafka-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-source-kafka-main.gen.yaml
@@ -5,6 +5,182 @@
 # ####                                                               ####
 # #######################################################################
 
+periodics:
+- annotations:
+    testgrid-dashboards: kn-plugin-source-kafka
+    testgrid-tab-name: continuous
+  cluster: prow-build
+  cron: 29 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-source-kafka
+    repo: kn-plugin-source-kafka
+  name: continuous_kn-plugin-source-kafka_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./test/presubmit-tests.sh
+      - --all-tests
+      env:
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: kn-plugin-source-kafka
+    testgrid-tab-name: nightly
+  cluster: prow-build
+  cron: 51 9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-source-kafka
+    repo: kn-plugin-source-kafka
+  name: nightly_kn-plugin-source-kafka_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --publish
+      - --tag-release
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/nightly-account/service-account.json
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/nightly-account
+        name: nightly-account
+        readOnly: true
+      - mountPath: /docker-graph
+        name: docker-graph
+      - mountPath: /lib/modules
+        name: modules
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: nightly-account
+      secret:
+        items:
+        - key: nightly.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - emptyDir: {}
+      name: docker-graph
+    - hostPath:
+        path: /lib/modules
+        type: Directory
+      name: modules
+    - hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+      name: cgroup
+- annotations:
+    testgrid-dashboards: kn-plugin-source-kafka
+    testgrid-tab-name: release
+  cluster: prow-build
+  cron: 43 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-source-kafka
+    repo: kn-plugin-source-kafka
+  name: release_kn-plugin-source-kafka_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --auto-release
+      - --release-gcs
+      - knative-releases/kn-plugin-source-kafka
+      - --release-gcr
+      - gcr.io/knative-releases
+      - --github-token
+      - /etc/hub-token/token
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: ORG_NAME
+        value: knative-sandbox
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/hub-token
+        name: hub-token
+        readOnly: true
+      - mountPath: /etc/release-account
+        name: release-account
+        readOnly: true
+      - mountPath: /docker-graph
+        name: docker-graph
+      - mountPath: /lib/modules
+        name: modules
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: hub-token
+      secret:
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
+    - name: release-account
+      secret:
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - emptyDir: {}
+      name: docker-graph
+    - hostPath:
+        path: /lib/modules
+        type: Directory
+      name: modules
+    - hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+      name: cgroup
 presubmits:
   knative-sandbox/kn-plugin-source-kafka:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-source-kamelet-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-source-kamelet-main.gen.yaml
@@ -5,6 +5,146 @@
 # ####                                                               ####
 # #######################################################################
 
+periodics:
+- annotations:
+    testgrid-dashboards: kn-plugin-source-kamelet
+    testgrid-tab-name: continuous
+  cluster: prow-build
+  cron: 48 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-source-kamelet
+    repo: kn-plugin-source-kamelet
+  name: continuous_kn-plugin-source-kamelet_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./test/presubmit-tests.sh
+      - --all-tests
+      env:
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: kn-plugin-source-kamelet
+    testgrid-tab-name: nightly
+  cluster: prow-build
+  cron: 32 9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-source-kamelet
+    repo: kn-plugin-source-kamelet
+  name: nightly_kn-plugin-source-kamelet_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --publish
+      - --tag-release
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/nightly-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/nightly-account
+        name: nightly-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: nightly-account
+      secret:
+        items:
+        - key: nightly.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: kn-plugin-source-kamelet
+    testgrid-tab-name: release
+  cluster: prow-build
+  cron: 44 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-source-kamelet
+    repo: kn-plugin-source-kamelet
+  name: release_kn-plugin-source-kamelet_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --auto-release
+      - --release-gcs
+      - knative-releases/kn-plugin-source-kamelet
+      - --release-gcr
+      - gcr.io/knative-releases
+      - --github-token
+      - /etc/hub-token/token
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: ORG_NAME
+        value: knative-sandbox
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/hub-token
+        name: hub-token
+        readOnly: true
+      - mountPath: /etc/release-account
+        name: release-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: hub-token
+      secret:
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
+    - name: release-account
+      secret:
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/kn-plugin-source-kamelet:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/net-certmanager-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-certmanager-main.gen.yaml
@@ -5,6 +5,153 @@
 # ####                                                               ####
 # #######################################################################
 
+periodics:
+- annotations:
+    testgrid-dashboards: net-certmanager
+    testgrid-tab-name: continuous
+  cluster: prow-build
+  cron: 24 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/net-certmanager
+    repo: net-certmanager
+  name: continuous_net-certmanager_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./test/presubmit-tests.sh
+      - --all-tests
+      env:
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: net-certmanager
+    testgrid-tab-name: nightly
+  cluster: prow-build
+  cron: 0 9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/net-certmanager
+    repo: net-certmanager
+  name: nightly_net-certmanager_main_periodic
+  reporter_config:
+    slack:
+      channel: net-certmanager
+      job_states_to_report:
+      - failure
+      report_template: |
+        "The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --publish
+      - --tag-release
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/nightly-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/nightly-account
+        name: nightly-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: nightly-account
+      secret:
+        items:
+        - key: nightly.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: net-certmanager
+    testgrid-tab-name: release
+  cluster: prow-build
+  cron: 32 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/net-certmanager
+    repo: net-certmanager
+  name: release_net-certmanager_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --auto-release
+      - --release-gcs
+      - knative-releases/net-certmanager
+      - --release-gcr
+      - gcr.io/knative-releases
+      - --github-token
+      - /etc/hub-token/token
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: ORG_NAME
+        value: knative-sandbox
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/hub-token
+        name: hub-token
+        readOnly: true
+      - mountPath: /etc/release-account
+        name: release-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: hub-token
+      secret:
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
+    - name: release-account
+      secret:
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/net-certmanager:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/net-contour-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-contour-main.gen.yaml
@@ -5,6 +5,153 @@
 # ####                                                               ####
 # #######################################################################
 
+periodics:
+- annotations:
+    testgrid-dashboards: net-contour
+    testgrid-tab-name: continuous
+  cluster: prow-build
+  cron: 55 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/net-contour
+    repo: net-contour
+  name: continuous_net-contour_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./test/presubmit-tests.sh
+      - --all-tests
+      env:
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: net-contour
+    testgrid-tab-name: nightly
+  cluster: prow-build
+  cron: 17 9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/net-contour
+    repo: net-contour
+  name: nightly_net-contour_main_periodic
+  reporter_config:
+    slack:
+      channel: net-contour
+      job_states_to_report:
+      - failure
+      report_template: |
+        "The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --publish
+      - --tag-release
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/nightly-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/nightly-account
+        name: nightly-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: nightly-account
+      secret:
+        items:
+        - key: nightly.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: net-contour
+    testgrid-tab-name: release
+  cluster: prow-build
+  cron: 13 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/net-contour
+    repo: net-contour
+  name: release_net-contour_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --auto-release
+      - --release-gcs
+      - knative-releases/net-contour
+      - --release-gcr
+      - gcr.io/knative-releases
+      - --github-token
+      - /etc/hub-token/token
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: ORG_NAME
+        value: knative-sandbox
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/hub-token
+        name: hub-token
+        readOnly: true
+      - mountPath: /etc/release-account
+        name: release-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: hub-token
+      secret:
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
+    - name: release-account
+      secret:
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/net-contour:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/net-gateway-api-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-gateway-api-main.gen.yaml
@@ -5,6 +5,153 @@
 # ####                                                               ####
 # #######################################################################
 
+periodics:
+- annotations:
+    testgrid-dashboards: net-gateway-api
+    testgrid-tab-name: continuous
+  cluster: prow-build
+  cron: 38 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/net-gateway-api
+    repo: net-gateway-api
+  name: continuous_net-gateway-api_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./test/presubmit-tests.sh
+      - --all-tests
+      env:
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: net-gateway-api
+    testgrid-tab-name: nightly
+  cluster: prow-build
+  cron: 6 9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/net-gateway-api
+    repo: net-gateway-api
+  name: nightly_net-gateway-api_main_periodic
+  reporter_config:
+    slack:
+      channel: net-gateway-api
+      job_states_to_report:
+      - failure
+      report_template: |
+        "The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --publish
+      - --tag-release
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/nightly-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/nightly-account
+        name: nightly-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: nightly-account
+      secret:
+        items:
+        - key: nightly.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: net-gateway-api
+    testgrid-tab-name: release
+  cluster: prow-build
+  cron: 50 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/net-gateway-api
+    repo: net-gateway-api
+  name: release_net-gateway-api_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --auto-release
+      - --release-gcs
+      - knative-releases/net-gateway-api
+      - --release-gcr
+      - gcr.io/knative-releases
+      - --github-token
+      - /etc/hub-token/token
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: ORG_NAME
+        value: knative-sandbox
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/hub-token
+        name: hub-token
+        readOnly: true
+      - mountPath: /etc/release-account
+        name: release-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: hub-token
+      secret:
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
+    - name: release-account
+      secret:
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/net-gateway-api:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/net-http01-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-http01-main.gen.yaml
@@ -5,6 +5,153 @@
 # ####                                                               ####
 # #######################################################################
 
+periodics:
+- annotations:
+    testgrid-dashboards: net-http01
+    testgrid-tab-name: continuous
+  cluster: prow-build
+  cron: 28 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/net-http01
+    repo: net-http01
+  name: continuous_net-http01_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./test/presubmit-tests.sh
+      - --all-tests
+      env:
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: net-http01
+    testgrid-tab-name: nightly
+  cluster: prow-build
+  cron: 20 9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/net-http01
+    repo: net-http01
+  name: nightly_net-http01_main_periodic
+  reporter_config:
+    slack:
+      channel: net-http01
+      job_states_to_report:
+      - failure
+      report_template: |
+        "The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --publish
+      - --tag-release
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/nightly-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/nightly-account
+        name: nightly-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: nightly-account
+      secret:
+        items:
+        - key: nightly.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: net-http01
+    testgrid-tab-name: release
+  cluster: prow-build
+  cron: 4 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/net-http01
+    repo: net-http01
+  name: release_net-http01_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --auto-release
+      - --release-gcs
+      - knative-releases/net-http01
+      - --release-gcr
+      - gcr.io/knative-releases
+      - --github-token
+      - /etc/hub-token/token
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: ORG_NAME
+        value: knative-sandbox
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/hub-token
+        name: hub-token
+        readOnly: true
+      - mountPath: /etc/release-account
+        name: release-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: hub-token
+      secret:
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
+    - name: release-account
+      secret:
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/net-http01:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/net-istio-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-istio-main.gen.yaml
@@ -5,6 +5,153 @@
 # ####                                                               ####
 # #######################################################################
 
+periodics:
+- annotations:
+    testgrid-dashboards: net-istio
+    testgrid-tab-name: continuous
+  cluster: prow-build
+  cron: 41 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/net-istio
+    repo: net-istio
+  name: continuous_net-istio_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./test/presubmit-tests.sh
+      - --all-tests
+      env:
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: net-istio
+    testgrid-tab-name: nightly
+  cluster: prow-build
+  cron: 35 9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/net-istio
+    repo: net-istio
+  name: nightly_net-istio_main_periodic
+  reporter_config:
+    slack:
+      channel: net-istio
+      job_states_to_report:
+      - failure
+      report_template: |
+        "The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --publish
+      - --tag-release
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/nightly-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/nightly-account
+        name: nightly-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: nightly-account
+      secret:
+        items:
+        - key: nightly.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: net-istio
+    testgrid-tab-name: release
+  cluster: prow-build
+  cron: 3 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/net-istio
+    repo: net-istio
+  name: release_net-istio_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --auto-release
+      - --release-gcs
+      - knative-releases/net-istio
+      - --release-gcr
+      - gcr.io/knative-releases
+      - --github-token
+      - /etc/hub-token/token
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: ORG_NAME
+        value: knative-sandbox
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/hub-token
+        name: hub-token
+        readOnly: true
+      - mountPath: /etc/release-account
+        name: release-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: hub-token
+      secret:
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
+    - name: release-account
+      secret:
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/net-istio:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/net-kourier-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-kourier-main.gen.yaml
@@ -5,6 +5,153 @@
 # ####                                                               ####
 # #######################################################################
 
+periodics:
+- annotations:
+    testgrid-dashboards: net-kourier
+    testgrid-tab-name: continuous
+  cluster: prow-build
+  cron: 54 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/net-kourier
+    repo: net-kourier
+  name: continuous_net-kourier_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./test/presubmit-tests.sh
+      - --all-tests
+      env:
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: net-kourier
+    testgrid-tab-name: nightly
+  cluster: prow-build
+  cron: 30 9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/net-kourier
+    repo: net-kourier
+  name: nightly_net-kourier_main_periodic
+  reporter_config:
+    slack:
+      channel: net-kourier
+      job_states_to_report:
+      - failure
+      report_template: |
+        "The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --publish
+      - --tag-release
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/nightly-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/nightly-account
+        name: nightly-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: nightly-account
+      secret:
+        items:
+        - key: nightly.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: net-kourier
+    testgrid-tab-name: release
+  cluster: prow-build
+  cron: 34 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/net-kourier
+    repo: net-kourier
+  name: release_net-kourier_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --auto-release
+      - --release-gcs
+      - knative-releases/net-kourier
+      - --release-gcr
+      - gcr.io/knative-releases
+      - --github-token
+      - /etc/hub-token/token
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: ORG_NAME
+        value: knative-sandbox
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/hub-token
+        name: hub-token
+        readOnly: true
+      - mountPath: /etc/release-account
+        name: release-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: hub-token
+      secret:
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
+    - name: release-account
+      secret:
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/net-kourier:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/sample-controller-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/sample-controller-main.gen.yaml
@@ -5,6 +5,105 @@
 # ####                                                               ####
 # #######################################################################
 
+periodics:
+- annotations:
+    testgrid-dashboards: sample-controller
+    testgrid-tab-name: nightly
+  cluster: prow-build
+  cron: 58 9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/sample-controller
+    repo: sample-controller
+  name: nightly_sample-controller_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --publish
+      - --tag-release
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/nightly-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/nightly-account
+        name: nightly-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: nightly-account
+      secret:
+        items:
+        - key: nightly.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: sample-controller
+    testgrid-tab-name: release
+  cluster: prow-build
+  cron: 14 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/sample-controller
+    repo: sample-controller
+  name: release_sample-controller_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --auto-release
+      - --release-gcs
+      - knative-releases/sample-controller
+      - --release-gcr
+      - gcr.io/knative-releases
+      - --github-token
+      - /etc/hub-token/token
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: ORG_NAME
+        value: knative-sandbox
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/hub-token
+        name: hub-token
+        readOnly: true
+      - mountPath: /etc/release-account
+        name: release-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: hub-token
+      secret:
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
+    - name: release-account
+      secret:
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/sample-controller:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/sample-source-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/sample-source-main.gen.yaml
@@ -5,6 +5,105 @@
 # ####                                                               ####
 # #######################################################################
 
+periodics:
+- annotations:
+    testgrid-dashboards: sample-source
+    testgrid-tab-name: nightly
+  cluster: prow-build
+  cron: 49 9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/sample-source
+    repo: sample-source
+  name: nightly_sample-source_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --publish
+      - --tag-release
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/nightly-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/nightly-account
+        name: nightly-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: nightly-account
+      secret:
+        items:
+        - key: nightly.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: sample-source
+    testgrid-tab-name: release
+  cluster: prow-build
+  cron: 29 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/sample-source
+    repo: sample-source
+  name: release_sample-source_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --auto-release
+      - --release-gcs
+      - knative-releases/sample-source
+      - --release-gcr
+      - gcr.io/knative-releases
+      - --github-token
+      - /etc/hub-token/token
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: ORG_NAME
+        value: knative-sandbox
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/hub-token
+        name: hub-token
+        readOnly: true
+      - mountPath: /etc/release-account
+        name: release-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: hub-token
+      secret:
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
+    - name: release-account
+      secret:
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/sample-source:
   - always_run: true

--- a/prow/jobs/generated/knative/client-main.gen.yaml
+++ b/prow/jobs/generated/knative/client-main.gen.yaml
@@ -5,6 +5,266 @@
 # ####                                                               ####
 # #######################################################################
 
+periodics:
+- annotations:
+    testgrid-dashboards: client
+    testgrid-tab-name: continuous
+  cluster: prow-build
+  cron: 4 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative
+    path_alias: knative.dev/client
+    repo: client
+  name: continuous_client_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./test/presubmit-tests.sh
+      - --all-tests
+      env:
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: client
+    testgrid-tab-name: tekton
+  cluster: prow-build
+  cron: 50 21 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative
+    path_alias: knative.dev/client
+    repo: client
+  name: tekton_client_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./test/tekton-tests.sh
+      env:
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: client
+    testgrid-tab-name: s390x-e2e-tests
+  cluster: prow-build
+  cron: 0 11 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative
+    path_alias: knative.dev/client
+    repo: client
+  name: s390x-e2e-tests_client_main_periodic
+  spec:
+    containers:
+    - args:
+      - bash
+      - -c
+      - |
+        mkdir -p /root/.kube
+        cat /opt/cluster/ci-script > connect.sh
+        chmod +x connect.sh
+        ./connect.sh client-main
+        kubectl get cm s390x-config-client -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
+        chmod +x adjust.sh
+        ./adjust.sh
+        ./test/e2e-tests.sh --run-tests
+      command:
+      - runner.sh
+      env:
+      - name: INGRESS_CLASS
+        value: contour.ingress.networking.knative.dev
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: KO_FLAGS
+        value: --platform=linux/s390x
+      - name: PLATFORM
+        value: linux/s390x
+      - name: KO_DOCKER_REPO
+        valueFrom:
+          secretKeyRef:
+            key: ko-docker-repo
+            name: s390x-cluster1
+      - name: DISABLE_MD_LINTING
+        value: "1"
+      - name: KUBECONFIG
+        value: /root/.kube/config
+      - name: DOCKER_CONFIG
+        value: /opt/cluster
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+      - mountPath: /opt/cluster
+        name: s390x-cluster1
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - name: s390x-cluster1
+      secret:
+        defaultMode: 384
+        secretName: s390x-cluster1
+- annotations:
+    testgrid-dashboards: client
+    testgrid-tab-name: nightly
+  cluster: prow-build
+  cron: 12 9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative
+    path_alias: knative.dev/client
+    repo: client
+  name: nightly_client_main_periodic
+  reporter_config:
+    slack:
+      channel: client
+      job_states_to_report:
+      - failure
+      report_template: |
+        "The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --publish
+      - --tag-release
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/nightly-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/nightly-account
+        name: nightly-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: nightly-account
+      secret:
+        items:
+        - key: nightly.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: client
+    testgrid-tab-name: release
+  cluster: prow-build
+  cron: 4 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative
+    path_alias: knative.dev/client
+    repo: client
+  name: release_client_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --auto-release
+      - --release-gcs
+      - knative-releases/client
+      - --release-gcr
+      - gcr.io/knative-releases
+      - --github-token
+      - /etc/hub-token/token
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/hub-token
+        name: hub-token
+        readOnly: true
+      - mountPath: /etc/release-account
+        name: release-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: hub-token
+      secret:
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
+    - name: release-account
+      secret:
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative/client:
   - always_run: true

--- a/prow/jobs/generated/knative/docs-main.gen.yaml
+++ b/prow/jobs/generated/knative/docs-main.gen.yaml
@@ -5,6 +5,66 @@
 # ####                                                               ####
 # #######################################################################
 
+periodics:
+- annotations:
+    testgrid-dashboards: docs
+    testgrid-tab-name: continuous
+  cluster: prow-build
+  cron: 12 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative
+    path_alias: knative.dev/docs
+    repo: docs
+  name: continuous_docs_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./test/presubmit-tests.sh
+      - --all-tests
+      env:
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+      - mountPath: /docker-graph
+        name: docker-graph
+      - mountPath: /lib/modules
+        name: modules
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - emptyDir: {}
+      name: docker-graph
+    - hostPath:
+        path: /lib/modules
+        type: Directory
+      name: modules
+    - hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+      name: cgroup
 presubmits:
   knative/docs:
   - always_run: true

--- a/prow/jobs/generated/knative/eventing-main.gen.yaml
+++ b/prow/jobs/generated/knative/eventing-main.gen.yaml
@@ -5,6 +5,405 @@
 # ####                                                               ####
 # #######################################################################
 
+periodics:
+- annotations:
+    testgrid-dashboards: eventing
+    testgrid-tab-name: continuous
+  cluster: prow-build
+  cron: 59 */12 * * *
+  decorate: true
+  decoration_config:
+    timeout: 3h0m0s
+  extra_refs:
+  - base_ref: main
+    org: knative
+    path_alias: knative.dev/eventing
+    repo: eventing
+  name: continuous_eventing_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./test/presubmit-tests.sh
+      - --all-tests
+      env:
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources:
+        limits:
+          memory: 16Gi
+        requests:
+          memory: 12Gi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: eventing
+    testgrid-tab-name: s390x-e2e-tests
+  cluster: prow-build
+  cron: 0 7 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative
+    path_alias: knative.dev/eventing
+    repo: eventing
+  name: s390x-e2e-tests_eventing_main_periodic
+  spec:
+    containers:
+    - args:
+      - bash
+      - -c
+      - |
+        mkdir -p /root/.kube
+        cat /opt/cluster/ci-script > connect.sh
+        chmod +x connect.sh
+        ./connect.sh eventing-main
+        kubectl get cm s390x-config-eventing -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
+        chmod +x adjust.sh
+        ./adjust.sh
+        ./test/e2e-tests.sh --run-tests
+      command:
+      - runner.sh
+      env:
+      - name: SYSTEM_NAMESPACE
+        value: knative-eventing
+      - name: SCALE_CHAOSDUCK_TO_ZERO
+        value: "1"
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: KO_FLAGS
+        value: --platform=linux/s390x
+      - name: PLATFORM
+        value: linux/s390x
+      - name: KO_DOCKER_REPO
+        valueFrom:
+          secretKeyRef:
+            key: ko-docker-repo
+            name: s390x-cluster1
+      - name: DISABLE_MD_LINTING
+        value: "1"
+      - name: KUBECONFIG
+        value: /root/.kube/config
+      - name: DOCKER_CONFIG
+        value: /opt/cluster
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources:
+        limits:
+          memory: 16Gi
+        requests:
+          memory: 12Gi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+      - mountPath: /opt/cluster
+        name: s390x-cluster1
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - name: s390x-cluster1
+      secret:
+        defaultMode: 384
+        secretName: s390x-cluster1
+- annotations:
+    testgrid-dashboards: eventing
+    testgrid-tab-name: s390x-e2e-reconciler-tests
+  cluster: prow-build
+  cron: 0 9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative
+    path_alias: knative.dev/eventing
+    repo: eventing
+  name: s390x-e2e-reconciler-tests_eventing_main_periodic
+  spec:
+    containers:
+    - args:
+      - bash
+      - -c
+      - |
+        mkdir -p /root/.kube
+        cat /opt/cluster/ci-script > connect.sh
+        chmod +x connect.sh
+        ./connect.sh eventing_rekt-main
+        kubectl get cm s390x-config-eventing -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
+        chmod +x adjust.sh
+        ./adjust.sh
+        ./test/e2e-rekt-tests.sh --run-tests
+      command:
+      - runner.sh
+      env:
+      - name: SYSTEM_NAMESPACE
+        value: knative-eventing
+      - name: SCALE_CHAOSDUCK_TO_ZERO
+        value: "1"
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: KO_FLAGS
+        value: --platform=linux/s390x
+      - name: PLATFORM
+        value: linux/s390x
+      - name: KO_DOCKER_REPO
+        valueFrom:
+          secretKeyRef:
+            key: ko-docker-repo
+            name: s390x-cluster1
+      - name: DISABLE_MD_LINTING
+        value: "1"
+      - name: KUBECONFIG
+        value: /root/.kube/config
+      - name: DOCKER_CONFIG
+        value: /opt/cluster
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources:
+        limits:
+          memory: 16Gi
+        requests:
+          memory: 12Gi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+      - mountPath: /opt/cluster
+        name: s390x-cluster1
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - name: s390x-cluster1
+      secret:
+        defaultMode: 384
+        secretName: s390x-cluster1
+- annotations:
+    testgrid-dashboards: eventing
+    testgrid-tab-name: ppc64le-e2e-tests
+  cluster: prow-build
+  cron: 0 7 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative
+    path_alias: knative.dev/eventing
+    repo: eventing
+  name: ppc64le-e2e-tests_eventing_main_periodic
+  spec:
+    containers:
+    - args:
+      - bash
+      - -c
+      - |
+        cat /opt/cluster/ci-script > /tmp/connect.sh
+        chmod +x /tmp/connect.sh
+        . /tmp/connect.sh ${CI_JOB}
+        ./test/e2e-tests.sh --run-tests
+      command:
+      - runner.sh
+      env:
+      - name: SYSTEM_NAMESPACE
+        value: knative-eventing
+      - name: SCALE_CHAOSDUCK_TO_ZERO
+        value: "1"
+      - name: CI_JOB
+        value: eventing-main
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: KO_FLAGS
+        value: --platform=linux/ppc64le
+      - name: PLATFORM
+        value: linux/ppc64le
+      - name: KO_DOCKER_REPO
+        value: registry.ppc64le
+      - name: DISABLE_MD_LINTING
+        value: "1"
+      - name: KUBECONFIG
+        value: /root/.kube/config
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources:
+        limits:
+          memory: 16Gi
+        requests:
+          memory: 12Gi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+      - mountPath: /opt/cluster
+        name: ppc64le-cluster
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - name: ppc64le-cluster
+      secret:
+        defaultMode: 384
+        secretName: ppc64le-cluster
+- annotations:
+    testgrid-dashboards: eventing
+    testgrid-tab-name: nightly
+  cluster: prow-build
+  cron: 9 9 * * *
+  decorate: true
+  decoration_config:
+    timeout: 3h0m0s
+  extra_refs:
+  - base_ref: main
+    org: knative
+    path_alias: knative.dev/eventing
+    repo: eventing
+  name: nightly_eventing_main_periodic
+  reporter_config:
+    slack:
+      channel: eventing
+      job_states_to_report:
+      - failure
+      report_template: |
+        "The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --publish
+      - --tag-release
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/nightly-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources:
+        limits:
+          memory: 16Gi
+        requests:
+          memory: 12Gi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/nightly-account
+        name: nightly-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: nightly-account
+      secret:
+        items:
+        - key: nightly.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: eventing
+    testgrid-tab-name: release
+  cluster: prow-build
+  cron: 41 */12 * * *
+  decorate: true
+  decoration_config:
+    timeout: 3h0m0s
+  extra_refs:
+  - base_ref: main
+    org: knative
+    path_alias: knative.dev/eventing
+    repo: eventing
+  name: release_eventing_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --auto-release
+      - --release-gcs
+      - knative-releases/eventing
+      - --release-gcr
+      - gcr.io/knative-releases
+      - --github-token
+      - /etc/hub-token/token
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources:
+        limits:
+          memory: 16Gi
+        requests:
+          memory: 12Gi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/hub-token
+        name: hub-token
+        readOnly: true
+      - mountPath: /etc/release-account
+        name: release-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: hub-token
+      secret:
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
+    - name: release-account
+      secret:
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative/eventing:
   - always_run: true

--- a/prow/jobs/generated/knative/operator-main.gen.yaml
+++ b/prow/jobs/generated/knative/operator-main.gen.yaml
@@ -5,6 +5,226 @@
 # ####                                                               ####
 # #######################################################################
 
+periodics:
+- annotations:
+    testgrid-dashboards: operator
+    testgrid-tab-name: continuous
+  cluster: prow-build
+  cron: 55 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative
+    path_alias: knative.dev/operator
+    repo: operator
+  name: continuous_operator_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./test/presubmit-tests.sh
+      - --all-tests
+      env:
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: operator
+    testgrid-tab-name: s390x-e2e-tests
+  cluster: prow-build
+  cron: 0 13 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative
+    path_alias: knative.dev/operator
+    repo: operator
+  name: s390x-e2e-tests_operator_main_periodic
+  spec:
+    containers:
+    - args:
+      - bash
+      - -c
+      - |
+        mkdir -p /root/.kube
+        cat /opt/cluster/ci-script > connect.sh
+        chmod +x connect.sh
+        ./connect.sh operator-main
+        kubectl get cm s390x-config-operator -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
+        chmod +x adjust.sh
+        ./adjust.sh
+        ./test/e2e-tests.sh --run-tests
+      command:
+      - runner.sh
+      env:
+      - name: INGRESS_CLASS
+        value: contour.ingress.networking.knative.dev
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: KO_FLAGS
+        value: --platform=linux/s390x
+      - name: PLATFORM
+        value: linux/s390x
+      - name: KO_DOCKER_REPO
+        valueFrom:
+          secretKeyRef:
+            key: ko-docker-repo
+            name: s390x-cluster1
+      - name: DISABLE_MD_LINTING
+        value: "1"
+      - name: KUBECONFIG
+        value: /root/.kube/config
+      - name: DOCKER_CONFIG
+        value: /opt/cluster
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+      - mountPath: /opt/cluster
+        name: s390x-cluster1
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - name: s390x-cluster1
+      secret:
+        defaultMode: 384
+        secretName: s390x-cluster1
+- annotations:
+    testgrid-dashboards: operator
+    testgrid-tab-name: nightly
+  cluster: prow-build
+  cron: 5 9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative
+    path_alias: knative.dev/operator
+    repo: operator
+  name: nightly_operator_main_periodic
+  reporter_config:
+    slack:
+      channel: operator
+      job_states_to_report:
+      - failure
+      report_template: |
+        "The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --publish
+      - --tag-release
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/nightly-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/nightly-account
+        name: nightly-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: nightly-account
+      secret:
+        items:
+        - key: nightly.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: operator
+    testgrid-tab-name: release
+  cluster: prow-build
+  cron: 45 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative
+    path_alias: knative.dev/operator
+    repo: operator
+  name: release_operator_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --auto-release
+      - --release-gcs
+      - knative-releases/operator
+      - --release-gcr
+      - gcr.io/knative-releases
+      - --github-token
+      - /etc/hub-token/token
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/hub-token
+        name: hub-token
+        readOnly: true
+      - mountPath: /etc/release-account
+        name: release-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: hub-token
+      secret:
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
+    - name: release-account
+      secret:
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative/operator:
   - always_run: true

--- a/prow/jobs/generated/knative/serving-main.gen.yaml
+++ b/prow/jobs/generated/knative/serving-main.gen.yaml
@@ -5,6 +5,770 @@
 # ####                                                               ####
 # #######################################################################
 
+periodics:
+- annotations:
+    testgrid-dashboards: serving
+    testgrid-tab-name: continuous
+  cluster: prow-build
+  cron: 45 */12 * * *
+  decorate: true
+  decoration_config:
+    timeout: 3h0m0s
+  extra_refs:
+  - base_ref: main
+    org: knative
+    path_alias: knative.dev/serving
+    repo: serving
+  name: continuous_serving_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./test/presubmit-tests.sh
+      - --all-tests
+      env:
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources:
+        limits:
+          memory: 16Gi
+        requests:
+          memory: 12Gi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: serving
+    testgrid-tab-name: istio-latest-mesh
+  cluster: prow-build
+  cron: 36 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative
+    path_alias: knative.dev/serving
+    repo: serving
+  name: istio-latest-mesh_serving_main_periodic
+  spec:
+    containers:
+    - args:
+      - ./test/presubmit-tests.sh
+      - --run-test
+      - ./test/e2e-tests.sh --istio-version latest --mesh
+      - --run-test
+      - ./test/e2e-auto-tls-tests.sh --istio-version latest --mesh
+      command:
+      - runner.sh
+      env:
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources:
+        limits:
+          memory: 16Gi
+        requests:
+          memory: 12Gi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: serving
+    testgrid-tab-name: istio-latest-no-mesh
+  cluster: prow-build
+  cron: 40 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative
+    path_alias: knative.dev/serving
+    repo: serving
+  name: istio-latest-no-mesh_serving_main_periodic
+  spec:
+    containers:
+    - args:
+      - ./test/presubmit-tests.sh
+      - --run-test
+      - ./test/e2e-tests.sh --istio-version latest --mesh
+      - --run-test
+      - ./test/e2e-auto-tls-tests.sh --istio-version latest --mesh
+      command:
+      - runner.sh
+      env:
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources:
+        limits:
+          memory: 16Gi
+        requests:
+          memory: 12Gi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: serving
+    testgrid-tab-name: istio-head-mesh
+  cluster: prow-build
+  cron: 27 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative
+    path_alias: knative.dev/serving
+    repo: serving
+  name: istio-head-mesh_serving_main_periodic
+  spec:
+    containers:
+    - args:
+      - ./test/presubmit-tests.sh
+      - --run-test
+      - ./test/e2e-tests.sh --istio-version head --mesh
+      - --run-test
+      - ./test/e2e-auto-tls-tests.sh --istio-version head --mesh
+      command:
+      - runner.sh
+      env:
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources:
+        limits:
+          memory: 16Gi
+        requests:
+          memory: 12Gi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: serving
+    testgrid-tab-name: istio-head-no-mesh
+  cluster: prow-build
+  cron: 37 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative
+    path_alias: knative.dev/serving
+    repo: serving
+  name: istio-head-no-mesh_serving_main_periodic
+  spec:
+    containers:
+    - args:
+      - ./test/presubmit-tests.sh
+      - --run-test
+      - ./test/e2e-tests.sh --istio-version head --no-mesh
+      - --run-test
+      - ./test/e2e-auto-tls-tests.sh --istio-version head --no-mesh
+      command:
+      - runner.sh
+      env:
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources:
+        limits:
+          memory: 16Gi
+        requests:
+          memory: 12Gi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: serving
+    testgrid-tab-name: kourier-stable
+  cluster: prow-build
+  cron: 7 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative
+    path_alias: knative.dev/serving
+    repo: serving
+  name: kourier-stable_serving_main_periodic
+  spec:
+    containers:
+    - args:
+      - ./test/presubmit-tests.sh
+      - --run-test
+      - ./test/e2e-tests.sh --kourier-version stable
+      - --run-test
+      - ./test/e2e-auto-tls-tests.sh --kourier-version stable --run-http01-auto-tls-tests
+      command:
+      - runner.sh
+      env:
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources:
+        limits:
+          memory: 16Gi
+        requests:
+          memory: 12Gi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: serving
+    testgrid-tab-name: contour-latest
+  cluster: prow-build
+  cron: 28 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative
+    path_alias: knative.dev/serving
+    repo: serving
+  name: contour-latest_serving_main_periodic
+  spec:
+    containers:
+    - args:
+      - ./test/presubmit-tests.sh
+      - --run-test
+      - ./test/e2e-tests.sh --contour-version latest
+      - --run-test
+      - ./test/e2e-auto-tls-tests.sh --contour-version latest --run-http01-auto-tls-tests
+      command:
+      - runner.sh
+      env:
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources:
+        limits:
+          memory: 16Gi
+        requests:
+          memory: 12Gi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: serving
+    testgrid-tab-name: gateway-api-latest
+  cluster: prow-build
+  cron: 47 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative
+    path_alias: knative.dev/serving
+    repo: serving
+  name: gateway-api-latest_serving_main_periodic
+  spec:
+    containers:
+    - args:
+      - ./test/presubmit-tests.sh
+      - --run-test
+      - ./test/e2e-tests.sh --gateway-api-version latest
+      command:
+      - runner.sh
+      env:
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources:
+        limits:
+          memory: 16Gi
+        requests:
+          memory: 12Gi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: serving
+    testgrid-tab-name: https
+  cluster: prow-build
+  cron: 11 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative
+    path_alias: knative.dev/serving
+    repo: serving
+  name: https_serving_main_periodic
+  spec:
+    containers:
+    - args:
+      - ./test/presubmit-tests.sh
+      - --run-test
+      - ./test/e2e-tests.sh --https
+      - --run-test
+      - ./test/e2e-auto-tls-tests.sh --https
+      command:
+      - runner.sh
+      env:
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources:
+        limits:
+          memory: 16Gi
+        requests:
+          memory: 12Gi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: serving
+    testgrid-tab-name: performance-tests-kperf
+  cluster: prow-build
+  cron: 39 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative
+    path_alias: knative.dev/serving
+    repo: serving
+  name: performance-tests-kperf_serving_main_periodic
+  spec:
+    containers:
+    - args:
+      - ./test/presubmit-tests.sh
+      - --run-test
+      - ./test/performance/performance-tests.sh
+      command:
+      - runner.sh
+      env:
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources:
+        limits:
+          memory: 16Gi
+        requests:
+          memory: 12Gi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: serving
+    testgrid-tab-name: s390x-kourier-tests
+  cluster: prow-build
+  cron: 0 3 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative
+    path_alias: knative.dev/serving
+    repo: serving
+  name: s390x-kourier-tests_serving_main_periodic
+  spec:
+    containers:
+    - args:
+      - bash
+      - -c
+      - |
+        mkdir -p /root/.kube
+        cat /opt/cluster/ci-script > connect.sh
+        chmod +x connect.sh
+        server_addr=$(./connect.sh kourier-main)
+        kubectl get cm s390x-config-serving -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
+        chmod +x adjust.sh
+        ./adjust.sh
+        export TEST_OPTIONS=$TEST_OPTIONS' --ingressendpoint '${server_addr}
+        ./test/e2e-tests.sh --run-tests --kourier-version latest
+      command:
+      - runner.sh
+      env:
+      - name: SYSTEM_NAMESPACE
+        value: knative-serving
+      - name: TEST_OPTIONS
+        value: --enable-alpha --enable-beta --resolvabledomain=false
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: KO_FLAGS
+        value: --platform=linux/s390x
+      - name: PLATFORM
+        value: linux/s390x
+      - name: KO_DOCKER_REPO
+        valueFrom:
+          secretKeyRef:
+            key: ko-docker-repo
+            name: s390x-cluster1
+      - name: DISABLE_MD_LINTING
+        value: "1"
+      - name: KUBECONFIG
+        value: /root/.kube/config
+      - name: DOCKER_CONFIG
+        value: /opt/cluster
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources:
+        limits:
+          memory: 16Gi
+        requests:
+          memory: 12Gi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+      - mountPath: /opt/cluster
+        name: s390x-cluster1
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - name: s390x-cluster1
+      secret:
+        defaultMode: 384
+        secretName: s390x-cluster1
+- annotations:
+    testgrid-dashboards: serving
+    testgrid-tab-name: s390x-contour-tests
+  cluster: prow-build
+  cron: 0 5 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative
+    path_alias: knative.dev/serving
+    repo: serving
+  name: s390x-contour-tests_serving_main_periodic
+  spec:
+    containers:
+    - args:
+      - bash
+      - -c
+      - |
+        mkdir -p /root/.kube
+        cat /opt/cluster/ci-script > connect.sh
+        chmod +x connect.sh
+        server_addr=$(./connect.sh contour-main)
+        kubectl get cm s390x-config-serving -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
+        chmod +x adjust.sh
+        ./adjust.sh
+        export TEST_OPTIONS=$TEST_OPTIONS' --ingressendpoint '${server_addr}
+        ./test/e2e-tests.sh --run-tests --contour-version latest
+      command:
+      - runner.sh
+      env:
+      - name: SYSTEM_NAMESPACE
+        value: knative-serving
+      - name: TEST_OPTIONS
+        value: --enable-alpha --enable-beta --resolvabledomain=false
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: KO_FLAGS
+        value: --platform=linux/s390x
+      - name: PLATFORM
+        value: linux/s390x
+      - name: KO_DOCKER_REPO
+        valueFrom:
+          secretKeyRef:
+            key: ko-docker-repo
+            name: s390x-cluster1
+      - name: DISABLE_MD_LINTING
+        value: "1"
+      - name: KUBECONFIG
+        value: /root/.kube/config
+      - name: DOCKER_CONFIG
+        value: /opt/cluster
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources:
+        limits:
+          memory: 16Gi
+        requests:
+          memory: 12Gi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+      - mountPath: /opt/cluster
+        name: s390x-cluster1
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - name: s390x-cluster1
+      secret:
+        defaultMode: 384
+        secretName: s390x-cluster1
+- annotations:
+    testgrid-dashboards: serving
+    testgrid-tab-name: nightly
+  cluster: prow-build
+  cron: 15 9 * * *
+  decorate: true
+  decoration_config:
+    timeout: 3h0m0s
+  extra_refs:
+  - base_ref: main
+    org: knative
+    path_alias: knative.dev/serving
+    repo: serving
+  name: nightly_serving_main_periodic
+  reporter_config:
+    slack:
+      channel: serving
+      job_states_to_report:
+      - failure
+      report_template: |
+        "The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --publish
+      - --tag-release
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/nightly-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources:
+        limits:
+          memory: 16Gi
+        requests:
+          memory: 12Gi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/nightly-account
+        name: nightly-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: nightly-account
+      secret:
+        items:
+        - key: nightly.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: serving
+    testgrid-tab-name: release
+  cluster: prow-build
+  cron: 11 */12 * * *
+  decorate: true
+  decoration_config:
+    timeout: 3h0m0s
+  extra_refs:
+  - base_ref: main
+    org: knative
+    path_alias: knative.dev/serving
+    repo: serving
+  name: release_serving_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --auto-release
+      - --release-gcs
+      - knative-releases/serving
+      - --release-gcr
+      - gcr.io/knative-releases
+      - --github-token
+      - /etc/hub-token/token
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
+      name: ""
+      resources:
+        limits:
+          memory: 16Gi
+        requests:
+          memory: 12Gi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/hub-token
+        name: hub-token
+        readOnly: true
+      - mountPath: /etc/release-account
+        name: release-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: hub-token
+      secret:
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
+    - name: release-account
+      secret:
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative/serving:
   - always_run: true

--- a/prow/jobs_config/knative-sandbox/async-component.yaml
+++ b/prow/jobs_config/knative-sandbox/async-component.yaml
@@ -19,18 +19,18 @@ jobs:
     types: [presubmit]
     command: [runner.sh, ./test/presubmit-tests.sh, --integration-tests]
 
-  # - name: continuous
-  #   types: [periodic]
-  #   command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
+  - name: continuous
+    types: [periodic]
+    command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
 
-  # - name: nightly
-  #   types: [periodic]
-  #   command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
-  #   requirements: [nightly]
-  #   excluded_requirements: [gcp]
+  - name: nightly
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
+    requirements: [nightly]
+    excluded_requirements: [gcp]
 
-  # - name: release
-  #   types: [periodic]
-  #   command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/async-component, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
-  #   requirements: [release]
-  #   excluded_requirements: [gcp]
+  - name: release
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/async-component, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
+    requirements: [release]
+    excluded_requirements: [gcp]

--- a/prow/jobs_config/knative-sandbox/container-freezer.yaml
+++ b/prow/jobs_config/knative-sandbox/container-freezer.yaml
@@ -19,18 +19,18 @@ jobs:
     types: [presubmit]
     command: [runner.sh, ./test/presubmit-tests.sh, --integration-tests]
 
-  # - name: continuous
-  #   types: [periodic]
-  #   command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
+  - name: continuous
+    types: [periodic]
+    command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
 
-  # - name: nightly
-  #   types: [periodic]
-  #   command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
-  #   requirements: [nightly]
-  #   excluded_requirements: [gcp]
+  - name: nightly
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
+    requirements: [nightly]
+    excluded_requirements: [gcp]
 
-  # - name: release
-  #   types: [periodic]
-  #   command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/container-freezer, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
-  #   requirements: [release]
-  #   excluded_requirements: [gcp]
+  - name: release
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/container-freezer, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
+    requirements: [release]
+    excluded_requirements: [gcp]

--- a/prow/jobs_config/knative-sandbox/eventing-autoscaler-keda.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-autoscaler-keda.yaml
@@ -15,18 +15,18 @@ jobs:
     command: [runner.sh, ./test/presubmit-tests.sh, --run-test, "./test/e2e-tests.sh --kafka-mt-source"]
     modifiers: [presubmit_optional]
 
-  # - name: continuous
-  #   types: [periodic]
-  #   command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
+  - name: continuous
+    types: [periodic]
+    command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
 
-  # - name: nightly
-  #   types: [periodic]
-  #   command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
-  #   requirements: [nightly]
-  #   excluded_requirements: [gcp]
+  - name: nightly
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
+    requirements: [nightly]
+    excluded_requirements: [gcp]
 
-  # - name: release
-  #   types: [periodic]
-  #   command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/eventing-autoscaler-keda, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
-  #   requirements: [release]
-  #   excluded_requirements: [gcp]
+  - name: release
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/eventing-autoscaler-keda, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
+    requirements: [release]
+    excluded_requirements: [gcp]

--- a/prow/jobs_config/knative-sandbox/eventing-awssqs.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-awssqs.yaml
@@ -4,19 +4,19 @@ branches: [main]
 image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
 imagePullPolicy: Always
 
-# jobs:
-#   - name: continuous
-#     types: [periodic]
-#     command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
+jobs:
+  - name: continuous
+    types: [periodic]
+    command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
 
-#   - name: nightly
-#     types: [periodic]
-#     command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
-#     requirements: [nightly]
-#     excluded_requirements: [gcp]
+  - name: nightly
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
+    requirements: [nightly]
+    excluded_requirements: [gcp]
 
-#   - name: release
-#     types: [periodic]
-#     command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/eventing-awssqs, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
-#     requirements: [release]
-#     excluded_requirements: [gcp]
+  - name: release
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/eventing-awssqs, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
+    requirements: [release]
+    excluded_requirements: [gcp]

--- a/prow/jobs_config/knative-sandbox/eventing-ceph.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-ceph.yaml
@@ -4,20 +4,20 @@ branches: [main]
 image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
 imagePullPolicy: Always
 
-# jobs:
-#   - name: continuous
-#     types: [periodic]
-#     command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
-#     requirements: [docker]
+jobs:
+  - name: continuous
+    types: [periodic]
+    command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
+    requirements: [docker]
 
-#   - name: nightly
-#     types: [periodic]
-#     command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
-#     requirements: [nightly, docker]
-#     excluded_requirements: [gcp]
+  - name: nightly
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
+    requirements: [nightly, docker]
+    excluded_requirements: [gcp]
 
-#   - name: release
-#     types: [periodic]
-#     command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/eventing-ceph, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
-#     requirements: [release, docker]
-#     excluded_requirements: [gcp]
+  - name: release
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/eventing-ceph, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
+    requirements: [release, docker]
+    excluded_requirements: [gcp]

--- a/prow/jobs_config/knative-sandbox/eventing-couchdb.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-couchdb.yaml
@@ -4,20 +4,20 @@ branches: [main]
 image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
 imagePullPolicy: Always
 
-# jobs:
-#   - name: continuous
-#     types: [periodic]
-#     command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
-#     requirements: [docker]
+jobs:
+  - name: continuous
+    types: [periodic]
+    command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
+    requirements: [docker]
 
-#   - name: nightly
-#     types: [periodic]
-#     command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
-#     requirements: [nightly, docker]
-#     excluded_requirements: [gcp]
+  - name: nightly
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
+    requirements: [nightly, docker]
+    excluded_requirements: [gcp]
 
-#   - name: release
-#     types: [periodic]
-#     command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/eventing-couchdb, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
-#     requirements: [release, docker]
-#     excluded_requirements: [gcp]
+  - name: release
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/eventing-couchdb, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
+    requirements: [release, docker]
+    excluded_requirements: [gcp]

--- a/prow/jobs_config/knative-sandbox/eventing-github.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-github.yaml
@@ -4,20 +4,20 @@ branches: [main]
 image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
 imagePullPolicy: Always
 
-# jobs:
-#   - name: continuous
-#     types: [periodic]
-#     command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
-#     requirements: [docker]
+jobs:
+  - name: continuous
+    types: [periodic]
+    command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
+    requirements: [docker]
 
-#   - name: nightly
-#     types: [periodic]
-#     command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
-#     requirements: [nightly, docker]
-#     excluded_requirements: [gcp]
+  - name: nightly
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
+    requirements: [nightly, docker]
+    excluded_requirements: [gcp]
 
-#   - name: release
-#     types: [periodic]
-#     command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/eventing-github, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
-#     requirements: [release, docker]
-#     excluded_requirements: [gcp]
+  - name: release
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/eventing-github, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
+    requirements: [release, docker]
+    excluded_requirements: [gcp]

--- a/prow/jobs_config/knative-sandbox/eventing-gitlab.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-gitlab.yaml
@@ -4,27 +4,27 @@ branches: [main]
 image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
 imagePullPolicy: Always
 
-# jobs:
-#   - name: continuous
-#     types: [periodic]
-#     command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
-#     requirements: [docker]
+jobs:
+  - name: continuous
+    types: [periodic]
+    command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
+    requirements: [docker]
 
-#   - name: nightly
-#     types: [periodic]
-#     command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
-#     requirements: [nightly, docker]
-#     excluded_requirements: [gcp]
+  - name: nightly
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
+    requirements: [nightly, docker]
+    excluded_requirements: [gcp]
 
-#   - name: release
-#     types: [periodic]
-#     command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/eventing-gitlab, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
-#     requirements: [release, docker]
-#     excluded_requirements: [gcp]
+  - name: release
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/eventing-gitlab, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
+    requirements: [release, docker]
+    excluded_requirements: [gcp]
 
-# resources_presets:
-#   default:
-#     limits:
-#       memory: 16Gi
-#     requests:
-#       memory: 12Gi
+resources_presets:
+  default:
+    limits:
+      memory: 16Gi
+    requests:
+      memory: 12Gi

--- a/prow/jobs_config/knative-sandbox/eventing-kafka-broker.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-kafka-broker.yaml
@@ -78,26 +78,26 @@ jobs:
       - name: EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO
         value: SASL_PLAIN
 
-  # - name: continuous
-  #   types: [periodic]
-  #   command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
-  #   requirements: [docker]
+  - name: continuous
+    types: [periodic]
+    command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
+    requirements: [docker]
 
-  # - name: nightly
-  #   types: [periodic]
-  #   command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
-  #   requirements: [nightly, docker]
-  #   excluded_requirements: [gcp]
-  #   reporter_config:
-  #     slack:
-  #       channel: eventing-kafka
-  #       report_template: |
-  #         "The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"
-  #       job_states_to_report:
-  #       - "failure"
+  - name: nightly
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
+    requirements: [nightly, docker]
+    excluded_requirements: [gcp]
+    reporter_config:
+      slack:
+        channel: eventing-kafka
+        report_template: |
+          "The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"
+        job_states_to_report:
+        - "failure"
 
-  # - name: release
-  #   types: [periodic]
-  #   command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/eventing-kafka-broker, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
-  #   requirements: [release, docker]
-  #   excluded_requirements: [gcp]
+  - name: release
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/eventing-kafka-broker, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
+    requirements: [release, docker]
+    excluded_requirements: [gcp]

--- a/prow/jobs_config/knative-sandbox/eventing-kafka.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-kafka.yaml
@@ -42,51 +42,51 @@ jobs:
     types: [presubmit]
     command: [runner.sh, ./test/presubmit-tests.sh, --run-test, "./test/e2e-upgrade-tests.sh"]
 
-  # - name: continuous
-  #   types: [periodic]
-  #   command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
-  #   requirements: [docker]
+  - name: continuous
+    types: [periodic]
+    command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
+    requirements: [docker]
 
-  # - name: nightly
-  #   types: [periodic]
-  #   command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
-  #   requirements: [nightly, docker]
-  #   excluded_requirements: [gcp]
-  #   reporter_config:
-  #     slack:
-  #       channel: eventing-kafka
-  #       report_template: |
-  #         "The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"
-  #       job_states_to_report:
-  #       - "failure"
+  - name: nightly
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
+    requirements: [nightly, docker]
+    excluded_requirements: [gcp]
+    reporter_config:
+      slack:
+        channel: eventing-kafka
+        report_template: |
+          "The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"
+        job_states_to_report:
+        - "failure"
 
-  # - name: release
-  #   types: [periodic]
-  #   command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/eventing-kafka, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
-  #   requirements: [release, docker]
-  #   excluded_requirements: [gcp]
+  - name: release
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/eventing-kafka, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
+    requirements: [release, docker]
+    excluded_requirements: [gcp]
 
-  # - name: s390x-e2e-tests
-  #   cron: 0 14 * * *
-  #   types: [periodic]
-  #   requirements: [s390x]
-  #   command: [runner.sh]
-  #   args:
-  #     - bash
-  #     - -c
-  #     - |
-  #       mkdir -p /root/.kube
-  #       cat /opt/cluster/ci-script > connect.sh
-  #       chmod +x connect.sh
-  #       ./connect.sh eventing_kafka-main
-  #       kubectl get cm s390x-config-eventing-kafka -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
-  #       chmod +x adjust.sh
-  #       ./adjust.sh
-  #       ./test/e2e-tests.sh --run-tests
-  #   env:
-  #     - name: SYSTEM_NAMESPACE
-  #       value: knative-eventing
-  #     - name: EVENTING_NAMESPACE
-  #       value: knative-eventing
-  #     - name: SCALE_CHAOSDUCK_TO_ZERO
-  #       value: "1"
+  - name: s390x-e2e-tests
+    cron: 0 14 * * *
+    types: [periodic]
+    requirements: [s390x]
+    command: [runner.sh]
+    args:
+      - bash
+      - -c
+      - |
+        mkdir -p /root/.kube
+        cat /opt/cluster/ci-script > connect.sh
+        chmod +x connect.sh
+        ./connect.sh eventing_kafka-main
+        kubectl get cm s390x-config-eventing-kafka -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
+        chmod +x adjust.sh
+        ./adjust.sh
+        ./test/e2e-tests.sh --run-tests
+    env:
+      - name: SYSTEM_NAMESPACE
+        value: knative-eventing
+      - name: EVENTING_NAMESPACE
+        value: knative-eventing
+      - name: SCALE_CHAOSDUCK_TO_ZERO
+        value: "1"

--- a/prow/jobs_config/knative-sandbox/eventing-kogito.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-kogito.yaml
@@ -19,25 +19,25 @@ jobs:
     types: [presubmit]
     command: [runner.sh, ./test/presubmit-tests.sh, --integration-tests]
 
-  # - name: continuous
-  #   types: [periodic]
-  #   command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
+  - name: continuous
+    types: [periodic]
+    command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
 
-  # - name: nightly
-  #   types: [periodic]
-  #   command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
-  #   requirements: [nightly]
-  #   excluded_requirements: [gcp]
-  #   reporter_config:
-  #     slack:
-  #       channel: eventing-sources
-  #       job_states_to_report:
-  #       - failure
-  #       report_template: |
-  #         "The nightly release job for Kogito failed, check the log: <{{.Status.URL}}|View logs>"
+  - name: nightly
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
+    requirements: [nightly]
+    excluded_requirements: [gcp]
+    reporter_config:
+      slack:
+        channel: eventing-sources
+        job_states_to_report:
+        - failure
+        report_template: |
+          "The nightly release job for Kogito failed, check the log: <{{.Status.URL}}|View logs>"
 
-  # - name: release
-  #   types: [periodic]
-  #   command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/eventing-kogito, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
-  #   requirements: [release]
-  #   excluded_requirements: [gcp]
+  - name: release
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/eventing-kogito, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
+    requirements: [release]
+    excluded_requirements: [gcp]

--- a/prow/jobs_config/knative-sandbox/eventing-natss.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-natss.yaml
@@ -4,26 +4,26 @@ branches: [main]
 image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
 imagePullPolicy: Always
 
-# jobs:
-#   - name: continuous
-#     types: [periodic]
-#     command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
+jobs:
+  - name: continuous
+    types: [periodic]
+    command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
 
-#   - name: nightly
-#     types: [periodic]
-#     command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
-#     requirements: [nightly]
-#     excluded_requirements: [gcp]
-#     reporter_config:
-#       slack:
-#         channel: eventing
-#         job_states_to_report:
-#         - failure
-#         report_template: |
-#           "The nightly release job for eventing-natss failed, check the log: <{{.Status.URL}}|View logs>"
+  - name: nightly
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
+    requirements: [nightly]
+    excluded_requirements: [gcp]
+    reporter_config:
+      slack:
+        channel: eventing
+        job_states_to_report:
+        - failure
+        report_template: |
+          "The nightly release job for eventing-natss failed, check the log: <{{.Status.URL}}|View logs>"
 
-#   - name: release
-#     types: [periodic]
-#     command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/eventing-natss, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
-#     requirements: [release]
-#     excluded_requirements: [gcp]
+  - name: release
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/eventing-natss, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
+    requirements: [release]
+    excluded_requirements: [gcp]

--- a/prow/jobs_config/knative-sandbox/eventing-rabbitmq.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-rabbitmq.yaml
@@ -4,26 +4,26 @@ branches: [main]
 image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
 imagePullPolicy: Always
 
-# jobs:
-#   - name: continuous
-#     types: [periodic]
-#     command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
+jobs:
+  - name: continuous
+    types: [periodic]
+    command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
 
-#   - name: nightly
-#     types: [periodic]
-#     command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
-#     requirements: [nightly]
-#     excluded_requirements: [gcp]
-#     reporter_config:
-#       slack:
-#         channel: eventing-rabbitmq
-#         job_states_to_report:
-#         - failure
-#         report_template: |
-#           "The nightly release job for eventing-rabbitmq failed, check the log: <{{.Status.URL}}|View logs>"
+  - name: nightly
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
+    requirements: [nightly]
+    excluded_requirements: [gcp]
+    reporter_config:
+      slack:
+        channel: eventing-rabbitmq
+        job_states_to_report:
+        - failure
+        report_template: |
+          "The nightly release job for eventing-rabbitmq failed, check the log: <{{.Status.URL}}|View logs>"
 
-#   - name: release
-#     types: [periodic]
-#     command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/eventing-rabbitmq, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
-#     requirements: [release]
-#     excluded_requirements: [gcp]
+  - name: release
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/eventing-rabbitmq, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
+    requirements: [release]
+    excluded_requirements: [gcp]

--- a/prow/jobs_config/knative-sandbox/eventing-redis.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-redis.yaml
@@ -4,20 +4,20 @@ branches: [main]
 image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
 imagePullPolicy: Always
 
-# jobs:
-#   - name: continuous
-#     types: [periodic]
-#     command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
-#     requirements: [docker]
+jobs:
+  - name: continuous
+    types: [periodic]
+    command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
+    requirements: [docker]
 
-#   - name: nightly
-#     types: [periodic]
-#     command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
-#     requirements: [nightly, docker]
-#     excluded_requirements: [gcp]
+  - name: nightly
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
+    requirements: [nightly, docker]
+    excluded_requirements: [gcp]
 
-#   - name: release
-#     types: [periodic]
-#     command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/eventing-redis, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
-#     requirements: [release, docker]
-#     excluded_requirements: [gcp]
+  - name: release
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/eventing-redis, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
+    requirements: [release, docker]
+    excluded_requirements: [gcp]

--- a/prow/jobs_config/knative-sandbox/kn-plugin-admin.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-admin.yaml
@@ -19,18 +19,18 @@ jobs:
     types: [presubmit]
     command: [runner.sh, ./test/presubmit-tests.sh, --integration-tests]
 
-  # - name: continuous
-  #   types: [periodic]
-  #   command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
+  - name: continuous
+    types: [periodic]
+    command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
 
-  # - name: nightly
-  #   types: [periodic]
-  #   command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
-  #   requirements: [nightly]
-  #   excluded_requirements: [gcp]
+  - name: nightly
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
+    requirements: [nightly]
+    excluded_requirements: [gcp]
 
-  # - name: release
-  #   types: [periodic]
-  #   command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/kn-plugin-admin, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
-  #   requirements: [release]
-  #   excluded_requirements: [gcp]
+  - name: release
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/kn-plugin-admin, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
+    requirements: [release]
+    excluded_requirements: [gcp]

--- a/prow/jobs_config/knative-sandbox/kn-plugin-diag.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-diag.yaml
@@ -19,6 +19,6 @@ jobs:
     types: [presubmit]
     command: [runner.sh, ./test/presubmit-tests.sh, --integration-tests]
 
-  # - name: continuous
-  #   types: [periodic]
-  #   command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
+  - name: continuous
+    types: [periodic]
+    command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]

--- a/prow/jobs_config/knative-sandbox/kn-plugin-event.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-event.yaml
@@ -19,18 +19,18 @@ jobs:
     types: [presubmit]
     command: [runner.sh, ./test/presubmit-tests.sh, --integration-tests]
 
-  # - name: continuous
-  #   types: [periodic]
-  #   command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
+  - name: continuous
+    types: [periodic]
+    command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
 
-  # - name: nightly
-  #   types: [periodic]
-  #   command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
-  #   requirements: [nightly]
-  #   excluded_requirements: [gcp]
+  - name: nightly
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
+    requirements: [nightly]
+    excluded_requirements: [gcp]
 
-  # - name: release
-  #   types: [periodic]
-  #   command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/kn-plugin-event, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
-  #   requirements: [release]
-  #   excluded_requirements: [gcp]
+  - name: release
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/kn-plugin-event, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
+    requirements: [release]
+    excluded_requirements: [gcp]

--- a/prow/jobs_config/knative-sandbox/kn-plugin-func.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-func.yaml
@@ -4,15 +4,15 @@ branches: [main]
 image: gcr.io/knative-tests/test-infra/prow-tests:v20220608-184bbc48
 imagePullPolicy: Always
 
-# jobs:
-#   - name: nightly
-#     types: [periodic]
-#     command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
-#     requirements: [nightly, docker]
-#     excluded_requirements: [gcp]
+jobs:
+  - name: nightly
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
+    requirements: [nightly, docker]
+    excluded_requirements: [gcp]
 
-#   - name: release
-#     types: [periodic]
-#     command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/kn-plugin-func, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
-#     requirements: [release, docker]
-#     excluded_requirements: [gcp]
+  - name: release
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/kn-plugin-func, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
+    requirements: [release, docker]
+    excluded_requirements: [gcp]

--- a/prow/jobs_config/knative-sandbox/kn-plugin-migration.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-migration.yaml
@@ -19,6 +19,6 @@ jobs:
     types: [presubmit]
     command: [runner.sh, ./test/presubmit-tests.sh, --integration-tests]
 
-  # - name: continuous
-  #   types: [periodic]
-  #   command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
+  - name: continuous
+    types: [periodic]
+    command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]

--- a/prow/jobs_config/knative-sandbox/kn-plugin-operator.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-operator.yaml
@@ -19,6 +19,6 @@ jobs:
     types: [presubmit]
     command: [runner.sh, ./test/presubmit-tests.sh, --integration-tests]
 
-  # - name: continuous
-  #   types: [periodic]
-  #   command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
+  - name: continuous
+    types: [periodic]
+    command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]

--- a/prow/jobs_config/knative-sandbox/kn-plugin-quickstart.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-quickstart.yaml
@@ -19,18 +19,18 @@ jobs:
     types: [presubmit]
     command: [runner.sh, ./test/presubmit-tests.sh, --integration-tests]
 
-  # - name: continuous
-  #   types: [periodic]
-  #   command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
+  - name: continuous
+    types: [periodic]
+    command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
 
-  # - name: nightly
-  #   types: [periodic]
-  #   command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
-  #   requirements: [nightly]
-  #   excluded_requirements: [gcp]
+  - name: nightly
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
+    requirements: [nightly]
+    excluded_requirements: [gcp]
 
-  # - name: release
-  #   types: [periodic]
-  #   command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/kn-plugin-quickstart, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
-  #   requirements: [release]
-  #   excluded_requirements: [gcp]
+  - name: release
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/kn-plugin-quickstart, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
+    requirements: [release]
+    excluded_requirements: [gcp]

--- a/prow/jobs_config/knative-sandbox/kn-plugin-sample.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-sample.yaml
@@ -19,6 +19,6 @@ jobs:
     types: [presubmit]
     command: [runner.sh, ./test/presubmit-tests.sh, --integration-tests]
 
-  # - name: continuous
-  #   types: [periodic]
-  #   command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
+  - name: continuous
+    types: [periodic]
+    command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]

--- a/prow/jobs_config/knative-sandbox/kn-plugin-service-log.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-service-log.yaml
@@ -19,18 +19,18 @@ jobs:
     types: [presubmit]
     command: [runner.sh, ./test/presubmit-tests.sh, --integration-tests]
 
-  # - name: continuous
-  #   types: [periodic]
-  #   command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
+  - name: continuous
+    types: [periodic]
+    command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
 
-  # - name: nightly
-  #   types: [periodic]
-  #   command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
-  #   requirements: [nightly, docker]
-  #   excluded_requirements: [gcp]
+  - name: nightly
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
+    requirements: [nightly, docker]
+    excluded_requirements: [gcp]
 
-  # - name: release
-  #   types: [periodic]
-  #   command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/kn-plugin-service-log, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
-  #   requirements: [release, docker]
-  #   excluded_requirements: [gcp]
+  - name: release
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/kn-plugin-service-log, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
+    requirements: [release, docker]
+    excluded_requirements: [gcp]

--- a/prow/jobs_config/knative-sandbox/kn-plugin-source-kafka.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-source-kafka.yaml
@@ -19,18 +19,18 @@ jobs:
     types: [presubmit]
     command: [runner.sh, ./test/presubmit-tests.sh, --integration-tests]
 
-  # - name: continuous
-  #   types: [periodic]
-  #   command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
+  - name: continuous
+    types: [periodic]
+    command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
 
-  # - name: nightly
-  #   types: [periodic]
-  #   command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
-  #   requirements: [nightly, docker]
-  #   excluded_requirements: [gcp]
+  - name: nightly
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
+    requirements: [nightly, docker]
+    excluded_requirements: [gcp]
 
-  # - name: release
-  #   types: [periodic]
-  #   command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/kn-plugin-source-kafka, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
-  #   requirements: [release, docker]
-  #   excluded_requirements: [gcp]
+  - name: release
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/kn-plugin-source-kafka, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
+    requirements: [release, docker]
+    excluded_requirements: [gcp]

--- a/prow/jobs_config/knative-sandbox/kn-plugin-source-kamelet.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-source-kamelet.yaml
@@ -19,18 +19,18 @@ jobs:
     types: [presubmit]
     command: [runner.sh, ./test/presubmit-tests.sh, --integration-tests]
 
-  # - name: continuous
-  #   types: [periodic]
-  #   command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
+  - name: continuous
+    types: [periodic]
+    command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
 
-  # - name: nightly
-  #   types: [periodic]
-  #   command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
-  #   requirements: [nightly]
-  #   excluded_requirements: [gcp]
+  - name: nightly
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
+    requirements: [nightly]
+    excluded_requirements: [gcp]
 
-  # - name: release
-  #   types: [periodic]
-  #   command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/kn-plugin-source-kamelet, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
-  #   requirements: [release]
-  #   excluded_requirements: [gcp]
+  - name: release
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/kn-plugin-source-kamelet, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
+    requirements: [release]
+    excluded_requirements: [gcp]

--- a/prow/jobs_config/knative-sandbox/net-certmanager.yaml
+++ b/prow/jobs_config/knative-sandbox/net-certmanager.yaml
@@ -19,25 +19,25 @@ jobs:
     types: [presubmit]
     command: [runner.sh, ./test/presubmit-tests.sh, --integration-tests]
 
-  # - name: continuous
-  #   types: [periodic]
-  #   command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
+  - name: continuous
+    types: [periodic]
+    command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
 
-  # - name: nightly
-  #   types: [periodic]
-  #   command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
-  #   requirements: [nightly]
-  #   excluded_requirements: [gcp]
-  #   reporter_config:
-  #     slack:
-  #       channel: net-certmanager
-  #       report_template: |
-  #         "The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"
-  #       job_states_to_report:
-  #       - "failure"
+  - name: nightly
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
+    requirements: [nightly]
+    excluded_requirements: [gcp]
+    reporter_config:
+      slack:
+        channel: net-certmanager
+        report_template: |
+          "The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"
+        job_states_to_report:
+        - "failure"
 
-  # - name: release
-  #   types: [periodic]
-  #   command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/net-certmanager, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
-  #   requirements: [release]
-  #   excluded_requirements: [gcp]
+  - name: release
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/net-certmanager, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
+    requirements: [release]
+    excluded_requirements: [gcp]

--- a/prow/jobs_config/knative-sandbox/net-contour.yaml
+++ b/prow/jobs_config/knative-sandbox/net-contour.yaml
@@ -19,25 +19,25 @@ jobs:
     types: [presubmit]
     command: [runner.sh, ./test/presubmit-tests.sh, --integration-tests]
 
-  # - name: continuous
-  #   types: [periodic]
-  #   command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
+  - name: continuous
+    types: [periodic]
+    command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
 
-  # - name: nightly
-  #   types: [periodic]
-  #   command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
-  #   requirements: [nightly]
-  #   excluded_requirements: [gcp]
-  #   reporter_config:
-  #     slack:
-  #       channel: net-contour
-  #       report_template: |
-  #         "The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"
-  #       job_states_to_report:
-  #       - "failure"
+  - name: nightly
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
+    requirements: [nightly]
+    excluded_requirements: [gcp]
+    reporter_config:
+      slack:
+        channel: net-contour
+        report_template: |
+          "The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"
+        job_states_to_report:
+        - "failure"
 
-  # - name: release
-  #   types: [periodic]
-  #   command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/net-contour, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
-  #   requirements: [release]
-  #   excluded_requirements: [gcp]
+  - name: release
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/net-contour, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
+    requirements: [release]
+    excluded_requirements: [gcp]

--- a/prow/jobs_config/knative-sandbox/net-gateway-api.yaml
+++ b/prow/jobs_config/knative-sandbox/net-gateway-api.yaml
@@ -19,25 +19,25 @@ jobs:
     types: [presubmit]
     command: [runner.sh, ./test/presubmit-tests.sh, --integration-tests]
 
-  # - name: continuous
-  #   types: [periodic]
-  #   command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
+  - name: continuous
+    types: [periodic]
+    command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
 
-  # - name: nightly
-  #   types: [periodic]
-  #   command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
-  #   requirements: [nightly]
-  #   excluded_requirements: [gcp]
-  #   reporter_config:
-  #     slack:
-  #       channel: net-gateway-api
-  #       report_template: |
-  #         "The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"
-  #       job_states_to_report:
-  #       - "failure"
+  - name: nightly
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
+    requirements: [nightly]
+    excluded_requirements: [gcp]
+    reporter_config:
+      slack:
+        channel: net-gateway-api
+        report_template: |
+          "The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"
+        job_states_to_report:
+        - "failure"
 
-  # - name: release
-  #   types: [periodic]
-  #   command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/net-gateway-api, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
-  #   requirements: [release]
-  #   excluded_requirements: [gcp]
+  - name: release
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/net-gateway-api, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
+    requirements: [release]
+    excluded_requirements: [gcp]

--- a/prow/jobs_config/knative-sandbox/net-http01.yaml
+++ b/prow/jobs_config/knative-sandbox/net-http01.yaml
@@ -19,25 +19,25 @@ jobs:
     types: [presubmit]
     command: [runner.sh, ./test/presubmit-tests.sh, --integration-tests]
 
-  # - name: continuous
-  #   types: [periodic]
-  #   command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
+  - name: continuous
+    types: [periodic]
+    command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
 
-  # - name: nightly
-  #   types: [periodic]
-  #   command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
-  #   requirements: [nightly]
-  #   excluded_requirements: [gcp]
-  #   reporter_config:
-  #     slack:
-  #       channel: net-http01
-  #       report_template: |
-  #         "The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"
-  #       job_states_to_report:
-  #       - "failure"
+  - name: nightly
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
+    requirements: [nightly]
+    excluded_requirements: [gcp]
+    reporter_config:
+      slack:
+        channel: net-http01
+        report_template: |
+          "The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"
+        job_states_to_report:
+        - "failure"
 
-  # - name: release
-  #   types: [periodic]
-  #   command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/net-http01, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
-  #   requirements: [release]
-  #   excluded_requirements: [gcp]
+  - name: release
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/net-http01, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
+    requirements: [release]
+    excluded_requirements: [gcp]

--- a/prow/jobs_config/knative-sandbox/net-istio.yaml
+++ b/prow/jobs_config/knative-sandbox/net-istio.yaml
@@ -27,25 +27,25 @@ jobs:
     types: [presubmit]
     command: [runner.sh, ./test/presubmit-tests.sh, --run-test, "./test/e2e-tests.sh --istio-version latest  --mesh"]
 
-  # - name: continuous
-  #   types: [periodic]
-  #   command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
+  - name: continuous
+    types: [periodic]
+    command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
 
-  # - name: nightly
-  #   types: [periodic]
-  #   command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
-  #   requirements: [nightly]
-  #   excluded_requirements: [gcp]
-  #   reporter_config:
-  #     slack:
-  #       channel: net-istio
-  #       report_template: |
-  #         "The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"
-  #       job_states_to_report:
-  #       - "failure"
+  - name: nightly
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
+    requirements: [nightly]
+    excluded_requirements: [gcp]
+    reporter_config:
+      slack:
+        channel: net-istio
+        report_template: |
+          "The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"
+        job_states_to_report:
+        - "failure"
 
-  # - name: release
-  #   types: [periodic]
-  #   command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/net-istio, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
-  #   requirements: [release]
-  #   excluded_requirements: [gcp]
+  - name: release
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/net-istio, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
+    requirements: [release]
+    excluded_requirements: [gcp]

--- a/prow/jobs_config/knative-sandbox/net-kourier.yaml
+++ b/prow/jobs_config/knative-sandbox/net-kourier.yaml
@@ -19,25 +19,25 @@ jobs:
     types: [presubmit]
     command: [runner.sh, ./test/presubmit-tests.sh, --integration-tests]
 
-  # - name: continuous
-  #   types: [periodic]
-  #   command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
+  - name: continuous
+    types: [periodic]
+    command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
 
-  # - name: nightly
-  #   types: [periodic]
-  #   command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
-  #   requirements: [nightly]
-  #   excluded_requirements: [gcp]
-  #   reporter_config:
-  #     slack:
-  #       channel: net-kourier
-  #       report_template: |
-  #         "The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"
-  #       job_states_to_report:
-  #       - "failure"
+  - name: nightly
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
+    requirements: [nightly]
+    excluded_requirements: [gcp]
+    reporter_config:
+      slack:
+        channel: net-kourier
+        report_template: |
+          "The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"
+        job_states_to_report:
+        - "failure"
 
-  # - name: release
-  #   types: [periodic]
-  #   command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/net-kourier, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
-  #   requirements: [release]
-  #   excluded_requirements: [gcp]
+  - name: release
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/net-kourier, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
+    requirements: [release]
+    excluded_requirements: [gcp]

--- a/prow/jobs_config/knative-sandbox/sample-controller.yaml
+++ b/prow/jobs_config/knative-sandbox/sample-controller.yaml
@@ -15,14 +15,14 @@ jobs:
     command: [runner.sh, ./test/presubmit-tests.sh, --unit-tests]
     excluded_requirements: [gcp]
 
-  # - name: nightly
-  #   types: [periodic]
-  #   command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
-  #   requirements: [nightly]
-  #   excluded_requirements: [gcp]
+  - name: nightly
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
+    requirements: [nightly]
+    excluded_requirements: [gcp]
 
-  # - name: release
-  #   types: [periodic]
-  #   command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/sample-controller, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
-  #   requirements: [release]
-  #   excluded_requirements: [gcp]
+  - name: release
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/sample-controller, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
+    requirements: [release]
+    excluded_requirements: [gcp]

--- a/prow/jobs_config/knative-sandbox/sample-source.yaml
+++ b/prow/jobs_config/knative-sandbox/sample-source.yaml
@@ -15,14 +15,14 @@ jobs:
     command: [runner.sh, ./test/presubmit-tests.sh, --unit-tests]
     excluded_requirements: [gcp]
 
-  # - name: nightly
-  #   types: [periodic]
-  #   command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
-  #   requirements: [nightly]
-  #   excluded_requirements: [gcp]
+  - name: nightly
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
+    requirements: [nightly]
+    excluded_requirements: [gcp]
 
-  # - name: release
-  #   types: [periodic]
-  #   command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/sample-source, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
-  #   requirements: [release]
-  #   excluded_requirements: [gcp]
+  - name: release
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/sample-source, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
+    requirements: [release]
+    excluded_requirements: [gcp]

--- a/prow/jobs_config/knative/client.yaml
+++ b/prow/jobs_config/knative/client.yaml
@@ -24,50 +24,50 @@ jobs:
     types: [presubmit]
     command: [runner.sh, ./test/presubmit-integration-tests-latest-release.sh]
 
-  # - name: continuous
-  #   types: [periodic]
-  #   command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
+  - name: continuous
+    types: [periodic]
+    command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
 
-  # - name: tekton
-  #   types: [periodic]
-  #   command: [runner.sh, ./test/tekton-tests.sh]
+  - name: tekton
+    types: [periodic]
+    command: [runner.sh, ./test/tekton-tests.sh]
 
-  # - name: s390x-e2e-tests
-  #   cron: 0 11 * * *
-  #   types: [periodic]
-  #   requirements: [s390x]
-  #   command: [runner.sh]
-  #   args:
-  #     - bash
-  #     - -c
-  #     - |
-  #       mkdir -p /root/.kube
-  #       cat /opt/cluster/ci-script > connect.sh
-  #       chmod +x connect.sh
-  #       ./connect.sh client-main
-  #       kubectl get cm s390x-config-client -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
-  #       chmod +x adjust.sh
-  #       ./adjust.sh
-  #       ./test/e2e-tests.sh --run-tests
-  #   env:
-  #     - name: INGRESS_CLASS
-  #       value: contour.ingress.networking.knative.dev
+  - name: s390x-e2e-tests
+    cron: 0 11 * * *
+    types: [periodic]
+    requirements: [s390x]
+    command: [runner.sh]
+    args:
+      - bash
+      - -c
+      - |
+        mkdir -p /root/.kube
+        cat /opt/cluster/ci-script > connect.sh
+        chmod +x connect.sh
+        ./connect.sh client-main
+        kubectl get cm s390x-config-client -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
+        chmod +x adjust.sh
+        ./adjust.sh
+        ./test/e2e-tests.sh --run-tests
+    env:
+      - name: INGRESS_CLASS
+        value: contour.ingress.networking.knative.dev
 
-  # - name: nightly
-  #   types: [periodic]
-  #   command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
-  #   requirements: [nightly]
-  #   excluded_requirements: [gcp]
-  #   reporter_config:
-  #     slack:
-  #       channel: client
-  #       report_template: |
-  #         "The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"
-  #       job_states_to_report:
-  #       - "failure"
+  - name: nightly
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
+    requirements: [nightly]
+    excluded_requirements: [gcp]
+    reporter_config:
+      slack:
+        channel: client
+        report_template: |
+          "The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"
+        job_states_to_report:
+        - "failure"
 
-  # - name: release
-  #   types: [periodic]
-  #   command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/client, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
-  #   requirements: [release]
-  #   excluded_requirements: [gcp]
+  - name: release
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/client, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
+    requirements: [release]
+    excluded_requirements: [gcp]

--- a/prow/jobs_config/knative/docs.yaml
+++ b/prow/jobs_config/knative/docs.yaml
@@ -15,7 +15,7 @@ jobs:
     command: [runner.sh, ./test/presubmit-tests.sh, --unit-tests]
     excluded_requirements: [gcp]
 
-  # - name: continuous
-  #   types: [periodic]
-  #   command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
-  #   requirements: [docker]
+  - name: continuous
+    types: [periodic]
+    command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
+    requirements: [docker]

--- a/prow/jobs_config/knative/eventing.yaml
+++ b/prow/jobs_config/knative/eventing.yaml
@@ -29,98 +29,98 @@ jobs:
     types: [presubmit]
     command: [runner.sh, ./test/presubmit-tests.sh, --run-test, ./test/e2e-upgrade-tests.sh]
 
-  # - name: continuous
-  #   types: [periodic]
-  #   timeout: 3h
-  #   command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
+  - name: continuous
+    types: [periodic]
+    timeout: 3h
+    command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
 
-  # - name: s390x-e2e-tests
-  #   cron: 0 7 * * *
-  #   types: [periodic]
-  #   requirements: [s390x]
-  #   command: [runner.sh]
-  #   args:
-  #     - bash
-  #     - -c
-  #     - |
-  #       mkdir -p /root/.kube
-  #       cat /opt/cluster/ci-script > connect.sh
-  #       chmod +x connect.sh
-  #       ./connect.sh eventing-main
-  #       kubectl get cm s390x-config-eventing -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
-  #       chmod +x adjust.sh
-  #       ./adjust.sh
-  #       ./test/e2e-tests.sh --run-tests
-  #   env:
-  #     - name: SYSTEM_NAMESPACE
-  #       value: knative-eventing
-  #     - name: SCALE_CHAOSDUCK_TO_ZERO
-  #       value: "1"
+  - name: s390x-e2e-tests
+    cron: 0 7 * * *
+    types: [periodic]
+    requirements: [s390x]
+    command: [runner.sh]
+    args:
+      - bash
+      - -c
+      - |
+        mkdir -p /root/.kube
+        cat /opt/cluster/ci-script > connect.sh
+        chmod +x connect.sh
+        ./connect.sh eventing-main
+        kubectl get cm s390x-config-eventing -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
+        chmod +x adjust.sh
+        ./adjust.sh
+        ./test/e2e-tests.sh --run-tests
+    env:
+      - name: SYSTEM_NAMESPACE
+        value: knative-eventing
+      - name: SCALE_CHAOSDUCK_TO_ZERO
+        value: "1"
 
-  # - name: s390x-e2e-reconciler-tests
-  #   cron: 0 9 * * *
-  #   types: [periodic]
-  #   requirements: [s390x]
-  #   command: [runner.sh]
-  #   args:
-  #     - bash
-  #     - -c
-  #     - |
-  #       mkdir -p /root/.kube
-  #       cat /opt/cluster/ci-script > connect.sh
-  #       chmod +x connect.sh
-  #       ./connect.sh eventing_rekt-main
-  #       kubectl get cm s390x-config-eventing -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
-  #       chmod +x adjust.sh
-  #       ./adjust.sh
-  #       ./test/e2e-rekt-tests.sh --run-tests
-  #   env:
-  #     - name: SYSTEM_NAMESPACE
-  #       value: knative-eventing
-  #     - name: SCALE_CHAOSDUCK_TO_ZERO
-  #       value: "1"
+  - name: s390x-e2e-reconciler-tests
+    cron: 0 9 * * *
+    types: [periodic]
+    requirements: [s390x]
+    command: [runner.sh]
+    args:
+      - bash
+      - -c
+      - |
+        mkdir -p /root/.kube
+        cat /opt/cluster/ci-script > connect.sh
+        chmod +x connect.sh
+        ./connect.sh eventing_rekt-main
+        kubectl get cm s390x-config-eventing -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
+        chmod +x adjust.sh
+        ./adjust.sh
+        ./test/e2e-rekt-tests.sh --run-tests
+    env:
+      - name: SYSTEM_NAMESPACE
+        value: knative-eventing
+      - name: SCALE_CHAOSDUCK_TO_ZERO
+        value: "1"
 
-  # - name: ppc64le-e2e-tests
-  #   cron: 0 7 * * *
-  #   types: [periodic]
-  #   requirements: [ppc64le]
-  #   command: [runner.sh]
-  #   args:
-  #     - bash
-  #     - -c
-  #     - |
-  #       cat /opt/cluster/ci-script > /tmp/connect.sh
-  #       chmod +x /tmp/connect.sh
-  #       . /tmp/connect.sh ${CI_JOB}
-  #       ./test/e2e-tests.sh --run-tests
-  #   env:
-  #     - name: SYSTEM_NAMESPACE
-  #       value: knative-eventing
-  #     - name: SCALE_CHAOSDUCK_TO_ZERO
-  #       value: "1"
-  #     - name: CI_JOB
-  #       value: "eventing-main"
+  - name: ppc64le-e2e-tests
+    cron: 0 7 * * *
+    types: [periodic]
+    requirements: [ppc64le]
+    command: [runner.sh]
+    args:
+      - bash
+      - -c
+      - |
+        cat /opt/cluster/ci-script > /tmp/connect.sh
+        chmod +x /tmp/connect.sh
+        . /tmp/connect.sh ${CI_JOB}
+        ./test/e2e-tests.sh --run-tests
+    env:
+      - name: SYSTEM_NAMESPACE
+        value: knative-eventing
+      - name: SCALE_CHAOSDUCK_TO_ZERO
+        value: "1"
+      - name: CI_JOB
+        value: "eventing-main"
 
-  # - name: nightly
-  #   types: [periodic]
-  #   timeout: 3h
-  #   command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
-  #   requirements: [nightly]
-  #   excluded_requirements: [gcp]
-  #   reporter_config:
-  #     slack:
-  #       channel: eventing
-  #       report_template: |
-  #         "The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"
-  #       job_states_to_report:
-  #       - "failure"
+  - name: nightly
+    types: [periodic]
+    timeout: 3h
+    command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
+    requirements: [nightly]
+    excluded_requirements: [gcp]
+    reporter_config:
+      slack:
+        channel: eventing
+        report_template: |
+          "The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"
+        job_states_to_report:
+        - "failure"
 
-  # - name: release
-  #   types: [periodic]
-  #   timeout: 3h
-  #   command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/eventing, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
-  #   requirements: [release]
-  #   excluded_requirements: [gcp]
+  - name: release
+    types: [periodic]
+    timeout: 3h
+    command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/eventing, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
+    requirements: [release]
+    excluded_requirements: [gcp]
 
 resources: high
 resources_presets:

--- a/prow/jobs_config/knative/operator.yaml
+++ b/prow/jobs_config/knative/operator.yaml
@@ -31,46 +31,46 @@ jobs:
     types: [presubmit]
     command: [runner.sh, ./test/presubmit-tests.sh, --run-test, ./test/e2e-eventing-upgrade-tests.sh]
 
-  # - name: continuous
-  #   types: [periodic]
-  #   command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
+  - name: continuous
+    types: [periodic]
+    command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
 
-  # - name: s390x-e2e-tests
-  #   cron: 0 13 * * *
-  #   types: [periodic]
-  #   requirements: [s390x]
-  #   command: [runner.sh]
-  #   args:
-  #     - bash
-  #     - -c
-  #     - |
-  #       mkdir -p /root/.kube
-  #       cat /opt/cluster/ci-script > connect.sh
-  #       chmod +x connect.sh
-  #       ./connect.sh operator-main
-  #       kubectl get cm s390x-config-operator -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
-  #       chmod +x adjust.sh
-  #       ./adjust.sh
-  #       ./test/e2e-tests.sh --run-tests
-  #   env:
-  #     - name: INGRESS_CLASS
-  #       value: contour.ingress.networking.knative.dev
+  - name: s390x-e2e-tests
+    cron: 0 13 * * *
+    types: [periodic]
+    requirements: [s390x]
+    command: [runner.sh]
+    args:
+      - bash
+      - -c
+      - |
+        mkdir -p /root/.kube
+        cat /opt/cluster/ci-script > connect.sh
+        chmod +x connect.sh
+        ./connect.sh operator-main
+        kubectl get cm s390x-config-operator -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
+        chmod +x adjust.sh
+        ./adjust.sh
+        ./test/e2e-tests.sh --run-tests
+    env:
+      - name: INGRESS_CLASS
+        value: contour.ingress.networking.knative.dev
 
-  # - name: nightly
-  #   types: [periodic]
-  #   command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
-  #   requirements: [nightly]
-  #   excluded_requirements: [gcp]
-  #   reporter_config:
-  #     slack:
-  #       channel: operator
-  #       report_template: |
-  #         "The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"
-  #       job_states_to_report:
-  #       - "failure"
+  - name: nightly
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
+    requirements: [nightly]
+    excluded_requirements: [gcp]
+    reporter_config:
+      slack:
+        channel: operator
+        report_template: |
+          "The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"
+        job_states_to_report:
+        - "failure"
 
-  # - name: release
-  #   types: [periodic]
-  #   command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/operator, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
-  #   requirements: [release]
-  #   excluded_requirements: [gcp]
+  - name: release
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/operator, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
+    requirements: [release]
+    excluded_requirements: [gcp]

--- a/prow/jobs_config/knative/serving.yaml
+++ b/prow/jobs_config/knative/serving.yaml
@@ -96,174 +96,174 @@ jobs:
     - "./test/e2e-auto-tls-tests.sh --https"
     modifiers: [presubmit_optional, presubmit_skipped]
 
-  # - name: continuous
-  #   timeout: 3h
-  #   types: [periodic]
-  #   command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
+  - name: continuous
+    timeout: 3h
+    types: [periodic]
+    command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
 
-  # - name: istio-latest-mesh
-  #   types: [periodic]
-  #   command:
-  #   - runner.sh
-  #   args:
-  #   - ./test/presubmit-tests.sh
-  #   - --run-test
-  #   - ./test/e2e-tests.sh --istio-version latest --mesh
-  #   - --run-test
-  #   - ./test/e2e-auto-tls-tests.sh --istio-version latest --mesh
+  - name: istio-latest-mesh
+    types: [periodic]
+    command:
+    - runner.sh
+    args:
+    - ./test/presubmit-tests.sh
+    - --run-test
+    - ./test/e2e-tests.sh --istio-version latest --mesh
+    - --run-test
+    - ./test/e2e-auto-tls-tests.sh --istio-version latest --mesh
 
-  # - name: istio-latest-no-mesh
-  #   types: [periodic]
-  #   command:
-  #   - runner.sh
-  #   args:
-  #   - ./test/presubmit-tests.sh
-  #   - --run-test
-  #   - ./test/e2e-tests.sh --istio-version latest --mesh
-  #   - --run-test
-  #   - ./test/e2e-auto-tls-tests.sh --istio-version latest --mesh
+  - name: istio-latest-no-mesh
+    types: [periodic]
+    command:
+    - runner.sh
+    args:
+    - ./test/presubmit-tests.sh
+    - --run-test
+    - ./test/e2e-tests.sh --istio-version latest --mesh
+    - --run-test
+    - ./test/e2e-auto-tls-tests.sh --istio-version latest --mesh
 
-  # - name: istio-head-mesh
-  #   types: [periodic]
-  #   command:
-  #   - runner.sh
-  #   args:
-  #   - ./test/presubmit-tests.sh
-  #   - --run-test
-  #   - ./test/e2e-tests.sh --istio-version head --mesh
-  #   - --run-test
-  #   - ./test/e2e-auto-tls-tests.sh --istio-version head --mesh
+  - name: istio-head-mesh
+    types: [periodic]
+    command:
+    - runner.sh
+    args:
+    - ./test/presubmit-tests.sh
+    - --run-test
+    - ./test/e2e-tests.sh --istio-version head --mesh
+    - --run-test
+    - ./test/e2e-auto-tls-tests.sh --istio-version head --mesh
 
-  # - name: istio-head-no-mesh
-  #   types: [periodic]
-  #   command:
-  #   - runner.sh
-  #   args:
-  #   - ./test/presubmit-tests.sh
-  #   - --run-test
-  #   - ./test/e2e-tests.sh --istio-version head --no-mesh
-  #   - --run-test
-  #   - ./test/e2e-auto-tls-tests.sh --istio-version head --no-mesh
+  - name: istio-head-no-mesh
+    types: [periodic]
+    command:
+    - runner.sh
+    args:
+    - ./test/presubmit-tests.sh
+    - --run-test
+    - ./test/e2e-tests.sh --istio-version head --no-mesh
+    - --run-test
+    - ./test/e2e-auto-tls-tests.sh --istio-version head --no-mesh
 
-  # - name: kourier-stable
-  #   types: [periodic]
-  #   command:
-  #   - runner.sh
-  #   args:
-  #   - ./test/presubmit-tests.sh
-  #   - --run-test
-  #   - ./test/e2e-tests.sh --kourier-version stable
-  #   - --run-test
-  #   - ./test/e2e-auto-tls-tests.sh --kourier-version stable --run-http01-auto-tls-tests
+  - name: kourier-stable
+    types: [periodic]
+    command:
+    - runner.sh
+    args:
+    - ./test/presubmit-tests.sh
+    - --run-test
+    - ./test/e2e-tests.sh --kourier-version stable
+    - --run-test
+    - ./test/e2e-auto-tls-tests.sh --kourier-version stable --run-http01-auto-tls-tests
 
-  # - name: contour-latest
-  #   types: [periodic]
-  #   command:
-  #   - runner.sh
-  #   args:
-  #   - ./test/presubmit-tests.sh
-  #   - --run-test
-  #   - ./test/e2e-tests.sh --contour-version latest
-  #   - --run-test
-  #   - ./test/e2e-auto-tls-tests.sh --contour-version latest --run-http01-auto-tls-tests
+  - name: contour-latest
+    types: [periodic]
+    command:
+    - runner.sh
+    args:
+    - ./test/presubmit-tests.sh
+    - --run-test
+    - ./test/e2e-tests.sh --contour-version latest
+    - --run-test
+    - ./test/e2e-auto-tls-tests.sh --contour-version latest --run-http01-auto-tls-tests
 
-  # - name: gateway-api-latest
-  #   types: [periodic]
-  #   command:
-  #   - runner.sh
-  #   args:
-  #   - ./test/presubmit-tests.sh
-  #   - --run-test
-  #   - ./test/e2e-tests.sh --gateway-api-version latest
+  - name: gateway-api-latest
+    types: [periodic]
+    command:
+    - runner.sh
+    args:
+    - ./test/presubmit-tests.sh
+    - --run-test
+    - ./test/e2e-tests.sh --gateway-api-version latest
 
-  # - name: https
-  #   types: [periodic]
-  #   command:
-  #   - runner.sh
-  #   args:
-  #   - ./test/presubmit-tests.sh
-  #   - --run-test
-  #   - ./test/e2e-tests.sh --https
-  #   - --run-test
-  #   - ./test/e2e-auto-tls-tests.sh --https
+  - name: https
+    types: [periodic]
+    command:
+    - runner.sh
+    args:
+    - ./test/presubmit-tests.sh
+    - --run-test
+    - ./test/e2e-tests.sh --https
+    - --run-test
+    - ./test/e2e-auto-tls-tests.sh --https
 
-  # - name: performance-tests-kperf
-  #   types: [periodic]
-  #   command:
-  #   - runner.sh
-  #   args:
-  #   - ./test/presubmit-tests.sh
-  #   - --run-test
-  #   - ./test/performance/performance-tests.sh
+  - name: performance-tests-kperf
+    types: [periodic]
+    command:
+    - runner.sh
+    args:
+    - ./test/presubmit-tests.sh
+    - --run-test
+    - ./test/performance/performance-tests.sh
 
-  # - name: s390x-kourier-tests
-  #   cron: 0 3 * * *
-  #   types: [periodic]
-  #   requirements: [s390x]
-  #   command: [runner.sh]
-  #   args:
-  #     - bash
-  #     - -c
-  #     - |
-  #       mkdir -p /root/.kube
-  #       cat /opt/cluster/ci-script > connect.sh
-  #       chmod +x connect.sh
-  #       server_addr=$(./connect.sh kourier-main)
-  #       kubectl get cm s390x-config-serving -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
-  #       chmod +x adjust.sh
-  #       ./adjust.sh
-  #       export TEST_OPTIONS=$TEST_OPTIONS' --ingressendpoint '${server_addr}
-  #       ./test/e2e-tests.sh --run-tests --kourier-version latest
-  #   env:
-  #     - name: SYSTEM_NAMESPACE
-  #       value: knative-serving
-  #     - name: TEST_OPTIONS
-  #       value: "--enable-alpha --enable-beta --resolvabledomain=false"
+  - name: s390x-kourier-tests
+    cron: 0 3 * * *
+    types: [periodic]
+    requirements: [s390x]
+    command: [runner.sh]
+    args:
+      - bash
+      - -c
+      - |
+        mkdir -p /root/.kube
+        cat /opt/cluster/ci-script > connect.sh
+        chmod +x connect.sh
+        server_addr=$(./connect.sh kourier-main)
+        kubectl get cm s390x-config-serving -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
+        chmod +x adjust.sh
+        ./adjust.sh
+        export TEST_OPTIONS=$TEST_OPTIONS' --ingressendpoint '${server_addr}
+        ./test/e2e-tests.sh --run-tests --kourier-version latest
+    env:
+      - name: SYSTEM_NAMESPACE
+        value: knative-serving
+      - name: TEST_OPTIONS
+        value: "--enable-alpha --enable-beta --resolvabledomain=false"
 
-  # - name: s390x-contour-tests
-  #   cron: 0 5 * * *
-  #   types: [periodic]
-  #   requirements: [s390x]
-  #   command: [runner.sh]
-  #   args:
-  #     - bash
-  #     - -c
-  #     - |
-  #       mkdir -p /root/.kube
-  #       cat /opt/cluster/ci-script > connect.sh
-  #       chmod +x connect.sh
-  #       server_addr=$(./connect.sh contour-main)
-  #       kubectl get cm s390x-config-serving -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
-  #       chmod +x adjust.sh
-  #       ./adjust.sh
-  #       export TEST_OPTIONS=$TEST_OPTIONS' --ingressendpoint '${server_addr}
-  #       ./test/e2e-tests.sh --run-tests --contour-version latest
-  #   env:
-  #     - name: SYSTEM_NAMESPACE
-  #       value: knative-serving
-  #     - name: TEST_OPTIONS
-  #       value: "--enable-alpha --enable-beta --resolvabledomain=false"
+  - name: s390x-contour-tests
+    cron: 0 5 * * *
+    types: [periodic]
+    requirements: [s390x]
+    command: [runner.sh]
+    args:
+      - bash
+      - -c
+      - |
+        mkdir -p /root/.kube
+        cat /opt/cluster/ci-script > connect.sh
+        chmod +x connect.sh
+        server_addr=$(./connect.sh contour-main)
+        kubectl get cm s390x-config-serving -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
+        chmod +x adjust.sh
+        ./adjust.sh
+        export TEST_OPTIONS=$TEST_OPTIONS' --ingressendpoint '${server_addr}
+        ./test/e2e-tests.sh --run-tests --contour-version latest
+    env:
+      - name: SYSTEM_NAMESPACE
+        value: knative-serving
+      - name: TEST_OPTIONS
+        value: "--enable-alpha --enable-beta --resolvabledomain=false"
 
-  # - name: nightly
-  #   types: [periodic]
-  #   timeout: 3h
-  #   command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
-  #   requirements: [nightly]
-  #   excluded_requirements: [gcp]
-  #   reporter_config:
-  #     slack:
-  #       channel: serving
-  #       report_template: |
-  #         "The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"
-  #       job_states_to_report:
-  #       - "failure"
+  - name: nightly
+    types: [periodic]
+    timeout: 3h
+    command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
+    requirements: [nightly]
+    excluded_requirements: [gcp]
+    reporter_config:
+      slack:
+        channel: serving
+        report_template: |
+          "The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"
+        job_states_to_report:
+        - "failure"
 
-  # - name: release
-  #   types: [periodic]
-  #   timeout: 3h
-  #   command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/serving, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
-  #   requirements: [release]
-  #   excluded_requirements: [gcp]
+  - name: release
+    types: [periodic]
+    timeout: 3h
+    command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/serving, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
+    requirements: [release]
+    excluded_requirements: [gcp]
 
 resources: high
 resources_presets:


### PR DESCRIPTION
Reverts knative/test-infra#3378

These prowjobs need to be enabled after the migration.

/hold

/cc @kvmware 