### PR TITLE
Disable Workload Identity for `test-pods/default` service account and update deck notice.

### DIFF
--- a/prow/cluster/build/200-serviceaccounts.yaml
+++ b/prow/cluster/build/200-serviceaccounts.yaml
@@ -24,13 +24,9 @@ metadata:
   name: test-runner
   namespace: test-pods
 ---
-# we need to drop the annotation on this service account after the istio prowgen is fixed.
-# There is a bug where a service account can't specified in requirements presets :(
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  annotations:
-    iam.gke.io/gcp-service-account: prow-job@knative-tests.iam.gserviceaccount.com
   name: default
   namespace: test-pods
 ---

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -75,7 +75,7 @@ deck:
     gcs_browser_prefix: https://console.cloud.google.com/storage/browser/
     testgrid_config: gs://knative-testgrid/config
     testgrid_root: https://testgrid.knative.dev/
-    announcement: "Prow will be migrated to a new GKE Cluster at 11/05/2022 14:00 UTC / 07:00 PDT , it will be offline for approximately six hours. Please reach out on productivity slack channel to report issues."
+    announcement: "Please reach out on the #productivity slack channel to report issues with Knative Test Infrastructure."
     lenses:
     - lens:
         name: metadata


### PR DESCRIPTION
**Which issue(s) this PR fixes**:<br>

Enabling Workload Identity also broke gcloud auth activate-service-account commands for some reason which it shouldn't. :confused: 

I will disable and reenable it when the istio prowgen has been fixed properly and all our jobs are running on custom kubernetes service accounts.

<!-- 
  Use `Fixes #<issue number>`, or `Fixes (paste link of issue)`
  to automatically close linked issue when the PR is merged.
  Uncomment and fill below if the PR does not close any issues.
-->
<!--
**What this PR does, why we need it**:<br>
-->

<!--
  If there is any golang code in this PR please uncomment the 
  `/lint` statement below to have Prow automatically lint it.
-->
<!--
  /lint
-->

/cc @kvmware