### PR TITLE
Move to EasyCLA instead of Google CLA.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -231,7 +231,7 @@ branch-protection:
       protect: true
       required_status_checks:
         contexts:
-        - cla/google
+        - EasyCLA
         - tide
       exclude:
       - "^dependabot/" # don't protect branches created by dependabot
@@ -248,7 +248,7 @@ branch-protection:
       protect: true
       required_status_checks:
         contexts:
-        - cla/google
+        - EasyCLA
         - tide
       exclude:
       - "^dependabot/" # don't protect branches created by dependabot


### PR DESCRIPTION
This commit changes the required status check for all repositories in
knative and knative-sandbox to require EasyCLA instead of Google's CLA.

Signed-off-by: Lance Ball <lball@redhat.com>
