### PR TITLE
s390x: disabled TLS check for remote registry with self-signed certificate

### DIFF
--- a/prow/jobs/generated/knative-sandbox/eventing-kafka-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kafka-main.gen.yaml
@@ -246,7 +246,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x
+        value: --platform=linux/s390x --insecure-registry
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO

--- a/prow/jobs/generated/knative/client-main.gen.yaml
+++ b/prow/jobs/generated/knative/client-main.gen.yaml
@@ -123,7 +123,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x
+        value: --platform=linux/s390x --insecure-registry
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO

--- a/prow/jobs/generated/knative/client-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative/client-release-1.2.gen.yaml
@@ -83,7 +83,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x
+        value: --platform=linux/s390x --insecure-registry
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO

--- a/prow/jobs/generated/knative/client-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative/client-release-1.3.gen.yaml
@@ -83,7 +83,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x
+        value: --platform=linux/s390x --insecure-registry
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO

--- a/prow/jobs/generated/knative/client-release-1.4.gen.yaml
+++ b/prow/jobs/generated/knative/client-release-1.4.gen.yaml
@@ -83,7 +83,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x
+        value: --platform=linux/s390x --insecure-registry
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO

--- a/prow/jobs/generated/knative/client-release-1.5.gen.yaml
+++ b/prow/jobs/generated/knative/client-release-1.5.gen.yaml
@@ -83,7 +83,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x
+        value: --platform=linux/s390x --insecure-registry
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO

--- a/prow/jobs/generated/knative/eventing-main.gen.yaml
+++ b/prow/jobs/generated/knative/eventing-main.gen.yaml
@@ -91,7 +91,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x
+        value: --platform=linux/s390x --insecure-registry
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO
@@ -172,7 +172,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x
+        value: --platform=linux/s390x --insecure-registry
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO

--- a/prow/jobs/generated/knative/eventing-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative/eventing-release-1.2.gen.yaml
@@ -91,7 +91,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x
+        value: --platform=linux/s390x --insecure-registry
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO
@@ -172,7 +172,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x
+        value: --platform=linux/s390x --insecure-registry
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO

--- a/prow/jobs/generated/knative/eventing-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative/eventing-release-1.3.gen.yaml
@@ -91,7 +91,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x
+        value: --platform=linux/s390x --insecure-registry
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO
@@ -172,7 +172,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x
+        value: --platform=linux/s390x --insecure-registry
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO

--- a/prow/jobs/generated/knative/eventing-release-1.4.gen.yaml
+++ b/prow/jobs/generated/knative/eventing-release-1.4.gen.yaml
@@ -91,7 +91,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x
+        value: --platform=linux/s390x --insecure-registry
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO
@@ -172,7 +172,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x
+        value: --platform=linux/s390x --insecure-registry
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO

--- a/prow/jobs/generated/knative/eventing-release-1.5.gen.yaml
+++ b/prow/jobs/generated/knative/eventing-release-1.5.gen.yaml
@@ -91,7 +91,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x
+        value: --platform=linux/s390x --insecure-registry
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO
@@ -172,7 +172,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x
+        value: --platform=linux/s390x --insecure-registry
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO

--- a/prow/jobs/generated/knative/operator-main.gen.yaml
+++ b/prow/jobs/generated/knative/operator-main.gen.yaml
@@ -83,7 +83,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x
+        value: --platform=linux/s390x --insecure-registry
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO

--- a/prow/jobs/generated/knative/operator-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative/operator-release-1.2.gen.yaml
@@ -83,7 +83,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x
+        value: --platform=linux/s390x --insecure-registry
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO

--- a/prow/jobs/generated/knative/operator-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative/operator-release-1.3.gen.yaml
@@ -83,7 +83,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x
+        value: --platform=linux/s390x --insecure-registry
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO

--- a/prow/jobs/generated/knative/operator-release-1.4.gen.yaml
+++ b/prow/jobs/generated/knative/operator-release-1.4.gen.yaml
@@ -83,7 +83,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x
+        value: --platform=linux/s390x --insecure-registry
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO

--- a/prow/jobs/generated/knative/operator-release-1.5.gen.yaml
+++ b/prow/jobs/generated/knative/operator-release-1.5.gen.yaml
@@ -83,7 +83,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x
+        value: --platform=linux/s390x --insecure-registry
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO

--- a/prow/jobs/generated/knative/serving-main.gen.yaml
+++ b/prow/jobs/generated/knative/serving-main.gen.yaml
@@ -711,7 +711,7 @@ periodics:
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       - name: KO_FLAGS
-        value: --platform=linux/s390x
+        value: --platform=linux/s390x --insecure-registry
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO
@@ -811,7 +811,7 @@ periodics:
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       - name: KO_FLAGS
-        value: --platform=linux/s390x
+        value: --platform=linux/s390x --insecure-registry
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO

--- a/prow/jobs/generated/knative/serving-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative/serving-release-1.2.gen.yaml
@@ -92,7 +92,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x
+        value: --platform=linux/s390x --insecure-registry
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO
@@ -174,7 +174,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x
+        value: --platform=linux/s390x --insecure-registry
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO

--- a/prow/jobs/generated/knative/serving-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative/serving-release-1.3.gen.yaml
@@ -92,7 +92,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x
+        value: --platform=linux/s390x --insecure-registry
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO
@@ -174,7 +174,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x
+        value: --platform=linux/s390x --insecure-registry
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO

--- a/prow/jobs/generated/knative/serving-release-1.4.gen.yaml
+++ b/prow/jobs/generated/knative/serving-release-1.4.gen.yaml
@@ -92,7 +92,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x
+        value: --platform=linux/s390x --insecure-registry
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO
@@ -174,7 +174,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x
+        value: --platform=linux/s390x --insecure-registry
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO

--- a/prow/jobs/generated/knative/serving-release-1.5.gen.yaml
+++ b/prow/jobs/generated/knative/serving-release-1.5.gen.yaml
@@ -92,7 +92,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x
+        value: --platform=linux/s390x --insecure-registry
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO
@@ -174,7 +174,7 @@ periodics:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/test-account/service-account.json
       - name: KO_FLAGS
-        value: --platform=linux/s390x
+        value: --platform=linux/s390x --insecure-registry
       - name: PLATFORM
         value: linux/s390x
       - name: KO_DOCKER_REPO

--- a/prow/jobs_config/.base.yaml
+++ b/prow/jobs_config/.base.yaml
@@ -104,7 +104,7 @@ requirement_presets:
   s390x:
     env:
       - name: KO_FLAGS
-        value: "--platform=linux/s390x"
+        value: "--platform=linux/s390x --insecure-registry"
       - name: PLATFORM
         value: "linux/s390x"
       - name: KO_DOCKER_REPO


### PR DESCRIPTION
Signed-off-by: Dirk Haubenreisser <haubenr@de.ibm.com>

**Which issue(s) this PR fixes**:<br>

This PR is to update the existing custom jobs for s390x to enable communication with a remote image registry that uses a self-signed certificate for HTTPS support by introducing a new flag for `ko`.
