### PR TITLE
Enable ArgoCD for managing cluster state

### DIFF
--- a/infra/gcp/dns/dns.tf
+++ b/infra/gcp/dns/dns.tf
@@ -26,6 +26,18 @@ module "knative_dev" {
     },
     {
       name = ""
+      type = "MX"
+      ttl  = 300
+      records = [
+        "1 aspmx.l.google.com.",
+        "5 alt1.aspmx.l.google.com.",
+        "5 alt2.aspmx.l.google.com.",
+        "10 alt3.aspmx.l.google.com.",
+        "10 alt4.aspmx.l.google.com.",
+      ]
+    },
+    {
+      name = ""
       type = "CAA"
       ttl  = 300
       records = [
@@ -38,7 +50,7 @@ module "knative_dev" {
       type = "TXT"
       ttl  = 300
       records = [
-        "\"v=spf1 ?all\"",
+        "\"v=spf1 include:_spf.google.com ~all\"",
         "google-site-verification=w5KR-YluNH94Htu_LcKidfaDfQhlyzRaCp4-_VI5yFY"
       ]
     },

--- a/infra/gcp/tests/iam.tf
+++ b/infra/gcp/tests/iam.tf
@@ -82,6 +82,12 @@ module "iam" {
       "serviceAccount:prow-job@knative-tests.iam.gserviceaccount.com",
       "serviceAccount:pwg-admins@knative-tests.iam.gserviceaccount.com"
     ]
+
+    "roles/iap.httpsResourceAccessor" = [
+      "group:kn-infra-gcp-org-admins@knative.team",
+      "domain:knative.team",
+      "group:wg-leads@knative.team"
+    ]
   }
 }
 

--- a/prow/cluster/gitops/README.md
+++ b/prow/cluster/gitops/README.md
@@ -2,7 +2,7 @@
 We use argocd to sync cluster state with the configuration specified in knative/test-infra.
 
 ArgoCD runs in the prow cluster and manages the following clusters:
-- prow 
+- prow
 - prow-build
 - ~~prow-trusted~~
 

--- a/prow/cluster/gitops/README.md
+++ b/prow/cluster/gitops/README.md
@@ -1,0 +1,21 @@
+
+We use argocd to sync cluster state with the configuration specified in knative/test-infra.
+
+ArgoCD runs in the prow cluster and manages the following clusters:
+- prow 
+- prow-build
+- ~~prow-trusted~~
+
+
+ArgoCD requires onetime bootstrap and occasional upgrades:
+- Deploy the contents of bootstrap `k create ns argocd && k apply -k prow/cluster/gitops/bootstrap -n argocd `
+- Download argocd cli
+- `argocd login -core`
+- `argocd cluster add gke_knative-tests_us-central1_prow-build`
+- `argocd cluster add gke_knative-tests_us-central1_prow`
+- `argocd cluster add gke_knative-tests_us-central1-a_prow-trusted`
+- `k apply -f prow/cluster/gitops/bootstrap/apps.yaml`
+
+
+Couple of notes:
+- Argo UI is accessible at https://argo.knative.dev, but it is restricted to the Google Groups that have IAP-secured Web App User on the knative-tests project.

--- a/prow/cluster/gitops/apps/eso-build.yaml
+++ b/prow/cluster/gitops/apps/eso-build.yaml
@@ -1,0 +1,29 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: external-secrets-build
+  namespace: argocd
+spec:
+  destination:
+    name: prow-build
+    namespace: external-secrets
+  source:
+    repoURL: 'https://charts.external-secrets.io'
+    targetRevision: v0.5.7
+    helm:
+      releaseName: external-secrets
+      parameters:
+        - name: installCRDs
+          value: 'true'
+        - name: serviceAccount.name
+          value: external-secrets
+        - name: serviceAccount.annotations.iam\.gke\.io/gcp-service-account
+          value: kubernetes-external-secrets-sa@knative-tests.iam.gserviceaccount.com
+    chart: external-secrets
+  project: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/prow/cluster/gitops/apps/eso-prow-build.yaml
+++ b/prow/cluster/gitops/apps/eso-prow-build.yaml
@@ -1,0 +1,27 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: external-secrets-prow-build
+  namespace: argocd
+spec:
+  destination:
+    name: prow-build
+    namespace: external-secrets
+  source:
+    repoURL: 'https://charts.external-secrets.io'
+    targetRevision: v0.5.7
+    helm:
+      releaseName: external-secrets
+      parameters:
+        - name: installCRDs
+          value: 'true'
+        - name: serviceAccount.name
+          value: external-secrets
+        - name: serviceAccount.annotations.iam\.gke\.io/gcp-service-account
+          value: kubernetes-external-secrets-sa@knative-tests.iam.gserviceaccount.com
+    chart: external-secrets
+  project: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/prow/cluster/gitops/apps/eso-prow-build.yaml
+++ b/prow/cluster/gitops/apps/eso-prow-build.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   destination:
     name: prow-build
-    namespace: external-secrets
+    namespace: default
   source:
     repoURL: 'https://charts.external-secrets.io'
     targetRevision: v0.5.7

--- a/prow/cluster/gitops/apps/eso-prow.yaml
+++ b/prow/cluster/gitops/apps/eso-prow.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   destination:
     name: in-cluster # argocd is running on prow cluster
-    namespace: external-secrets
+    namespace: default
   source:
     repoURL: 'https://charts.external-secrets.io'
     targetRevision: v0.5.7
@@ -22,8 +22,8 @@ spec:
     chart: external-secrets
   project: default
   syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
+    # automated:
+    #   prune: true
+    #   selfHeal: true
     syncOptions:
       - CreateNamespace=true

--- a/prow/cluster/gitops/apps/eso-prow.yaml
+++ b/prow/cluster/gitops/apps/eso-prow.yaml
@@ -1,11 +1,11 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: external-secrets-build
+  name: external-secrets-prow
   namespace: argocd
 spec:
   destination:
-    name: prow-build
+    name: in-cluster # argocd is running on prow cluster
     namespace: external-secrets
   source:
     repoURL: 'https://charts.external-secrets.io'

--- a/prow/cluster/gitops/apps/eso-trusted.yaml
+++ b/prow/cluster/gitops/apps/eso-trusted.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   destination:
     name: prow-trusted
-    namespace: external-secrets
+    namespace: default
   source:
     repoURL: 'https://charts.external-secrets.io'
     targetRevision: v0.5.7

--- a/prow/cluster/gitops/apps/eso-trusted.yaml
+++ b/prow/cluster/gitops/apps/eso-trusted.yaml
@@ -1,0 +1,29 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: external-secrets-trusted
+  namespace: argocd
+spec:
+  destination:
+    name: prow-trusted
+    namespace: external-secrets
+  source:
+    repoURL: 'https://charts.external-secrets.io'
+    targetRevision: v0.5.7
+    helm:
+      releaseName: external-secrets
+      parameters:
+        - name: installCRDs
+          value: 'true'
+        - name: serviceAccount.name
+          value: external-secrets
+        - name: serviceAccount.annotations.iam\.gke\.io/gcp-service-account
+          value: kubernetes-external-secrets-sa@knative-tests.iam.gserviceaccount.com
+    chart: external-secrets
+  project: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/prow/cluster/gitops/apps/prow-build.yaml
+++ b/prow/cluster/gitops/apps/prow-build.yaml
@@ -16,5 +16,3 @@ spec:
     automated:
       prune: true
       selfHeal: true
-    syncOptions:
-      - CreateNamespace=true

--- a/prow/cluster/gitops/apps/prow-build.yaml
+++ b/prow/cluster/gitops/apps/prow-build.yaml
@@ -1,0 +1,15 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: prow-build
+  namespace: argocd
+spec:
+  destination:
+    name: prow-build
+    namespace: test-pods
+  project: default
+  source:
+    path: prow/cluster/build
+    repoURL: https://github.com/knative/test-infra
+    targetRevision: main
+

--- a/prow/cluster/gitops/apps/prow.yaml
+++ b/prow/cluster/gitops/apps/prow.yaml
@@ -1,20 +1,18 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: prow-build
+  name: prow
   namespace: argocd
 spec:
   destination:
-    name: prow-build
-    namespace: test-pods
+    name: in-cluster # argocd is running on prow cluster
+    namespace: default
   project: default
   source:
-    path: prow/cluster/build
+    path: prow/cluster/control-plane
     repoURL: https://github.com/knative/test-infra
     targetRevision: main
   syncPolicy:
     automated:
       prune: true
       selfHeal: true
-    syncOptions:
-      - CreateNamespace=true

--- a/prow/cluster/gitops/bootstrap/apps.yaml
+++ b/prow/cluster/gitops/bootstrap/apps.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: apps
+  namespace: argocd
+spec:
+  destination:
+    namespace: argocd
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: prow/cluster/gitops/apps
+    repoURL: https://github.com/knative/test-infra
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: false
+      selfHeal: true

--- a/prow/cluster/gitops/bootstrap/argocd-cm-rbac.yaml
+++ b/prow/cluster/gitops/bootstrap/argocd-cm-rbac.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-rbac-cm
+data:
+  policy.default: role:readonly

--- a/prow/cluster/gitops/bootstrap/argocd-cm.yaml
+++ b/prow/cluster/gitops/bootstrap/argocd-cm.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cm
+data:
+  url: https://argo.knative.dev
+  users.anonymous.enabled: "true"
+  application.instanceLabelKey: knative.dev/instance
+  resource.compareoptions: |
+    ignoreAggregatedRoles: true
+  resource.customizations: |
+    admissionregistration.k8s.io/MutatingWebhookConfiguration:
+      ignoreDifferences: |
+        jqPathExpressions:
+        - '.webhooks[]?.clientConfig.caBundle'
+  dex.config: |
+    connectors:
+      - type: authproxy
+        id: iap_proxy
+        name: "Google IAP Proxy"
+        config:
+          userHeader: "X-Goog-Authenticated-User-Email"

--- a/prow/cluster/gitops/bootstrap/argocd-server-service.yaml
+++ b/prow/cluster/gitops/bootstrap/argocd-server-service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    cloud.google.com/app-protocols: '{"https":"HTTPS","http":"HTTP"}'
+    cloud.google.com/neg: '{"ingress": true}'
+    cloud.google.com/backend-config: '{"default": "argocd"}'
+  name: argocd-server
+spec:
+  type: NodePort

--- a/prow/cluster/gitops/bootstrap/extras.yaml
+++ b/prow/cluster/gitops/bootstrap/extras.yaml
@@ -1,0 +1,40 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: argo
+  namespace: argocd
+  annotations:
+    kubernetes.io/ingress.global-static-ip-name: argo-ingress
+    networking.gke.io/managed-certificates: argo-knative-dev
+spec:
+  rules:
+  - host: argo.knative.dev
+    http:
+      paths:
+      - path: /*
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: argocd-server
+            port:
+              number: 443
+---
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: argo-knative-dev
+  namespace: argocd
+spec:
+  domains:
+  - argo.knative.dev
+---
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: argocd
+  namespace: argocd
+spec:
+  iap:
+    enabled: true
+    oauthclientCredentials:
+      secretName: iap-secret

--- a/prow/cluster/gitops/bootstrap/kustomization.yaml
+++ b/prow/cluster/gitops/bootstrap/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- https://raw.githubusercontent.com/argoproj/argo-cd/v2.4.3/manifests/ha/install.yaml
+- extras.yaml
+
+patchesStrategicMerge:
+- argocd-server-service.yaml
+- argocd-cm.yaml
+- argocd-cm-rbac.yaml


### PR DESCRIPTION
Fixes: #3363 

/cc @dprotaso @kvmware 

/hold I need to remove the external-secrets operator code from the repo and load it as Helm Chart before merging this PR.

https://argo.knative.dev 