### PR TITLE
Add prow job for client-main e2e test on ppc64le

### DIFF
--- a/prow/jobs/generated/knative/client-main.gen.yaml
+++ b/prow/jobs/generated/knative/client-main.gen.yaml
@@ -164,6 +164,74 @@ periodics:
         secretName: s390x-cluster1
 - annotations:
     testgrid-dashboards: client
+    testgrid-tab-name: ppc64le-e2e-tests
+  cluster: prow-build
+  cron: 0 11 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative
+    path_alias: knative.dev/client
+    repo: client
+  name: ppc64le-e2e-tests_client_main_periodic
+  spec:
+    containers:
+    - args:
+      - bash
+      - -c
+      - |
+        cat /opt/cluster/ci-script > /tmp/connect.sh
+        chmod +x /tmp/connect.sh
+        . /tmp/connect.sh ${CI_JOB}
+        ./test/e2e-tests.sh --run-tests
+      command:
+      - runner.sh
+      env:
+      - name: INGRESS_CLASS
+        value: contour.ingress.networking.knative.dev
+      - name: CI_JOB
+        value: client-main
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: KO_FLAGS
+        value: --platform=linux/ppc64le
+      - name: PLATFORM
+        value: linux/ppc64le
+      - name: KO_DOCKER_REPO
+        value: registry.ppc64le
+      - name: DISABLE_MD_LINTING
+        value: "1"
+      - name: KUBECONFIG
+        value: /root/.kube/config
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220623-6fb57832
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+      - mountPath: /opt/cluster
+        name: ppc64le-cluster
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - name: ppc64le-cluster
+      secret:
+        defaultMode: 384
+        secretName: ppc64le-cluster
+- annotations:
+    testgrid-dashboards: client
     testgrid-tab-name: nightly
   cluster: prow-build
   cron: 12 9 * * *

--- a/prow/jobs_config/knative/client.yaml
+++ b/prow/jobs_config/knative/client.yaml
@@ -53,6 +53,25 @@ jobs:
       - name: INGRESS_CLASS
         value: contour.ingress.networking.knative.dev
 
+  - name: ppc64le-e2e-tests
+    cron: 0 11 * * *
+    types: [periodic]
+    requirements: [ppc64le]
+    command: [runner.sh]
+    args:
+      - bash
+      - -c
+      - |
+        cat /opt/cluster/ci-script > /tmp/connect.sh
+        chmod +x /tmp/connect.sh
+        . /tmp/connect.sh ${CI_JOB}
+        ./test/e2e-tests.sh --run-tests
+    env:
+      - name: INGRESS_CLASS
+        value: contour.ingress.networking.knative.dev
+      - name: CI_JOB
+        value: "client-main"
+
   - name: nightly
     types: [periodic]
     command: [runner.sh, ./hack/release.sh, --publish, --tag-release]

--- a/tools/release-jobs-syncer/pkg/jobs_sync.go
+++ b/tools/release-jobs-syncer/pkg/jobs_sync.go
@@ -45,7 +45,7 @@ const (
 var extraPeriodicProwJobsToSync map[string]sets.String = map[string]sets.String{
 	"knative/serving":  sets.NewString("s390x-kourier-tests", "s390x-contour-tests"),
 	"knative/eventing": sets.NewString("s390x-e2e-tests", "s390x-e2e-reconciler-tests", "ppc64le-e2e-tests"),
-	"knative/client":   sets.NewString("s390x-e2e-tests","ppc64le-e2e-tests"),
+	"knative/client":   sets.NewString("s390x-e2e-tests", "ppc64le-e2e-tests"),
 	"knative/operator": sets.NewString("s390x-e2e-tests"),
 }
 

--- a/tools/release-jobs-syncer/pkg/jobs_sync.go
+++ b/tools/release-jobs-syncer/pkg/jobs_sync.go
@@ -45,7 +45,7 @@ const (
 var extraPeriodicProwJobsToSync map[string]sets.String = map[string]sets.String{
 	"knative/serving":  sets.NewString("s390x-kourier-tests", "s390x-contour-tests"),
 	"knative/eventing": sets.NewString("s390x-e2e-tests", "s390x-e2e-reconciler-tests", "ppc64le-e2e-tests"),
-	"knative/client":   sets.NewString("s390x-e2e-tests"),
+	"knative/client":   sets.NewString("s390x-e2e-tests","ppc64le-e2e-tests"),
 	"knative/operator": sets.NewString("s390x-e2e-tests"),
 }
 


### PR DESCRIPTION
Signed-off-by: mdafsanhossain <Mdafsan.Hossain@ibm.com>

**Which issue(s) this PR fixes**:<br>This PR adds nightly CI testing job for knative/client on ppc64le hardware. This is in continuation to the previous PR #3255 for enabling nightly CI on IBM power.

/cc @coryrc
