### PR TITLE
Add new Shared GKE Cluster

### DIFF
--- a/infra/gcp/.terraform.lock.hcl
+++ b/infra/gcp/.terraform.lock.hcl
@@ -1,28 +1,9 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/hashicorp/external" {
-  version = "2.2.2"
-  hashes = [
-    "h1:VUkgcWvCliS0HO4kt7oEQhFD2gcx/59XpwMqxfCU1kE=",
-    "zh:0b84ab0af2e28606e9c0c1289343949339221c3ab126616b831ddb5aaef5f5ca",
-    "zh:10cf5c9b9524ca2e4302bf02368dc6aac29fb50aeaa6f7758cce9aa36ae87a28",
-    "zh:56a016ee871c8501acb3f2ee3b51592ad7c3871a1757b098838349b17762ba6b",
-    "zh:719d6ef39c50e4cffc67aa67d74d195adaf42afcf62beab132dafdb500347d39",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:7fbfc4d37435ac2f717b0316f872f558f608596b389b895fcb549f118462d327",
-    "zh:8ac71408204db606ce63fe8f9aeaf1ddc7751d57d586ec421e62d440c402e955",
-    "zh:a4cacdb06f114454b6ed0033add28006afa3f65a0ea7a43befe45fc82e6809fb",
-    "zh:bb5ce3132b52ae32b6cc005bc9f7627b95259b9ffe556de4dad60d47d47f21f0",
-    "zh:bb60d2976f125ffd232a7ccb4b3f81e7109578b23c9c6179f13a11d125dca82a",
-    "zh:f9540ecd2e056d6e71b9ea5f5a5cf8f63dd5c25394b9db831083a9d4ea99b372",
-    "zh:ffd998b55b8a64d4335a090b6956b4bf8855b290f7554dd38db3302de9c41809",
-  ]
-}
-
 provider "registry.terraform.io/hashicorp/google" {
   version     = "4.15.0"
-  constraints = ">= 3.43.0, >= 3.50.0, >= 3.53.0, ~> 4.5, 4.15.0, < 5.0.0"
+  constraints = ">= 2.12.0, >= 3.43.0, >= 3.45.0, >= 3.50.0, >= 3.53.0, >= 3.83.0, ~> 4.5, ~> 4.11, 4.15.0, < 5.0.0"
   hashes = [
     "h1:kCR1yWEPkPv1R6qsKlAarmXtUVLsbP6ogsfJmaYyV0M=",
     "zh:179d039e925fe5f2f3400a1c79ee08483c60decfcb0f01f589caa3a43f1c936f",
@@ -41,7 +22,7 @@ provider "registry.terraform.io/hashicorp/google" {
 
 provider "registry.terraform.io/hashicorp/google-beta" {
   version     = "4.15.0"
-  constraints = ">= 3.1.0, >= 3.43.0, >= 3.50.0, ~> 4.5, 4.15.0, < 5.0.0"
+  constraints = ">= 3.43.0, >= 3.45.0, >= 3.50.0, >= 3.53.0, >= 4.10.0, ~> 4.11, 4.15.0, < 5.0.0"
   hashes = [
     "h1:Cupn0m42MugM84c6l8Lf2COayheuv4FdEzcI6tLzLXI=",
     "zh:07fc12806f1ff8aa9ae2d95587a1861cf90ff2e08c456e23e98acd2f8d9d86a9",
@@ -60,7 +41,7 @@ provider "registry.terraform.io/hashicorp/google-beta" {
 
 provider "registry.terraform.io/hashicorp/kubernetes" {
   version     = "2.10.0"
-  constraints = "~> 2.0"
+  constraints = "~> 2.10"
   hashes = [
     "h1:v+xmcw54lMETOlhKPO61AlbxGB0OU8BphMfOO62e0Uo=",
     "zh:0b011e77f02bc05194062c0a39f321a4f1bea0bae61787b0c1f5808f6efb2a26",

--- a/infra/gcp/analytics/README.md
+++ b/infra/gcp/analytics/README.md
@@ -1,0 +1,3 @@
+# Knative Analytics
+
+This project holds the analytics dataset used by Knative.

--- a/infra/gcp/iam.tf
+++ b/infra/gcp/iam.tf
@@ -6,37 +6,37 @@ module "iam" {
 
   bindings = {
     "roles/iam.organizationRoleAdmin" = [
-      "group:kn-infra-gcp-org-admins@knative.team",
+      "group:kn-infra-gcp-org-admins@knative.dev",
       "serviceAccount:terraform@knative-seed.iam.gserviceaccount.com",
     ]
 
     "roles/resourcemanager.organizationAdmin" = [
-      "group:kn-infra-gcp-org-admins@knative.team",
+      "group:kn-infra-gcp-org-admins@knative.dev",
       "serviceAccount:terraform@knative-seed.iam.gserviceaccount.com",
     ]
 
     "roles/cloudsupport.techSupportEditor" = [
-      "domain:knative.team",
-      "group:kn-infra-gcp-org-admins@knative.team"
+      "domain:knative.dev",
+      "group:kn-infra-gcp-org-admins@knative.dev"
     ]
 
     "roles/owner" = [
-      "group:kn-infra-gcp-org-admins@knative.team",
+      "group:kn-infra-gcp-org-admins@knative.dev",
       "serviceAccount:terraform@knative-seed.iam.gserviceaccount.com",
     ]
 
     "roles/resourcemanager.folderAdmin" = [
-      "group:kn-infra-gcp-org-admins@knative.team",
+      "group:kn-infra-gcp-org-admins@knative.dev",
       "serviceAccount:terraform@knative-seed.iam.gserviceaccount.com",
     ]
 
     "roles/browser" = [
-      "domain:knative.team",
+      "domain:knative.dev",
       "group:gke-security-groups@knative.dev",
     ]
 
     "roles/resourcemanager.projectCreator" = [
-      "group:kn-infra-gcp-org-admins@knative.team",
+      "group:kn-infra-gcp-org-admins@knative.dev",
       "serviceAccount:terraform@knative-seed.iam.gserviceaccount.com",
     ]
   }

--- a/infra/gcp/iam.tf
+++ b/infra/gcp/iam.tf
@@ -32,6 +32,7 @@ module "iam" {
 
     "roles/browser" = [
       "domain:knative.team",
+      "group:gke-security-groups@knative.dev",
     ]
 
     "roles/resourcemanager.projectCreator" = [

--- a/infra/gcp/main.tf
+++ b/infra/gcp/main.tf
@@ -34,3 +34,7 @@ module "releases" {
 module "nightly" {
   source = "./nightly"
 }
+
+module "shared" {
+  source = "./shared"
+}

--- a/infra/gcp/nightly/cosign.tf
+++ b/infra/gcp/nightly/cosign.tf
@@ -4,6 +4,7 @@ module "cosign" {
 
   project_id          = module.project.project_id
   purpose             = "ASYMMETRIC_SIGN"
+  key_algorithm       = "EC_SIGN_P384_SHA384"
   key_rotation_period = "7776000s" # 90 days
   location            = "global"
   keyring             = "cosign"

--- a/infra/gcp/nightly/main.tf
+++ b/infra/gcp/nightly/main.tf
@@ -6,7 +6,7 @@ module "project" {
   project_id      = "knative-nightly"
   folder_id       = "1055082993535"
   org_id          = "22054930418"
-  billing_account = "014273-543CE9-58CE57"
+  billing_account = "01DDAC-7D2015-6E152D"
 
   # Sane project defaults
   default_service_account     = "keep"

--- a/infra/gcp/releases/main.tf
+++ b/infra/gcp/releases/main.tf
@@ -6,7 +6,7 @@ module "project" {
   project_id      = "knative-releases"
   folder_id       = "1055082993535"
   org_id          = "22054930418"
-  billing_account = "014273-543CE9-58CE57"
+  billing_account = "018CEF-0F96A6-4D1A14"
 
   # Sane project defaults
   default_service_account     = "keep"

--- a/infra/gcp/shared/README.md
+++ b/infra/gcp/shared/README.md
@@ -1,6 +1,6 @@
-# Knative Shared Project
+# Knative Community Project
 
-This project runs a shared gke cluster for members of the project to run workloads on.
+This GCP project runs a shared gke cluster for members of the project to run workloads on.
 
 Pay *extra* attention when modifying GKE Clusters as others are running workloads on it.
 
@@ -8,5 +8,5 @@ Key Infrastructure:
 - shared cluster
 
 Getting access to this project:
-- We are leveraging [Google Groups for RBAC]() so make a sure a group called k8s-infra-rbac-{namespace}@knative.dev exists in knative/community repo.
-- Deploy the namespace and rbac binding in the prow/
+- We are leveraging [Google Groups for RBAC](https://cloud.google.com/kubernetes-engine/docs/how-to/google-groups-rbac) so make a sure a group called k8s-infra-rbac-{namespace}@knative.dev exists in knative/community repo.
+- Add the namespace and rbac binding in the infra/k8s/shared folder.

--- a/infra/gcp/shared/README.md
+++ b/infra/gcp/shared/README.md
@@ -1,0 +1,12 @@
+# Knative Shared Project
+
+This project runs a shared gke cluster for members of the project to run workloads on.
+
+Pay *extra* attention when modifying GKE Clusters as others are running workloads on it.
+
+Key Infrastructure:
+- shared cluster
+
+Getting access to this project:
+- We are leveraging [Google Groups for RBAC]() so make a sure a group called k8s-infra-rbac-{namespace}@knative.dev exists in knative/community repo.
+- Deploy the namespace and rbac binding in the prow/

--- a/infra/gcp/shared/gke.tf
+++ b/infra/gcp/shared/gke.tf
@@ -1,62 +1,62 @@
-# // WARNING, MAKE SURE YOU DON"T DESTROY THIS CLUSTER ACCIDENTALLY
+// WARNING, MAKE SURE YOU DON"T DESTROY THIS CLUSTER ACCIDENTALLY
 
-# module "shared" {
-#   source                               = "terraform-google-modules/kubernetes-engine/google//modules/beta-public-cluster"
-#   version                              = "~> 21"
-#   project_id                           = module.project.project_id
-#   name                                 = "shared"
-#   region                               = "us-central1"
-#   release_channel                      = "RAPID"
-#   network                              = module.vpc.network_name
-#   subnetwork                           = module.vpc.subnets["us-central1/gke-subnet-01"].name
-#   ip_range_pods                        = "gke-pods-01"
-#   ip_range_services                    = "gke-services-01"
-#   http_load_balancing                  = true
-#   network_policy                       = false
-#   horizontal_pod_autoscaling           = true
-#   filestore_csi_driver                 = false
-#   create_service_account               = false
-#   remove_default_node_pool             = true
-#   gce_pd_csi_driver                    = true
-#   # monitoring_enable_managed_prometheus = true
-#   authenticator_security_group         = "gke-security-groups@knative.dev"
-#   cluster_autoscaling = {
-#     enabled             = false
-#     autoscaling_profile = "OPTIMIZE_UTILIZATION"
-#     gpu_resources       = []
-#     max_cpu_cores       = null
-#     max_memory_gb       = null
-#     min_cpu_cores       = null
-#     min_memory_gb       = null
-#   }
+module "shared" {
+  source                               = "terraform-google-modules/kubernetes-engine/google//modules/beta-public-cluster"
+  version                              = "~> 21"
+  project_id                           = module.project.project_id
+  name                                 = "shared"
+  region                               = "us-central1"
+  release_channel                      = "RAPID"
+  network                              = module.vpc.network_name
+  subnetwork                           = module.vpc.subnets["us-central1/gke-subnet-01"].name
+  ip_range_pods                        = "gke-pods-01"
+  ip_range_services                    = "gke-services-01"
+  http_load_balancing                  = true
+  network_policy                       = false
+  horizontal_pod_autoscaling           = true
+  filestore_csi_driver                 = false
+  create_service_account               = false
+  remove_default_node_pool             = true
+  gce_pd_csi_driver                    = true
+  # monitoring_enable_managed_prometheus = true
+  authenticator_security_group         = "gke-security-groups@knative.dev"
+  cluster_autoscaling = {
+    enabled             = false
+    autoscaling_profile = "OPTIMIZE_UTILIZATION"
+    gpu_resources       = []
+    max_cpu_cores       = null
+    max_memory_gb       = null
+    min_cpu_cores       = null
+    min_memory_gb       = null
+  }
 
-#   cluster_resource_labels = {
-#     cluster     = "shared"
-#     role        = "shared"
-#     environment = "production"
-#   }
+  cluster_resource_labels = {
+    cluster     = "shared"
+    role        = "shared"
+    environment = "production"
+  }
 
-#   node_pools = [
-#     {
-#       name               = "main-pool-v1"
-#       machine_type       = "e2-standard-2"
-#       node_locations     = "us-central1-c,us-central1-f"
-#       min_count          = 1
-#       max_count          = 2
-#       disk_size_gb       = 100
-#       disk_type          = "pd-standard"
-#       image_type         = "COS_CONTAINERD"
-#       auto_repair        = true
-#       auto_upgrade       = true
-#       service_account    = google_service_account.gke_nodes.email
-#       enable_secure_boot = true
-#       initial_node_count = 1
-#     },
-#   ]
+  node_pools = [
+    {
+      name               = "main-pool-v1"
+      machine_type       = "e2-standard-2"
+      node_locations     = "us-central1-c,us-central1-f"
+      min_count          = 1
+      max_count          = 2
+      disk_size_gb       = 100
+      disk_type          = "pd-standard"
+      image_type         = "COS_CONTAINERD"
+      auto_repair        = true
+      auto_upgrade       = true
+      service_account    = google_service_account.gke_nodes.email
+      enable_secure_boot = true
+      initial_node_count = 1
+    },
+  ]
 
-#   node_pools_labels = {
-#     all = {
-#       environment = "production"
-#     }
-#   }
-# }
+  node_pools_labels = {
+    all = {
+      environment = "production"
+    }
+  }
+}

--- a/infra/gcp/shared/gke.tf
+++ b/infra/gcp/shared/gke.tf
@@ -1,0 +1,62 @@
+# // WARNING, MAKE SURE YOU DON"T DESTROY THIS CLUSTER ACCIDENTALLY
+
+# module "shared" {
+#   source                               = "terraform-google-modules/kubernetes-engine/google//modules/beta-public-cluster"
+#   version                              = "~> 21"
+#   project_id                           = module.project.project_id
+#   name                                 = "shared"
+#   region                               = "us-central1"
+#   release_channel                      = "RAPID"
+#   network                              = module.vpc.network_name
+#   subnetwork                           = module.vpc.subnets["us-central1/gke-subnet-01"].name
+#   ip_range_pods                        = "gke-pods-01"
+#   ip_range_services                    = "gke-services-01"
+#   http_load_balancing                  = true
+#   network_policy                       = false
+#   horizontal_pod_autoscaling           = true
+#   filestore_csi_driver                 = false
+#   create_service_account               = false
+#   remove_default_node_pool             = true
+#   gce_pd_csi_driver                    = true
+#   # monitoring_enable_managed_prometheus = true
+#   authenticator_security_group         = "gke-security-groups@knative.dev"
+#   cluster_autoscaling = {
+#     enabled             = false
+#     autoscaling_profile = "OPTIMIZE_UTILIZATION"
+#     gpu_resources       = []
+#     max_cpu_cores       = null
+#     max_memory_gb       = null
+#     min_cpu_cores       = null
+#     min_memory_gb       = null
+#   }
+
+#   cluster_resource_labels = {
+#     cluster     = "shared"
+#     role        = "shared"
+#     environment = "production"
+#   }
+
+#   node_pools = [
+#     {
+#       name               = "main-pool-v1"
+#       machine_type       = "e2-standard-2"
+#       node_locations     = "us-central1-c,us-central1-f"
+#       min_count          = 1
+#       max_count          = 2
+#       disk_size_gb       = 100
+#       disk_type          = "pd-standard"
+#       image_type         = "COS_CONTAINERD"
+#       auto_repair        = true
+#       auto_upgrade       = true
+#       service_account    = google_service_account.gke_nodes.email
+#       enable_secure_boot = true
+#       initial_node_count = 1
+#     },
+#   ]
+
+#   node_pools_labels = {
+#     all = {
+#       environment = "production"
+#     }
+#   }
+# }

--- a/infra/gcp/shared/iam.tf
+++ b/infra/gcp/shared/iam.tf
@@ -1,0 +1,40 @@
+module "iam" {
+  source  = "terraform-google-modules/iam/google//modules/projects_iam"
+  version = "~> 7"
+
+  projects = ["knative-tests"]
+
+  mode = "authoritative"
+
+  bindings = {
+
+    "roles/artifactregistry.reader" = [
+      "serviceAccount:${google_service_account.gke_nodes.email}",
+    ]
+
+    "roles/logging.logWriter" = [
+      "serviceAccount:${google_service_account.gke_nodes.email}",
+    ]
+
+    "roles/monitoring.metricWriter" = [
+      "serviceAccount:${google_service_account.gke_nodes.email}",
+    ]
+
+    "roles/monitoring.viewer" = [ # Required for Managed Prometheus
+      "serviceAccount:${google_service_account.gke_nodes.email}",
+    ]
+
+    "roles/viewer" = [ # Will change this in the near future
+      "group:wg-leads@knative.team"
+    ]
+    "roles/container.viewer" = [
+      "group:gke-security-groups@knative.dev"
+    ]
+  }
+}
+
+resource "google_service_account" "gke_nodes" {
+  account_id   = "gke-nodes"
+  display_name = "GKE Nodes"
+  project      = module.project.project_id
+}

--- a/infra/gcp/shared/iam.tf
+++ b/infra/gcp/shared/iam.tf
@@ -2,7 +2,7 @@ module "iam" {
   source  = "terraform-google-modules/iam/google//modules/projects_iam"
   version = "~> 7"
 
-  projects = ["knative-tests"]
+  projects = [module.project.project_id]
 
   mode = "authoritative"
 
@@ -25,11 +25,12 @@ module "iam" {
     ]
 
     "roles/viewer" = [ # Will change this in the near future
-      "group:wg-leads@knative.team"
+      "group:wg-leads@knative.team",
+      # "group:gke-security-groups@knative.dev"
     ]
-    "roles/container.viewer" = [
-      "group:gke-security-groups@knative.dev"
-    ]
+    # "roles/container.viewer" = [
+    #   "group:gke-security-groups@knative.dev"
+    # ]
   }
 }
 

--- a/infra/gcp/shared/main.tf
+++ b/infra/gcp/shared/main.tf
@@ -1,0 +1,23 @@
+module "project" {
+  source  = "terraform-google-modules/project-factory/google"
+  version = "~> 12"
+
+  name            = "Knative Shared Infra"
+  project_id      = "knative-shared"
+  folder_id       = "1055082993535"
+  org_id          = "22054930418"
+  billing_account = "018CEF-0F96A6-4D1A14"
+
+  # Sane project defaults
+  default_service_account     = "keep"
+  disable_services_on_destroy = false
+  create_project_sa           = false
+  random_project_id           = false
+  auto_create_network         = true
+
+
+  activate_apis = [
+    "compute.googleapis.com",
+    "container.googleapis.com"
+  ]
+}

--- a/infra/gcp/shared/main.tf
+++ b/infra/gcp/shared/main.tf
@@ -2,8 +2,8 @@ module "project" {
   source  = "terraform-google-modules/project-factory/google"
   version = "~> 12"
 
-  name            = "Knative Shared Infra"
-  project_id      = "knative-shared"
+  name            = "Knative Community Infra"
+  project_id      = "knative-community"
   folder_id       = "1055082993535"
   org_id          = "22054930418"
   billing_account = "018CEF-0F96A6-4D1A14"

--- a/infra/gcp/shared/vpc.tf
+++ b/infra/gcp/shared/vpc.tf
@@ -1,0 +1,30 @@
+module "vpc" {
+  source  = "terraform-google-modules/network/google"
+  version = "~> 5"
+
+  project_id   = module.project.project_id
+  network_name = "gke"
+  routing_mode = "GLOBAL"
+
+  subnets = [
+    {
+      subnet_name           = "gke-subnet-01"
+      subnet_ip             = "10.251.0.0/20"
+      subnet_region         = "us-central1"
+      subnet_private_access = "true"
+    },
+  ]
+
+  secondary_ranges = {
+    gke-subnet-01 = [
+      {
+        range_name    = "gke-services-01"
+        ip_cidr_range = "10.251.32.0/20"
+      },
+      {
+        range_name    = "gke-pods-01"
+        ip_cidr_range = "10.251.64.0/20"
+      },
+    ]
+  }
+}

--- a/infra/gcp/terraform.tfvars
+++ b/infra/gcp/terraform.tfvars
@@ -1,4 +1,4 @@
 
 billing_account = "014273-543CE9-58CE57"
 org_id          = "organizations/22054930418"
-domain          = "knative.team"
+domain          = "knative.dev"

--- a/infra/gcp/tests/cosign.tf
+++ b/infra/gcp/tests/cosign.tf
@@ -1,9 +1,10 @@
 module "cosign" {
   source  = "terraform-google-modules/kms/google"
-  version = "~> 2.1"
+  version = "~> 2.2"
 
   project_id          = module.project.project_id
   purpose             = "ASYMMETRIC_SIGN"
+  key_algorithm       = "EC_SIGN_P384_SHA384"
   key_rotation_period = "7776000s" # 90 days
   location            = "global"
   keyring             = "cosign"

--- a/infra/gcp/tests/iam.tf
+++ b/infra/gcp/tests/iam.tf
@@ -15,24 +15,19 @@ module "iam" {
 
     "roles/cloudbuild.builds.editor" = [
       "serviceAccount:prow-job@knative-tests.iam.gserviceaccount.com",
-      "serviceAccount:pwg-admins@knative-tests.iam.gserviceaccount.com"
     ]
 
     "roles/container.admin" = [
       "serviceAccount:prow-deployer@knative-tests.iam.gserviceaccount.com",
-      "serviceAccount:pwg-admins@knative-tests.iam.gserviceaccount.com"
     ]
 
     "roles/container.clusterAdmin" = [
-      "serviceAccount:workload-metrics-svc-acct@knative-tests.iam.gserviceaccount.com"
     ],
 
     "roles/iam.serviceAccountTokenCreator" = [
-      "serviceAccount:workload-metrics-svc-acct@knative-tests.iam.gserviceaccount.com"
     ],
 
     "roles/iam.serviceAccountUser" : [
-      "serviceAccount:workload-metrics-svc-acct@knative-tests.iam.gserviceaccount.com"
     ],
 
 
@@ -80,7 +75,6 @@ module "iam" {
 
     "roles/viewer" = [
       "serviceAccount:prow-job@knative-tests.iam.gserviceaccount.com",
-      "serviceAccount:pwg-admins@knative-tests.iam.gserviceaccount.com"
     ]
 
     "roles/iap.httpsResourceAccessor" = [

--- a/infra/gcp/tests/iam.tf
+++ b/infra/gcp/tests/iam.tf
@@ -78,8 +78,8 @@ module "iam" {
     ]
 
     "roles/iap.httpsResourceAccessor" = [
-      "group:kn-infra-gcp-org-admins@knative.team",
-      "domain:knative.team",
+      "group:kn-infra-gcp-org-admins@knative.dev",
+      "domain:knative.dev",
       "group:wg-leads@knative.team"
     ]
   }

--- a/infra/gcp/tests/main.tf
+++ b/infra/gcp/tests/main.tf
@@ -6,7 +6,7 @@ module "project" {
   project_id      = "knative-tests"
   folder_id       = "1055082993535"
   org_id          = "22054930418"
-  billing_account = "014273-543CE9-58CE57"
+  billing_account = "018CEF-0F96A6-4D1A14"
 
   # Sane project defaults
   default_service_account     = "keep"

--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -1,4 +1,4 @@
 # Kubernetes Infrastructure 
 
 This folder is used by ArgoCD to drive GitOps configuration on the following clusters:
-- knative-shared/shared
+- projects/knative-community/locations/us-central1/shared

--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -1,0 +1,4 @@
+# Kubernetes Infrastructure 
+
+This folder is used by ArgoCD to drive GitOps configuration on the following clusters:
+- knative-shared/shared

--- a/infra/k8s/shared/perf-tests.yaml
+++ b/infra/k8s/shared/perf-tests.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: perf-tests
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: namespace-user
+  namespace: perf-tests
+subjects:
+  - kind: Group
+    name: k8s-infra-rbac-perf-tests@knative.dev
+roleRef:
+  kind: ClusterRole
+  name: namespace-user
+  apiGroup: rbac.authorization.k8s.io
+
+

--- a/infra/k8s/shared/rbac.yaml
+++ b/infra/k8s/shared/rbac.yaml
@@ -1,0 +1,13 @@
+# This role will be scoped to namespace when used with RoleBinding
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: namespace-user
+rules:
+  - apiGroups:
+      - "*"
+    resources:
+      - "*"
+    verbs:
+      - "*"
+

--- a/prow/cluster/gitops/apps/shared.yaml
+++ b/prow/cluster/gitops/apps/shared.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: prow
+  namespace: argocd
+spec:
+  destination:
+    name: shared
+    namespace: default
+  project: default
+  source:
+    path: infra/k8s/shared
+    repoURL: https://github.com/knative/test-infra
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true


### PR DESCRIPTION
@nader-ziada reached out about running perf-tests somewhere and I agreed to spin up a shared gke cluster for running workloads.

https://knative.slack.com/archives/CCSNR4FCH/p1656340237373339

This PR does the following:
- some drift fix
- creates a new project called knative-shared. It will hold the GKE Cluster and infra requested by users of the cluster.
- New GKE Cluster
- Each project/request gets its own namespace with rbac driven by ArgoCD.
- Cluster will be enrolled manually to ArgoCD

Other non CI/CD workloads that need to ran by the community can be put on this cluster.

/cc @kvmware 