### PR TITLE
Update cron timings for client-main job to avoid conflict with eventi…

### DIFF
--- a/prow/jobs/generated/knative/client-main.gen.yaml
+++ b/prow/jobs/generated/knative/client-main.gen.yaml
@@ -166,7 +166,7 @@ periodics:
     testgrid-dashboards: client
     testgrid-tab-name: ppc64le-e2e-tests
   cluster: prow-build
-  cron: 0 11 * * *
+  cron: 0 9 * * *
   decorate: true
   extra_refs:
   - base_ref: main

--- a/prow/jobs_config/knative/client.yaml
+++ b/prow/jobs_config/knative/client.yaml
@@ -54,7 +54,7 @@ jobs:
         value: contour.ingress.networking.knative.dev
 
   - name: ppc64le-e2e-tests
-    cron: 0 11 * * *
+    cron: 0 9 * * *
     types: [periodic]
     requirements: [ppc64le]
     command: [runner.sh]


### PR DESCRIPTION
Signed-off-by: mdafsanhossain <Mdafsan.Hossain@ibm.com>

**Which issue(s) this PR fixes**:<br> This PR updates the cron timings for client-main prow job on ppc64le to avoid conflicts with eventing-1.4 prow job.

/cc @coryrc @upodroid

<!-- 
  Use `Fixes #<issue number>`, or `Fixes (paste link of issue)`
  to automatically close linked issue when the PR is merged.
  Uncomment and fill below if the PR does not close any issues.
-->
<!--
**What this PR does, why we need it**:<br>
-->

<!--
  If there is any golang code in this PR please uncomment the 
  `/lint` statement below to have Prow automatically lint it.
-->
<!--
  /lint
-->
