### PR TITLE
Add prow job for operator-main e2e test on ppc64le

### DIFF
--- a/prow/jobs/generated/knative/operator-main.gen.yaml
+++ b/prow/jobs/generated/knative/operator-main.gen.yaml
@@ -124,6 +124,74 @@ periodics:
         secretName: s390x-cluster1
 - annotations:
     testgrid-dashboards: operator
+    testgrid-tab-name: ppc64le-e2e-tests
+  cluster: prow-build
+  cron: 0 13 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative
+    path_alias: knative.dev/operator
+    repo: operator
+  name: ppc64le-e2e-tests_operator_main_periodic
+  spec:
+    containers:
+    - args:
+      - bash
+      - -c
+      - |
+        cat /opt/cluster/ci-script > /tmp/connect.sh
+        chmod +x /tmp/connect.sh
+        . /tmp/connect.sh ${CI_JOB}
+        ./test/e2e-tests.sh --run-tests
+      command:
+      - runner.sh
+      env:
+      - name: CI_JOB
+        value: operator-main
+      - name: INGRESS_CLASS
+        value: contour.ingress.networking.knative.dev
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: KO_FLAGS
+        value: --platform=linux/ppc64le
+      - name: PLATFORM
+        value: linux/ppc64le
+      - name: KO_DOCKER_REPO
+        value: registry.ppc64le
+      - name: DISABLE_MD_LINTING
+        value: "1"
+      - name: KUBECONFIG
+        value: /root/.kube/config
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220630-9ea214bf
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+      - mountPath: /opt/cluster
+        name: ppc64le-cluster
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - name: ppc64le-cluster
+      secret:
+        defaultMode: 384
+        secretName: ppc64le-cluster
+- annotations:
+    testgrid-dashboards: operator
     testgrid-tab-name: nightly
   cluster: prow-build
   cron: 5 9 * * *

--- a/prow/jobs_config/knative/operator.yaml
+++ b/prow/jobs_config/knative/operator.yaml
@@ -55,7 +55,7 @@ jobs:
     env:
       - name: INGRESS_CLASS
         value: contour.ingress.networking.knative.dev
-       
+
   - name: ppc64le-e2e-tests
     cron: 0 13 * * *
     types: [periodic]

--- a/prow/jobs_config/knative/operator.yaml
+++ b/prow/jobs_config/knative/operator.yaml
@@ -55,6 +55,25 @@ jobs:
     env:
       - name: INGRESS_CLASS
         value: contour.ingress.networking.knative.dev
+       
+  - name: ppc64le-e2e-tests
+    cron: 0 13 * * *
+    types: [periodic]
+    requirements: [ppc64le]
+    command: [runner.sh]
+    args:
+      - bash
+      - -c
+      - |
+        cat /opt/cluster/ci-script > /tmp/connect.sh
+        chmod +x /tmp/connect.sh
+        . /tmp/connect.sh ${CI_JOB}
+        ./test/e2e-tests.sh --run-tests
+    env:
+      - name: CI_JOB
+        value: "operator-main"
+      - name: INGRESS_CLASS
+        value: contour.ingress.networking.knative.dev
 
   - name: nightly
     types: [periodic]

--- a/tools/release-jobs-syncer/pkg/jobs_sync.go
+++ b/tools/release-jobs-syncer/pkg/jobs_sync.go
@@ -46,7 +46,7 @@ var extraPeriodicProwJobsToSync map[string]sets.String = map[string]sets.String{
 	"knative/serving":  sets.NewString("s390x-kourier-tests", "s390x-contour-tests"),
 	"knative/eventing": sets.NewString("s390x-e2e-tests", "s390x-e2e-reconciler-tests", "ppc64le-e2e-tests"),
 	"knative/client":   sets.NewString("s390x-e2e-tests", "ppc64le-e2e-tests"),
-	"knative/operator": sets.NewString("s390x-e2e-tests"),
+	"knative/operator": sets.NewString("s390x-e2e-tests", "ppc64le-e2e-tests"),
 }
 
 func syncProwJobsForRelease(configRootPath, org, repo, releaseToRemove, releaseToAdd string) error {


### PR DESCRIPTION
Signed-off-by: mdafsanhossain <Mdafsan.Hossain@ibm.com>

**Which issue(s) this PR fixes**:<br>This PR adds nightly CI prow job for knative/operator on ppc64le hardware.

/cc @upodroid

<!-- 
  Use `Fixes #<issue number>`, or `Fixes (paste link of issue)`
  to automatically close linked issue when the PR is merged.
  Uncomment and fill below if the PR does not close any issues.
-->
<!--
**What this PR does, why we need it**:<br>
-->

<!--
  If there is any golang code in this PR please uncomment the 
  `/lint` statement below to have Prow automatically lint it.
-->
<!--
  /lint
-->
