### PR TITLE
Add auto-release config for kn-plugin-operator

### DIFF
--- a/prow/jobs/generated/knative-sandbox/kn-plugin-operator-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-operator-main.gen.yaml
@@ -47,6 +47,104 @@ periodics:
         - key: service-account-key.json
           path: service-account.json
         secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: kn-plugin-operator
+    testgrid-tab-name: nightly
+  cluster: prow-build
+  cron: 25 9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-operator
+    repo: kn-plugin-operator
+  name: nightly_kn-plugin-operator_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --publish
+      - --tag-release
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/nightly-account/service-account.json
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220630-9ea214bf
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/nightly-account
+        name: nightly-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: nightly-account
+      secret:
+        items:
+        - key: nightly.json
+          path: service-account.json
+        secretName: prow-google-credentials
+- annotations:
+    testgrid-dashboards: kn-plugin-operator
+    testgrid-tab-name: release
+  cluster: prow-build
+  cron: 29 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/kn-plugin-operator
+    repo: kn-plugin-operator
+  name: release_kn-plugin-operator_main_periodic
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./hack/release.sh
+      - --auto-release
+      - --release-gcs
+      - knative-releases/kn-plugin-operator
+      - --release-gcr
+      - gcr.io/knative-releases
+      - --github-token
+      - /etc/hub-token/token
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/release-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: ORG_NAME
+        value: knative-sandbox
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220630-9ea214bf
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/hub-token
+        name: hub-token
+        readOnly: true
+      - mountPath: /etc/release-account
+        name: release-account
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: hub-token
+      secret:
+        items:
+        - key: hub_token
+          path: token
+        secretName: github-credentials
+    - name: release-account
+      secret:
+        items:
+        - key: release.json
+          path: service-account.json
+        secretName: prow-google-credentials
 presubmits:
   knative-sandbox/kn-plugin-operator:
   - always_run: true

--- a/prow/jobs_config/knative-sandbox/kn-plugin-operator.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-operator.yaml
@@ -22,3 +22,15 @@ jobs:
   - name: continuous
     types: [periodic]
     command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
+
+  - name: nightly
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
+    requirements: [nightly]
+    excluded_requirements: [gcp]
+
+  - name: release
+    types: [periodic]
+    command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/kn-plugin-operator, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
+    requirements: [release]
+    excluded_requirements: [gcp]


### PR DESCRIPTION

**What this PR does, why we need it**:<br>
We'd like to onboard operator plugin to release train. Therefore this PR adds release job config for `knative-sandbox/kn-plugin-operator` project.


/cc @houshengbo @maximilien @knative/knative-release-leads 
<!--
  If there is any golang code in this PR please uncomment the 
  `/lint` statement below to have Prow automatically lint it.
-->
<!--
  /lint
-->
