### PR TITLE
Adjusted s390x job schedule for new operator 1.6 release

### DIFF
--- a/prow/jobs/generated/knative/operator-release-1.6.gen.yaml
+++ b/prow/jobs/generated/knative/operator-release-1.6.gen.yaml
@@ -51,7 +51,7 @@ periodics:
     testgrid-dashboards: knative-release-1.6
     testgrid-tab-name: operator-s390x-e2e-tests
   cluster: prow-build
-  cron: 0 13 * * *
+  cron: 30 1 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.6

--- a/prow/jobs_config/knative/operator-release-1.6.yaml
+++ b/prow/jobs_config/knative/operator-release-1.6.yaml
@@ -78,7 +78,7 @@ jobs:
     ./test/e2e-tests.sh --run-tests
   command:
   - runner.sh
-  cron: 0 13 * * *
+  cron: 30 1 * * *
   env:
   - name: INGRESS_CLASS
     value: contour.ingress.networking.knative.dev


### PR DESCRIPTION
**Which issue(s) this PR fixes**:<br>

This PR updates the s390x-related prow jobs for *operator* release 1.6.

Note: this is a follow-up to PR #3420 which was already merged a few days ago.