### PR TITLE
Fixed operator e2e s390x test job

### DIFF
--- a/prow/jobs/generated/knative/operator-release-1.6.gen.yaml
+++ b/prow/jobs/generated/knative/operator-release-1.6.gen.yaml
@@ -68,7 +68,7 @@ periodics:
         mkdir -p /root/.kube
         cat /opt/cluster/ci-script > connect.sh
         chmod +x connect.sh
-        ./connect.sh operator-main
+        ./connect.sh operator-16
         kubectl get cm s390x-config-operator -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
         chmod +x adjust.sh
         ./adjust.sh

--- a/prow/jobs_config/knative/operator-release-1.6.yaml
+++ b/prow/jobs_config/knative/operator-release-1.6.yaml
@@ -71,7 +71,7 @@ jobs:
     mkdir -p /root/.kube
     cat /opt/cluster/ci-script > connect.sh
     chmod +x connect.sh
-    ./connect.sh operator-main
+    ./connect.sh operator-16
     kubectl get cm s390x-config-operator -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
     chmod +x adjust.sh
     ./adjust.sh


### PR DESCRIPTION
**Which issue(s) this PR fixes**:<br>

This PR fixes the operator e2e test job for s390x for release-1.6. The issue was that a due to a copy-paste mistake the wrong  s390x VSI in IBM Cloud was targeted.
