### PR TITLE
Updated s390x prow job schedule

### DIFF
--- a/prow/jobs/generated/knative-sandbox/eventing-kafka-broker-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kafka-broker-main.gen.yaml
@@ -206,6 +206,249 @@ periodics:
         path: /sys/fs/cgroup
         type: Directory
       name: cgroup
+- annotations:
+    testgrid-dashboards: eventing-kafka-broker
+    testgrid-tab-name: s390x-e2e-tests-ssl
+  cluster: prow-build
+  cron: 20 7 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/eventing-kafka-broker
+    repo: eventing-kafka-broker
+  name: s390x-e2e-tests-ssl_eventing-kafka-broker_main_periodic
+  spec:
+    containers:
+    - args:
+      - bash
+      - -c
+      - |
+        mkdir -p /root/.kube
+        cat /opt/cluster/ci-script > connect.sh
+        chmod +x connect.sh
+        ./connect.sh eventing_kafka-broker-ssl-main
+        kubectl get cm s390x-config-eventing-kafka-broker -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
+        chmod +x adjust.sh
+        ./adjust.sh
+        ./test/e2e-tests.sh --run-tests
+      command:
+      - runner.sh
+      env:
+      - name: SYSTEM_NAMESPACE
+        value: knative-eventing
+      - name: EVENTING_NAMESPACE
+        value: knative-eventing
+      - name: SCALE_CHAOSDUCK_TO_ZERO
+        value: "1"
+      - name: EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO
+        value: SSL
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: KO_FLAGS
+        value: --platform=linux/s390x --insecure-registry
+      - name: PLATFORM
+        value: linux/s390x
+      - name: KO_DOCKER_REPO
+        valueFrom:
+          secretKeyRef:
+            key: ko-docker-repo
+            name: s390x-cluster1
+      - name: DISABLE_MD_LINTING
+        value: "1"
+      - name: KUBECONFIG
+        value: /root/.kube/config
+      - name: DOCKER_CONFIG
+        value: /opt/cluster
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220718-ea7fb341
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+      - mountPath: /opt/cluster
+        name: s390x-cluster1
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - name: s390x-cluster1
+      secret:
+        defaultMode: 384
+        secretName: s390x-cluster1
+- annotations:
+    testgrid-dashboards: eventing-kafka-broker
+    testgrid-tab-name: s390x-e2e-tests-sasl-ssl
+  cluster: prow-build
+  cron: 20 8 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/eventing-kafka-broker
+    repo: eventing-kafka-broker
+  name: s390x-e2e-tests-sasl-ssl_eventing-kafka-broker_main_periodic
+  spec:
+    containers:
+    - args:
+      - bash
+      - -c
+      - |
+        mkdir -p /root/.kube
+        cat /opt/cluster/ci-script > connect.sh
+        chmod +x connect.sh
+        ./connect.sh eventing_kafka-broker-sasl-ssl-main
+        kubectl get cm s390x-config-eventing-kafka-broker -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
+        chmod +x adjust.sh
+        ./adjust.sh
+        ./test/e2e-tests.sh --run-tests
+      command:
+      - runner.sh
+      env:
+      - name: SYSTEM_NAMESPACE
+        value: knative-eventing
+      - name: EVENTING_NAMESPACE
+        value: knative-eventing
+      - name: SCALE_CHAOSDUCK_TO_ZERO
+        value: "1"
+      - name: EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO
+        value: SASL_SSL
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: KO_FLAGS
+        value: --platform=linux/s390x --insecure-registry
+      - name: PLATFORM
+        value: linux/s390x
+      - name: KO_DOCKER_REPO
+        valueFrom:
+          secretKeyRef:
+            key: ko-docker-repo
+            name: s390x-cluster1
+      - name: DISABLE_MD_LINTING
+        value: "1"
+      - name: KUBECONFIG
+        value: /root/.kube/config
+      - name: DOCKER_CONFIG
+        value: /opt/cluster
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220718-ea7fb341
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+      - mountPath: /opt/cluster
+        name: s390x-cluster1
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - name: s390x-cluster1
+      secret:
+        defaultMode: 384
+        secretName: s390x-cluster1
+- annotations:
+    testgrid-dashboards: eventing-kafka-broker
+    testgrid-tab-name: s390x-e2e-tests-sasl-plain
+  cluster: prow-build
+  cron: 20 9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative-sandbox
+    path_alias: knative.dev/eventing-kafka-broker
+    repo: eventing-kafka-broker
+  name: s390x-e2e-tests-sasl-plain_eventing-kafka-broker_main_periodic
+  spec:
+    containers:
+    - args:
+      - bash
+      - -c
+      - |
+        mkdir -p /root/.kube
+        cat /opt/cluster/ci-script > connect.sh
+        chmod +x connect.sh
+        ./connect.sh eventing_kafka-broker-sasl-plain-main
+        kubectl get cm s390x-config-eventing-kafka-broker -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
+        chmod +x adjust.sh
+        ./adjust.sh
+        ./test/e2e-tests.sh --run-tests
+      command:
+      - runner.sh
+      env:
+      - name: SYSTEM_NAMESPACE
+        value: knative-eventing
+      - name: EVENTING_NAMESPACE
+        value: knative-eventing
+      - name: SCALE_CHAOSDUCK_TO_ZERO
+        value: "1"
+      - name: EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO
+        value: SASL_PLAIN
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: KO_FLAGS
+        value: --platform=linux/s390x --insecure-registry
+      - name: PLATFORM
+        value: linux/s390x
+      - name: KO_DOCKER_REPO
+        valueFrom:
+          secretKeyRef:
+            key: ko-docker-repo
+            name: s390x-cluster1
+      - name: DISABLE_MD_LINTING
+        value: "1"
+      - name: KUBECONFIG
+        value: /root/.kube/config
+      - name: DOCKER_CONFIG
+        value: /opt/cluster
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220718-ea7fb341
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+      - mountPath: /opt/cluster
+        name: s390x-cluster1
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - name: s390x-cluster1
+      secret:
+        defaultMode: 384
+        secretName: s390x-cluster1
 presubmits:
   knative-sandbox/eventing-kafka-broker:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/eventing-kafka-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kafka-main.gen.yaml
@@ -210,7 +210,7 @@ periodics:
     testgrid-dashboards: eventing-kafka
     testgrid-tab-name: s390x-e2e-tests
   cluster: prow-build
-  cron: 0 14 * * *
+  cron: 20 6 * * *
   decorate: true
   extra_refs:
   - base_ref: main

--- a/prow/jobs/generated/knative/client-main.gen.yaml
+++ b/prow/jobs/generated/knative/client-main.gen.yaml
@@ -91,7 +91,7 @@ periodics:
     testgrid-dashboards: client
     testgrid-tab-name: s390x-e2e-tests
   cluster: prow-build
-  cron: 0 11 * * *
+  cron: 20 1 * * *
   decorate: true
   extra_refs:
   - base_ref: main

--- a/prow/jobs/generated/knative/client-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative/client-release-1.3.gen.yaml
@@ -51,7 +51,7 @@ periodics:
     testgrid-dashboards: knative-release-1.3
     testgrid-tab-name: client-s390x-e2e-tests
   cluster: prow-build
-  cron: 40 3 * * *
+  cron: 20 5 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.3

--- a/prow/jobs/generated/knative/client-release-1.4.gen.yaml
+++ b/prow/jobs/generated/knative/client-release-1.4.gen.yaml
@@ -51,7 +51,7 @@ periodics:
     testgrid-dashboards: knative-release-1.4
     testgrid-tab-name: client-s390x-e2e-tests
   cluster: prow-build
-  cron: 10 15 * * *
+  cron: 20 9 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.4

--- a/prow/jobs/generated/knative/client-release-1.5.gen.yaml
+++ b/prow/jobs/generated/knative/client-release-1.5.gen.yaml
@@ -51,7 +51,7 @@ periodics:
     testgrid-dashboards: knative-release-1.5
     testgrid-tab-name: client-s390x-e2e-tests
   cluster: prow-build
-  cron: 20 19 * * *
+  cron: 20 13 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.5

--- a/prow/jobs/generated/knative/client-release-1.6.gen.yaml
+++ b/prow/jobs/generated/knative/client-release-1.6.gen.yaml
@@ -51,7 +51,7 @@ periodics:
     testgrid-dashboards: knative-release-1.6
     testgrid-tab-name: client-s390x-e2e-tests
   cluster: prow-build
-  cron: 30 23 * * *
+  cron: 20 17 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.6

--- a/prow/jobs/generated/knative/eventing-main.gen.yaml
+++ b/prow/jobs/generated/knative/eventing-main.gen.yaml
@@ -57,7 +57,7 @@ periodics:
     testgrid-dashboards: eventing
     testgrid-tab-name: s390x-e2e-tests
   cluster: prow-build
-  cron: 0 7 * * *
+  cron: 20 4 * * *
   decorate: true
   extra_refs:
   - base_ref: main
@@ -138,7 +138,7 @@ periodics:
     testgrid-dashboards: eventing
     testgrid-tab-name: s390x-e2e-reconciler-tests
   cluster: prow-build
-  cron: 0 9 * * *
+  cron: 20 5 * * *
   decorate: true
   extra_refs:
   - base_ref: main

--- a/prow/jobs/generated/knative/eventing-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative/eventing-release-1.3.gen.yaml
@@ -57,7 +57,7 @@ periodics:
     testgrid-dashboards: knative-release-1.3
     testgrid-tab-name: eventing-s390x-e2e-reconciler-tests
   cluster: prow-build
-  cron: 40 1 * * *
+  cron: 20 9 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.3
@@ -138,7 +138,7 @@ periodics:
     testgrid-dashboards: knative-release-1.3
     testgrid-tab-name: eventing-s390x-e2e-tests
   cluster: prow-build
-  cron: 40 23 * * *
+  cron: 20 8 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.3

--- a/prow/jobs/generated/knative/eventing-release-1.4.gen.yaml
+++ b/prow/jobs/generated/knative/eventing-release-1.4.gen.yaml
@@ -57,7 +57,7 @@ periodics:
     testgrid-dashboards: knative-release-1.4
     testgrid-tab-name: eventing-s390x-e2e-tests
   cluster: prow-build
-  cron: 10 11 * * *
+  cron: 20 12 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.4
@@ -138,7 +138,7 @@ periodics:
     testgrid-dashboards: knative-release-1.4
     testgrid-tab-name: eventing-s390x-e2e-reconciler-tests
   cluster: prow-build
-  cron: 10 13 * * *
+  cron: 20 13 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.4

--- a/prow/jobs/generated/knative/eventing-release-1.5.gen.yaml
+++ b/prow/jobs/generated/knative/eventing-release-1.5.gen.yaml
@@ -57,7 +57,7 @@ periodics:
     testgrid-dashboards: knative-release-1.5
     testgrid-tab-name: eventing-s390x-e2e-tests
   cluster: prow-build
-  cron: 20 15 * * *
+  cron: 20 16 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.5

--- a/prow/jobs/generated/knative/eventing-release-1.6.gen.yaml
+++ b/prow/jobs/generated/knative/eventing-release-1.6.gen.yaml
@@ -57,7 +57,7 @@ periodics:
     testgrid-dashboards: knative-release-1.6
     testgrid-tab-name: eventing-s390x-e2e-tests
   cluster: prow-build
-  cron: 30 19 * * *
+  cron: 20 20 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.6
@@ -138,7 +138,7 @@ periodics:
     testgrid-dashboards: knative-release-1.6
     testgrid-tab-name: eventing-s390x-e2e-reconciler-tests
   cluster: prow-build
-  cron: 30 21 * * *
+  cron: 20 21 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.6

--- a/prow/jobs/generated/knative/operator-main.gen.yaml
+++ b/prow/jobs/generated/knative/operator-main.gen.yaml
@@ -51,7 +51,7 @@ periodics:
     testgrid-dashboards: operator
     testgrid-tab-name: s390x-e2e-tests
   cluster: prow-build
-  cron: 0 13 * * *
+  cron: 20 0 * * *
   decorate: true
   extra_refs:
   - base_ref: main

--- a/prow/jobs/generated/knative/operator-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative/operator-release-1.3.gen.yaml
@@ -51,7 +51,7 @@ periodics:
     testgrid-dashboards: knative-release-1.3
     testgrid-tab-name: operator-s390x-e2e-tests
   cluster: prow-build
-  cron: 40 5 * * *
+  cron: 20 4 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.3

--- a/prow/jobs/generated/knative/operator-release-1.4.gen.yaml
+++ b/prow/jobs/generated/knative/operator-release-1.4.gen.yaml
@@ -51,7 +51,7 @@ periodics:
     testgrid-dashboards: knative-release-1.4
     testgrid-tab-name: operator-s390x-e2e-tests
   cluster: prow-build
-  cron: 10 17 * * *
+  cron: 20 8 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.4

--- a/prow/jobs/generated/knative/operator-release-1.5.gen.yaml
+++ b/prow/jobs/generated/knative/operator-release-1.5.gen.yaml
@@ -51,7 +51,7 @@ periodics:
     testgrid-dashboards: knative-release-1.5
     testgrid-tab-name: operator-s390x-e2e-tests
   cluster: prow-build
-  cron: 20 21 * * *
+  cron: 20 12 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.5

--- a/prow/jobs/generated/knative/operator-release-1.6.gen.yaml
+++ b/prow/jobs/generated/knative/operator-release-1.6.gen.yaml
@@ -126,7 +126,7 @@ periodics:
     testgrid-dashboards: knative-release-1.6
     testgrid-tab-name: operator-ppc64le-e2e-tests
   cluster: prow-build
-  cron: 0 14 * * *
+  cron: 20 16 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.6

--- a/prow/jobs/generated/knative/serving-main.gen.yaml
+++ b/prow/jobs/generated/knative/serving-main.gen.yaml
@@ -674,7 +674,7 @@ periodics:
     testgrid-dashboards: serving
     testgrid-tab-name: s390x-kourier-tests
   cluster: prow-build
-  cron: 0 3 * * *
+  cron: 20 2 * * *
   decorate: true
   extra_refs:
   - base_ref: main
@@ -774,7 +774,7 @@ periodics:
     testgrid-dashboards: serving
     testgrid-tab-name: s390x-contour-tests
   cluster: prow-build
-  cron: 0 5 * * *
+  cron: 20 3 * * *
   decorate: true
   extra_refs:
   - base_ref: main

--- a/prow/jobs/generated/knative/serving-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative/serving-release-1.3.gen.yaml
@@ -57,7 +57,7 @@ periodics:
     testgrid-dashboards: knative-release-1.3
     testgrid-tab-name: serving-s390x-kourier-tests
   cluster: prow-build
-  cron: 40 19 * * *
+  cron: 20 6 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.3
@@ -139,7 +139,7 @@ periodics:
     testgrid-dashboards: knative-release-1.3
     testgrid-tab-name: serving-s390x-contour-tests
   cluster: prow-build
-  cron: 40 21 * * *
+  cron: 20 7 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.3

--- a/prow/jobs/generated/knative/serving-release-1.4.gen.yaml
+++ b/prow/jobs/generated/knative/serving-release-1.4.gen.yaml
@@ -57,7 +57,7 @@ periodics:
     testgrid-dashboards: knative-release-1.4
     testgrid-tab-name: serving-s390x-kourier-tests
   cluster: prow-build
-  cron: 10 7 * * *
+  cron: 20 10 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.4
@@ -139,7 +139,7 @@ periodics:
     testgrid-dashboards: knative-release-1.4
     testgrid-tab-name: serving-s390x-contour-tests
   cluster: prow-build
-  cron: 10 9 * * *
+  cron: 20 11 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.4

--- a/prow/jobs/generated/knative/serving-release-1.5.gen.yaml
+++ b/prow/jobs/generated/knative/serving-release-1.5.gen.yaml
@@ -57,7 +57,7 @@ periodics:
     testgrid-dashboards: knative-release-1.5
     testgrid-tab-name: serving-s390x-kourier-tests
   cluster: prow-build
-  cron: 20 11 * * *
+  cron: 20 14 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.5
@@ -139,7 +139,7 @@ periodics:
     testgrid-dashboards: knative-release-1.5
     testgrid-tab-name: serving-s390x-contour-tests
   cluster: prow-build
-  cron: 20 13 * * *
+  cron: 20 15 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.5

--- a/prow/jobs/generated/knative/serving-release-1.6.gen.yaml
+++ b/prow/jobs/generated/knative/serving-release-1.6.gen.yaml
@@ -75,7 +75,7 @@ periodics:
     testgrid-dashboards: knative-release-1.6
     testgrid-tab-name: serving-s390x-kourier-tests
   cluster: prow-build
-  cron: 30 15 * * *
+  cron: 20 18 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.6
@@ -175,7 +175,7 @@ periodics:
     testgrid-dashboards: knative-release-1.6
     testgrid-tab-name: serving-s390x-contour-tests
   cluster: prow-build
-  cron: 30 17 * * *
+  cron: 20 19 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.6

--- a/prow/jobs_config/knative-sandbox/eventing-kafka-broker.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-kafka-broker.yaml
@@ -101,3 +101,84 @@ jobs:
     command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/eventing-kafka-broker, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
     requirements: [release, docker]
     excluded_requirements: [gcp]
+
+  - name: s390x-e2e-tests-ssl
+    cron: 20 7 * * *
+    types: [periodic]
+    requirements: [s390x]
+    command: [runner.sh]
+    args:
+      - bash
+      - -c
+      - |
+        mkdir -p /root/.kube
+        cat /opt/cluster/ci-script > connect.sh
+        chmod +x connect.sh
+        ./connect.sh eventing_kafka-broker-ssl-main
+        kubectl get cm s390x-config-eventing-kafka-broker -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
+        chmod +x adjust.sh
+        ./adjust.sh
+        ./test/e2e-tests.sh --run-tests
+    env:
+      - name: SYSTEM_NAMESPACE
+        value: knative-eventing
+      - name: EVENTING_NAMESPACE
+        value: knative-eventing
+      - name: SCALE_CHAOSDUCK_TO_ZERO
+        value: "1"
+      - name: EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO
+        value: SSL
+
+  - name: s390x-e2e-tests-sasl-ssl
+    cron: 20 8 * * *
+    types: [periodic]
+    requirements: [s390x]
+    command: [runner.sh]
+    args:
+      - bash
+      - -c
+      - |
+        mkdir -p /root/.kube
+        cat /opt/cluster/ci-script > connect.sh
+        chmod +x connect.sh
+        ./connect.sh eventing_kafka-broker-sasl-ssl-main
+        kubectl get cm s390x-config-eventing-kafka-broker -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
+        chmod +x adjust.sh
+        ./adjust.sh
+        ./test/e2e-tests.sh --run-tests
+    env:
+      - name: SYSTEM_NAMESPACE
+        value: knative-eventing
+      - name: EVENTING_NAMESPACE
+        value: knative-eventing
+      - name: SCALE_CHAOSDUCK_TO_ZERO
+        value: "1"
+      - name: EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO
+        value: SASL_SSL
+
+  - name: s390x-e2e-tests-sasl-plain
+    cron: 20 9 * * *
+    types: [periodic]
+    requirements: [s390x]
+    command: [runner.sh]
+    args:
+      - bash
+      - -c
+      - |
+        mkdir -p /root/.kube
+        cat /opt/cluster/ci-script > connect.sh
+        chmod +x connect.sh
+        ./connect.sh eventing_kafka-broker-sasl-plain-main
+        kubectl get cm s390x-config-eventing-kafka-broker -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
+        chmod +x adjust.sh
+        ./adjust.sh
+        ./test/e2e-tests.sh --run-tests
+    env:
+      - name: SYSTEM_NAMESPACE
+        value: knative-eventing
+      - name: EVENTING_NAMESPACE
+        value: knative-eventing
+      - name: SCALE_CHAOSDUCK_TO_ZERO
+        value: "1"
+      - name: EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO
+        value: SASL_PLAIN

--- a/prow/jobs_config/knative-sandbox/eventing-kafka.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-kafka.yaml
@@ -67,7 +67,7 @@ jobs:
     excluded_requirements: [gcp]
 
   - name: s390x-e2e-tests
-    cron: 0 14 * * *
+    cron: 20 6 * * *
     types: [periodic]
     requirements: [s390x]
     command: [runner.sh]

--- a/prow/jobs_config/knative/client-release-1.3.yaml
+++ b/prow/jobs_config/knative/client-release-1.3.yaml
@@ -64,7 +64,7 @@ jobs:
   - name: INGRESS_CLASS
     value: contour.ingress.networking.knative.dev
   name: s390x-e2e-tests
-  cron: 40 3 * * *
+  cron: 20 5 * * *
   requirements:
   - s390x
   types:

--- a/prow/jobs_config/knative/client-release-1.4.yaml
+++ b/prow/jobs_config/knative/client-release-1.4.yaml
@@ -60,7 +60,7 @@ jobs:
     ./test/e2e-tests.sh --run-tests
   command:
   - runner.sh
-  cron: 10 15 * * *
+  cron: 20 9 * * *
   env:
   - name: INGRESS_CLASS
     value: contour.ingress.networking.knative.dev

--- a/prow/jobs_config/knative/client-release-1.5.yaml
+++ b/prow/jobs_config/knative/client-release-1.5.yaml
@@ -61,7 +61,7 @@ jobs:
     ./test/e2e-tests.sh --run-tests
   command:
   - runner.sh
-  cron: 20 19 * * *
+  cron: 20 13 * * *
   env:
   - name: INGRESS_CLASS
     value: contour.ingress.networking.knative.dev

--- a/prow/jobs_config/knative/client-release-1.6.yaml
+++ b/prow/jobs_config/knative/client-release-1.6.yaml
@@ -61,7 +61,7 @@ jobs:
     ./test/e2e-tests.sh --run-tests
   command:
   - runner.sh
-  cron: 30 23 * * *
+  cron: 20 17 * * *
   env:
   - name: INGRESS_CLASS
     value: contour.ingress.networking.knative.dev

--- a/prow/jobs_config/knative/client.yaml
+++ b/prow/jobs_config/knative/client.yaml
@@ -33,7 +33,7 @@ jobs:
     command: [runner.sh, ./test/tekton-tests.sh]
 
   - name: s390x-e2e-tests
-    cron: 0 11 * * *
+    cron: 20 1 * * *
     types: [periodic]
     requirements: [s390x]
     command: [runner.sh]

--- a/prow/jobs_config/knative/eventing-release-1.3.yaml
+++ b/prow/jobs_config/knative/eventing-release-1.3.yaml
@@ -81,7 +81,7 @@ jobs:
   - name: SCALE_CHAOSDUCK_TO_ZERO
     value: "1"
   name: s390x-e2e-reconciler-tests
-  cron: 40 1 * * *
+  cron: 20 9 * * *
   requirements:
   - s390x
   types:
@@ -106,7 +106,7 @@ jobs:
   - name: SCALE_CHAOSDUCK_TO_ZERO
     value: "1"
   name: s390x-e2e-tests
-  cron: 40 23 * * *
+  cron: 20 8 * * *
   requirements:
   - s390x
   types:

--- a/prow/jobs_config/knative/eventing-release-1.4.yaml
+++ b/prow/jobs_config/knative/eventing-release-1.4.yaml
@@ -75,7 +75,7 @@ jobs:
     ./test/e2e-tests.sh --run-tests
   command:
   - runner.sh
-  cron: 10 11 * * *
+  cron: 20 12 * * *
   env:
   - name: SYSTEM_NAMESPACE
     value: knative-eventing
@@ -100,7 +100,7 @@ jobs:
     ./test/e2e-rekt-tests.sh --run-tests
   command:
   - runner.sh
-  cron: 10 13 * * *
+  cron: 20 13 * * *
   env:
   - name: SYSTEM_NAMESPACE
     value: knative-eventing

--- a/prow/jobs_config/knative/eventing-release-1.5.yaml
+++ b/prow/jobs_config/knative/eventing-release-1.5.yaml
@@ -75,7 +75,7 @@ jobs:
     ./test/e2e-tests.sh --run-tests
   command:
   - runner.sh
-  cron: 20 15 * * *
+  cron: 20 16 * * *
   env:
   - name: SYSTEM_NAMESPACE
     value: knative-eventing

--- a/prow/jobs_config/knative/eventing-release-1.6.yaml
+++ b/prow/jobs_config/knative/eventing-release-1.6.yaml
@@ -75,7 +75,7 @@ jobs:
     ./test/e2e-tests.sh --run-tests
   command:
   - runner.sh
-  cron: 30 19 * * *
+  cron: 20 20 * * *
   env:
   - name: SYSTEM_NAMESPACE
     value: knative-eventing
@@ -100,7 +100,7 @@ jobs:
     ./test/e2e-rekt-tests.sh --run-tests
   command:
   - runner.sh
-  cron: 30 21 * * *
+  cron: 20 21 * * *
   env:
   - name: SYSTEM_NAMESPACE
     value: knative-eventing

--- a/prow/jobs_config/knative/eventing.yaml
+++ b/prow/jobs_config/knative/eventing.yaml
@@ -35,7 +35,7 @@ jobs:
     command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
 
   - name: s390x-e2e-tests
-    cron: 0 7 * * *
+    cron: 20 4 * * *
     types: [periodic]
     requirements: [s390x]
     command: [runner.sh]
@@ -58,7 +58,7 @@ jobs:
         value: "1"
 
   - name: s390x-e2e-reconciler-tests
-    cron: 0 9 * * *
+    cron: 20 5 * * *
     types: [periodic]
     requirements: [s390x]
     command: [runner.sh]

--- a/prow/jobs_config/knative/operator-release-1.3.yaml
+++ b/prow/jobs_config/knative/operator-release-1.3.yaml
@@ -82,7 +82,7 @@ jobs:
   - name: INGRESS_CLASS
     value: contour.ingress.networking.knative.dev
   name: s390x-e2e-tests
-  cron: 40 5 * * *
+  cron: 20 4 * * *
   requirements:
   - s390x
   types:

--- a/prow/jobs_config/knative/operator-release-1.4.yaml
+++ b/prow/jobs_config/knative/operator-release-1.4.yaml
@@ -78,7 +78,7 @@ jobs:
     ./test/e2e-tests.sh --run-tests
   command:
   - runner.sh
-  cron: 10 17 * * *
+  cron: 20 8 * * *
   env:
   - name: INGRESS_CLASS
     value: contour.ingress.networking.knative.dev

--- a/prow/jobs_config/knative/operator-release-1.5.yaml
+++ b/prow/jobs_config/knative/operator-release-1.5.yaml
@@ -78,7 +78,7 @@ jobs:
     ./test/e2e-tests.sh --run-tests
   command:
   - runner.sh
-  cron: 20 21 * * *
+  cron: 20 12 * * *
   env:
   - name: INGRESS_CLASS
     value: contour.ingress.networking.knative.dev

--- a/prow/jobs_config/knative/operator-release-1.6.yaml
+++ b/prow/jobs_config/knative/operator-release-1.6.yaml
@@ -97,7 +97,7 @@ jobs:
     ./test/e2e-tests.sh --run-tests
   command:
   - runner.sh
-  cron: 0 14 * * *
+  cron: 20 16 * * *
   env:
   - name: CI_JOB
     value: operator-release-1.6

--- a/prow/jobs_config/knative/operator.yaml
+++ b/prow/jobs_config/knative/operator.yaml
@@ -36,7 +36,7 @@ jobs:
     command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
 
   - name: s390x-e2e-tests
-    cron: 0 13 * * *
+    cron: 20 0 * * *
     types: [periodic]
     requirements: [s390x]
     command: [runner.sh]

--- a/prow/jobs_config/knative/serving-release-1.3.yaml
+++ b/prow/jobs_config/knative/serving-release-1.3.yaml
@@ -194,7 +194,7 @@ jobs:
   - name: TEST_OPTIONS
     value: --enable-alpha --enable-beta --resolvabledomain=false
   name: s390x-kourier-tests
-  cron: 40 19 * * *
+  cron: 20 6 * * *
   requirements:
   - s390x
   types:
@@ -220,7 +220,7 @@ jobs:
   - name: TEST_OPTIONS
     value: --enable-alpha --enable-beta --resolvabledomain=false
   name: s390x-contour-tests
-  cron: 40 21 * * *
+  cron: 20 7 * * *
   requirements:
   - s390x
   types:

--- a/prow/jobs_config/knative/serving-release-1.4.yaml
+++ b/prow/jobs_config/knative/serving-release-1.4.yaml
@@ -188,7 +188,7 @@ jobs:
     ./test/e2e-tests.sh --run-tests --kourier-version latest
   command:
   - runner.sh
-  cron: 10 7 * * *
+  cron: 20 10 * * *
   env:
   - name: SYSTEM_NAMESPACE
     value: knative-serving
@@ -214,7 +214,7 @@ jobs:
     ./test/e2e-tests.sh --run-tests --contour-version latest
   command:
   - runner.sh
-  cron: 10 9 * * *
+  cron: 20 11 * * *
   env:
   - name: SYSTEM_NAMESPACE
     value: knative-serving

--- a/prow/jobs_config/knative/serving-release-1.5.yaml
+++ b/prow/jobs_config/knative/serving-release-1.5.yaml
@@ -199,7 +199,7 @@ jobs:
     ./test/e2e-tests.sh --run-tests --kourier-version latest
   command:
   - runner.sh
-  cron: 20 11 * * *
+  cron: 20 14 * * *
   env:
   - name: SYSTEM_NAMESPACE
     value: knative-serving
@@ -225,7 +225,7 @@ jobs:
     ./test/e2e-tests.sh --run-tests --contour-version latest
   command:
   - runner.sh
-  cron: 20 13 * * *
+  cron: 20 15 * * *
   env:
   - name: SYSTEM_NAMESPACE
     value: knative-serving

--- a/prow/jobs_config/knative/serving-release-1.6.yaml
+++ b/prow/jobs_config/knative/serving-release-1.6.yaml
@@ -199,7 +199,7 @@ jobs:
     ./test/e2e-tests.sh --run-tests --kourier-version latest
   command:
   - runner.sh
-  cron: 30 15 * * *
+  cron: 20 18 * * *
   env:
   - name: SYSTEM_NAMESPACE
     value: knative-serving
@@ -225,7 +225,7 @@ jobs:
     ./test/e2e-tests.sh --run-tests --contour-version latest
   command:
   - runner.sh
-  cron: 30 17 * * *
+  cron: 20 19 * * *
   env:
   - name: SYSTEM_NAMESPACE
     value: knative-serving

--- a/prow/jobs_config/knative/serving.yaml
+++ b/prow/jobs_config/knative/serving.yaml
@@ -198,7 +198,7 @@ jobs:
     - ./test/performance/performance-tests.sh
 
   - name: s390x-kourier-tests
-    cron: 0 3 * * *
+    cron: 20 2 * * *
     types: [periodic]
     requirements: [s390x]
     command: [runner.sh]
@@ -222,7 +222,7 @@ jobs:
         value: "--enable-alpha --enable-beta --resolvabledomain=false"
 
   - name: s390x-contour-tests
-    cron: 0 5 * * *
+    cron: 20 3 * * *
     types: [periodic]
     requirements: [s390x]
     command: [runner.sh]


### PR DESCRIPTION
This PR updates all prow job schedules for the s390x platform. This schedule update is required due to a rework of the internal IBM Cloud zSystems VSI worker preparation logic / schedule.

As a result of this rework all s390x-related prow jobs are expected to fail for 72h max.