### PR TITLE
Deploy `gcsweb`

### DIFF
--- a/infra/gcp/dns/dns.tf
+++ b/infra/gcp/dns/dns.tf
@@ -63,6 +63,14 @@ module "knative_dev" {
       ]
     },
     {
+      name = "gcsweb"
+      type = "A"
+      ttl  = 300
+      records = [
+        "35.201.93.215",
+      ]
+    },
+    {
       name = "elections"
       type = "CNAME"
       ttl  = 300

--- a/infra/gcp/nightly/cosign.tf
+++ b/infra/gcp/nightly/cosign.tf
@@ -4,8 +4,8 @@ module "cosign" {
 
   project_id          = module.project.project_id
   purpose             = "ASYMMETRIC_SIGN"
+  key_rotation_period = "" # 90 days
   key_algorithm       = "EC_SIGN_P384_SHA384"
-  key_rotation_period = "7776000s" # 90 days
   location            = "global"
   keyring             = "cosign"
   keys                = ["signing-key"]
@@ -14,7 +14,7 @@ module "cosign" {
 module "cosign_iam" {
   source        = "terraform-google-modules/iam/google//modules/kms_key_rings_iam"
   version       = "~> 7"
-  kms_key_rings = [module.cosign.keyring_name]
+  kms_key_rings = [module.cosign.keyring_resource.id]
   mode          = "authoritative"
 
   bindings = {

--- a/prow/cluster/control-plane/303-prow-knative-dev_managedcertificate.yaml
+++ b/prow/cluster/control-plane/303-prow-knative-dev_managedcertificate.yaml
@@ -19,3 +19,4 @@ metadata:
 spec:
   domains:
   - prow.knative.dev
+  - gcsweb.knative.dev

--- a/prow/cluster/control-plane/400-ingress.yaml
+++ b/prow/cluster/control-plane/400-ingress.yaml
@@ -24,20 +24,30 @@ metadata:
     networking.gke.io/managed-certificates: prow-knative-dev
 spec:
   rules:
-  - host: prow.knative.dev
-    http:
-      paths:
-      - path: /*
-        pathType: ImplementationSpecific
-        backend:
-          service:
-            name: deck
-            port:
-              number: 80
-      - path: /ghapp-hook
-        pathType: ImplementationSpecific
-        backend:
-          service:
-            name: hook
-            port:
-              number: 8888
+    - host: prow.knative.dev
+      http:
+        paths:
+          - path: /*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: deck
+                port:
+                  number: 80
+          - path: /ghapp-hook
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: hook
+                port:
+                  number: 8888
+    - host: gcsweb.knative.dev
+      http:
+        paths:
+          - path: /*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: gcsweb
+                port:
+                  number: 80

--- a/prow/cluster/control-plane/gcsweb.yaml
+++ b/prow/cluster/control-plane/gcsweb.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gcsweb
+  namespace: gcsweb
+  labels:
+    app: gcsweb
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: gcsweb
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: gcsweb
+    spec:
+      terminationGracePeriodSeconds: 30
+      containers:
+        - name: gcsweb
+          image: k8s.gcr.io/gcsweb:v1.1.0
+          args:
+            - -upgrade-proxied-http-to-https
+            # prow bucket
+            - -b=knative-prow
+            # release buckets
+            - -b=knative-releases
+            - -b=knative-nightly
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          resources:
+            limits:
+              cpu: 0.2
+              memory: 256Mi
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 3
+            timeoutSeconds: 2
+            failureThreshold: 2
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 3
+            timeoutSeconds: 2
+            failureThreshold: 2
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gcsweb
+  namespace: gcsweb
+  labels:
+    app: gcsweb
+spec:
+  selector:
+    app: gcsweb
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080


### PR DESCRIPTION
This PR deploys [gcsweb](https://github.com/kubernetes/k8s.io/tree/main/apps/gcsweb) application. If you use the Kubernetes Prow, this should be very familiar.

https://gcsweb.k8s.io/gcs/kubernetes-release/release/

I will update prow in a separate PR.

/cc @kvmware