### PR TITLE
Workload Identity Enablement - Part Two

### DIFF
--- a/infra/gcp/shared/gke.tf
+++ b/infra/gcp/shared/gke.tf
@@ -1,25 +1,25 @@
 // WARNING, MAKE SURE YOU DON"T DESTROY THIS CLUSTER ACCIDENTALLY
 
 module "shared" {
-  source                               = "terraform-google-modules/kubernetes-engine/google//modules/beta-public-cluster"
-  version                              = "~> 21"
-  project_id                           = module.project.project_id
-  name                                 = "shared"
-  region                               = "us-central1"
-  release_channel                      = "RAPID"
-  network                              = module.vpc.network_name
-  subnetwork                           = module.vpc.subnets["us-central1/gke-subnet-01"].name
-  ip_range_pods                        = "gke-pods-01"
-  ip_range_services                    = "gke-services-01"
-  http_load_balancing                  = true
-  network_policy                       = false
-  horizontal_pod_autoscaling           = true
-  filestore_csi_driver                 = false
-  create_service_account               = false
-  remove_default_node_pool             = true
-  gce_pd_csi_driver                    = true
+  source                     = "terraform-google-modules/kubernetes-engine/google//modules/beta-public-cluster"
+  version                    = "~> 21"
+  project_id                 = module.project.project_id
+  name                       = "shared"
+  region                     = "us-central1"
+  release_channel            = "RAPID"
+  network                    = module.vpc.network_name
+  subnetwork                 = module.vpc.subnets["us-central1/gke-subnet-01"].name
+  ip_range_pods              = "gke-pods-01"
+  ip_range_services          = "gke-services-01"
+  http_load_balancing        = true
+  network_policy             = false
+  horizontal_pod_autoscaling = true
+  filestore_csi_driver       = false
+  create_service_account     = false
+  remove_default_node_pool   = true
+  gce_pd_csi_driver          = true
   # monitoring_enable_managed_prometheus = true
-  authenticator_security_group         = "gke-security-groups@knative.dev"
+  authenticator_security_group = "gke-security-groups@knative.dev"
   cluster_autoscaling = {
     enabled             = false
     autoscaling_profile = "OPTIMIZE_UTILIZATION"

--- a/infra/gcp/tests/buckets.tf
+++ b/infra/gcp/tests/buckets.tf
@@ -1,0 +1,46 @@
+
+resource "google_storage_bucket" "prow" {
+  name                        = "knative-prow"
+  location                    = "US"
+  storage_class               = "STANDARD"
+  uniform_bucket_level_access = true
+  lifecycle_rule {
+    action {
+      storage_class = "NEARLINE"
+      type          = "SetStorageClass"
+    }
+    condition {
+      age                        = 180
+    }
+  }
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age                        = 210
+    }
+  }
+}
+
+module "iam_prow_bucket" {
+  source          = "terraform-google-modules/iam/google//modules/storage_buckets_iam"
+  storage_buckets = [google_storage_bucket.prow.name]
+  version         = "~> 7"
+
+  mode = "authoritative"
+
+  bindings = {
+    "roles/storage.objectAdmin" = [
+      "serviceAccount:prow-job@knative-nightly.iam.gserviceaccount.com",
+      "serviceAccount:prow-job@knative-releases.iam.gserviceaccount.com",
+      "serviceAccount:${google_service_account.prow_job.email}",
+      "serviceAccount:${google_service_account.prow_pod_utils.email}",
+      "serviceAccount:${google_service_account.gsuite.email}",
+    ]
+    "roles/storage.objectViewer" = [
+      "allUsers",
+    ]
+  }
+}

--- a/infra/gcp/tests/cosign.tf
+++ b/infra/gcp/tests/cosign.tf
@@ -5,7 +5,7 @@ module "cosign" {
   project_id          = module.project.project_id
   purpose             = "ASYMMETRIC_SIGN"
   key_algorithm       = "EC_SIGN_P384_SHA384"
-  key_rotation_period = "7776000s" # 90 days
+  key_rotation_period = ""
   location            = "global"
   keyring             = "cosign"
   keys                = ["signing-key-v2"]
@@ -14,7 +14,7 @@ module "cosign" {
 module "cosign_iam" {
   source        = "terraform-google-modules/iam/google//modules/kms_key_rings_iam"
   version       = "~> 7"
-  kms_key_rings = [module.cosign.keyring_name]
+  kms_key_rings = [module.cosign.keyring_resource.id]
   mode          = "authoritative"
 
   bindings = {

--- a/infra/gcp/tests/prow.tf
+++ b/infra/gcp/tests/prow.tf
@@ -69,3 +69,20 @@ resource "google_service_account" "prow_job" {
   display_name = "Prow Job Knative Test Runner"
   project      = "knative-tests"
 }
+
+// GSuite Groups Manager
+resource "google_service_account_iam_binding" "gsuite" {
+  service_account_id = google_service_account.gsuite.name
+  role               = "roles/iam.workloadIdentityUser"
+
+  members = [
+    "serviceAccount:knative-tests.svc.id.goog[test-pods/gsuite-groups-manager]",
+  ]
+}
+
+resource "google_service_account" "gsuite" {
+  account_id   = "gsuite-groups-manager"
+  display_name = "GSuite Groups Manager"
+  project      = "knative-tests"
+  description  = "Service account for managing knative.team gsuite groups."
+}

--- a/prow/cluster/build/200-serviceaccounts.yaml
+++ b/prow/cluster/build/200-serviceaccounts.yaml
@@ -27,6 +27,8 @@ metadata:
 kind: ServiceAccount
 apiVersion: v1
 metadata:
+  # annotations:
+  #   iam.gke.io/gcp-service-account: prow-pod-utils@knative-tests.iam.gserviceaccount.com
   name: default
   namespace: test-pods
 ---

--- a/prow/cluster/control-plane/301-rbac.yaml
+++ b/prow/cluster/control-plane/301-rbac.yaml
@@ -402,7 +402,6 @@ subjects:
   name: "tide"
   namespace: default
 ---
-
 kind: ServiceAccount
 apiVersion: v1
 metadata:
@@ -498,3 +497,11 @@ roleRef:
 subjects:
 - kind: User
   name: prow-control-plane@knative-tests.iam.gserviceaccount.com
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: prow-pod-utils@knative-tests.iam.gserviceaccount.com
+  name: default
+  namespace: default

--- a/prow/cluster/gitops/apps/prow-trusted.yaml
+++ b/prow/cluster/gitops/apps/prow-trusted.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: prow-trusted
+  namespace: argocd
+spec:
+  destination:
+    name: prow-trusted
+    namespace: default
+  project: default
+  source:
+    path: prow/cluster/trusted
+    repoURL: https://github.com/knative/test-infra
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/prow/cluster/trusted/limitrange.yaml
+++ b/prow/cluster/trusted/limitrange.yaml
@@ -1,0 +1,24 @@
+# Copyright 2022 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limit-range
+  namespace: test-pods
+spec:
+  limits:
+    - defaultRequest:
+        cpu: 100m
+      type: Container

--- a/prow/cluster/trusted/monitoring.yaml
+++ b/prow/cluster/trusted/monitoring.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  labels:
+    app.kubernetes.io/name: external-secrets
+  name: external-secrets
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: external-secrets
+  endpoints:
+  - port: metrics
+    interval: 30s

--- a/prow/cluster/trusted/namespace.yaml
+++ b/prow/cluster/trusted/namespace.yaml
@@ -1,0 +1,18 @@
+# Copyright 2022 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-pods

--- a/prow/cluster/trusted/secrets.yaml
+++ b/prow/cluster/trusted/secrets.yaml
@@ -1,0 +1,8 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: knative-tests
+spec:
+  provider:
+    gcpsm:
+      projectID: knative-tests

--- a/prow/cluster/trusted/serviceaccounts.yaml
+++ b/prow/cluster/trusted/serviceaccounts.yaml
@@ -1,0 +1,24 @@
+# DON'T FORGET TO COMPLETE THE WORKLOAD IDENTITY CONFIGURATION.
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: prow-pod-utils@knative-tests.iam.gserviceaccount.com
+  name: default
+  namespace: test-pods
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: gsuite-groups-manager@knative-tests.iam.gserviceaccount.com
+  name: gsuite-groups-manager
+  namespace: test-pods
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+annotations:
+  iam.gke.io/gcp-service-account: prow-deployer@knative-tests.iam.gserviceaccount.com
+name: prow-deployer
+namespace: test-pods

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -32,7 +32,7 @@ plank:
         gcs_configuration:
           bucket: "knative-prow"
           path_strategy: "explicit"
-        gcs_credentials_secret: "test-account"
+        gcs_credentials_secret: ""
         resources:
           sidecar:
             requests:
@@ -72,7 +72,7 @@ deck:
   google_analytics: G-Z5SCKHSFYJ
   spyglass:
     size_limit: 500000000 # 500MB
-    gcs_browser_prefix: https://console.cloud.google.com/storage/browser/
+    gcs_browser_prefix: https://gcsweb.knative.dev/gcs/
     testgrid_config: gs://knative-testgrid/config
     testgrid_root: https://testgrid.knative.dev/
     announcement: "Please reach out on the #productivity slack channel to report issues with Knative Test Infrastructure."


### PR DESCRIPTION
Part of #3345 

This PR does the following:
- Enables `gcsweb` on deck after #3444 is merged
- Enables Workload Identity on trusted and default cluster.
- Adds more resources under IaC management.
- Enables GitOps for prow-trusted cluster.

/cc @kvmware 