### PR TITLE
Fixed prow job schedule

### DIFF
--- a/prow/jobs/generated/knative/operator-release-1.6.gen.yaml
+++ b/prow/jobs/generated/knative/operator-release-1.6.gen.yaml
@@ -51,7 +51,7 @@ periodics:
     testgrid-dashboards: knative-release-1.6
     testgrid-tab-name: operator-s390x-e2e-tests
   cluster: prow-build
-  cron: 30 1 * * *
+  cron: 20 16 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.6
@@ -126,7 +126,7 @@ periodics:
     testgrid-dashboards: knative-release-1.6
     testgrid-tab-name: operator-ppc64le-e2e-tests
   cluster: prow-build
-  cron: 20 16 * * *
+  cron: 0 14 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.6

--- a/prow/jobs_config/knative/operator-release-1.6.yaml
+++ b/prow/jobs_config/knative/operator-release-1.6.yaml
@@ -78,7 +78,7 @@ jobs:
     ./test/e2e-tests.sh --run-tests
   command:
   - runner.sh
-  cron: 30 1 * * *
+  cron: 20 16 * * *
   env:
   - name: INGRESS_CLASS
     value: contour.ingress.networking.knative.dev
@@ -97,7 +97,7 @@ jobs:
     ./test/e2e-tests.sh --run-tests
   command:
   - runner.sh
-  cron: 20 16 * * *
+  cron: 0 14 * * *
   env:
   - name: CI_JOB
     value: operator-release-1.6


### PR DESCRIPTION
This PR fixes a mix-up of the prow job schedules for operator release-1.6 for s390x and ppc64le.

Signed-off-by: Dirk Haubenreisser <haubenr@de.ibm.com>
