### PR TITLE
Add prow job for eventing-reconciler test on ppc64le

### DIFF
--- a/prow/jobs/generated/knative/eventing-main.gen.yaml
+++ b/prow/jobs/generated/knative/eventing-main.gen.yaml
@@ -291,6 +291,80 @@ periodics:
         secretName: ppc64le-cluster
 - annotations:
     testgrid-dashboards: eventing
+    testgrid-tab-name: ppc64le-e2e-reconciler-tests
+  cluster: prow-build
+  cron: 30 4 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative
+    path_alias: knative.dev/eventing
+    repo: eventing
+  name: ppc64le-e2e-reconciler-tests_eventing_main_periodic
+  spec:
+    containers:
+    - args:
+      - bash
+      - -c
+      - |
+        cat /opt/cluster/ci-script > /tmp/connect.sh
+        chmod +x /tmp/connect.sh
+        . /tmp/connect.sh ${CI_JOB}
+        ./test/e2e-rekt-tests.sh --run-tests
+      command:
+      - runner.sh
+      env:
+      - name: SYSTEM_NAMESPACE
+        value: knative-eventing
+      - name: SCALE_CHAOSDUCK_TO_ZERO
+        value: "1"
+      - name: CI_JOB
+        value: eventing_rekt-main
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: KO_FLAGS
+        value: --platform=linux/ppc64le
+      - name: PLATFORM
+        value: linux/ppc64le
+      - name: KO_DOCKER_REPO
+        value: registry.ppc64le
+      - name: DISABLE_MD_LINTING
+        value: "1"
+      - name: KUBECONFIG
+        value: /root/.kube/config
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220725-95d896f4
+      name: ""
+      resources:
+        limits:
+          memory: 16Gi
+        requests:
+          memory: 12Gi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+      - mountPath: /opt/cluster
+        name: ppc64le-cluster
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - name: ppc64le-cluster
+      secret:
+        defaultMode: 384
+        secretName: ppc64le-cluster
+- annotations:
+    testgrid-dashboards: eventing
     testgrid-tab-name: nightly
   cluster: prow-build
   cron: 9 9 * * *

--- a/prow/jobs_config/knative/eventing.yaml
+++ b/prow/jobs_config/knative/eventing.yaml
@@ -101,6 +101,27 @@ jobs:
       - name: CI_JOB
         value: "eventing-main"
 
+  - name: ppc64le-e2e-reconciler-tests
+    cron: 30 4 * * *
+    types: [periodic]
+    requirements: [ppc64le]
+    command: [runner.sh]
+    args:
+      - bash
+      - -c
+      - |
+        cat /opt/cluster/ci-script > /tmp/connect.sh
+        chmod +x /tmp/connect.sh
+        . /tmp/connect.sh ${CI_JOB}
+        ./test/e2e-rekt-tests.sh --run-tests
+    env:
+      - name: SYSTEM_NAMESPACE
+        value: knative-eventing
+      - name: SCALE_CHAOSDUCK_TO_ZERO
+        value: "1"
+      - name: CI_JOB
+        value: "eventing_rekt-main"
+
   - name: nightly
     types: [periodic]
     timeout: 3h

--- a/tools/release-jobs-syncer/pkg/jobs_sync.go
+++ b/tools/release-jobs-syncer/pkg/jobs_sync.go
@@ -44,7 +44,7 @@ const (
 // the load with Prow.
 var extraPeriodicProwJobsToSync map[string]sets.String = map[string]sets.String{
 	"knative/serving":  sets.NewString("s390x-kourier-tests", "s390x-contour-tests"),
-	"knative/eventing": sets.NewString("s390x-e2e-tests", "s390x-e2e-reconciler-tests", "ppc64le-e2e-tests"),
+	"knative/eventing": sets.NewString("s390x-e2e-tests", "s390x-e2e-reconciler-tests", "ppc64le-e2e-tests", "ppc64le-e2e-reconciler-tests"),
 	"knative/client":   sets.NewString("s390x-e2e-tests", "ppc64le-e2e-tests"),
 	"knative/operator": sets.NewString("s390x-e2e-tests", "ppc64le-e2e-tests"),
 }


### PR DESCRIPTION
Signed-off-by: mdafsanhossain <Mdafsan.Hossain@ibm.com>

**Which issue(s) this PR fixes**:<br>This PR adds nightly prow job for `eventing-reconciler` e2e test on ppc64le.


<!-- 
  Use `Fixes #<issue number>`, or `Fixes (paste link of issue)`
  to automatically close linked issue when the PR is merged.
  Uncomment and fill below if the PR does not close any issues.
-->
<!--
**What this PR does, why we need it**:<br>
-->

<!--
  If there is any golang code in this PR please uncomment the 
  `/lint` statement below to have Prow automatically lint it.
-->
<!--
  /lint
-->
