### PR TITLE
Fix argocd typos

### DIFF
--- a/prow/cluster/gitops/apps/eso-prow-build.yaml
+++ b/prow/cluster/gitops/apps/eso-prow-build.yaml
@@ -9,7 +9,7 @@ spec:
     namespace: default
   source:
     repoURL: 'https://charts.external-secrets.io'
-    targetRevision: v0.5.7
+    targetRevision: v0.5.8
     helm:
       releaseName: external-secrets
       parameters:

--- a/prow/cluster/gitops/apps/eso-prow.yaml
+++ b/prow/cluster/gitops/apps/eso-prow.yaml
@@ -9,7 +9,7 @@ spec:
     namespace: default
   source:
     repoURL: 'https://charts.external-secrets.io'
-    targetRevision: v0.5.7
+    targetRevision: v0.5.8
     helm:
       releaseName: external-secrets
       parameters:
@@ -22,8 +22,8 @@ spec:
     chart: external-secrets
   project: default
   syncPolicy:
-    # automated:
-    #   prune: true
-    #   selfHeal: true
+    automated:
+      prune: true
+      selfHeal: true
     syncOptions:
       - CreateNamespace=true

--- a/prow/cluster/gitops/apps/eso-trusted.yaml
+++ b/prow/cluster/gitops/apps/eso-trusted.yaml
@@ -9,7 +9,7 @@ spec:
     namespace: default
   source:
     repoURL: 'https://charts.external-secrets.io'
-    targetRevision: v0.5.7
+    targetRevision: v0.5.8
     helm:
       releaseName: external-secrets
       parameters:

--- a/prow/cluster/gitops/apps/shared.yaml
+++ b/prow/cluster/gitops/apps/shared.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: prow
+  name: shared
   namespace: argocd
 spec:
   destination:


### PR DESCRIPTION
I made a typo in the argocd app name when I deployed #3409 

Also bumping ESO.

/cc @kvmware 