### PR TITLE
Remove dry-run fixing teams

### DIFF
--- a/prow/jobs/custom/peribolos.yaml
+++ b/prow/jobs/custom/peribolos.yaml
@@ -19,7 +19,6 @@ presubmits:
   knative/community:
   # Run on the prow-trusted build cluster as it needs access to the github oauth token.
   - name: pull-knative-peribolos
-    optional: true
     agent: kubernetes
     decorate: true
     path_alias: knative.dev/community
@@ -43,9 +42,6 @@ presubmits:
         - "--min-admins=5"
         - "--fix-org=true"
         - "--fix-org-members=true"
-        - "--fix-teams=true"
-        - "--fix-team-members=true"
-        - "--fix-team-repos=true"
         - "--fix-repos=true"
         - "--github-hourly-tokens=1200"
         # Set --confirm=false to only validate the configuration file.
@@ -61,7 +57,6 @@ presubmits:
 
   # Run on the prow-trusted build cluster as it needs access to the github oauth token.
   - name: pull-knative-sandbox-peribolos
-    optional: true
     agent: kubernetes
     decorate: true
     path_alias: knative.dev/community
@@ -85,9 +80,6 @@ presubmits:
         - "--min-admins=5"
         - "--fix-org=true"
         - "--fix-org-members=true"
-        - "--fix-teams=true"
-        - "--fix-team-members=true"
-        - "--fix-team-repos=true"
         - "--fix-repos=true"
         - "--github-hourly-tokens=1200"
         # Set --confirm=false to only validate the configuration file.


### PR DESCRIPTION
Peribolos, in dry-run mode, naively checks for team members even when the team is being created which causes the job to fail. Instead remove checking for teams in the dry-run and let https://github.com/knative/community/pull/1136 take care of validation.

This also removes the optional flag I put in to get us around this bug as this and https://github.com/knative/community/pull/1136 should fix that now.