### PR TITLE
add secret for perf tests

### DIFF
--- a/prow/cluster/build/600-kubernetes_external_secrets.yaml
+++ b/prow/cluster/build/600-kubernetes_external_secrets.yaml
@@ -214,3 +214,46 @@ spec:
     remoteRef:
       key: slack-tokens
       property: token
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: perf-tests
+spec:
+  provider:
+    gcpsm:
+      projectID: knative-community
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: influxdb
+  namespace: test-pods
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: perf-tests
+  target:
+    name: influx_token
+  data:
+  - secretKey: influx_token_file
+    remoteRef:
+      key: influxdb_token
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: influxdb
+  namespace: test-pods
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: perf-tests
+  target:
+    name: influx_url
+  data:
+  - secretKey: influx_url_file
+    remoteRef:
+      key: influxdb_url

--- a/prow/jobs/generated/knative/serving-main.gen.yaml
+++ b/prow/jobs/generated/knative/serving-main.gen.yaml
@@ -672,6 +672,78 @@ periodics:
       name: cgroup
 - annotations:
     testgrid-dashboards: serving
+    testgrid-tab-name: performance-tests-mako
+  cluster: prow-build
+  cron: 43 */9 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative
+    path_alias: knative.dev/serving
+    repo: serving
+  name: performance-tests-mako_serving_main_periodic
+  spec:
+    containers:
+    - args:
+      - ./test/presubmit-tests.sh
+      - --run-test
+      - ./test/performance/performance-tests-mako.sh
+      command:
+      - runner.sh
+      env:
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220725-a4aaff33
+      name: ""
+      resources:
+        limits:
+          memory: 16Gi
+        requests:
+          memory: 12Gi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+      - mountPath: /docker-graph
+        name: docker-graph
+      - mountPath: /lib/modules
+        name: modules
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+      - mountPath: /etc/influx-secret-volume
+        name: influx-secret-volume
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - emptyDir: {}
+      name: docker-graph
+    - hostPath:
+        path: /lib/modules
+        type: Directory
+      name: modules
+    - hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+      name: cgroup
+    - name: influx-secret-volume
+      secret:
+        defaultMode: 384
+        secretName: influx-secret
+- annotations:
+    testgrid-dashboards: serving
     testgrid-tab-name: s390x-kourier-tests
   cluster: prow-build
   cron: 20 2 * * *
@@ -1387,6 +1459,9 @@ presubmits:
           name: modules
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /etc/influx-secret-volume
+          name: influx-secret-volume
+          readOnly: true
       nodeSelector:
         type: testing
       volumes:
@@ -1406,6 +1481,10 @@ presubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - name: influx-secret-volume
+        secret:
+          defaultMode: 384
+          secretName: influx-secret
   - always_run: false
     branches:
     - ^main$

--- a/prow/jobs_config/.base.yaml
+++ b/prow/jobs_config/.base.yaml
@@ -83,6 +83,20 @@ requirement_presets:
           path: /sys/fs/cgroup
           type: Directory
 
+  perf:
+    env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+    volumeMounts:
+      - name: influx-secret-volume
+        mountPath: /etc/influx-secret-volume
+        readOnly: true
+    volumes:
+      - name: influx-secret-volume
+        secret:
+          secretName: influx-secret
+          defaultMode: 0600
+
   gcp:
     env:
       - name: E2E_CLUSTER_REGION

--- a/prow/jobs_config/knative/serving.yaml
+++ b/prow/jobs_config/knative/serving.yaml
@@ -36,6 +36,7 @@ jobs:
 
   - name: performance-tests-mako
     types: [presubmit]
+    requirements: [perf]
     command: [runner.sh, ./test/presubmit-tests.sh, --run-test, ./test/performance/performance-tests-mako.sh]
     modifiers: [presubmit_optional, presubmit_skipped]
 
@@ -196,6 +197,16 @@ jobs:
     - ./test/presubmit-tests.sh
     - --run-test
     - ./test/performance/performance-tests.sh
+
+  - name: performance-tests-mako
+    types: [periodic]
+    requirements: [perf]
+    command:
+    - runner.sh
+    args:
+    - ./test/presubmit-tests.sh
+    - --run-test
+    - ./test/performance/performance-tests-mako.sh
 
   - name: s390x-kourier-tests
     cron: 20 2 * * *


### PR DESCRIPTION


<!-- 
  Use `Fixes #<issue number>`, or `Fixes (paste link of issue)`
  to automatically close linked issue when the PR is merged.
  Uncomment and fill below if the PR does not close any issues.
-->
<!--
**What this PR does, why we need it**:<br>
-->

- add secret to the serving perf tests job so it can access influxdb running on the community cluster, secret already added in gcp secret manager

<!--
  If there is any golang code in this PR please uncomment the 
  `/lint` statement below to have Prow automatically lint it.
-->
<!--
  /lint
-->
