### PR TITLE
[s390x] add release 1.7 jobs

### DIFF
--- a/prow/jobs/generated/knative-sandbox/eventing-kafka-broker-release-1.7.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kafka-broker-release-1.7.gen.yaml
@@ -145,6 +145,249 @@ periodics:
         path: /sys/fs/cgroup
         type: Directory
       name: cgroup
+- annotations:
+    testgrid-dashboards: knative-sandbox-release-1.7
+    testgrid-tab-name: eventing-kafka-broker-s390x-e2e-tests-ssl
+  cluster: prow-build
+  cron: 20 11 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: release-1.7
+    org: knative-sandbox
+    path_alias: knative.dev/eventing-kafka-broker
+    repo: eventing-kafka-broker
+  name: s390x-e2e-tests-ssl_eventing-kafka-broker_release-1.7_periodic
+  spec:
+    containers:
+    - args:
+      - bash
+      - -c
+      - |
+        mkdir -p /root/.kube
+        cat /opt/cluster/ci-script > connect.sh
+        chmod +x connect.sh
+        ./connect.sh eventing_kafka-broker-ssl-17
+        kubectl get cm s390x-config-eventing-kafka-broker -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
+        chmod +x adjust.sh
+        ./adjust.sh
+        ./test/e2e-tests.sh --run-tests
+      command:
+      - runner.sh
+      env:
+      - name: SYSTEM_NAMESPACE
+        value: knative-eventing
+      - name: EVENTING_NAMESPACE
+        value: knative-eventing
+      - name: SCALE_CHAOSDUCK_TO_ZERO
+        value: "1"
+      - name: EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO
+        value: SSL
+      - name: BROKER_CLASS
+        value: Kafka
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: KO_FLAGS
+        value: --platform=linux/s390x --insecure-registry
+      - name: PLATFORM
+        value: linux/s390x
+      - name: KO_DOCKER_REPO
+        valueFrom:
+          secretKeyRef:
+            key: ko-docker-repo
+            name: s390x-cluster1
+      - name: KUBECONFIG
+        value: /root/.kube/config
+      - name: DOCKER_CONFIG
+        value: /opt/cluster
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220822-af47ef80
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+      - mountPath: /opt/cluster
+        name: s390x-cluster1
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - name: s390x-cluster1
+      secret:
+        defaultMode: 384
+        secretName: s390x-cluster1
+- annotations:
+    testgrid-dashboards: knative-sandbox-release-1.7
+    testgrid-tab-name: eventing-kafka-broker-s390x-e2e-tests-sasl-ssl
+  cluster: prow-build
+  cron: 20 12 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: release-1.7
+    org: knative-sandbox
+    path_alias: knative.dev/eventing-kafka-broker
+    repo: eventing-kafka-broker
+  name: s390x-e2e-tests-sasl-ssl_eventing-kafka-broker_release-1.7_periodic
+  spec:
+    containers:
+    - args:
+      - bash
+      - -c
+      - |
+        mkdir -p /root/.kube
+        cat /opt/cluster/ci-script > connect.sh
+        chmod +x connect.sh
+        ./connect.sh eventing_kafka-broker-sasl-ssl-17
+        kubectl get cm s390x-config-eventing-kafka-broker -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
+        chmod +x adjust.sh
+        ./adjust.sh
+        ./test/e2e-tests.sh --run-tests
+      command:
+      - runner.sh
+      env:
+      - name: SYSTEM_NAMESPACE
+        value: knative-eventing
+      - name: EVENTING_NAMESPACE
+        value: knative-eventing
+      - name: SCALE_CHAOSDUCK_TO_ZERO
+        value: "1"
+      - name: EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO
+        value: SASL_SSL
+      - name: BROKER_CLASS
+        value: Kafka
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: KO_FLAGS
+        value: --platform=linux/s390x --insecure-registry
+      - name: PLATFORM
+        value: linux/s390x
+      - name: KO_DOCKER_REPO
+        valueFrom:
+          secretKeyRef:
+            key: ko-docker-repo
+            name: s390x-cluster1
+      - name: KUBECONFIG
+        value: /root/.kube/config
+      - name: DOCKER_CONFIG
+        value: /opt/cluster
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220822-af47ef80
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+      - mountPath: /opt/cluster
+        name: s390x-cluster1
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - name: s390x-cluster1
+      secret:
+        defaultMode: 384
+        secretName: s390x-cluster1
+- annotations:
+    testgrid-dashboards: knative-sandbox-release-1.7
+    testgrid-tab-name: eventing-kafka-broker-s390x-e2e-tests-sasl-plain
+  cluster: prow-build
+  cron: 20 13 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: release-1.7
+    org: knative-sandbox
+    path_alias: knative.dev/eventing-kafka-broker
+    repo: eventing-kafka-broker
+  name: s390x-e2e-tests-sasl-plain_eventing-kafka-broker_release-1.7_periodic
+  spec:
+    containers:
+    - args:
+      - bash
+      - -c
+      - |
+        mkdir -p /root/.kube
+        cat /opt/cluster/ci-script > connect.sh
+        chmod +x connect.sh
+        ./connect.sh eventing_kafka-broker-sasl-plain-17
+        kubectl get cm s390x-config-eventing-kafka-broker -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
+        chmod +x adjust.sh
+        ./adjust.sh
+        ./test/e2e-tests.sh --run-tests
+      command:
+      - runner.sh
+      env:
+      - name: SYSTEM_NAMESPACE
+        value: knative-eventing
+      - name: EVENTING_NAMESPACE
+        value: knative-eventing
+      - name: SCALE_CHAOSDUCK_TO_ZERO
+        value: "1"
+      - name: EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO
+        value: SASL_PLAIN
+      - name: BROKER_CLASS
+        value: Kafka
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: KO_FLAGS
+        value: --platform=linux/s390x --insecure-registry
+      - name: PLATFORM
+        value: linux/s390x
+      - name: KO_DOCKER_REPO
+        valueFrom:
+          secretKeyRef:
+            key: ko-docker-repo
+            name: s390x-cluster1
+      - name: KUBECONFIG
+        value: /root/.kube/config
+      - name: DOCKER_CONFIG
+        value: /opt/cluster
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220822-af47ef80
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+      - mountPath: /opt/cluster
+        name: s390x-cluster1
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - name: s390x-cluster1
+      secret:
+        defaultMode: 384
+        secretName: s390x-cluster1
 presubmits:
   knative-sandbox/eventing-kafka-broker:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/eventing-kafka-release-1.7.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kafka-release-1.7.gen.yaml
@@ -143,6 +143,83 @@ periodics:
         path: /sys/fs/cgroup
         type: Directory
       name: cgroup
+- annotations:
+    testgrid-dashboards: knative-sandbox-release-1.7
+    testgrid-tab-name: eventing-kafka-s390x-e2e-tests
+  cluster: prow-build
+  cron: 20 10 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: release-1.7
+    org: knative-sandbox
+    path_alias: knative.dev/eventing-kafka
+    repo: eventing-kafka
+  name: s390x-e2e-tests_eventing-kafka_release-1.7_periodic
+  spec:
+    containers:
+    - args:
+      - bash
+      - -c
+      - |
+        mkdir -p /root/.kube
+        cat /opt/cluster/ci-script > connect.sh
+        chmod +x connect.sh
+        ./connect.sh eventing_kafka-17
+        kubectl get cm s390x-config-eventing-kafka -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
+        chmod +x adjust.sh
+        ./adjust.sh
+        ./test/e2e-tests.sh --run-tests
+      command:
+      - runner.sh
+      env:
+      - name: SYSTEM_NAMESPACE
+        value: knative-eventing
+      - name: EVENTING_NAMESPACE
+        value: knative-eventing
+      - name: SCALE_CHAOSDUCK_TO_ZERO
+        value: "1"
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: KO_FLAGS
+        value: --platform=linux/s390x --insecure-registry
+      - name: PLATFORM
+        value: linux/s390x
+      - name: KO_DOCKER_REPO
+        valueFrom:
+          secretKeyRef:
+            key: ko-docker-repo
+            name: s390x-cluster1
+      - name: KUBECONFIG
+        value: /root/.kube/config
+      - name: DOCKER_CONFIG
+        value: /opt/cluster
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20220822-af47ef80
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+      - mountPath: /opt/cluster
+        name: s390x-cluster1
+        readOnly: true
+    nodeSelector:
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - name: s390x-cluster1
+      secret:
+        defaultMode: 384
+        secretName: s390x-cluster1
 presubmits:
   knative-sandbox/eventing-kafka:
   - always_run: true

--- a/prow/jobs/generated/knative/client-release-1.7.gen.yaml
+++ b/prow/jobs/generated/knative/client-release-1.7.gen.yaml
@@ -51,7 +51,7 @@ periodics:
     testgrid-dashboards: knative-release-1.7
     testgrid-tab-name: client-s390x-e2e-tests
   cluster: prow-build
-  cron: 20 1 * * *
+  cron: 20 5 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.7
@@ -68,7 +68,7 @@ periodics:
         mkdir -p /root/.kube
         cat /opt/cluster/ci-script > connect.sh
         chmod +x connect.sh
-        ./connect.sh client-main
+        ./connect.sh client-17
         kubectl get cm s390x-config-client -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
         chmod +x adjust.sh
         ./adjust.sh

--- a/prow/jobs/generated/knative/eventing-release-1.7.gen.yaml
+++ b/prow/jobs/generated/knative/eventing-release-1.7.gen.yaml
@@ -57,7 +57,7 @@ periodics:
     testgrid-dashboards: knative-release-1.7
     testgrid-tab-name: eventing-s390x-e2e-tests
   cluster: prow-build
-  cron: 20 4 * * *
+  cron: 20 8 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.7
@@ -74,7 +74,7 @@ periodics:
         mkdir -p /root/.kube
         cat /opt/cluster/ci-script > connect.sh
         chmod +x connect.sh
-        ./connect.sh eventing-main
+        ./connect.sh eventing-17
         kubectl get cm s390x-config-eventing -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
         chmod +x adjust.sh
         ./adjust.sh
@@ -136,7 +136,7 @@ periodics:
     testgrid-dashboards: knative-release-1.7
     testgrid-tab-name: eventing-s390x-e2e-reconciler-tests
   cluster: prow-build
-  cron: 20 5 * * *
+  cron: 20 9 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.7
@@ -153,7 +153,7 @@ periodics:
         mkdir -p /root/.kube
         cat /opt/cluster/ci-script > connect.sh
         chmod +x connect.sh
-        ./connect.sh eventing_rekt-main
+        ./connect.sh eventing_rekt-17
         kubectl get cm s390x-config-eventing -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
         chmod +x adjust.sh
         ./adjust.sh

--- a/prow/jobs/generated/knative/serving-release-1.7.gen.yaml
+++ b/prow/jobs/generated/knative/serving-release-1.7.gen.yaml
@@ -75,7 +75,7 @@ periodics:
     testgrid-dashboards: knative-release-1.7
     testgrid-tab-name: serving-s390x-kourier-tests
   cluster: prow-build
-  cron: 20 2 * * *
+  cron: 20 6 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.7
@@ -92,7 +92,7 @@ periodics:
         mkdir -p /root/.kube
         cat /opt/cluster/ci-script > connect.sh
         chmod +x connect.sh
-        server_addr=$(./connect.sh kourier-main)
+        server_addr=$(./connect.sh kourier-17)
         kubectl get cm s390x-config-serving -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
         chmod +x adjust.sh
         ./adjust.sh
@@ -173,7 +173,7 @@ periodics:
     testgrid-dashboards: knative-release-1.7
     testgrid-tab-name: serving-s390x-contour-tests
   cluster: prow-build
-  cron: 20 3 * * *
+  cron: 20 7 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.7
@@ -190,7 +190,7 @@ periodics:
         mkdir -p /root/.kube
         cat /opt/cluster/ci-script > connect.sh
         chmod +x connect.sh
-        server_addr=$(./connect.sh contour-main)
+        server_addr=$(./connect.sh contour-17)
         kubectl get cm s390x-config-serving -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
         chmod +x adjust.sh
         ./adjust.sh

--- a/prow/jobs_config/knative-sandbox/eventing-kafka-broker-release-1.7.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-kafka-broker-release-1.7.yaml
@@ -211,5 +211,89 @@ jobs:
   - docker
   types:
   - periodic
+- name: s390x-e2e-tests-ssl
+  cron: 20 11 * * *
+  types: [periodic]
+  requirements: [s390x]
+  command: [runner.sh]
+  args:
+    - bash
+    - -c
+    - |
+      mkdir -p /root/.kube
+      cat /opt/cluster/ci-script > connect.sh
+      chmod +x connect.sh
+      ./connect.sh eventing_kafka-broker-ssl-17
+      kubectl get cm s390x-config-eventing-kafka-broker -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
+      chmod +x adjust.sh
+      ./adjust.sh
+      ./test/e2e-tests.sh --run-tests
+  env:
+    - name: SYSTEM_NAMESPACE
+      value: knative-eventing
+    - name: EVENTING_NAMESPACE
+      value: knative-eventing
+    - name: SCALE_CHAOSDUCK_TO_ZERO
+      value: "1"
+    - name: EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO
+      value: SSL
+    - name: BROKER_CLASS
+      value: Kafka
+- name: s390x-e2e-tests-sasl-ssl
+  cron: 20 12 * * *
+  types: [periodic]
+  requirements: [s390x]
+  command: [runner.sh]
+  args:
+    - bash
+    - -c
+    - |
+      mkdir -p /root/.kube
+      cat /opt/cluster/ci-script > connect.sh
+      chmod +x connect.sh
+      ./connect.sh eventing_kafka-broker-sasl-ssl-17
+      kubectl get cm s390x-config-eventing-kafka-broker -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
+      chmod +x adjust.sh
+      ./adjust.sh
+      ./test/e2e-tests.sh --run-tests
+  env:
+    - name: SYSTEM_NAMESPACE
+      value: knative-eventing
+    - name: EVENTING_NAMESPACE
+      value: knative-eventing
+    - name: SCALE_CHAOSDUCK_TO_ZERO
+      value: "1"
+    - name: EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO
+      value: SASL_SSL
+    - name: BROKER_CLASS
+      value: Kafka
+- name: s390x-e2e-tests-sasl-plain
+  cron: 20 13 * * *
+  types: [periodic]
+  requirements: [s390x]
+  command: [runner.sh]
+  args:
+    - bash
+    - -c
+    - |
+      mkdir -p /root/.kube
+      cat /opt/cluster/ci-script > connect.sh
+      chmod +x connect.sh
+      ./connect.sh eventing_kafka-broker-sasl-plain-17
+      kubectl get cm s390x-config-eventing-kafka-broker -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
+      chmod +x adjust.sh
+      ./adjust.sh
+      ./test/e2e-tests.sh --run-tests
+  env:
+    - name: SYSTEM_NAMESPACE
+      value: knative-eventing
+    - name: EVENTING_NAMESPACE
+      value: knative-eventing
+    - name: SCALE_CHAOSDUCK_TO_ZERO
+      value: "1"
+    - name: EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO
+      value: SASL_PLAIN
+    - name: BROKER_CLASS
+      value: Kafka
 org: knative-sandbox
 repo: eventing-kafka-broker

--- a/prow/jobs_config/knative-sandbox/eventing-kafka-release-1.7.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-kafka-release-1.7.yaml
@@ -109,5 +109,29 @@ jobs:
   - docker
   types:
   - periodic
+- name: s390x-e2e-tests
+  cron: 20 10 * * *
+  types: [periodic]
+  requirements: [s390x]
+  command: [runner.sh]
+  args:
+    - bash
+    - -c
+    - |
+      mkdir -p /root/.kube
+      cat /opt/cluster/ci-script > connect.sh
+      chmod +x connect.sh
+      ./connect.sh eventing_kafka-17
+      kubectl get cm s390x-config-eventing-kafka -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
+      chmod +x adjust.sh
+      ./adjust.sh
+      ./test/e2e-tests.sh --run-tests
+  env:
+    - name: SYSTEM_NAMESPACE
+      value: knative-eventing
+    - name: EVENTING_NAMESPACE
+      value: knative-eventing
+    - name: SCALE_CHAOSDUCK_TO_ZERO
+      value: "1"
 org: knative-sandbox
 repo: eventing-kafka

--- a/prow/jobs_config/knative/client-release-1.7.yaml
+++ b/prow/jobs_config/knative/client-release-1.7.yaml
@@ -54,14 +54,14 @@ jobs:
     mkdir -p /root/.kube
     cat /opt/cluster/ci-script > connect.sh
     chmod +x connect.sh
-    ./connect.sh client-main
+    ./connect.sh client-17
     kubectl get cm s390x-config-client -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
     chmod +x adjust.sh
     ./adjust.sh
     ./test/e2e-tests.sh --run-tests
   command:
   - runner.sh
-  cron: 20 1 * * *
+  cron: 20 5 * * *
   env:
   - name: INGRESS_CLASS
     value: contour.ingress.networking.knative.dev

--- a/prow/jobs_config/knative/eventing-release-1.7.yaml
+++ b/prow/jobs_config/knative/eventing-release-1.7.yaml
@@ -68,14 +68,14 @@ jobs:
     mkdir -p /root/.kube
     cat /opt/cluster/ci-script > connect.sh
     chmod +x connect.sh
-    ./connect.sh eventing-main
+    ./connect.sh eventing-17
     kubectl get cm s390x-config-eventing -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
     chmod +x adjust.sh
     ./adjust.sh
     ./test/e2e-tests.sh --run-tests
   command:
   - runner.sh
-  cron: 20 4 * * *
+  cron: 20 8 * * *
   env:
   - name: SYSTEM_NAMESPACE
     value: knative-eventing
@@ -93,14 +93,14 @@ jobs:
     mkdir -p /root/.kube
     cat /opt/cluster/ci-script > connect.sh
     chmod +x connect.sh
-    ./connect.sh eventing_rekt-main
+    ./connect.sh eventing_rekt-17
     kubectl get cm s390x-config-eventing -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
     chmod +x adjust.sh
     ./adjust.sh
     ./test/e2e-rekt-tests.sh --run-tests
   command:
   - runner.sh
-  cron: 20 5 * * *
+  cron: 20 9 * * *
   env:
   - name: SYSTEM_NAMESPACE
     value: knative-eventing

--- a/prow/jobs_config/knative/serving-release-1.7.yaml
+++ b/prow/jobs_config/knative/serving-release-1.7.yaml
@@ -193,7 +193,7 @@ jobs:
     mkdir -p /root/.kube
     cat /opt/cluster/ci-script > connect.sh
     chmod +x connect.sh
-    server_addr=$(./connect.sh kourier-main)
+    server_addr=$(./connect.sh kourier-17)
     kubectl get cm s390x-config-serving -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
     chmod +x adjust.sh
     ./adjust.sh
@@ -201,7 +201,7 @@ jobs:
     ./test/e2e-tests.sh --run-tests --kourier-version latest
   command:
   - runner.sh
-  cron: 20 2 * * *
+  cron: 20 6 * * *
   env:
   - name: SYSTEM_NAMESPACE
     value: knative-serving
@@ -219,7 +219,7 @@ jobs:
     mkdir -p /root/.kube
     cat /opt/cluster/ci-script > connect.sh
     chmod +x connect.sh
-    server_addr=$(./connect.sh contour-main)
+    server_addr=$(./connect.sh contour-17)
     kubectl get cm s390x-config-serving -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
     chmod +x adjust.sh
     ./adjust.sh
@@ -227,7 +227,7 @@ jobs:
     ./test/e2e-tests.sh --run-tests --contour-version latest
   command:
   - runner.sh
-  cron: 20 3 * * *
+  cron: 20 7 * * *
   env:
   - name: SYSTEM_NAMESPACE
     value: knative-serving


### PR DESCRIPTION
This PR updates the s390x-related prow jobs for release 1.7.

Note: The prow job update for operator is still missing as there is no operator release-1.7 available yet.