### PR TITLE
Fix `run_job.sh` scripts

### DIFF
--- a/config/Makefile
+++ b/config/Makefile
@@ -25,7 +25,7 @@ TESTGRID_GCS  ?= knative-testgrid
 
 CLUSTER           ?= prow
 BUILD_CLUSTER     ?= knative-prow-build-cluster
-ZONE              ?= us-central1-f
+REGION            ?= us-central1
 JOB_NAMESPACE     ?= test-pods
 
 SKIP_CONFIG_BACKUP        ?=
@@ -41,8 +41,8 @@ PROW_CONFIG_GCS                 ?= gs://$(PROW_GCS)/configs
 
 # Useful shortcuts.
 
-SET_CONTEXT                     := gcloud container clusters get-credentials "$(CLUSTER)" --project="$(PROJECT)" --zone="$(ZONE)"
-SET_BUILD_CLUSTER_CONTEXT       := gcloud container clusters get-credentials "$(BUILD_CLUSTER)" --project="$(PROJECT)" --zone="$(ZONE)"
+SET_CONTEXT                     := gcloud container clusters get-credentials "$(CLUSTER)" --project="$(PROJECT)" --region="$(REGION)"
+SET_BUILD_CLUSTER_CONTEXT       := gcloud container clusters get-credentials "$(BUILD_CLUSTER)" --project="$(PROJECT)" --region="$(REGION)"
 UNSET_CONTEXT                   := kubectl config unset current-context
 
 .PHONY: help activate-serviceaccount get-cluster-credentials unset-cluster-credentials

--- a/guides/manual_release.md
+++ b/guides/manual_release.md
@@ -169,7 +169,8 @@ Example:
    `[RELEASE_BRANCH_VERSION-]` with the release branch number (e.g., `1.4`)
 
    ```
-   cd config/prow
+   # run gcloud auth login first and pull the latest commit in main branch
+   cd prow/jobs
    ./run_job.sh release_MODULE_release-[RELEASE_BRANCH_VERSION]_periodic
    ```
 
@@ -195,6 +196,7 @@ Example:
    module name (e.g., `serving` or `eventing`).
 
    ```
+   # run gcloud auth login first and pull the latest commit in main branch
    cd config/prow
    ./run_job.sh ci-knative-MODULE-nightly-release
    ```


### PR DESCRIPTION
We moved some files around in the repo sometime ago + moved to regional cluster and the run_job.sh script hasn't been updated.

/cc @dprotaso @kvmware 