### PR TITLE
[s390x] add operator release 1.7 jobs

### DIFF
--- a/prow/jobs/generated/knative/operator-release-1.7.gen.yaml
+++ b/prow/jobs/generated/knative/operator-release-1.7.gen.yaml
@@ -51,7 +51,7 @@ periodics:
     testgrid-dashboards: knative-release-1.7
     testgrid-tab-name: operator-s390x-e2e-tests
   cluster: prow-build
-  cron: 20 0 * * *
+  cron: 20 4 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.7
@@ -68,7 +68,7 @@ periodics:
         mkdir -p /root/.kube
         cat /opt/cluster/ci-script > connect.sh
         chmod +x connect.sh
-        ./connect.sh operator-main
+        ./connect.sh operator-17
         kubectl get cm s390x-config-operator -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
         chmod +x adjust.sh
         ./adjust.sh

--- a/prow/jobs_config/knative/operator-release-1.7.yaml
+++ b/prow/jobs_config/knative/operator-release-1.7.yaml
@@ -71,14 +71,14 @@ jobs:
     mkdir -p /root/.kube
     cat /opt/cluster/ci-script > connect.sh
     chmod +x connect.sh
-    ./connect.sh operator-main
+    ./connect.sh operator-17
     kubectl get cm s390x-config-operator -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
     chmod +x adjust.sh
     ./adjust.sh
     ./test/e2e-tests.sh --run-tests
   command:
   - runner.sh
-  cron: 20 0 * * *
+  cron: 20 4 * * *
   env:
   - name: INGRESS_CLASS
     value: contour.ingress.networking.knative.dev


### PR DESCRIPTION
This PR updates the s390x-related prow jobs for *operator* release 1.7.

This is a follow-up to PR https://github.com/knative/test-infra/pull/3496.