### PR TITLE
Create signing identities for `cosign`

### DIFF
--- a/infra/gcp/nightly/iam.tf
+++ b/infra/gcp/nightly/iam.tf
@@ -33,3 +33,19 @@ resource "google_service_account_iam_binding" "prow_job" {
     "serviceAccount:knative-tests.svc.id.goog[test-pods/nightly]",
   ]
 }
+
+resource "google_service_account" "signer" {
+  account_id   = "signer"
+  display_name = "Used for signing nightly images with cosign"
+  project      = module.project.project_id
+}
+
+resource "google_service_account_iam_binding" "signer" {
+  service_account_id = google_service_account.signer.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+
+  members = [
+    "group:kn-infra-gcp-org-admins@knative.dev",
+    "serviceAccount:${google_service_account.prow_job.email}",
+  ]
+}

--- a/infra/gcp/releases/iam.tf
+++ b/infra/gcp/releases/iam.tf
@@ -32,3 +32,19 @@ resource "google_service_account_iam_binding" "prow_job" {
     "serviceAccount:knative-tests.svc.id.goog[test-pods/release]",
   ]
 }
+
+resource "google_service_account" "signer" {
+  account_id   = "signer"
+  display_name = "Used for signing release images with cosign"
+  project      = module.project.project_id
+}
+
+resource "google_service_account_iam_binding" "signer" {
+  service_account_id = google_service_account.signer.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+
+  members = [
+    "serviceAccount:${google_service_account.prow_job.email}",
+    // DO NOT ADD ANY OTHER PRINCIPAL HERE AS THIS ROLE ALLOWS OIDC TOKENS TO BE CREATED FOR THIS USER
+  ]
+}

--- a/prow/cluster/build/serviceaccounts.yaml
+++ b/prow/cluster/build/serviceaccounts.yaml
@@ -53,5 +53,5 @@ kind: ServiceAccount
 metadata:
   annotations:
     iam.gke.io/gcp-service-account: testgrid-updater@knative-tests.iam.gserviceaccount.com
-name: testgrid-updater
-namespace: test-pods
+  name: testgrid-updater
+  namespace: test-pods


### PR DESCRIPTION
This PR creates two service accounts:
- `signer@knative-releases.iam.gserviceaccount.com`
- `signer@knative-nightly.iam.gserviceaccount.com`

I will be using Keyless Signing with cosign to sign out images and binaries with these principals.

Also fixing a typo in a k8s manifest.

/cc @kvmware 