### PR TITLE
Sign Images and Binaries for net-certmanager and client nightlies

### DIFF
--- a/prow/jobs/generated/knative-sandbox/net-certmanager-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-certmanager-main.gen.yaml
@@ -75,6 +75,8 @@ periodics:
       - --publish
       - --tag-release
       env:
+      - name: SIGN_IMAGES
+        value: "true"
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
       image: gcr.io/knative-tests/test-infra/prow-tests:v20220907-3f920d69

--- a/prow/jobs/generated/knative/client-main.gen.yaml
+++ b/prow/jobs/generated/knative/client-main.gen.yaml
@@ -257,6 +257,8 @@ periodics:
       - --publish
       - --tag-release
       env:
+      - name: SIGN_IMAGES
+        value: "true"
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
       image: gcr.io/knative-tests/test-infra/prow-tests:v20220907-3f920d69

--- a/prow/jobs_config/knative-sandbox/net-certmanager.yaml
+++ b/prow/jobs_config/knative-sandbox/net-certmanager.yaml
@@ -34,7 +34,9 @@ jobs:
           "The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"
         job_states_to_report:
         - "failure"
-
+    env:
+    - name: SIGN_IMAGES
+      value: "true"
   - name: release
     types: [periodic]
     command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/net-certmanager, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]

--- a/prow/jobs_config/knative/client.yaml
+++ b/prow/jobs_config/knative/client.yaml
@@ -83,7 +83,9 @@ jobs:
           "The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"
         job_states_to_report:
         - "failure"
-
+    env:
+    - name: SIGN_IMAGES
+      value: "true"
   - name: release
     types: [periodic]
     command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/client, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]

--- a/tools/modscope/README.md
+++ b/tools/modscope/README.md
@@ -35,11 +35,11 @@ knative.dev/hack/schema
 ## Installation
 
 ```shell
-$ go install knative.dev/hack/tools/modscope@latest
+$ go install knative.dev/test-infra/tools/modscope@latest
 ```
 
 or use the `go run` command:
 
 ```shell
-$ go run knative.dev/hack/tools/modscope@latest --help
+$ go run knative.dev/test-infra/tools/modscope@latest --help
 ```


### PR DESCRIPTION
I need to bump the deps in knative/client and knative-sandbox/net-certmanager.

/hold

/cc @kvmware 