### PR TITLE
skip unknown contexts for docs

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -228,6 +228,8 @@ tide:
             skip-unknown-contexts: true
           eventing:
             skip-unknown-contexts: true
+          docs:
+            skip-unknown-contexts: true
       knative-sandbox:
         repos:
           eventing-kafka-broker:


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paul@paulschweigert.com>

A number of the actions aren't necessary for the docs repo (or only run against the code samples, which aren't undergoing a lot of changes). Others are useful (like the linting) but can block if they fail on things like the code samples. So let's make them optional, that way PRs can still merge without needing an admin to override them.

Should get one of the docs WG leads to sign off on this
/assign @abrennan89 @snneji 