### PR TITLE
Process stale issues/PRs via Prow

### DIFF
--- a/prow/jobs/custom/stale.yaml
+++ b/prow/jobs/custom/stale.yaml
@@ -138,4 +138,4 @@ periodics:
       volumes:
         - name: token
           secret:
-            secretName: k8s-triage-robot-github-token
+            secretName: github-token-for-peribolos

--- a/prow/jobs/custom/stale.yaml
+++ b/prow/jobs/custom/stale.yaml
@@ -4,7 +4,7 @@ periodics:
     cluster: prow-trusted
     decorate: true
     annotations:
-      testgrid-dashboards: sig-contribex-k8s-triage-robot
+      testgrid-dashboards: utilities
       description: Adds lifecycle/stale to stale issues after 30d of inactivity
       testgrid-tab-name: stale
     spec:

--- a/prow/jobs/custom/stale.yaml
+++ b/prow/jobs/custom/stale.yaml
@@ -1,0 +1,141 @@
+periodics:
+  - name: ci-knative-robot-stale
+    interval: 1h
+    cluster: prow-trusted
+    decorate: true
+    annotations:
+      testgrid-dashboards: sig-contribex-k8s-triage-robot
+      description: Adds lifecycle/stale to stale issues after 30d of inactivity
+      testgrid-tab-name: stale
+    spec:
+      containers:
+        - image: gcr.io/k8s-prow/commenter:v20220916-c3af09ab20
+          command:
+            - commenter
+          args:
+            - |-
+              --query=org:knative
+              org:knative-sandbox
+              -label:lifecycle/frozen
+              label:lifecycle/stale
+              -label:lifecycle/rotten
+              -repo:knative/community
+            - --updated=720h
+            - --token=/etc/github-token/token
+            - --endpoint=http://ghproxy.default.svc.cluster.local
+            - |-
+              --comment=This issue or pull request is stale because it has been open for 90 days with no activity.
+
+              This bot triages issues and PRs according to the following rules:
+              - After 90d of inactivity, `lifecycle/stale` is applied
+              - After 30d of inactivity since `lifecycle/stale` was applied, the issue is closed
+
+              You can:
+              - Mark this issue or PR as fresh with `/remove-lifecycle rotten`
+              - Close this issue or PR with `/close`
+
+              /lifecycle stale
+
+            - --template
+            - --ceiling=10
+            - --confirm
+          volumeMounts:
+            - name: token
+              mountPath: /etc/github-token
+      volumes:
+        - name: token
+          secret:
+            secretName: github-token-for-peribolos
+  - name: ci-knative-robot-close-issues
+    interval: 1h
+    cluster: prow-trusted
+    decorate: true
+    annotations:
+      testgrid-dashboards: utilities
+      description: Closes stale issues after 30d of inactivity
+      testgrid-tab-name: close-issues
+    spec:
+      containers:
+        - image: gcr.io/k8s-prow/commenter:v20220916-c3af09ab20
+          command:
+            - commenter
+          args:
+            - |-
+              --query=org:knative
+              org:knative-sandbox
+              -label:lifecycle/frozen
+              label:lifecycle/rotten
+              is:issue
+            - --updated=720h
+            - --token=/etc/github-token/token
+            - --endpoint=http://ghproxy.default.svc.cluster.local
+            - |-
+              --comment=This issue is stale because it has been open for 90 days with no activity.
+
+              This bot triages issues and PRs according to the following rules:
+              - After 90d of inactivity, `lifecycle/stale` label is applied
+              - After 30d of inactivity since `lifecycle/stale` label was applied, the issue is closed
+
+              You can:
+              - Reopen this issue with `/reopen`
+              - Mark this issue as fresh with `/remove-lifecycle rotten`
+
+              /close not-planned
+
+            - --template
+            - --ceiling=10
+            - --confirm
+          volumeMounts:
+            - name: token
+              mountPath: /etc/github-token
+      volumes:
+        - name: token
+          secret:
+            secretName: github-token-for-peribolos
+  - name: ci-knative-robot-close-prs
+    interval: 1h
+    cluster: prow-trusted
+    decorate: true
+    annotations:
+      testgrid-dashboards: utilities
+      description: Closes stale pull requests after 30d of inactivity
+      testgrid-tab-name: close-prs
+    spec:
+      containers:
+      - image: gcr.io/k8s-prow/commenter:v20220916-c3af09ab20
+        command:
+          - commenter
+        args:
+          - |-
+            --query=org:knative
+            org:knative-sandbox
+            -label:lifecycle/frozen
+            label:lifecycle/stale
+            -repo:knative/community
+            is:pr
+          - --updated=720h
+          - --token=/etc/github-token/token
+          - --endpoint=http://ghproxy.default.svc.cluster.local
+          - |-
+            --comment=This pull request is stale because it has been open for 90 days with no activity.
+
+            This bot triages PRs according to the following rules:
+            - After 90d of inactivity, `lifecycle/stale` label is applied
+            - After 30d of inactivity since `lifecycle/stale` label was applied, the issue is closed
+
+            You can:
+            - Reopen this PR with `/reopen`
+            - Mark this PR as fresh with `/remove-lifecycle stale`
+
+            /close
+
+          - --template
+          - --ceiling=10
+          - --confirm
+        volumeMounts:
+          - name: token
+            mountPath: /etc/github-token
+      volumes:
+        - name: token
+          secret:
+            secretName: k8s-triage-robot-github-token


### PR DESCRIPTION
This PR implements prow jobs that replace the stale action we propagate to every repo.
https://github.com/knative-sandbox/knobots/blob/main/workflow-templates/knative-stale.yaml

Doing it in Prow is much simpler and supports repo exclusions, not-as-planned closure.

Copied from k8s stale bot config https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml but we go straight from stale to closed instead of stale => rotten => closed.


/cc @dprotaso