### PR TITLE
Fix typo from notarizing `kn-plugin-quickstart`

### DIFF
--- a/prow/jobs/generated/knative-sandbox/kn-plugin-quickstart-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-quickstart-main.gen.yaml
@@ -67,9 +67,12 @@ periodics:
       - ./hack/release.sh
       - --publish
       - --tag-release
-      - --apple-codesign-key=/etc/notary/cert.p12
-      - --apple-notary-api-key=/etc/notary/key.json
-      - --apple-codesign-password-file=/etc/notary/password
+      - --apple-codesign-key
+      - /etc/notary/cert.p12
+      - --apple-notary-api-key
+      - /etc/notary/key.json
+      - --apple-codesign-password-file
+      - /etc/notary/password
       env:
       - name: SIGN_IMAGES
         value: "true"

--- a/prow/jobs_config/knative-sandbox/kn-plugin-quickstart.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-quickstart.yaml
@@ -25,9 +25,9 @@ jobs:
   - name: nightly
     types: [periodic]
     command: [runner.sh, ./hack/release.sh, --publish, --tag-release,
-      --apple-codesign-key=/etc/notary/cert.p12,
-      --apple-notary-api-key=/etc/notary/key.json,
-      --apple-codesign-password-file=/etc/notary/password]
+      --apple-codesign-key, /etc/notary/cert.p12,
+      --apple-notary-api-key, /etc/notary/key.json,
+      --apple-codesign-password-file, /etc/notary/password]
     requirements: [nightly-notary]
     excluded_requirements: [gcp]
 


### PR DESCRIPTION
Fixing a typo from #3544 

https://prow.knative.dev/view/gs/knative-prow/logs/nightly_kn-plugin-quickstart_main_periodic/1577016257016762368

/cc @kvmware 