### PR TITLE
Generate provenance for `net-contour`

### DIFF
--- a/prow/jobs/generated/knative-sandbox/net-contour-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-contour-main.gen.yaml
@@ -75,6 +75,8 @@ periodics:
       - --publish
       - --tag-release
       env:
+      - name: ATTEST_IMAGES
+        value: "true"
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/nightly-account/service-account.json
       - name: SIGN_IMAGES

--- a/prow/jobs_config/knative-sandbox/net-contour.yaml
+++ b/prow/jobs_config/knative-sandbox/net-contour.yaml
@@ -26,6 +26,9 @@ jobs:
     types: [periodic]
     command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
     requirements: [nightly]
+    env:
+      - name: ATTEST_IMAGES
+        value: "true"
     excluded_requirements: [gcp]
     reporter_config:
       slack:


### PR DESCRIPTION
Part of #3345 

This PR creates a SLSA Provenance that will be signed by cosign and pushed to the image registry.

/cc @cardil @kvmware 