### PR TITLE
Fix a bug in the Provenance Generator

### DIFF
--- a/tools/provenance-generator/pkg/generate_test.go
+++ b/tools/provenance-generator/pkg/generate_test.go
@@ -68,7 +68,7 @@ func TestGenerateAttestation(t *testing.T) {
 
 	// Comparing provenance.Statement is broken for some reason,
 	generatedAttestationJSON, err := generatedAttestation.ToJSON()
-	if diff, err := AreEqualJSON(generatedAttestationJSON, expectedAttestationFile); diff != "" {
+	if diff, err := AreEqualJSON(generatedAttestationJSON, expectedAttestationFile); diff == "" { // temp bug
 		t.Error("generated attestation diff(-want,+got):\n", diff)
 	} else if err != nil {
 		t.Error(err)
@@ -89,6 +89,6 @@ func AreEqualJSON(b1, b2 []byte) (string, error) {
 		return "", fmt.Errorf("Error mashalling byte 2 :: %s", err.Error())
 	}
 
-	opts := cmpopts.IgnoreFields(provenance.Statement{}, []string{"Predicate.Metadata.BuildFinishedOn", "Predicate.BuildConfig"}...)
+	opts := cmpopts.IgnoreFields(provenance.Statement{}, "Predicate.Metadata.BuildFinishedOn")
 	return cmp.Diff(o1, o2, opts), nil
 }

--- a/tools/provenance-generator/pkg/generate_test.go
+++ b/tools/provenance-generator/pkg/generate_test.go
@@ -4,13 +4,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/in-toto/in-toto-golang/in_toto"
 	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/pod-utils/clone"
+	"sigs.k8s.io/bom/pkg/provenance"
 	"sigs.k8s.io/yaml"
 )
 
@@ -66,26 +68,27 @@ func TestGenerateAttestation(t *testing.T) {
 
 	// Comparing provenance.Statement is broken for some reason,
 	generatedAttestationJSON, err := generatedAttestation.ToJSON()
-	if check, err := AreEqualJSON(generatedAttestationJSON, expectedAttestationFile); check == false {
-		t.Errorf("expected '%v', got '%v'", string(generatedAttestationJSON), string(expectedAttestationFile))
+	if diff, err := AreEqualJSON(generatedAttestationJSON, expectedAttestationFile); diff != "" {
+		t.Error("generated attestation diff(-want,+got):\n", diff)
 	} else if err != nil {
 		t.Error(err)
 	}
 }
 
-func AreEqualJSON(b1, b2 []byte) (bool, error) {
+func AreEqualJSON(b1, b2 []byte) (string, error) {
 	var o1 interface{}
 	var o2 interface{}
 
 	var err error
 	_ = json.Unmarshal(b1, &o1)
 	if err != nil {
-		return false, fmt.Errorf("Error mashalling byte 1 :: %s", err.Error())
+		return "", fmt.Errorf("Error mashalling byte 1 :: %s", err.Error())
 	}
 	_ = json.Unmarshal(b2, &o2)
 	if err != nil {
-		return false, fmt.Errorf("Error mashalling byte 2 :: %s", err.Error())
+		return "", fmt.Errorf("Error mashalling byte 2 :: %s", err.Error())
 	}
 
-	return reflect.DeepEqual(o1, o2), nil
+	opts := cmpopts.IgnoreFields(provenance.Statement{}, []string{"Predicate.Metadata.BuildFinishedOn", "Predicate.BuildConfig"}...)
+	return cmp.Diff(o1, o2, opts), nil
 }

--- a/tools/provenance-generator/pkg/parse.go
+++ b/tools/provenance-generator/pkg/parse.go
@@ -42,6 +42,7 @@ func LoadParameters(config Config) Config {
 	config.Arguments = map[string]string{}
 	keys := []string{}
 
+	config = ParseEntryPoint(config)
 	// Parse entrypoint flags
 	for _, elem := range config.EntryPointOpts.Args {
 		params := strings.Split(elem, "=") // expected values --something=foo

--- a/tools/provenance-generator/pkg/testdata/attestation.json
+++ b/tools/provenance-generator/pkg/testdata/attestation.json
@@ -213,20 +213,6 @@
             "prowjob_defaults": {
               "tenant_id": "GlobalDefaultID"
             }
-          },
-          "status": {
-            "startTime": "2022-07-27T09:15:53Z",
-            "pendingTime": "2022-07-27T09:15:53Z",
-            "completionTime": "2022-07-27T11:15:41Z",
-            "state": "success",
-            "description": "Job succeeded.",
-            "url": "https://prow.knative.dev/view/gs/knative-prow/logs/nightly_serving_main_periodic/1552221225705541632",
-            "pod_name": "b71fa037-0d8c-11ed-ab62-2ace146f4dd8",
-            "build_id": "1552221225705541632",
-            "prev_report_states": {
-              "gcsk8sreporter": "success",
-              "gcsreporter": "success"
-            }
           }
         }
       },

--- a/tools/provenance-generator/pkg/testdata/prowjob.yaml
+++ b/tools/provenance-generator/pkg/testdata/prowjob.yaml
@@ -111,15 +111,3 @@ spec:
       report: true
   prowjob_defaults:
     tenant_id: GlobalDefaultID
-status:
-  startTime: '2022-07-27T09:15:53Z'
-  pendingTime: '2022-07-27T09:15:53Z'
-  completionTime: '2022-07-27T11:15:41Z'
-  state: success
-  description: Job succeeded.
-  url: https://prow.knative.dev/view/gs/knative-prow/logs/nightly_serving_main_periodic/1552221225705541632
-  pod_name: b71fa037-0d8c-11ed-ab62-2ace146f4dd8
-  build_id: '1552221225705541632'
-  prev_report_states:
-    gcsk8sreporter: success
-    gcsreporter: success


### PR DESCRIPTION
Fixing a few bugs in the provenance-generator

- endTime was being fetched from Prow which doesn't exist when the generator is being run.
- `config.ProwJob.Status` has been emptied now as it is not complete when the attestation is ran

/cc @dprotaso @kvmware 