### PR TITLE
Add `ghproxy` to trusted cluster

### DIFF
--- a/prow/autobump-config/knative.yaml
+++ b/prow/autobump-config/knative.yaml
@@ -12,6 +12,7 @@ targetVersion: "upstream"
 includedConfigPaths:
   - "prow/cluster/control-plane"
   - "prow/cluster/build"
+  - "prow/cluster/trusted"
   - "prow/jobs"
 extraFiles:
   - "prow/config.yaml"

--- a/prow/cluster/trusted/ghproxy.yaml
+++ b/prow/cluster/trusted/ghproxy.yaml
@@ -1,0 +1,98 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  namespace: default
+  labels:
+    app: ghproxy
+  name: ghproxy
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi
+  # gce-ssd-retain is specified in config/prow/cluster/gce-ssd-retain_storageclass.yaml
+  #
+  # If you are setting up your own Prow instance you can do any of the following:
+  # 1) Delete this to use the default storage class for your cluster.
+  # 2) Specify your own storage class.
+  # 3) If you are using GKE you can use the gce-ssd-retain storage class. It can be
+  #    created with: `kubectl create -f config/prow/cluster/gce-ssd-retain_storageclass.yaml
+  storageClassName: gce-ssd-retain
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: default
+  name: ghproxy
+  labels:
+    app: ghproxy
+spec:
+  selector:
+    matchLabels:
+      app: ghproxy
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: ghproxy
+    spec:
+      containers:
+        - name: ghproxy
+          image: gcr.io/k8s-prow/ghproxy:v20221007-08c3d7a2a6
+          args:
+            - --cache-dir=/cache
+            - --cache-sizeGB=99
+            - --legacy-disable-disk-cache-partitions-by-auth-header=false
+          ports:
+          - name: main
+            containerPort: 8888
+          - name: metrics
+            containerPort: 9090
+          volumeMounts:
+            - name: cache
+              mountPath: /cache
+      volumes:
+        - name: cache
+          persistentVolumeClaim:
+            claimName: ghproxy
+      # run on our dedicated node
+#      tolerations:
+#        - key: "dedicated"
+#          operator: "Equal"
+#          value: "ghproxy"
+#          effect: "NoSchedule"
+#      nodeSelector:
+#        dedicated: "ghproxy"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: ghproxy
+  namespace: default
+  name: ghproxy
+spec:
+  ports:
+  - name: main
+    port: 80
+    protocol: TCP
+    targetPort: 8888
+  - name: metrics
+    port: 9090
+  selector:
+    app: ghproxy

--- a/prow/cluster/trusted/serviceaccounts.yaml
+++ b/prow/cluster/trusted/serviceaccounts.yaml
@@ -20,5 +20,5 @@ kind: ServiceAccount
 metadata:
   annotations:
     iam.gke.io/gcp-service-account: prow-deployer@knative-tests.iam.gserviceaccount.com
-name: prow-deployer
-namespace: test-pods
+  name: prow-deployer
+  namespace: test-pods


### PR DESCRIPTION
/cc @kvmware 

For some reason, ghproxy wasn't running in the trusted cluster and it is causing the github stale prow jobs to fail.