### PR TITLE
ls-tags is sorted and could print comma separated string

### DIFF
--- a/tools/go-ls-tags/cli/app.go
+++ b/tools/go-ls-tags/cli/app.go
@@ -42,8 +42,9 @@ func (a App) Command() *cobra.Command {
 				Exclude:    arg.exclude,
 				Directory:  arg.directory,
 				IgnoreFile: arg.ignoreFile,
+				Sort:       arg.sort,
 			}
-			pres := presenter{cmd}
+			pres := presenter{cmd, arg.joiner}
 			return pres.present(lister.List(cmd.Context()))
 		},
 	}

--- a/tools/go-ls-tags/cli/app_test.go
+++ b/tools/go-ls-tags/cli/app_test.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"path"
 	"reflect"
-	"sort"
 	"strings"
 	"testing"
 
@@ -44,6 +43,10 @@ func TestApp(t *testing.T) {
 		name: "no options",
 		args: []string{},
 		tags: []string{"test_tag_v1", "test_tag_v2"},
+	}, {
+		name:      "with comma joiner",
+		args:      []string{"--joiner", ","},
+		fragments: []string{"test_tag_v1,test_tag_v2"},
 	}, {
 		name: "using absolute ignorefile",
 		args: []string{
@@ -94,8 +97,6 @@ func (tc *testCase) test(t *testing.T) {
 	if len(tc.tags) > 0 {
 		want := tc.tags
 		got := strings.Split(strings.Trim(text, "\n"), "\n")
-		sort.Strings(want)
-		sort.Strings(got)
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("mismatch\nwant %q\n got %q", want, got)
 		}

--- a/tools/go-ls-tags/cli/args.go
+++ b/tools/go-ls-tags/cli/args.go
@@ -27,6 +27,8 @@ type args struct {
 	ignoreFile string
 	extension  string
 	exclude    []string
+	joiner     string
+	sort       bool
 }
 
 func withArgs(root *cobra.Command, a *args) *cobra.Command {
@@ -47,5 +49,14 @@ func withArgs(root *cobra.Command, a *args) *cobra.Command {
 		"exclude",
 		tags.DefaultExcludes,
 		"Directories to exclude")
+	pf.StringVar(&a.joiner,
+		"joiner",
+		"\n",
+		"Tags will be joined with this string on output")
+	pf.BoolVar(&a.sort,
+		"sort",
+		true,
+		"If true then tags will be sorted",
+	)
 	return root
 }

--- a/tools/go-ls-tags/cli/presenter.go
+++ b/tools/go-ls-tags/cli/presenter.go
@@ -16,8 +16,11 @@ limitations under the License.
 
 package cli
 
+import "strings"
+
 type presenter struct {
 	printer
+	joiner string
 }
 
 func (p presenter) present(tags []string, err error) error {
@@ -25,9 +28,7 @@ func (p presenter) present(tags []string, err error) error {
 		p.PrintErr("Error: ", err)
 		return err
 	}
-	for _, tag := range tags {
-		p.Println(tag)
-	}
+	p.Println(strings.Join(tags, p.joiner))
 	return nil
 }
 

--- a/tools/go-ls-tags/main_test.go
+++ b/tools/go-ls-tags/main_test.go
@@ -19,7 +19,6 @@ package main
 import (
 	"bytes"
 	"reflect"
-	"sort"
 	"strings"
 	"testing"
 
@@ -71,8 +70,6 @@ func (tc *testCase) test(t *testing.T) {
 	if len(tc.tags) > 0 {
 		want := tc.tags
 		got := strings.Split(strings.Trim(text, "\n"), "\n")
-		sort.Strings(want)
-		sort.Strings(got)
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("mismatch\nwant %q\n got %q", want, got)
 		}

--- a/tools/go-ls-tags/tags/lister.go
+++ b/tools/go-ls-tags/tags/lister.go
@@ -18,6 +18,7 @@ limitations under the License.
 
 import (
 	"context"
+	"sort"
 
 	"knative.dev/test-infra/pkg/logging"
 	"knative.dev/test-infra/tools/go-ls-tags/tags/index"
@@ -40,6 +41,7 @@ type Lister struct {
 	IgnoreFile string
 	Extension  string
 	Exclude    []string
+	Sort       bool
 }
 
 // List all used Go build tags, or errors.
@@ -56,6 +58,9 @@ func (l Lister) List(ctx context.Context) ([]string, error) {
 		return nil, errwrap(err)
 	}
 	tags, err = l.filterIgnored(ctx, tags)
+	if l.Sort {
+		sort.Strings(tags)
+	}
 	log.Infof("Found tags: %q", tags)
 	return tags, err
 }


### PR DESCRIPTION
**Which issue(s) this PR fixes**:<br>
Related https://github.com/knative/actions/pull/72
Related https://github.com/knative/hack/pull/238

<!--
  If there is any golang code in this PR please uncomment the 
  `/lint` statement below to have Prow automatically lint it.
-->
<!--
  /lint
-->

/kind enhancement