### PR TITLE
add a dns record for perf tests dashboard

### DIFF
--- a/infra/gcp/dns/dns.tf
+++ b/infra/gcp/dns/dns.tf
@@ -142,6 +142,13 @@ module "knative_dev" {
         "83ded2db-0c5e-4f1f-ab89-93105195240d.12.authorize.certificatemanager.goog.",
       ]
     },
+    {
+      name = "perf"
+      type = "A"
+      ttl  = 300
+      records = [
+        "34.170.87.98",
+    },
   ]
 }
 


### PR DESCRIPTION
add a dns record for perf tests dashboard pointing to grafana on the community cluster
