### PR TITLE
Allow jobs to be cancelled in the UI + run only one prowjob at a time for nightly/release jobs

### DIFF
--- a/prow/cluster/control-plane/301-rbac.yaml
+++ b/prow/cluster/control-plane/301-rbac.yaml
@@ -104,6 +104,7 @@ rules:
       - watch
       # Required when deck runs with `--rerun-creates-job=true`
       - create
+      - patch
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/prow/jobs/generated/knative-sandbox/container-freezer-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/container-freezer-main.gen.yaml
@@ -59,6 +59,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/container-freezer
     repo: container-freezer
+  max_concurrency: 1
   name: nightly_container-freezer_main_periodic
   spec:
     containers:
@@ -102,6 +103,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/container-freezer
     repo: container-freezer
+  max_concurrency: 1
   name: release_container-freezer_main_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative-sandbox/eventing-autoscaler-keda-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-autoscaler-keda-main.gen.yaml
@@ -59,6 +59,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/eventing-autoscaler-keda
     repo: eventing-autoscaler-keda
+  max_concurrency: 1
   name: nightly_eventing-autoscaler-keda_main_periodic
   spec:
     containers:
@@ -102,6 +103,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/eventing-autoscaler-keda
     repo: eventing-autoscaler-keda
+  max_concurrency: 1
   name: release_eventing-autoscaler-keda_main_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative-sandbox/eventing-autoscaler-keda-release-1.5.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-autoscaler-keda-release-1.5.gen.yaml
@@ -59,6 +59,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/eventing-autoscaler-keda
     repo: eventing-autoscaler-keda
+  max_concurrency: 1
   name: release_eventing-autoscaler-keda_release-1.5_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative-sandbox/eventing-autoscaler-keda-release-1.6.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-autoscaler-keda-release-1.6.gen.yaml
@@ -59,6 +59,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/eventing-autoscaler-keda
     repo: eventing-autoscaler-keda
+  max_concurrency: 1
   name: release_eventing-autoscaler-keda_release-1.6_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative-sandbox/eventing-autoscaler-keda-release-1.7.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-autoscaler-keda-release-1.7.gen.yaml
@@ -59,6 +59,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/eventing-autoscaler-keda
     repo: eventing-autoscaler-keda
+  max_concurrency: 1
   name: release_eventing-autoscaler-keda_release-1.7_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative-sandbox/eventing-autoscaler-keda-release-1.8.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-autoscaler-keda-release-1.8.gen.yaml
@@ -59,6 +59,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/eventing-autoscaler-keda
     repo: eventing-autoscaler-keda
+  max_concurrency: 1
   name: release_eventing-autoscaler-keda_release-1.8_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative-sandbox/eventing-awssqs-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-awssqs-main.gen.yaml
@@ -59,6 +59,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/eventing-awssqs
     repo: eventing-awssqs
+  max_concurrency: 1
   name: nightly_eventing-awssqs_main_periodic
   spec:
     containers:
@@ -102,6 +103,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/eventing-awssqs
     repo: eventing-awssqs
+  max_concurrency: 1
   name: release_eventing-awssqs_main_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative-sandbox/eventing-ceph-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-ceph-main.gen.yaml
@@ -77,6 +77,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/eventing-ceph
     repo: eventing-ceph
+  max_concurrency: 1
   name: nightly_eventing-ceph_main_periodic
   spec:
     containers:
@@ -138,6 +139,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/eventing-ceph
     repo: eventing-ceph
+  max_concurrency: 1
   name: release_eventing-ceph_main_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative-sandbox/eventing-couchdb-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-couchdb-main.gen.yaml
@@ -77,6 +77,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/eventing-couchdb
     repo: eventing-couchdb
+  max_concurrency: 1
   name: nightly_eventing-couchdb_main_periodic
   spec:
     containers:
@@ -138,6 +139,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/eventing-couchdb
     repo: eventing-couchdb
+  max_concurrency: 1
   name: release_eventing-couchdb_main_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative-sandbox/eventing-github-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-github-main.gen.yaml
@@ -77,6 +77,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/eventing-github
     repo: eventing-github
+  max_concurrency: 1
   name: nightly_eventing-github_main_periodic
   spec:
     containers:
@@ -138,6 +139,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/eventing-github
     repo: eventing-github
+  max_concurrency: 1
   name: release_eventing-github_main_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative-sandbox/eventing-gitlab-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-gitlab-main.gen.yaml
@@ -17,6 +17,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/eventing-gitlab
     repo: eventing-gitlab
+  max_concurrency: 1
   name: continuous_eventing-gitlab_main_periodic
   spec:
     containers:
@@ -146,6 +147,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/eventing-gitlab
     repo: eventing-gitlab
+  max_concurrency: 1
   name: release_eventing-gitlab_main_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative-sandbox/eventing-kafka-broker-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kafka-broker-main.gen.yaml
@@ -79,6 +79,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/eventing-kafka-broker
     repo: eventing-kafka-broker
+  max_concurrency: 1
   name: nightly_eventing-kafka-broker_main_periodic
   reporter_config:
     slack:
@@ -149,6 +150,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/eventing-kafka-broker
     repo: eventing-kafka-broker
+  max_concurrency: 1
   name: release_eventing-kafka-broker_main_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative-sandbox/eventing-kafka-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kafka-main.gen.yaml
@@ -77,6 +77,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/eventing-kafka
     repo: eventing-kafka
+  max_concurrency: 1
   name: nightly_eventing-kafka_main_periodic
   reporter_config:
     slack:
@@ -145,6 +146,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/eventing-kafka
     repo: eventing-kafka
+  max_concurrency: 1
   name: release_eventing-kafka_main_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative-sandbox/eventing-kogito-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kogito-main.gen.yaml
@@ -59,6 +59,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/eventing-kogito
     repo: eventing-kogito
+  max_concurrency: 1
   name: nightly_eventing-kogito_main_periodic
   reporter_config:
     slack:
@@ -109,6 +110,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/eventing-kogito
     repo: eventing-kogito
+  max_concurrency: 1
   name: release_eventing-kogito_main_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative-sandbox/eventing-natss-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-natss-main.gen.yaml
@@ -59,6 +59,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/eventing-natss
     repo: eventing-natss
+  max_concurrency: 1
   name: nightly_eventing-natss_main_periodic
   reporter_config:
     slack:
@@ -109,6 +110,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/eventing-natss
     repo: eventing-natss
+  max_concurrency: 1
   name: release_eventing-natss_main_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative-sandbox/eventing-rabbitmq-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-rabbitmq-main.gen.yaml
@@ -59,6 +59,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/eventing-rabbitmq
     repo: eventing-rabbitmq
+  max_concurrency: 1
   name: nightly_eventing-rabbitmq_main_periodic
   reporter_config:
     slack:
@@ -109,6 +110,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/eventing-rabbitmq
     repo: eventing-rabbitmq
+  max_concurrency: 1
   name: release_eventing-rabbitmq_main_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative-sandbox/eventing-redis-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-redis-main.gen.yaml
@@ -77,6 +77,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/eventing-redis
     repo: eventing-redis
+  max_concurrency: 1
   name: nightly_eventing-redis_main_periodic
   spec:
     containers:
@@ -138,6 +139,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/eventing-redis
     repo: eventing-redis
+  max_concurrency: 1
   name: release_eventing-redis_main_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-admin-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-admin-main.gen.yaml
@@ -59,6 +59,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/kn-plugin-admin
     repo: kn-plugin-admin
+  max_concurrency: 1
   name: nightly_kn-plugin-admin_main_periodic
   spec:
     containers:
@@ -111,6 +112,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/kn-plugin-admin
     repo: kn-plugin-admin
+  max_concurrency: 1
   name: release_kn-plugin-admin_main_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-event-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-event-main.gen.yaml
@@ -59,6 +59,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/kn-plugin-event
     repo: kn-plugin-event
+  max_concurrency: 1
   name: nightly_kn-plugin-event_main_periodic
   spec:
     containers:
@@ -111,6 +112,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/kn-plugin-event
     repo: kn-plugin-event
+  max_concurrency: 1
   name: release_kn-plugin-event_main_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-quickstart-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-quickstart-main.gen.yaml
@@ -59,6 +59,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/kn-plugin-quickstart
     repo: kn-plugin-quickstart
+  max_concurrency: 1
   name: nightly_kn-plugin-quickstart_main_periodic
   spec:
     containers:
@@ -111,6 +112,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/kn-plugin-quickstart
     repo: kn-plugin-quickstart
+  max_concurrency: 1
   name: release_kn-plugin-quickstart_main_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-source-kafka-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-source-kafka-main.gen.yaml
@@ -59,6 +59,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/kn-plugin-source-kafka
     repo: kn-plugin-source-kafka
+  max_concurrency: 1
   name: nightly_kn-plugin-source-kafka_main_periodic
   spec:
     containers:
@@ -129,6 +130,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/kn-plugin-source-kafka
     repo: kn-plugin-source-kafka
+  max_concurrency: 1
   name: release_kn-plugin-source-kafka_main_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative-sandbox/net-certmanager-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-certmanager-main.gen.yaml
@@ -59,6 +59,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/net-certmanager
     repo: net-certmanager
+  max_concurrency: 1
   name: nightly_net-certmanager_main_periodic
   reporter_config:
     slack:
@@ -109,6 +110,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/net-certmanager
     repo: net-certmanager
+  max_concurrency: 1
   name: release_net-certmanager_main_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative-sandbox/net-contour-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-contour-main.gen.yaml
@@ -59,6 +59,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/net-contour
     repo: net-contour
+  max_concurrency: 1
   name: nightly_net-contour_main_periodic
   reporter_config:
     slack:
@@ -111,6 +112,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/net-contour
     repo: net-contour
+  max_concurrency: 1
   name: release_net-contour_main_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative-sandbox/net-gateway-api-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-gateway-api-main.gen.yaml
@@ -59,6 +59,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/net-gateway-api
     repo: net-gateway-api
+  max_concurrency: 1
   name: nightly_net-gateway-api_main_periodic
   reporter_config:
     slack:
@@ -109,6 +110,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/net-gateway-api
     repo: net-gateway-api
+  max_concurrency: 1
   name: release_net-gateway-api_main_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative-sandbox/net-http01-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-http01-main.gen.yaml
@@ -59,6 +59,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/net-http01
     repo: net-http01
+  max_concurrency: 1
   name: nightly_net-http01_main_periodic
   reporter_config:
     slack:
@@ -109,6 +110,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/net-http01
     repo: net-http01
+  max_concurrency: 1
   name: release_net-http01_main_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative-sandbox/net-istio-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-istio-main.gen.yaml
@@ -59,6 +59,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/net-istio
     repo: net-istio
+  max_concurrency: 1
   name: nightly_net-istio_main_periodic
   reporter_config:
     slack:
@@ -109,6 +110,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/net-istio
     repo: net-istio
+  max_concurrency: 1
   name: release_net-istio_main_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative-sandbox/net-kourier-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-kourier-main.gen.yaml
@@ -59,6 +59,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/net-kourier
     repo: net-kourier
+  max_concurrency: 1
   name: nightly_net-kourier_main_periodic
   reporter_config:
     slack:
@@ -109,6 +110,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/net-kourier
     repo: net-kourier
+  max_concurrency: 1
   name: release_net-kourier_main_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative-sandbox/sample-source-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/sample-source-main.gen.yaml
@@ -17,6 +17,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/sample-source
     repo: sample-source
+  max_concurrency: 1
   name: nightly_sample-source_main_periodic
   spec:
     containers:
@@ -60,6 +61,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/sample-source
     repo: sample-source
+  max_concurrency: 1
   name: release_sample-source_main_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative-sandbox/security-guard-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/security-guard-main.gen.yaml
@@ -59,6 +59,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/security-guard
     repo: security-guard
+  max_concurrency: 1
   name: nightly_security-guard_main_periodic
   spec:
     containers:
@@ -102,6 +103,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/security-guard
     repo: security-guard
+  max_concurrency: 1
   name: release_security-guard_main_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative-sandbox/security-guard-release-0.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/security-guard-release-0.1.gen.yaml
@@ -59,6 +59,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/security-guard
     repo: security-guard
+  max_concurrency: 1
   name: release_security-guard_release-0.1_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative-sandbox/security-guard-release-0.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/security-guard-release-0.2.gen.yaml
@@ -59,6 +59,7 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/security-guard
     repo: security-guard
+  max_concurrency: 1
   name: release_security-guard_release-0.2_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative/client-main.gen.yaml
+++ b/prow/jobs/generated/knative/client-main.gen.yaml
@@ -241,6 +241,7 @@ periodics:
     org: knative
     path_alias: knative.dev/client
     repo: client
+  max_concurrency: 1
   name: nightly_client_main_periodic
   reporter_config:
     slack:
@@ -300,6 +301,7 @@ periodics:
     org: knative
     path_alias: knative.dev/client
     repo: client
+  max_concurrency: 1
   name: release_client_main_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative/client-release-1.5.gen.yaml
+++ b/prow/jobs/generated/knative/client-release-1.5.gen.yaml
@@ -133,6 +133,7 @@ periodics:
     org: knative
     path_alias: knative.dev/client
     repo: client
+  max_concurrency: 1
   name: release_client_release-1.5_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative/client-release-1.6.gen.yaml
+++ b/prow/jobs/generated/knative/client-release-1.6.gen.yaml
@@ -200,6 +200,7 @@ periodics:
     org: knative
     path_alias: knative.dev/client
     repo: client
+  max_concurrency: 1
   name: release_client_release-1.6_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative/client-release-1.7.gen.yaml
+++ b/prow/jobs/generated/knative/client-release-1.7.gen.yaml
@@ -200,6 +200,7 @@ periodics:
     org: knative
     path_alias: knative.dev/client
     repo: client
+  max_concurrency: 1
   name: release_client_release-1.7_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative/client-release-1.8.gen.yaml
+++ b/prow/jobs/generated/knative/client-release-1.8.gen.yaml
@@ -200,6 +200,7 @@ periodics:
     org: knative
     path_alias: knative.dev/client
     repo: client
+  max_concurrency: 1
   name: release_client_release-1.8_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative/eventing-main.gen.yaml
+++ b/prow/jobs/generated/knative/eventing-main.gen.yaml
@@ -373,6 +373,7 @@ periodics:
     org: knative
     path_alias: knative.dev/eventing
     repo: eventing
+  max_concurrency: 1
   name: nightly_eventing_main_periodic
   reporter_config:
     slack:
@@ -380,7 +381,7 @@ periodics:
       job_states_to_report:
       - failure
       report_template: |
-        "The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"
+        "The nightly release has failed, please check the logs: <{{.Status.URL}}|View logs>"
   spec:
     containers:
     - command:
@@ -429,6 +430,7 @@ periodics:
     org: knative
     path_alias: knative.dev/eventing
     repo: eventing
+  max_concurrency: 1
   name: release_eventing_main_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative/eventing-release-1.5.gen.yaml
+++ b/prow/jobs/generated/knative/eventing-release-1.5.gen.yaml
@@ -300,6 +300,7 @@ periodics:
     org: knative
     path_alias: knative.dev/eventing
     repo: eventing
+  max_concurrency: 1
   name: release_eventing_release-1.5_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative/eventing-release-1.6.gen.yaml
+++ b/prow/jobs/generated/knative/eventing-release-1.6.gen.yaml
@@ -300,6 +300,7 @@ periodics:
     org: knative
     path_alias: knative.dev/eventing
     repo: eventing
+  max_concurrency: 1
   name: release_eventing_release-1.6_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative/eventing-release-1.7.gen.yaml
+++ b/prow/jobs/generated/knative/eventing-release-1.7.gen.yaml
@@ -373,6 +373,7 @@ periodics:
     org: knative
     path_alias: knative.dev/eventing
     repo: eventing
+  max_concurrency: 1
   name: release_eventing_release-1.7_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative/eventing-release-1.8.gen.yaml
+++ b/prow/jobs/generated/knative/eventing-release-1.8.gen.yaml
@@ -373,6 +373,7 @@ periodics:
     org: knative
     path_alias: knative.dev/eventing
     repo: eventing
+  max_concurrency: 1
   name: release_eventing_release-1.8_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative/func-main.gen.yaml
+++ b/prow/jobs/generated/knative/func-main.gen.yaml
@@ -17,7 +17,15 @@ periodics:
     org: knative
     path_alias: knative.dev/func
     repo: func
+  max_concurrency: 1
   name: nightly_func_main_periodic
+  reporter_config:
+    slack:
+      channel: functions
+      job_states_to_report:
+      - failure
+      report_template: |
+        "The nightly release has failed, please check the logs: <{{.Status.URL}}|View logs>"
   spec:
     containers:
     - command:
@@ -87,6 +95,7 @@ periodics:
     org: knative
     path_alias: knative.dev/func
     repo: func
+  max_concurrency: 1
   name: release_func_main_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative/func-release-1.7.gen.yaml
+++ b/prow/jobs/generated/knative/func-release-1.7.gen.yaml
@@ -17,6 +17,7 @@ periodics:
     org: knative
     path_alias: knative.dev/func
     repo: func
+  max_concurrency: 1
   name: release_func_release-1.7_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative/func-release-1.8.gen.yaml
+++ b/prow/jobs/generated/knative/func-release-1.8.gen.yaml
@@ -17,6 +17,7 @@ periodics:
     org: knative
     path_alias: knative.dev/func
     repo: func
+  max_concurrency: 1
   name: release_func_release-1.8_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative/operator-main.gen.yaml
+++ b/prow/jobs/generated/knative/operator-main.gen.yaml
@@ -200,6 +200,7 @@ periodics:
     org: knative
     path_alias: knative.dev/operator
     repo: operator
+  max_concurrency: 1
   name: nightly_operator_main_periodic
   reporter_config:
     slack:
@@ -250,6 +251,7 @@ periodics:
     org: knative
     path_alias: knative.dev/operator
     repo: operator
+  max_concurrency: 1
   name: release_operator_main_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative/operator-release-1.5.gen.yaml
+++ b/prow/jobs/generated/knative/operator-release-1.5.gen.yaml
@@ -133,6 +133,7 @@ periodics:
     org: knative
     path_alias: knative.dev/operator
     repo: operator
+  max_concurrency: 1
   name: release_operator_release-1.5_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative/operator-release-1.6.gen.yaml
+++ b/prow/jobs/generated/knative/operator-release-1.6.gen.yaml
@@ -200,6 +200,7 @@ periodics:
     org: knative
     path_alias: knative.dev/operator
     repo: operator
+  max_concurrency: 1
   name: release_operator_release-1.6_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative/operator-release-1.7.gen.yaml
+++ b/prow/jobs/generated/knative/operator-release-1.7.gen.yaml
@@ -200,6 +200,7 @@ periodics:
     org: knative
     path_alias: knative.dev/operator
     repo: operator
+  max_concurrency: 1
   name: release_operator_release-1.7_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative/serving-main.gen.yaml
+++ b/prow/jobs/generated/knative/serving-main.gen.yaml
@@ -841,6 +841,7 @@ periodics:
     org: knative
     path_alias: knative.dev/serving
     repo: serving
+  max_concurrency: 1
   name: nightly_serving_main_periodic
   reporter_config:
     slack:
@@ -914,6 +915,7 @@ periodics:
     org: knative
     path_alias: knative.dev/serving
     repo: serving
+  max_concurrency: 1
   name: release_serving_main_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative/serving-release-1.5.gen.yaml
+++ b/prow/jobs/generated/knative/serving-release-1.5.gen.yaml
@@ -229,6 +229,7 @@ periodics:
     org: knative
     path_alias: knative.dev/serving
     repo: serving
+  max_concurrency: 1
   name: release_serving_release-1.5_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative/serving-release-1.6.gen.yaml
+++ b/prow/jobs/generated/knative/serving-release-1.6.gen.yaml
@@ -283,6 +283,7 @@ periodics:
     org: knative
     path_alias: knative.dev/serving
     repo: serving
+  max_concurrency: 1
   name: release_serving_release-1.6_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative/serving-release-1.7.gen.yaml
+++ b/prow/jobs/generated/knative/serving-release-1.7.gen.yaml
@@ -283,6 +283,7 @@ periodics:
     org: knative
     path_alias: knative.dev/serving
     repo: serving
+  max_concurrency: 1
   name: release_serving_release-1.7_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative/serving-release-1.8.gen.yaml
+++ b/prow/jobs/generated/knative/serving-release-1.8.gen.yaml
@@ -253,6 +253,7 @@ periodics:
     org: knative
     path_alias: knative.dev/serving
     repo: serving
+  max_concurrency: 1
   name: release_serving_release-1.8_periodic
   spec:
     containers:

--- a/prow/jobs_config/knative-sandbox/container-freezer.yaml
+++ b/prow/jobs_config/knative-sandbox/container-freezer.yaml
@@ -32,12 +32,14 @@ jobs:
     command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
     requirements: [nightly]
     excluded_requirements: [gcp]
+    max_concurrency: 1
 
   - name: release
     types: [periodic]
     command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/container-freezer, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
     requirements: [release]
     excluded_requirements: [gcp]
+    max_concurrency: 1
 
   - name: performance-tests
     types: [periodic]

--- a/prow/jobs_config/knative-sandbox/eventing-autoscaler-keda-release-1.5.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-autoscaler-keda-release-1.5.yaml
@@ -49,6 +49,7 @@ jobs:
   - release-1.5
   excluded_requirements:
   - gcp
+  max_concurrency: 1
   name: release
   requirements:
   - release

--- a/prow/jobs_config/knative-sandbox/eventing-autoscaler-keda-release-1.6.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-autoscaler-keda-release-1.6.yaml
@@ -50,6 +50,7 @@ jobs:
   excluded_requirements:
   - gcp
   name: release
+  max_concurrency: 1
   requirements:
   - release
   types:

--- a/prow/jobs_config/knative-sandbox/eventing-autoscaler-keda-release-1.7.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-autoscaler-keda-release-1.7.yaml
@@ -50,6 +50,7 @@ jobs:
   excluded_requirements:
   - gcp
   name: release
+  max_concurrency: 1
   requirements:
   - release
   types:

--- a/prow/jobs_config/knative-sandbox/eventing-autoscaler-keda-release-1.8.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-autoscaler-keda-release-1.8.yaml
@@ -49,6 +49,7 @@ jobs:
   - release-1.8
   excluded_requirements:
   - gcp
+  max_concurrency: 1
   name: release
   requirements:
   - release

--- a/prow/jobs_config/knative-sandbox/eventing-autoscaler-keda.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-autoscaler-keda.yaml
@@ -22,10 +22,12 @@ jobs:
     types: [periodic]
     command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
     requirements: [nightly]
+    max_concurrency: 1
     excluded_requirements: [gcp]
 
   - name: release
     types: [periodic]
     command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/eventing-autoscaler-keda, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
     requirements: [release]
+    max_concurrency: 1
     excluded_requirements: [gcp]

--- a/prow/jobs_config/knative-sandbox/eventing-awssqs.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-awssqs.yaml
@@ -13,9 +13,11 @@ jobs:
     command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
     requirements: [nightly]
     excluded_requirements: [gcp]
+    max_concurrency: 1
 
   - name: release
     types: [periodic]
     command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/eventing-awssqs, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
     requirements: [release]
     excluded_requirements: [gcp]
+    max_concurrency: 1

--- a/prow/jobs_config/knative-sandbox/eventing-ceph.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-ceph.yaml
@@ -14,9 +14,11 @@ jobs:
     command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
     requirements: [nightly, docker]
     excluded_requirements: [gcp]
+    max_concurrency: 1
 
   - name: release
     types: [periodic]
     command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/eventing-ceph, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
     requirements: [release, docker]
     excluded_requirements: [gcp]
+    max_concurrency: 1

--- a/prow/jobs_config/knative-sandbox/eventing-couchdb.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-couchdb.yaml
@@ -14,9 +14,11 @@ jobs:
     command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
     requirements: [nightly, docker]
     excluded_requirements: [gcp]
+    max_concurrency: 1
 
   - name: release
     types: [periodic]
     command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/eventing-couchdb, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
     requirements: [release, docker]
     excluded_requirements: [gcp]
+    max_concurrency: 1

--- a/prow/jobs_config/knative-sandbox/eventing-github.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-github.yaml
@@ -14,9 +14,11 @@ jobs:
     command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
     requirements: [nightly, docker]
     excluded_requirements: [gcp]
+    max_concurrency: 1
 
   - name: release
     types: [periodic]
     command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/eventing-github, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
     requirements: [release, docker]
     excluded_requirements: [gcp]
+    max_concurrency: 1

--- a/prow/jobs_config/knative-sandbox/eventing-gitlab.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-gitlab.yaml
@@ -8,6 +8,7 @@ jobs:
     types: [periodic]
     command: [runner.sh, ./test/presubmit-tests.sh, --all-tests]
     requirements: [docker]
+    max_concurrency: 1
 
   - name: nightly
     types: [periodic]
@@ -20,6 +21,7 @@ jobs:
     command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/eventing-gitlab, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
     requirements: [release, docker]
     excluded_requirements: [gcp]
+    max_concurrency: 1
 
 resources_presets:
   default:

--- a/prow/jobs_config/knative-sandbox/eventing-kafka-broker.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-kafka-broker.yaml
@@ -127,6 +127,7 @@ jobs:
     command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
     requirements: [nightly, docker]
     excluded_requirements: [gcp]
+    max_concurrency: 1
     reporter_config:
       slack:
         channel: eventing-kafka
@@ -143,6 +144,7 @@ jobs:
     command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/eventing-kafka-broker, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
     requirements: [release, docker]
     excluded_requirements: [gcp]
+    max_concurrency: 1
 
   - name: s390x-e2e-tests-ssl
     cron: 20 7 * * *

--- a/prow/jobs_config/knative-sandbox/eventing-kafka.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-kafka.yaml
@@ -51,6 +51,7 @@ jobs:
     command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
     requirements: [nightly, docker]
     excluded_requirements: [gcp]
+    max_concurrency: 1
     reporter_config:
       slack:
         channel: eventing-kafka
@@ -64,6 +65,7 @@ jobs:
     command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/eventing-kafka, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
     requirements: [release, docker]
     excluded_requirements: [gcp]
+    max_concurrency: 1
 
   - name: s390x-e2e-tests
     cron: 20 6 * * *

--- a/prow/jobs_config/knative-sandbox/eventing-kogito.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-kogito.yaml
@@ -27,6 +27,7 @@ jobs:
     command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
     requirements: [nightly]
     excluded_requirements: [gcp]
+    max_concurrency: 1
     reporter_config:
       slack:
         channel: eventing-sources
@@ -40,3 +41,4 @@ jobs:
     command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/eventing-kogito, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
     requirements: [release]
     excluded_requirements: [gcp]
+    max_concurrency: 1

--- a/prow/jobs_config/knative-sandbox/eventing-natss.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-natss.yaml
@@ -13,6 +13,7 @@ jobs:
     command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
     requirements: [nightly]
     excluded_requirements: [gcp]
+    max_concurrency: 1
     reporter_config:
       slack:
         channel: eventing
@@ -26,3 +27,4 @@ jobs:
     command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/eventing-natss, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
     requirements: [release]
     excluded_requirements: [gcp]
+    max_concurrency: 1

--- a/prow/jobs_config/knative-sandbox/eventing-rabbitmq.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-rabbitmq.yaml
@@ -13,6 +13,7 @@ jobs:
     command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
     requirements: [nightly]
     excluded_requirements: [gcp]
+    max_concurrency: 1
     reporter_config:
       slack:
         channel: eventing-rabbitmq
@@ -26,3 +27,4 @@ jobs:
     command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/eventing-rabbitmq, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
     requirements: [release]
     excluded_requirements: [gcp]
+    max_concurrency: 1

--- a/prow/jobs_config/knative-sandbox/eventing-redis.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-redis.yaml
@@ -14,9 +14,11 @@ jobs:
     command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
     requirements: [nightly, docker]
     excluded_requirements: [gcp]
+    max_concurrency: 1
 
   - name: release
     types: [periodic]
     command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/eventing-redis, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
     requirements: [release, docker]
     excluded_requirements: [gcp]
+    max_concurrency: 1

--- a/prow/jobs_config/knative-sandbox/kn-plugin-admin.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-admin.yaml
@@ -30,6 +30,7 @@ jobs:
       --apple-codesign-password-file, /etc/notary/password]
     requirements: [nightly-notary]
     excluded_requirements: [gcp]
+    max_concurrency: 1
 
   - name: release
     types: [periodic]
@@ -39,3 +40,4 @@ jobs:
       --apple-codesign-password-file, /etc/notary/password]
     requirements: [release-notary]
     excluded_requirements: [gcp]
+    max_concurrency: 1

--- a/prow/jobs_config/knative-sandbox/kn-plugin-event.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-event.yaml
@@ -30,6 +30,7 @@ jobs:
       --apple-codesign-password-file, /etc/notary/password]
     requirements: [nightly-notary]
     excluded_requirements: [gcp]
+    max_concurrency: 1
 
   - name: release
     types: [periodic]
@@ -39,3 +40,4 @@ jobs:
       --apple-codesign-password-file, /etc/notary/password]
     requirements: [release-notary]
     excluded_requirements: [gcp]
+    max_concurrency: 1

--- a/prow/jobs_config/knative-sandbox/kn-plugin-quickstart.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-quickstart.yaml
@@ -30,6 +30,7 @@ jobs:
       --apple-codesign-password-file, /etc/notary/password]
     requirements: [nightly-notary]
     excluded_requirements: [gcp]
+    max_concurrency: 1
 
   - name: release
     types: [periodic]
@@ -39,3 +40,4 @@ jobs:
       --apple-codesign-password-file, /etc/notary/password]
     requirements: [release-notary]
     excluded_requirements: [gcp]
+    max_concurrency: 1

--- a/prow/jobs_config/knative-sandbox/kn-plugin-source-kafka.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-source-kafka.yaml
@@ -30,6 +30,7 @@ jobs:
       --apple-codesign-password-file, /etc/notary/password]
     requirements: [nightly-notary, docker]
     excluded_requirements: [gcp]
+    max_concurrency: 1
 
   - name: release
     types: [periodic]
@@ -39,3 +40,4 @@ jobs:
       --apple-codesign-password-file, /etc/notary/password]
     requirements: [release-notary, docker]
     excluded_requirements: [gcp]
+    max_concurrency: 1

--- a/prow/jobs_config/knative-sandbox/net-certmanager.yaml
+++ b/prow/jobs_config/knative-sandbox/net-certmanager.yaml
@@ -27,6 +27,7 @@ jobs:
     command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
     requirements: [nightly]
     excluded_requirements: [gcp]
+    max_concurrency: 1
     reporter_config:
       slack:
         channel: net-certmanager
@@ -37,8 +38,10 @@ jobs:
     env:
     - name: SIGN_IMAGES
       value: "true"
+
   - name: release
     types: [periodic]
     command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/net-certmanager, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
     requirements: [release]
     excluded_requirements: [gcp]
+    max_concurrency: 1

--- a/prow/jobs_config/knative-sandbox/net-contour.yaml
+++ b/prow/jobs_config/knative-sandbox/net-contour.yaml
@@ -25,6 +25,7 @@ jobs:
   - name: nightly
     types: [periodic]
     command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
+    max_concurrency: 1
     requirements: [nightly]
     env:
       - name: ATTEST_IMAGES
@@ -43,3 +44,4 @@ jobs:
     command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/net-contour, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
     requirements: [release]
     excluded_requirements: [gcp]
+    max_concurrency: 1

--- a/prow/jobs_config/knative-sandbox/net-gateway-api.yaml
+++ b/prow/jobs_config/knative-sandbox/net-gateway-api.yaml
@@ -27,6 +27,7 @@ jobs:
     command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
     requirements: [nightly]
     excluded_requirements: [gcp]
+    max_concurrency: 1
     reporter_config:
       slack:
         channel: net-gateway-api
@@ -40,3 +41,4 @@ jobs:
     command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/net-gateway-api, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
     requirements: [release]
     excluded_requirements: [gcp]
+    max_concurrency: 1

--- a/prow/jobs_config/knative-sandbox/net-http01.yaml
+++ b/prow/jobs_config/knative-sandbox/net-http01.yaml
@@ -26,6 +26,7 @@ jobs:
     types: [periodic]
     command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
     requirements: [nightly]
+    max_concurrency: 1
     excluded_requirements: [gcp]
     reporter_config:
       slack:
@@ -40,3 +41,4 @@ jobs:
     command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/net-http01, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
     requirements: [release]
     excluded_requirements: [gcp]
+    max_concurrency: 1

--- a/prow/jobs_config/knative-sandbox/net-istio.yaml
+++ b/prow/jobs_config/knative-sandbox/net-istio.yaml
@@ -35,6 +35,7 @@ jobs:
     command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
     requirements: [nightly]
     excluded_requirements: [gcp]
+    max_concurrency: 1
     reporter_config:
       slack:
         channel: net-istio
@@ -48,3 +49,4 @@ jobs:
     command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/net-istio, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
     requirements: [release]
     excluded_requirements: [gcp]
+    max_concurrency: 1

--- a/prow/jobs_config/knative-sandbox/net-kourier.yaml
+++ b/prow/jobs_config/knative-sandbox/net-kourier.yaml
@@ -27,6 +27,7 @@ jobs:
     command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
     requirements: [nightly]
     excluded_requirements: [gcp]
+    max_concurrency: 1
     reporter_config:
       slack:
         channel: net-kourier
@@ -40,3 +41,4 @@ jobs:
     command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/net-kourier, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
     requirements: [release]
     excluded_requirements: [gcp]
+    max_concurrency: 1

--- a/prow/jobs_config/knative-sandbox/sample-source.yaml
+++ b/prow/jobs_config/knative-sandbox/sample-source.yaml
@@ -19,9 +19,11 @@ jobs:
     command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
     requirements: [nightly]
     excluded_requirements: [gcp]
+    max_concurrency: 1
 
   - name: release
     types: [periodic]
     command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/sample-source, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
     requirements: [release]
     excluded_requirements: [gcp]
+    max_concurrency: 1

--- a/prow/jobs_config/knative-sandbox/security-guard-release-0.1.yaml
+++ b/prow/jobs_config/knative-sandbox/security-guard-release-0.1.yaml
@@ -55,6 +55,7 @@ jobs:
   excluded_requirements:
   - gcp
   name: release
+  max_concurrency: 1
   requirements:
   - release
   types:

--- a/prow/jobs_config/knative-sandbox/security-guard-release-0.2.yaml
+++ b/prow/jobs_config/knative-sandbox/security-guard-release-0.2.yaml
@@ -55,6 +55,7 @@ jobs:
   excluded_requirements:
   - gcp
   name: release
+  max_concurrency: 1
   requirements:
   - release
   types:

--- a/prow/jobs_config/knative-sandbox/security-guard.yaml
+++ b/prow/jobs_config/knative-sandbox/security-guard.yaml
@@ -27,9 +27,11 @@ jobs:
     command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
     requirements: [nightly]
     excluded_requirements: [gcp]
+    max_concurrency: 1
 
   - name: release
     types: [periodic]
     command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/security-guard, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
     requirements: [release]
     excluded_requirements: [gcp]
+    max_concurrency: 1

--- a/prow/jobs_config/knative/client-release-1.5.yaml
+++ b/prow/jobs_config/knative/client-release-1.5.yaml
@@ -85,6 +85,7 @@ jobs:
   excluded_requirements:
   - gcp
   name: release
+  max_concurrency: 1
   requirements:
   - release
   types:

--- a/prow/jobs_config/knative/client-release-1.6.yaml
+++ b/prow/jobs_config/knative/client-release-1.6.yaml
@@ -106,6 +106,7 @@ jobs:
   excluded_requirements:
   - gcp
   name: release
+  max_concurrency: 1
   requirements:
   - release
   types:

--- a/prow/jobs_config/knative/client-release-1.7.yaml
+++ b/prow/jobs_config/knative/client-release-1.7.yaml
@@ -106,6 +106,7 @@ jobs:
   excluded_requirements:
   - gcp
   name: release
+  max_concurrency: 1
   requirements:
   - release
   types:

--- a/prow/jobs_config/knative/client-release-1.8.yaml
+++ b/prow/jobs_config/knative/client-release-1.8.yaml
@@ -112,6 +112,7 @@ jobs:
   excluded_requirements:
   - gcp
   name: release
+  max_concurrency: 1
   requirements:
   - release-notary
   types:

--- a/prow/jobs_config/knative/client.yaml
+++ b/prow/jobs_config/knative/client.yaml
@@ -79,6 +79,7 @@ jobs:
       --apple-codesign-password-file, /etc/notary/password]
     requirements: [nightly-notary]
     excluded_requirements: [gcp]
+    max_concurrency: 1
     reporter_config:
       slack:
         channel: client
@@ -94,3 +95,4 @@ jobs:
       --apple-codesign-password-file, /etc/notary/password]
     requirements: [release-notary]
     excluded_requirements: [gcp]
+    max_concurrency: 1

--- a/prow/jobs_config/knative/eventing-release-1.5.yaml
+++ b/prow/jobs_config/knative/eventing-release-1.5.yaml
@@ -148,6 +148,7 @@ jobs:
   - release-1.5
   excluded_requirements:
   - gcp
+  max_concurrency: 1
   name: release
   requirements:
   - release

--- a/prow/jobs_config/knative/eventing-release-1.6.yaml
+++ b/prow/jobs_config/knative/eventing-release-1.6.yaml
@@ -148,6 +148,7 @@ jobs:
   - release-1.6
   excluded_requirements:
   - gcp
+  max_concurrency: 1
   name: release
   requirements:
   - release

--- a/prow/jobs_config/knative/eventing-release-1.7.yaml
+++ b/prow/jobs_config/knative/eventing-release-1.7.yaml
@@ -172,6 +172,7 @@ jobs:
   excluded_requirements:
   - gcp
   name: release
+  max_concurrency: 1
   requirements:
   - release
   timeout: 3h0m0s

--- a/prow/jobs_config/knative/eventing-release-1.8.yaml
+++ b/prow/jobs_config/knative/eventing-release-1.8.yaml
@@ -172,6 +172,7 @@ jobs:
   excluded_requirements:
   - gcp
   name: release
+  max_concurrency: 1
   requirements:
   - release
   timeout: 3h0m0s

--- a/prow/jobs_config/knative/eventing.yaml
+++ b/prow/jobs_config/knative/eventing.yaml
@@ -127,11 +127,12 @@ jobs:
     command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
     requirements: [nightly]
     excluded_requirements: [gcp]
+    max_concurrency: 1
     reporter_config:
       slack:
         channel: eventing
         report_template: |
-          "The nightly release job fails, check the log: <{{.Status.URL}}|View logs>"
+          "The nightly release has failed, please check the logs: <{{.Status.URL}}|View logs>"
         job_states_to_report:
         - "failure"
 
@@ -141,6 +142,7 @@ jobs:
     command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/eventing, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
     requirements: [release]
     excluded_requirements: [gcp]
+    max_concurrency: 1
 
 resources: high
 resources_presets:

--- a/prow/jobs_config/knative/func-release-1.7.yaml
+++ b/prow/jobs_config/knative/func-release-1.7.yaml
@@ -28,6 +28,7 @@ jobs:
   - release-1.7
   excluded_requirements:
   - gcp
+  max_concurrency: 1
   name: release
   requirements:
   - release-notary

--- a/prow/jobs_config/knative/func-release-1.8.yaml
+++ b/prow/jobs_config/knative/func-release-1.8.yaml
@@ -29,6 +29,7 @@ jobs:
   excluded_requirements:
   - gcp
   name: release
+  max_concurrency: 1
   requirements:
   - release-notary
   - docker

--- a/prow/jobs_config/knative/func.yaml
+++ b/prow/jobs_config/knative/func.yaml
@@ -12,6 +12,14 @@ jobs:
       --apple-codesign-password-file, /etc/notary/password]
     requirements: [nightly-notary, docker]
     excluded_requirements: [gcp]
+    max_concurrency: 1
+    reporter_config:
+      slack:
+        channel: functions
+        report_template: |
+          "The nightly release has failed, please check the logs: <{{.Status.URL}}|View logs>"
+        job_states_to_report:
+        - "failure"
 
   - name: release
     types: [periodic]
@@ -20,4 +28,5 @@ jobs:
       --apple-notary-api-key, /etc/notary/key.json,
       --apple-codesign-password-file, /etc/notary/password]
     requirements: [release-notary, docker]
+    max_concurrency: 1
     excluded_requirements: [gcp]

--- a/prow/jobs_config/knative/operator-release-1.5.yaml
+++ b/prow/jobs_config/knative/operator-release-1.5.yaml
@@ -101,6 +101,7 @@ jobs:
   - release-1.5
   excluded_requirements:
   - gcp
+  max_concurrency: 1
   name: release
   requirements:
   - release

--- a/prow/jobs_config/knative/operator-release-1.6.yaml
+++ b/prow/jobs_config/knative/operator-release-1.6.yaml
@@ -122,6 +122,7 @@ jobs:
   - release-1.6
   excluded_requirements:
   - gcp
+  max_concurrency: 1
   name: release
   requirements:
   - release

--- a/prow/jobs_config/knative/operator-release-1.7.yaml
+++ b/prow/jobs_config/knative/operator-release-1.7.yaml
@@ -122,6 +122,7 @@ jobs:
   - release-1.7
   excluded_requirements:
   - gcp
+  max_concurrency: 1
   name: release
   requirements:
   - release

--- a/prow/jobs_config/knative/operator.yaml
+++ b/prow/jobs_config/knative/operator.yaml
@@ -79,6 +79,7 @@ jobs:
     command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
     requirements: [nightly]
     excluded_requirements: [gcp]
+    max_concurrency: 1
     reporter_config:
       slack:
         channel: operator
@@ -92,3 +93,4 @@ jobs:
     command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/operator, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
     requirements: [release]
     excluded_requirements: [gcp]
+    max_concurrency: 1

--- a/prow/jobs_config/knative/serving-release-1.5.yaml
+++ b/prow/jobs_config/knative/serving-release-1.5.yaml
@@ -251,6 +251,7 @@ jobs:
   excluded_requirements:
   - gcp
   name: release
+  max_concurrency: 1
   requirements:
   - release
   timeout: 3h0m0s

--- a/prow/jobs_config/knative/serving-release-1.6.yaml
+++ b/prow/jobs_config/knative/serving-release-1.6.yaml
@@ -251,6 +251,7 @@ jobs:
   excluded_requirements:
   - gcp
   name: release
+  max_concurrency: 1
   requirements:
   - release
   timeout: 3h0m0s

--- a/prow/jobs_config/knative/serving-release-1.7.yaml
+++ b/prow/jobs_config/knative/serving-release-1.7.yaml
@@ -253,6 +253,7 @@ jobs:
   excluded_requirements:
   - gcp
   name: release
+  max_concurrency: 1
   requirements:
   - release
   timeout: 3h0m0s

--- a/prow/jobs_config/knative/serving-release-1.8.yaml
+++ b/prow/jobs_config/knative/serving-release-1.8.yaml
@@ -253,6 +253,7 @@ jobs:
   excluded_requirements:
   - gcp
   name: release
+  max_concurrency: 1
   requirements:
   - release
   timeout: 3h0m0s

--- a/prow/jobs_config/knative/serving.yaml
+++ b/prow/jobs_config/knative/serving.yaml
@@ -261,6 +261,7 @@ jobs:
     command: [runner.sh, ./hack/release.sh, --publish, --tag-release]
     requirements: [nightly]
     excluded_requirements: [gcp]
+    max_concurrency: 1
     reporter_config:
       slack:
         channel: serving
@@ -275,6 +276,7 @@ jobs:
     command: [runner.sh, ./hack/release.sh, --auto-release, --release-gcs, knative-releases/serving, --release-gcr, gcr.io/knative-releases, --github-token, /etc/hub-token/token]
     requirements: [release]
     excluded_requirements: [gcp]
+    max_concurrency: 1
 
 resources: high
 resources_presets:


### PR DESCRIPTION
This change allows:
- Prowjobs can now be cancelled from the web browser without the need to login to the cluster. https://kubernetes.slack.com/archives/CDECRSC5U/p1666217793138119
- Various teams listed here https://github.com/knative/test-infra/blob/main/prow/config.yaml#L140 can cancel and rerun jobs.
-  I have set max_concurrency for all release/nightly jobs to 1 to avoid multiple concurrent runs.

/cc @kvmware
