### PR TITLE
Add prow jobs for serving contour & kourier e2e tests on ppc64le

### DIFF
--- a/prow/jobs/generated/knative/serving-main.gen.yaml
+++ b/prow/jobs/generated/knative/serving-main.gen.yaml
@@ -830,6 +830,170 @@ periodics:
         secretName: s390x-cluster1
 - annotations:
     testgrid-dashboards: serving
+    testgrid-tab-name: ppc64le-kourier-tests
+  cluster: prow-build
+  cron: 30 21 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative
+    path_alias: knative.dev/serving
+    repo: serving
+  name: ppc64le-kourier-tests_serving_main_periodic
+  spec:
+    containers:
+    - args:
+      - bash
+      - -c
+      - |
+        cat /opt/cluster/ci-script > /tmp/connect.sh
+        chmod +x /tmp/connect.sh
+        . /tmp/connect.sh ${CI_JOB}
+        export TEST_OPTIONS=$TEST_OPTIONS' --ingressendpoint 'cluster.ppc64le
+        ./test/e2e-tests.sh --run-tests --kourier-version latest
+      command:
+      - runner.sh
+      env:
+      - name: CI_JOB
+        value: kourier-main
+      - name: SYSTEM_NAMESPACE
+        value: knative-serving
+      - name: TEST_OPTIONS
+        value: --enable-alpha --enable-beta --resolvabledomain=false
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      - name: KO_FLAGS
+        value: --platform=linux/ppc64le
+      - name: PLATFORM
+        value: linux/ppc64le
+      - name: KO_DOCKER_REPO
+        value: registry.ppc64le
+      - name: KUBECONFIG
+        value: /root/.kube/config
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20221107-8ebeb5c4
+      name: ""
+      resources:
+        limits:
+          memory: 16Gi
+        requests:
+          memory: 12Gi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /docker-graph
+        name: docker-graph
+      - mountPath: /lib/modules
+        name: modules
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+      - mountPath: /opt/cluster
+        name: ppc64le-cluster
+        readOnly: true
+    nodeSelector:
+      kubernetes.io/arch: amd64
+      type: testing
+    serviceAccountName: test-runner
+    volumes:
+    - emptyDir: {}
+      name: docker-graph
+    - hostPath:
+        path: /lib/modules
+        type: Directory
+      name: modules
+    - hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+      name: cgroup
+    - name: ppc64le-cluster
+      secret:
+        defaultMode: 384
+        secretName: ppc64le-cluster
+- annotations:
+    testgrid-dashboards: serving
+    testgrid-tab-name: ppc64le-contour-tests
+  cluster: prow-build
+  cron: 30 23 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: knative
+    path_alias: knative.dev/serving
+    repo: serving
+  name: ppc64le-contour-tests_serving_main_periodic
+  spec:
+    containers:
+    - args:
+      - bash
+      - -c
+      - |
+        cat /opt/cluster/ci-script > /tmp/connect.sh
+        chmod +x /tmp/connect.sh
+        . /tmp/connect.sh ${CI_JOB}
+        export TEST_OPTIONS=$TEST_OPTIONS' --ingressendpoint 'cluster.ppc64le
+        ./test/e2e-tests.sh --run-tests --contour-version latest
+      command:
+      - runner.sh
+      env:
+      - name: CI_JOB
+        value: contour-main
+      - name: SYSTEM_NAMESPACE
+        value: knative-serving
+      - name: TEST_OPTIONS
+        value: --enable-alpha --enable-beta --resolvabledomain=false
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      - name: KO_FLAGS
+        value: --platform=linux/ppc64le
+      - name: PLATFORM
+        value: linux/ppc64le
+      - name: KO_DOCKER_REPO
+        value: registry.ppc64le
+      - name: KUBECONFIG
+        value: /root/.kube/config
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20221107-8ebeb5c4
+      name: ""
+      resources:
+        limits:
+          memory: 16Gi
+        requests:
+          memory: 12Gi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /docker-graph
+        name: docker-graph
+      - mountPath: /lib/modules
+        name: modules
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+      - mountPath: /opt/cluster
+        name: ppc64le-cluster
+        readOnly: true
+    nodeSelector:
+      kubernetes.io/arch: amd64
+      type: testing
+    serviceAccountName: test-runner
+    volumes:
+    - emptyDir: {}
+      name: docker-graph
+    - hostPath:
+        path: /lib/modules
+        type: Directory
+      name: modules
+    - hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+      name: cgroup
+    - name: ppc64le-cluster
+      secret:
+        defaultMode: 384
+        secretName: ppc64le-cluster
+- annotations:
+    testgrid-dashboards: serving
     testgrid-tab-name: nightly
   cluster: prow-build
   cron: 15 9 * * *

--- a/prow/jobs_config/knative/serving.yaml
+++ b/prow/jobs_config/knative/serving.yaml
@@ -255,6 +255,50 @@ jobs:
       - name: TEST_OPTIONS
         value: "--enable-alpha --enable-beta --resolvabledomain=false"
 
+  - name: ppc64le-kourier-tests
+    cron: 30 21 * * *
+    types: [periodic]
+    requirements: [ppc64le]
+    command: [runner.sh]
+    args:
+      - bash
+      - -c
+      - |
+        cat /opt/cluster/ci-script > /tmp/connect.sh
+        chmod +x /tmp/connect.sh
+        . /tmp/connect.sh ${CI_JOB}
+        export TEST_OPTIONS=$TEST_OPTIONS' --ingressendpoint 'cluster.ppc64le
+        ./test/e2e-tests.sh --run-tests --kourier-version latest
+    env:
+      - name: SYSTEM_NAMESPACE
+        value: knative-serving
+      - name: TEST_OPTIONS
+        value: "--enable-alpha --enable-beta --resolvabledomain=false"
+      - name: CI_JOB
+        value: "kourier-main" 
+
+  - name: ppc64le-contour-tests
+    cron: 30 23 * * *
+    types: [periodic]
+    requirements: [ppc64le]
+    command: [runner.sh]
+    args:
+      - bash
+      - -c
+      - |
+        cat /opt/cluster/ci-script > /tmp/connect.sh
+        chmod +x /tmp/connect.sh
+        . /tmp/connect.sh ${CI_JOB}
+        export TEST_OPTIONS=$TEST_OPTIONS' --ingressendpoint 'cluster.ppc64le
+        ./test/e2e-tests.sh --run-tests --contour-version latest
+    env:
+      - name: SYSTEM_NAMESPACE
+        value: knative-serving
+      - name: TEST_OPTIONS
+        value: "--enable-alpha --enable-beta --resolvabledomain=false"
+      - name: CI_JOB
+        value: "contour-main"
+
   - name: nightly
     types: [periodic]
     timeout: 3h

--- a/tools/release-jobs-syncer/pkg/jobs_sync.go
+++ b/tools/release-jobs-syncer/pkg/jobs_sync.go
@@ -43,7 +43,7 @@ const (
 // By default only the continuous Prow jobs will be synced in order to reduce
 // the load with Prow.
 var extraPeriodicProwJobsToSync map[string]sets.String = map[string]sets.String{
-	"knative/serving":  sets.NewString("s390x-kourier-tests", "s390x-contour-tests"),
+	"knative/serving":  sets.NewString("s390x-kourier-tests", "s390x-contour-tests", "ppc64le-kourier-tests", "ppc64le-contour-tests"),
 	"knative/eventing": sets.NewString("s390x-e2e-tests", "s390x-e2e-reconciler-tests", "ppc64le-e2e-tests", "ppc64le-e2e-reconciler-tests"),
 	"knative/client":   sets.NewString("s390x-e2e-tests", "ppc64le-e2e-tests"),
 	"knative/operator": sets.NewString("s390x-e2e-tests", "ppc64le-e2e-tests"),


### PR DESCRIPTION
Signed-off-by: mdafsanhossain <Mdafsan.Hossain@ibm.com>

**Which issue(s) this PR fixes**:<br>This PR adds nightly CI jobs for knative serving/contour & serving/kourier on ppc64le architecture.

<!-- 
  Use `Fixes #<issue number>`, or `Fixes (paste link of issue)`
  to automatically close linked issue when the PR is merged.
  Uncomment and fill below if the PR does not close any issues.
-->
<!--
**What this PR does, why we need it**:<br>
-->

<!--
  If there is any golang code in this PR please uncomment the 
  `/lint` statement below to have Prow automatically lint it.
-->
<!--
  /lint
-->
