### PR TITLE
Use the GKE auth plugin in order to avoid spammy test output

### DIFF
--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -256,6 +256,7 @@ COPY --from=external-rust-gets /usr/local/cargo/bin/rcodesign /usr/local/bin/rco
 RUN rm -f /usr/local/bin/source-gvm-and-run.sh
 
 ENV PATH /go/bin:$PATH
+ENV USE_GKE_GCLOUD_AUTH_PLUGIN True
 
 # Extract versions
 RUN ko version > /ko_version


### PR DESCRIPTION
Details here: https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke

/assign @upodroid 