### PR TITLE
Remove notarisation flags from func 1.7 jobs

### DIFF
--- a/prow/jobs/generated/knative/func-release-1.7.gen.yaml
+++ b/prow/jobs/generated/knative/func-release-1.7.gen.yaml
@@ -31,12 +31,6 @@ periodics:
       - gcr.io/knative-releases
       - --github-token
       - /etc/hub-token/token
-      - --apple-codesign-key
-      - /etc/notary/cert.p12
-      - --apple-notary-api-key
-      - /etc/notary/key.json
-      - --apple-codesign-password-file
-      - /etc/notary/password
       - --branch
       - release-1.7
       env:

--- a/prow/jobs_config/knative/func-release-1.7.yaml
+++ b/prow/jobs_config/knative/func-release-1.7.yaml
@@ -18,12 +18,6 @@ jobs:
   - gcr.io/knative-releases
   - --github-token
   - /etc/hub-token/token
-  - --apple-codesign-key
-  - /etc/notary/cert.p12
-  - --apple-notary-api-key
-  - /etc/notary/key.json
-  - --apple-codesign-password-file
-  - /etc/notary/password
   - --branch
   - release-1.7
   excluded_requirements:


### PR DESCRIPTION
When the repo got renamed, the 1.7 job was deleted so a new one was made with the latest flag and it uses features not backported to 1.7.

/cc @lance @evankanderson 