### PR TITLE
:bug: Use the GKE production API instead of beta

### DIFF
--- a/tools/kntest/pkg/kubetest2/gke/options.go
+++ b/tools/kntest/pkg/kubetest2/gke/options.go
@@ -26,7 +26,7 @@ func addOptions(gkeCmd *cobra.Command, cfg *kubetest2.GKEClusterConfig) {
 	f := gkeCmd.Flags()
 	f.StringVar(&cfg.GCPServiceAccount, "gcp-service-account", "", "The GCP service account used for creating the cluster.")
 	f.StringVar(&cfg.Environment, "environment", "prod", "The GKE environment, must be one of prod, staging, staging2 and test.")
-	f.StringVar(&cfg.CommandGroup, "command-group", "beta", "The gcloud command group, must be alpha, beta or empty.")
+	f.StringVar(&cfg.CommandGroup, "command-group", "", "The gcloud command group, must be alpha, beta or empty.")
 	f.StringVar(&cfg.GCPProjectID, "gcp-project-id", "", "GCP project ID for creating the cluster")
 
 	f.StringVar(&cfg.Name, "name", "", "The GKE cluster name.")


### PR DESCRIPTION
**Which issue(s) this PR fixes**:<br>
Fixes partially https://github.com/knative-sandbox/kn-plugin-event/issues/242

**What this PR does, why we need it**:<br>

This PR uses the default of production GKE API instead of beta.


<!--
  /lint
-->
