### PR TITLE
skips unknown contexts for async component

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -232,6 +232,8 @@ tide:
             skip-unknown-contexts: true
       knative-sandbox:
         repos:
+          async-component:
+            skip-unknown-contexts: true
           eventing-kafka-broker:
             skip-unknown-contexts: true
           reconciler-test:


### PR DESCRIPTION
**Which issue(s) this PR fixes**:<br>
Fixes https://github.com/knative-sandbox/async-component/issues/121

Appears there's some difference in how network activity is handled between the two, this should sidestep the failure of the duplicate test run by GH actions.
<!-- 
  Use `Fixes #<issue number>`, or `Fixes (paste link of issue)`
  to automatically close linked issue when the PR is merged.
  Uncomment and fill below if the PR does not close any issues.
-->
<!--
**What this PR does, why we need it**:<br>
-->

<!--
  If there is any golang code in this PR please uncomment the 
  `/lint` statement below to have Prow automatically lint it.
-->
<!--
  /lint
-->
