### PR TITLE
update PR template

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -1,17 +1,22 @@
-**Which issue(s) this PR fixes**:<br>
-Fixes #
-
-<!-- 
+<!--
   Use `Fixes #<issue number>`, or `Fixes (paste link of issue)`
   to automatically close linked issue when the PR is merged.
-  Uncomment and fill below if the PR does not close any issues.
+-->
+**Which issue(s) this PR fixes**:<br>
+Fixes
+
+
+
+<!--
+  Uncomment and fill out below if the PR does not close any issues.
 -->
 <!--
 **What this PR does, why we need it**:<br>
+<Explanation goes here>
 -->
 
 <!--
-  If there is any golang code in this PR please uncomment the 
+  If there is any golang code in this PR please uncomment the
   `/lint` statement below to have Prow automatically lint it.
 -->
 <!--


### PR DESCRIPTION
**What this PR does, why we need it**:<br>
Format the pr template to be more clear.
Remove the `#` after the `Fixes` line so when one pastes a link a double ## does not occur thus not closing the issue.