### PR TITLE
Check for obsolete releases

### DIFF
--- a/tools/release-jobs-syncer/pkg/release.go
+++ b/tools/release-jobs-syncer/pkg/release.go
@@ -113,16 +113,18 @@ func updateProwJobsForReleases(gc ghutil.GithubOperations, orgRepoReleaseMap map
 		sortReleases(releases)
 		log.Printf("Existing releases for %s/%s: %v", org, repo, releases)
 		log.Printf("Latest release for %s/%s: %s", org, repo, latest)
-		// Skip if the latest release has already been configured.
+
+		releaseToAdd := ""
 		if len(releases) != 0 && releases[len(releases)-1] == latest {
-			log.Printf("%s is already added for %s/%s:%v, skipping it", latest, org, repo, releases)
-			continue
+			log.Printf("%s is already added for %s/%s:%v", latest, org, repo, releases)
+		} else { // There is a new release
+			releaseToAdd = latest
+			releases = append(releases, latest)
 		}
 
-		releaseToAdd := latest
 		releaseToRemove := ""
 		// If the number of releases is already maximum, remove the earliest one.
-		if len(releases) == maxReleaseBranches {
+		if len(releases) > maxReleaseBranches {
 			releaseToRemove = releases[0]
 		}
 


### PR DESCRIPTION
<!--
  Use `Fixes #<issue number>`, or `Fixes (paste link of issue)`
  to automatically close linked issue when the PR is merged.
-->
**Which issue(s) this PR fixes**:<br>
Fixes https://github.com/knative/test-infra/issues/3638

On https://github.com/knative/test-infra/pull/3643 where the max branches was reduced the older release branches were not cleaned up because there was not a new release being released at the same time.

This was a limitation in the release syncer tool which skipped if no release was being added. These changes allows one to run the tool at anytime to cleanup old releases regardless if there is a new release added or not.