### PR TITLE
bump go versions to latest patch

### DIFF
--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -162,8 +162,8 @@ COPY images/prow-tests/source-gvm-and-run.sh /usr/local/bin
 # Install our versions of Go.
 # We only install the latest 3 versions of Go which should be enough for
 # all Knative repositories.
-RUN source-gvm-and-run.sh install go1.18.9 --prefer-binary
-RUN source-gvm-and-run.sh install go1.19.4 --prefer-binary
+RUN source-gvm-and-run.sh install go1.18.10 --prefer-binary
+RUN source-gvm-and-run.sh install go1.19.5 --prefer-binary
 RUN source-gvm-and-run.sh use go1.19 --default
 
 # protoc and required golang tooling


### PR DESCRIPTION
1.19.5 - https://go.dev/doc/devel/release#go1.19.minor
1.18.10 - https://go.dev/doc/devel/release#go1.18.minor