### PR TITLE
Generate Provenances for Release jobs under knative-sandbox

### DIFF
--- a/prow/jobs/generated/knative-sandbox/async-component-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/async-component-main.gen.yaml
@@ -124,6 +124,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/container-freezer-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/container-freezer-main.gen.yaml
@@ -126,6 +126,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/container-freezer-release-0.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/container-freezer-release-0.1.gen.yaml
@@ -81,6 +81,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/eventing-autoscaler-keda-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-autoscaler-keda-main.gen.yaml
@@ -126,6 +126,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/eventing-autoscaler-keda-release-1.6.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-autoscaler-keda-release-1.6.gen.yaml
@@ -82,6 +82,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/eventing-autoscaler-keda-release-1.7.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-autoscaler-keda-release-1.7.gen.yaml
@@ -82,6 +82,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/eventing-autoscaler-keda-release-1.8.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-autoscaler-keda-release-1.8.gen.yaml
@@ -82,6 +82,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/eventing-awssqs-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-awssqs-main.gen.yaml
@@ -126,6 +126,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/eventing-awssqs-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-awssqs-release-1.0.gen.yaml
@@ -81,6 +81,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/eventing-awssqs-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-awssqs-release-1.1.gen.yaml
@@ -81,6 +81,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/eventing-awssqs-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-awssqs-release-1.2.gen.yaml
@@ -81,6 +81,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/eventing-ceph-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-ceph-main.gen.yaml
@@ -162,6 +162,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667

--- a/prow/jobs/generated/knative-sandbox/eventing-ceph-release-1.6.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-ceph-release-1.6.gen.yaml
@@ -99,6 +99,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667

--- a/prow/jobs/generated/knative-sandbox/eventing-ceph-release-1.7.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-ceph-release-1.7.gen.yaml
@@ -99,6 +99,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667

--- a/prow/jobs/generated/knative-sandbox/eventing-ceph-release-1.8.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-ceph-release-1.8.gen.yaml
@@ -99,6 +99,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667

--- a/prow/jobs/generated/knative-sandbox/eventing-couchdb-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-couchdb-main.gen.yaml
@@ -162,6 +162,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667

--- a/prow/jobs/generated/knative-sandbox/eventing-couchdb-release-1.0.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-couchdb-release-1.0.gen.yaml
@@ -99,6 +99,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/eventing-couchdb-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-couchdb-release-1.1.gen.yaml
@@ -99,6 +99,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/eventing-github-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-github-main.gen.yaml
@@ -162,6 +162,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667

--- a/prow/jobs/generated/knative-sandbox/eventing-github-release-1.6.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-github-release-1.6.gen.yaml
@@ -99,6 +99,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667

--- a/prow/jobs/generated/knative-sandbox/eventing-github-release-1.7.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-github-release-1.7.gen.yaml
@@ -99,6 +99,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667

--- a/prow/jobs/generated/knative-sandbox/eventing-github-release-1.8.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-github-release-1.8.gen.yaml
@@ -99,6 +99,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667

--- a/prow/jobs/generated/knative-sandbox/eventing-gitlab-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-gitlab-main.gen.yaml
@@ -170,6 +170,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667

--- a/prow/jobs/generated/knative-sandbox/eventing-gitlab-release-1.6.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-gitlab-release-1.6.gen.yaml
@@ -103,6 +103,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667

--- a/prow/jobs/generated/knative-sandbox/eventing-gitlab-release-1.7.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-gitlab-release-1.7.gen.yaml
@@ -103,6 +103,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667

--- a/prow/jobs/generated/knative-sandbox/eventing-gitlab-release-1.8.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-gitlab-release-1.8.gen.yaml
@@ -103,6 +103,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667

--- a/prow/jobs/generated/knative-sandbox/eventing-kafka-broker-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kafka-broker-main.gen.yaml
@@ -175,6 +175,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667

--- a/prow/jobs/generated/knative-sandbox/eventing-kafka-broker-release-1.6.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kafka-broker-release-1.6.gen.yaml
@@ -99,6 +99,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667

--- a/prow/jobs/generated/knative-sandbox/eventing-kafka-broker-release-1.7.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kafka-broker-release-1.7.gen.yaml
@@ -101,6 +101,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667

--- a/prow/jobs/generated/knative-sandbox/eventing-kafka-broker-release-1.8.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kafka-broker-release-1.8.gen.yaml
@@ -103,6 +103,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667

--- a/prow/jobs/generated/knative-sandbox/eventing-kafka-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kafka-main.gen.yaml
@@ -169,6 +169,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667

--- a/prow/jobs/generated/knative-sandbox/eventing-kafka-release-1.6.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kafka-release-1.6.gen.yaml
@@ -99,6 +99,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667

--- a/prow/jobs/generated/knative-sandbox/eventing-kafka-release-1.7.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kafka-release-1.7.gen.yaml
@@ -99,6 +99,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667

--- a/prow/jobs/generated/knative-sandbox/eventing-kafka-release-1.8.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kafka-release-1.8.gen.yaml
@@ -99,6 +99,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667

--- a/prow/jobs/generated/knative-sandbox/eventing-kogito-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kogito-main.gen.yaml
@@ -133,6 +133,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/eventing-kogito-release-1.6.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kogito-release-1.6.gen.yaml
@@ -81,6 +81,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/eventing-kogito-release-1.7.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kogito-release-1.7.gen.yaml
@@ -81,6 +81,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/eventing-kogito-release-1.8.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kogito-release-1.8.gen.yaml
@@ -81,6 +81,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/eventing-natss-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-natss-main.gen.yaml
@@ -133,6 +133,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/eventing-natss-release-1.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-natss-release-1.2.gen.yaml
@@ -81,6 +81,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/eventing-natss-release-1.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-natss-release-1.3.gen.yaml
@@ -81,6 +81,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/eventing-natss-release-1.4.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-natss-release-1.4.gen.yaml
@@ -81,6 +81,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/eventing-rabbitmq-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-rabbitmq-main.gen.yaml
@@ -133,6 +133,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/eventing-rabbitmq-release-1.6.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-rabbitmq-release-1.6.gen.yaml
@@ -81,6 +81,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/eventing-rabbitmq-release-1.7.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-rabbitmq-release-1.7.gen.yaml
@@ -81,6 +81,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/eventing-rabbitmq-release-1.8.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-rabbitmq-release-1.8.gen.yaml
@@ -81,6 +81,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/eventing-redis-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-redis-main.gen.yaml
@@ -162,6 +162,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667

--- a/prow/jobs/generated/knative-sandbox/eventing-redis-release-1.6.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-redis-release-1.6.gen.yaml
@@ -99,6 +99,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667

--- a/prow/jobs/generated/knative-sandbox/eventing-redis-release-1.7.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-redis-release-1.7.gen.yaml
@@ -99,6 +99,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667

--- a/prow/jobs/generated/knative-sandbox/eventing-redis-release-1.8.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-redis-release-1.8.gen.yaml
@@ -99,6 +99,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-admin-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-admin-main.gen.yaml
@@ -141,6 +141,8 @@ periodics:
         value: "true"
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-admin-release-1.6.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-admin-release-1.6.gen.yaml
@@ -81,6 +81,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-admin-release-1.7.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-admin-release-1.7.gen.yaml
@@ -81,6 +81,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-admin-release-1.8.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-admin-release-1.8.gen.yaml
@@ -87,6 +87,8 @@ periodics:
         value: "true"
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-event-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-event-main.gen.yaml
@@ -141,6 +141,8 @@ periodics:
         value: "true"
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-event-release-1.6.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-event-release-1.6.gen.yaml
@@ -81,6 +81,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-event-release-1.7.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-event-release-1.7.gen.yaml
@@ -81,6 +81,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-event-release-1.8.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-event-release-1.8.gen.yaml
@@ -87,6 +87,8 @@ periodics:
         value: "true"
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-operator-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-operator-main.gen.yaml
@@ -139,6 +139,8 @@ periodics:
         value: "true"
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-operator-release-1.6.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-operator-release-1.6.gen.yaml
@@ -81,6 +81,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-operator-release-1.7.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-operator-release-1.7.gen.yaml
@@ -81,6 +81,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-operator-release-1.8.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-operator-release-1.8.gen.yaml
@@ -87,6 +87,8 @@ periodics:
         value: "true"
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-quickstart-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-quickstart-main.gen.yaml
@@ -141,6 +141,8 @@ periodics:
         value: "true"
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-quickstart-release-1.6.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-quickstart-release-1.6.gen.yaml
@@ -81,6 +81,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-quickstart-release-1.7.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-quickstart-release-1.7.gen.yaml
@@ -81,6 +81,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-quickstart-release-1.8.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-quickstart-release-1.8.gen.yaml
@@ -87,6 +87,8 @@ periodics:
         value: "true"
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-service-log-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-service-log-main.gen.yaml
@@ -156,6 +156,8 @@ periodics:
         value: "true"
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-service-log-release-1.1.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-service-log-release-1.1.gen.yaml
@@ -81,6 +81,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-source-kafka-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-source-kafka-main.gen.yaml
@@ -159,6 +159,8 @@ periodics:
         value: "true"
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-source-kafka-release-1.6.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-source-kafka-release-1.6.gen.yaml
@@ -81,6 +81,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-source-kafka-release-1.7.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-source-kafka-release-1.7.gen.yaml
@@ -81,6 +81,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-source-kafka-release-1.8.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-source-kafka-release-1.8.gen.yaml
@@ -87,6 +87,8 @@ periodics:
         value: "true"
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-source-kamelet-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-source-kamelet-main.gen.yaml
@@ -139,6 +139,8 @@ periodics:
         value: "true"
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-source-kamelet-release-1.6.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-source-kamelet-release-1.6.gen.yaml
@@ -81,6 +81,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-source-kamelet-release-1.7.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-source-kamelet-release-1.7.gen.yaml
@@ -81,6 +81,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-source-kamelet-release-1.8.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-source-kamelet-release-1.8.gen.yaml
@@ -87,6 +87,8 @@ periodics:
         value: "true"
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/net-certmanager-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-certmanager-main.gen.yaml
@@ -133,6 +133,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/net-certmanager-release-1.7.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-certmanager-release-1.7.gen.yaml
@@ -81,6 +81,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/net-certmanager-release-1.8.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-certmanager-release-1.8.gen.yaml
@@ -81,6 +81,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/net-certmanager-release-1.9.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-certmanager-release-1.9.gen.yaml
@@ -82,6 +82,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/net-contour-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-contour-main.gen.yaml
@@ -133,6 +133,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/net-contour-release-1.7.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-contour-release-1.7.gen.yaml
@@ -81,6 +81,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/net-contour-release-1.8.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-contour-release-1.8.gen.yaml
@@ -81,6 +81,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/net-contour-release-1.9.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-contour-release-1.9.gen.yaml
@@ -82,6 +82,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/net-gateway-api-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-gateway-api-main.gen.yaml
@@ -177,6 +177,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/net-gateway-api-release-1.7.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-gateway-api-release-1.7.gen.yaml
@@ -81,6 +81,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/net-gateway-api-release-1.8.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-gateway-api-release-1.8.gen.yaml
@@ -81,6 +81,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/net-gateway-api-release-1.9.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-gateway-api-release-1.9.gen.yaml
@@ -40,6 +40,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/net-http01-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-http01-main.gen.yaml
@@ -133,6 +133,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/net-http01-release-1.7.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-http01-release-1.7.gen.yaml
@@ -81,6 +81,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/net-http01-release-1.8.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-http01-release-1.8.gen.yaml
@@ -81,6 +81,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/net-http01-release-1.9.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-http01-release-1.9.gen.yaml
@@ -82,6 +82,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/net-istio-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-istio-main.gen.yaml
@@ -133,6 +133,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/net-istio-release-1.7.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-istio-release-1.7.gen.yaml
@@ -81,6 +81,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/net-istio-release-1.8.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-istio-release-1.8.gen.yaml
@@ -81,6 +81,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/net-istio-release-1.9.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-istio-release-1.9.gen.yaml
@@ -82,6 +82,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/net-kourier-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-kourier-main.gen.yaml
@@ -133,6 +133,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/net-kourier-release-1.7.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-kourier-release-1.7.gen.yaml
@@ -81,6 +81,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/net-kourier-release-1.8.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-kourier-release-1.8.gen.yaml
@@ -81,6 +81,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/net-kourier-release-1.9.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/net-kourier-release-1.9.gen.yaml
@@ -82,6 +82,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/sample-controller-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/sample-controller-main.gen.yaml
@@ -82,6 +82,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/sample-controller-release-1.7.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/sample-controller-release-1.7.gen.yaml
@@ -39,6 +39,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/sample-controller-release-1.8.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/sample-controller-release-1.8.gen.yaml
@@ -39,6 +39,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/sample-controller-release-1.9.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/sample-controller-release-1.9.gen.yaml
@@ -39,6 +39,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/sample-source-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/sample-source-main.gen.yaml
@@ -84,6 +84,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/sample-source-release-1.6.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/sample-source-release-1.6.gen.yaml
@@ -39,6 +39,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/sample-source-release-1.7.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/sample-source-release-1.7.gen.yaml
@@ -39,6 +39,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/sample-source-release-1.8.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/sample-source-release-1.8.gen.yaml
@@ -39,6 +39,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/scaling-group-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/scaling-group-main.gen.yaml
@@ -126,6 +126,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/security-guard-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/security-guard-main.gen.yaml
@@ -126,6 +126,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/security-guard-release-0.2.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/security-guard-release-0.2.gen.yaml
@@ -82,6 +82,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/security-guard-release-0.3.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/security-guard-release-0.3.gen.yaml
@@ -82,6 +82,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs/generated/knative-sandbox/security-guard-release-0.4.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/security-guard-release-0.4.gen.yaml
@@ -82,6 +82,8 @@ periodics:
         value: us-central1
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
       image: gcr.io/knative-tests/test-infra/prow-tests:v20230116-208c6667
       name: ""
       resources: {}

--- a/prow/jobs_config/knative-sandbox/.base.yaml
+++ b/prow/jobs_config/knative-sandbox/.base.yaml
@@ -10,6 +10,8 @@ requirement_presets:
       # ORG_NAME must be set to knative-sandbox, overwriting the preset in root .base.yaml
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
     volumeMounts:
       - name: hub-token
         mountPath: /etc/hub-token
@@ -42,6 +44,8 @@ requirement_presets:
      # ORG_NAME must be set to knative-sandbox, overwriting the preset in root .base.yaml
       - name: ORG_NAME
         value: knative-sandbox
+      - name: ATTEST_IMAGES
+        value: "true"
     volumeMounts:
       - name: hub-token
         mountPath: /etc/hub-token


### PR DESCRIPTION
I forgot that the release jobs for knative-sandbox are overriden.

Follow up from #3673 

/cc @psschwei @evankanderson 