### PR TITLE
Make eventing-kafka upgrade job optional

### DIFF
--- a/prow/jobs/generated/knative-sandbox/eventing-kafka-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kafka-main.gen.yaml
@@ -597,6 +597,7 @@ presubmits:
     cluster: prow-build
     decorate: true
     name: upgrade-tests_eventing-kafka_main
+    optional: true
     path_alias: knative.dev/eventing-kafka
     rerun_command: /test upgrade-tests
     spec:

--- a/prow/jobs_config/knative-sandbox/eventing-kafka.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-kafka.yaml
@@ -40,6 +40,7 @@ jobs:
   - name: upgrade-tests
     types: [presubmit]
     command: [runner.sh, ./test/presubmit-tests.sh, --run-test, "./test/e2e-upgrade-tests.sh"]
+    modifiers: [presubmit_optional]
 
   - name: continuous
     types: [periodic]


### PR DESCRIPTION
Due to some deprecated/removed API versions we have some chicken-egg problems on the upgrade test jobs (see https://github.com/knative-sandbox/eventing-kafka/pull/1287 for example).
This PR marks them as optional in the meantime