### PR TITLE
Deploy Testgrid API

### DIFF
--- a/infra/gcp/dns/dns.tf
+++ b/infra/gcp/dns/dns.tf
@@ -79,6 +79,14 @@ module "knative_dev" {
       ]
     },
     {
+      name = "api.testgrid"
+      type = "A"
+      ttl  = 300
+      records = [
+        "35.201.93.215",
+      ]
+    },
+    {
       name = "grafana"
       type = "A"
       ttl  = 300

--- a/infra/gcp/tests/prow.tf
+++ b/infra/gcp/tests/prow.tf
@@ -114,6 +114,7 @@ resource "google_service_account_iam_binding" "testgrid_updater" {
     "serviceAccount:k8s-testgrid.svc.id.goog[knative/summarizer]",
     "serviceAccount:k8s-testgrid.svc.id.goog[knative/tabulator]",
     "serviceAccount:k8s-testgrid.svc.id.goog[knative/updater]",
+    "serviceAccount:knative-tests.svc.id.goog[default/testgrid]",
   ]
 }
 

--- a/prow/cluster/control-plane/303-prow-knative-dev_managedcertificate.yaml
+++ b/prow/cluster/control-plane/303-prow-knative-dev_managedcertificate.yaml
@@ -20,3 +20,11 @@ spec:
   domains:
   - prow.knative.dev
   - gcsweb.knative.dev
+---
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: api-testgrid-knative-dev
+spec:
+  domains:
+  - api.testgrid.knative.dev

--- a/prow/cluster/control-plane/ingress.yaml
+++ b/prow/cluster/control-plane/ingress.yaml
@@ -21,7 +21,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: "gce"
     kubernetes.io/ingress.global-static-ip-name: prow-ingress
-    networking.gke.io/managed-certificates: prow-knative-dev
+    networking.gke.io/managed-certificates: "prow-knative-dev,api-testgrid-knative-dev"
 spec:
   rules:
     - host: prow.knative.dev
@@ -49,5 +49,15 @@ spec:
             backend:
               service:
                 name: gcsweb
+                port:
+                  number: 80
+    - host: api.testgrid.knative.dev
+      http:
+        paths:
+          - path: /*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: testgrid-api
                 port:
                   number: 80

--- a/prow/cluster/control-plane/testgrid.yaml
+++ b/prow/cluster/control-plane/testgrid.yaml
@@ -1,0 +1,55 @@
+# Testgrid will become selfhostable at some point in the future.
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: testgrid-api
+  namespace: default
+  labels:
+    app: testgrid
+    channel: stable
+    component: api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: testgrid
+      channel: stable
+      component: api
+  template:
+    metadata:
+      labels:
+        app: testgrid
+        channel: stable
+        component: api
+    spec:
+      serviceAccountName: testgrid
+      containers:
+        - name: api
+          image: gcr.io/k8s-testgrid/api:v20230118-v0.0.154-12-g7617c747
+          args:
+          - --scope=gs://knative-own-testgrid
+          - --port=8080
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: testgrid-updater@knative-tests.iam.gserviceaccount.com
+  name: testgrid
+  namespace: default
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: testgrid-api
+  namespace: default
+spec:
+  type: NodePort
+  selector:
+    app: testgrid
+    component: api
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080


### PR DESCRIPTION
/cc @kvmware 

[Testgrid](https://github.com/GoogleCloudPlatform/testgrid) will be selfhostable soon so this component serves the data in testgrid via a new API.

/hold
I'll merge this later in the weekend.