### PR TITLE
add release 1.9 jobs for s390x

### DIFF
--- a/prow/jobs/generated/knative-sandbox/eventing-kafka-release-1.9.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kafka-release-1.9.gen.yaml
@@ -148,6 +148,85 @@ periodics:
         path: /sys/fs/cgroup
         type: Directory
       name: cgroup
+- annotations:
+    testgrid-dashboards: knative-sandbox-release-1.9
+    testgrid-tab-name: eventing-kafka-s390x-e2e-tests
+  cluster: prow-build
+  cron: 20 18 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: release-1.9
+    org: knative-sandbox
+    path_alias: knative.dev/eventing-kafka
+    repo: eventing-kafka
+  max_concurrency: 1
+  name: s390x-e2e-tests_eventing-kafka_release-1.9_periodic
+  spec:
+    containers:
+    - args:
+      - bash
+      - -c
+      - |
+        mkdir -p /root/.kube
+        cat /opt/cluster/ci-script > connect.sh
+        chmod +x connect.sh
+        ./connect.sh eventing_kafka-19
+        kubectl get cm s390x-config-eventing-kafka -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
+        chmod +x adjust.sh
+        ./adjust.sh
+        ./test/e2e-tests.sh --run-tests
+      command:
+      - runner.sh
+      env:
+      - name: EVENTING_NAMESPACE
+        value: knative-eventing
+      - name: SCALE_CHAOSDUCK_TO_ZERO
+        value: "1"
+      - name: SYSTEM_NAMESPACE
+        value: knative-eventing
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: KO_FLAGS
+        value: --platform=linux/s390x --insecure-registry
+      - name: PLATFORM
+        value: linux/s390x
+      - name: KO_DOCKER_REPO
+        valueFrom:
+          secretKeyRef:
+            key: ko-docker-repo
+            name: s390x-cluster1
+      - name: KUBECONFIG
+        value: /root/.kube/config
+      - name: DOCKER_CONFIG
+        value: /opt/cluster
+      image: gcr.io/knative-tests/test-infra/prow-tests:v20230126-0d51bee0
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/test-account
+        name: test-account
+        readOnly: true
+      - mountPath: /opt/cluster
+        name: s390x-cluster1
+        readOnly: true
+    nodeSelector:
+      kubernetes.io/arch: amd64
+      type: testing
+    volumes:
+    - name: test-account
+      secret:
+        items:
+        - key: service-account-key.json
+          path: service-account.json
+        secretName: prow-google-credentials
+    - name: s390x-cluster1
+      secret:
+        defaultMode: 384
+        secretName: s390x-cluster1
 presubmits:
   knative-sandbox/eventing-kafka:
   - always_run: true

--- a/prow/jobs/generated/knative-sandbox/eventing-kafka-release-1.9.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/eventing-kafka-release-1.9.gen.yaml
@@ -159,7 +159,6 @@ periodics:
     org: knative-sandbox
     path_alias: knative.dev/eventing-kafka
     repo: eventing-kafka
-  max_concurrency: 1
   name: s390x-e2e-tests_eventing-kafka_release-1.9_periodic
   spec:
     containers:

--- a/prow/jobs/generated/knative/client-release-1.9.gen.yaml
+++ b/prow/jobs/generated/knative/client-release-1.9.gen.yaml
@@ -52,7 +52,7 @@ periodics:
     testgrid-dashboards: knative-release-1.9
     testgrid-tab-name: client-s390x-e2e-tests
   cluster: prow-build
-  cron: 20 1 * * *
+  cron: 20 13 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.9
@@ -69,7 +69,7 @@ periodics:
         mkdir -p /root/.kube
         cat /opt/cluster/ci-script > connect.sh
         chmod +x connect.sh
-        ./connect.sh client-main
+        ./connect.sh client-19
         kubectl get cm s390x-config-client -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
         chmod +x adjust.sh
         ./adjust.sh

--- a/prow/jobs/generated/knative/eventing-release-1.9.gen.yaml
+++ b/prow/jobs/generated/knative/eventing-release-1.9.gen.yaml
@@ -58,7 +58,7 @@ periodics:
     testgrid-dashboards: knative-release-1.9
     testgrid-tab-name: eventing-s390x-e2e-tests
   cluster: prow-build
-  cron: 20 4 * * *
+  cron: 20 16 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.9
@@ -75,7 +75,7 @@ periodics:
         mkdir -p /root/.kube
         cat /opt/cluster/ci-script > connect.sh
         chmod +x connect.sh
-        ./connect.sh eventing-main
+        ./connect.sh eventing-19
         kubectl get cm s390x-config-eventing -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
         chmod +x adjust.sh
         ./adjust.sh
@@ -138,7 +138,7 @@ periodics:
     testgrid-dashboards: knative-release-1.9
     testgrid-tab-name: eventing-s390x-e2e-reconciler-tests
   cluster: prow-build
-  cron: 20 5 * * *
+  cron: 20 17 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.9
@@ -155,7 +155,7 @@ periodics:
         mkdir -p /root/.kube
         cat /opt/cluster/ci-script > connect.sh
         chmod +x connect.sh
-        ./connect.sh eventing_rekt-main
+        ./connect.sh eventing_rekt-19
         kubectl get cm s390x-config-eventing -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
         chmod +x adjust.sh
         ./adjust.sh

--- a/prow/jobs/generated/knative/operator-release-1.9.gen.yaml
+++ b/prow/jobs/generated/knative/operator-release-1.9.gen.yaml
@@ -52,7 +52,7 @@ periodics:
     testgrid-dashboards: knative-release-1.9
     testgrid-tab-name: operator-s390x-e2e-tests
   cluster: prow-build
-  cron: 20 0 * * *
+  cron: 20 12 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.9
@@ -69,7 +69,7 @@ periodics:
         mkdir -p /root/.kube
         cat /opt/cluster/ci-script > connect.sh
         chmod +x connect.sh
-        ./connect.sh operator-main
+        ./connect.sh operator-19
         kubectl get cm s390x-config-operator -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
         chmod +x adjust.sh
         ./adjust.sh

--- a/prow/jobs/generated/knative/serving-release-1.9.gen.yaml
+++ b/prow/jobs/generated/knative/serving-release-1.9.gen.yaml
@@ -66,7 +66,7 @@ periodics:
     testgrid-dashboards: knative-release-1.9
     testgrid-tab-name: serving-s390x-kourier-tests
   cluster: prow-build
-  cron: 20 2 * * *
+  cron: 20 14 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.9
@@ -83,7 +83,7 @@ periodics:
         mkdir -p /root/.kube
         cat /opt/cluster/ci-script > connect.sh
         chmod +x connect.sh
-        server_addr=$(./connect.sh kourier-main)
+        server_addr=$(./connect.sh kourier-19)
         kubectl get cm s390x-config-serving -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
         chmod +x adjust.sh
         ./adjust.sh
@@ -155,7 +155,7 @@ periodics:
     testgrid-dashboards: knative-release-1.9
     testgrid-tab-name: serving-s390x-contour-tests
   cluster: prow-build
-  cron: 20 3 * * *
+  cron: 20 15 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.9
@@ -172,7 +172,7 @@ periodics:
         mkdir -p /root/.kube
         cat /opt/cluster/ci-script > connect.sh
         chmod +x connect.sh
-        server_addr=$(./connect.sh contour-main)
+        server_addr=$(./connect.sh contour-19)
         kubectl get cm s390x-config-serving -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
         chmod +x adjust.sh
         ./adjust.sh

--- a/prow/jobs_config/knative-sandbox/eventing-kafka-release-1.9.yaml
+++ b/prow/jobs_config/knative-sandbox/eventing-kafka-release-1.9.yaml
@@ -112,5 +112,29 @@ jobs:
   - docker
   types:
   - periodic
+- name: s390x-e2e-tests
+  cron: 20 18 * * *
+  types: [periodic]
+  requirements: [s390x]
+  command: [runner.sh]
+  args:
+    - bash
+    - -c
+    - |
+      mkdir -p /root/.kube
+      cat /opt/cluster/ci-script > connect.sh
+      chmod +x connect.sh
+      ./connect.sh eventing_kafka-19
+      kubectl get cm s390x-config-eventing-kafka -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
+      chmod +x adjust.sh
+      ./adjust.sh
+      ./test/e2e-tests.sh --run-tests
+  env:
+    - name: SYSTEM_NAMESPACE
+      value: knative-eventing
+    - name: EVENTING_NAMESPACE
+      value: knative-eventing
+    - name: SCALE_CHAOSDUCK_TO_ZERO
+      value: "1"
 org: knative-sandbox
 repo: eventing-kafka

--- a/prow/jobs_config/knative/client-release-1.9.yaml
+++ b/prow/jobs_config/knative/client-release-1.9.yaml
@@ -54,14 +54,14 @@ jobs:
     mkdir -p /root/.kube
     cat /opt/cluster/ci-script > connect.sh
     chmod +x connect.sh
-    ./connect.sh client-main
+    ./connect.sh client-19
     kubectl get cm s390x-config-client -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
     chmod +x adjust.sh
     ./adjust.sh
     ./test/e2e-tests.sh --run-tests
   command:
   - runner.sh
-  cron: 20 1 * * *
+  cron: 20 13 * * *
   env:
   - name: INGRESS_CLASS
     value: contour.ingress.networking.knative.dev

--- a/prow/jobs_config/knative/eventing-release-1.9.yaml
+++ b/prow/jobs_config/knative/eventing-release-1.9.yaml
@@ -66,14 +66,14 @@ jobs:
     mkdir -p /root/.kube
     cat /opt/cluster/ci-script > connect.sh
     chmod +x connect.sh
-    ./connect.sh eventing-main
+    ./connect.sh eventing-19
     kubectl get cm s390x-config-eventing -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
     chmod +x adjust.sh
     ./adjust.sh
     ./test/e2e-tests.sh --run-tests
   command:
   - runner.sh
-  cron: 20 4 * * *
+  cron: 20 16 * * *
   env:
   - name: SYSTEM_NAMESPACE
     value: knative-eventing
@@ -91,14 +91,14 @@ jobs:
     mkdir -p /root/.kube
     cat /opt/cluster/ci-script > connect.sh
     chmod +x connect.sh
-    ./connect.sh eventing_rekt-main
+    ./connect.sh eventing_rekt-19
     kubectl get cm s390x-config-eventing -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
     chmod +x adjust.sh
     ./adjust.sh
     ./test/e2e-rekt-tests.sh --run-tests
   command:
   - runner.sh
-  cron: 20 5 * * *
+  cron: 20 17 * * *
   env:
   - name: SYSTEM_NAMESPACE
     value: knative-eventing

--- a/prow/jobs_config/knative/operator-release-1.9.yaml
+++ b/prow/jobs_config/knative/operator-release-1.9.yaml
@@ -71,14 +71,14 @@ jobs:
     mkdir -p /root/.kube
     cat /opt/cluster/ci-script > connect.sh
     chmod +x connect.sh
-    ./connect.sh operator-main
+    ./connect.sh operator-19
     kubectl get cm s390x-config-operator -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
     chmod +x adjust.sh
     ./adjust.sh
     ./test/e2e-tests.sh --run-tests
   command:
   - runner.sh
-  cron: 20 0 * * *
+  cron: 20 12 * * *
   env:
   - name: INGRESS_CLASS
     value: contour.ingress.networking.knative.dev

--- a/prow/jobs_config/knative/serving-release-1.9.yaml
+++ b/prow/jobs_config/knative/serving-release-1.9.yaml
@@ -204,7 +204,7 @@ jobs:
     mkdir -p /root/.kube
     cat /opt/cluster/ci-script > connect.sh
     chmod +x connect.sh
-    server_addr=$(./connect.sh kourier-main)
+    server_addr=$(./connect.sh kourier-19)
     kubectl get cm s390x-config-serving -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
     chmod +x adjust.sh
     ./adjust.sh
@@ -212,7 +212,7 @@ jobs:
     ./test/e2e-tests.sh --run-tests --kourier-version latest
   command:
   - runner.sh
-  cron: 20 2 * * *
+  cron: 20 14 * * *
   env:
   - name: SYSTEM_NAMESPACE
     value: knative-serving
@@ -230,7 +230,7 @@ jobs:
     mkdir -p /root/.kube
     cat /opt/cluster/ci-script > connect.sh
     chmod +x connect.sh
-    server_addr=$(./connect.sh contour-main)
+    server_addr=$(./connect.sh contour-19)
     kubectl get cm s390x-config-serving -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
     chmod +x adjust.sh
     ./adjust.sh
@@ -238,7 +238,7 @@ jobs:
     ./test/e2e-tests.sh --run-tests --contour-version latest
   command:
   - runner.sh
-  cron: 20 3 * * *
+  cron: 20 15 * * *
   env:
   - name: SYSTEM_NAMESPACE
     value: knative-serving


### PR DESCRIPTION
This PR updates the s390x-related prow jobs for release 1.9.

Note: The prow job update for eventing-kafka-broker is missing since there are no kafka-broker release 1.9 available yet.