### PR TITLE
Refactor selector with feedback from 3696

### DIFF
--- a/pkg/gomod/check.go
+++ b/pkg/gomod/check.go
@@ -30,7 +30,7 @@ import (
 // Check examines a go mod file for dependencies and  determines if each have a release artifact
 // based on the ruleset provided. Check leverages the same rules used by
 // knative.dev/test-infra/pkg/git.Repo().BestRefFor
-func Check(gomod, release, moduleRelease string, selector Selector, ruleset git.RulesetType, out io.Writer) error {
+func Check(gomod, release, moduleRelease string, selector Matcher, ruleset git.RulesetType, out io.Writer) error {
 	modulePkgs, _, err := Modules([]string{gomod}, selector)
 	if err != nil {
 		return err

--- a/pkg/gomod/float.go
+++ b/pkg/gomod/float.go
@@ -28,7 +28,7 @@ import (
 // Returns the set of module refs that were found. If no ref is found for a
 // dependency, Float omits that ref from the returned list. Float leverages
 // the same rules used by knative.dev/test-infra/pkg/git.Repo().BestRefFor
-func Float(gomod, release, moduleRelease string, selector Selector, ruleset git.RulesetType) ([]string, error) {
+func Float(gomod, release, moduleRelease string, selector Matcher, ruleset git.RulesetType) ([]string, error) {
 	_, packages, err := Modules([]string{gomod}, selector)
 	if err != nil {
 		return nil, err

--- a/pkg/gomod/modules.go
+++ b/pkg/gomod/modules.go
@@ -26,7 +26,7 @@ import (
 
 // Modules returns a map of given given modules to their direct dependencies,
 // and a list of unique dependencies.
-func Modules(gomod []string, selector Selector) (map[string][]string, []string, error) {
+func Modules(gomod []string, selector Matcher) (map[string][]string, []string, error) {
 	if len(gomod) == 0 {
 		return nil, nil, errors.New("no go module files provided")
 	}
@@ -52,7 +52,7 @@ func Modules(gomod []string, selector Selector) (map[string][]string, []string, 
 
 // Module returns the name and a list of direct dependencies for a given module.
 // TODO: support url and gopath at some point for the gomod string.
-func Module(gomod string, selector Selector) (string, []string, error) {
+func Module(gomod string, selector Matcher) (string, []string, error) {
 	b, err := ioutil.ReadFile(gomod)
 	if err != nil {
 		return "", nil, err
@@ -70,7 +70,7 @@ func Module(gomod string, selector Selector) (string, []string, error) {
 			continue
 		}
 		// Look for requirements that have the prefix of domain.
-		if selector.Select(r.Mod.Path) && !packages.Has(r.Mod.Path) {
+		if selector(r.Mod.Path) && !packages.Has(r.Mod.Path) {
 			packages.Insert(r.Mod.Path)
 		}
 	}

--- a/pkg/gomod/release_meta.go
+++ b/pkg/gomod/release_meta.go
@@ -47,11 +47,7 @@ func ReleaseStatus(gomod, release, moduleRelease string, out io.Writer) (*Releas
 		return nil, err
 	}
 
-	module, _, err := Module(gomod, Selector{
-		Includes: []Matcher{MatcherFunc(func(m string) bool {
-			return true
-		})},
-	})
+	module, _, err := Module(gomod, func(string) bool { return true })
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/gomod/selector.go
+++ b/pkg/gomod/selector.go
@@ -1,11 +1,10 @@
 package gomod
 
 import (
-	"log"
 	"strings"
-	"sync"
 
 	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"knative.dev/test-infra/pkg/gowork"
 )
 
@@ -15,21 +14,7 @@ var (
 )
 
 // Matcher matches a module name.
-type Matcher interface {
-	// Match returns true if the module name matches.
-	Match(modname string) bool
-}
-
-// MatcherFunc is a function that implements the Matcher interface.
-func MatcherFunc(fn matcherFunc) Matcher {
-	return fn
-}
-
-type matcherFunc func(modname string) bool
-
-func (fn matcherFunc) Match(modname string) bool {
-	return fn(modname)
-}
+type Matcher func(modname string) bool
 
 // Selector is a set of matchers that can be used to select a subset of modules.
 type Selector struct {
@@ -38,67 +23,68 @@ type Selector struct {
 }
 
 // Select returns true if the module should be selected.
-func (s Selector) Select(modname string) bool {
-	selected := false
-	for _, m := range s.Includes {
-		if m.Match(modname) {
-			selected = true
-			break
-		}
-	}
-	if !selected {
-		return false
-	}
-	for _, m := range s.Excludes {
-		if m.Match(modname) {
+func (s Selector) Match(modname string) bool {
+	for _, match := range s.Excludes {
+		if match(modname) {
 			return false
 		}
 	}
-	return true
-}
 
-// CurrentModulesMatcher matches the current project modules.
-type CurrentModulesMatcher struct {
-	once sync.Once
-	mods []gowork.Module
-	err  error
-}
-
-func (c *CurrentModulesMatcher) Match(modname string) bool {
-	c.once.Do(func() {
-		os := gowork.RealSystem{}
-		c.mods, c.err = gowork.List(os, os)
-		if c.err != nil && errors.Is(c.err, gowork.ErrInvalidGowork) {
-			var m *gowork.Module
-			m, c.err = gowork.Current(os, os)
-			if m != nil {
-				c.mods = []gowork.Module{*m}
-			}
-		}
-	})
-	if c.err != nil {
-		log.Fatal(c.err)
-	}
-	for _, m := range c.mods {
-		if m.Name == modname {
+	for _, match := range s.Includes {
+		if match(modname) {
 			return true
 		}
 	}
+
 	return false
+}
+
+// Assert that Selector.Match implements Matcher
+var selector_type_assert = Selector{}
+var _ Matcher = selector_type_assert.Match
+
+// CurrentModulesMatcher matches the current project modules.
+func CurrentModulesMatcher() (Matcher, error) {
+	os := gowork.RealSystem{}
+	knownMods := sets.NewString()
+	mods, err := gowork.List(os, os)
+	if err != nil {
+		if !errors.Is(err, gowork.ErrInvalidGowork) {
+			return nil, err
+		}
+		m, err := gowork.Current(os, os)
+		if err != nil {
+			return nil, err
+		}
+		if m != nil {
+			mods = []gowork.Module{*m}
+		}
+	}
+
+	for _, m := range mods {
+		knownMods.Insert(m.Name)
+	}
+
+	return knownMods.Has, nil
 }
 
 // DefaultSelector returns a selector that includes modules with given domain,
 // but excludes the current project modules.
-func DefaultSelector(domain string) (Selector, error) {
+func DefaultSelector(domain string) (Matcher, error) {
 	domain = strings.TrimSpace(domain)
 	if len(domain) == 0 {
-		return Selector{}, ErrNoDomain
+		return func(string) bool { return true }, ErrNoDomain
+	}
+
+	currentModules, err := CurrentModulesMatcher()
+	if err != nil {
+		return nil, err
 	}
 
 	return Selector{
-		Includes: []Matcher{MatcherFunc(func(modname string) bool {
+		Includes: []Matcher{func(modname string) bool {
 			return strings.HasPrefix(modname, domain)
-		})},
-		Excludes: []Matcher{&CurrentModulesMatcher{}},
-	}, nil
+		}},
+		Excludes: []Matcher{currentModules},
+	}.Match, nil
 }

--- a/pkg/gomod/selector_test.go
+++ b/pkg/gomod/selector_test.go
@@ -22,7 +22,7 @@ func TestDefaultSelector(t *testing.T) {
 	}
 	selected := make([]string, 0, len(mods))
 	for _, mod := range mods {
-		if sel.Select(mod) {
+		if sel(mod) {
 			selected = append(selected, mod)
 		}
 	}


### PR DESCRIPTION
I decided to follow up on my comments on #3696 for filtering Buoy modules.

I figured writing the refactor was the easiest way to communicate my ideas; this removes the need for `MatcherFunc` and simplifies the calling inferface for `Module` and `Modules` in a few places.  I'm considering replacing `Selector` with 'In()` and `Except`, but I'm not sure it is a substantial improvement.  (`Excludes` is only used in one place, and `In(string...)` and `Except(Matcher, Matcher)` would cover the same cases.)

/assign @cardil


<!--
/lint
-->
