### PR TITLE
bump go versions

### DIFF
--- a/images/prow-tests/Dockerfile
+++ b/images/prow-tests/Dockerfile
@@ -162,8 +162,9 @@ COPY images/prow-tests/source-gvm-and-run.sh /usr/local/bin
 # Install our versions of Go.
 # We only install the latest 3 versions of Go which should be enough for
 # all Knative repositories.
-RUN source-gvm-and-run.sh install go1.18.10 --prefer-binary
-RUN source-gvm-and-run.sh install go1.19.5 --prefer-binary
+
+RUN source-gvm-and-run.sh install go1.20.1 --prefer-binary
+RUN source-gvm-and-run.sh install go1.19.6 --prefer-binary
 RUN source-gvm-and-run.sh use go1.19 --default
 
 # protoc and required golang tooling


### PR DESCRIPTION
I cut a whole bunch of releases but it was for naught because we didn't have the right go version in Prow.

## Changes
- Bump default go version to 1.19.6
- Include go1.20.1 in the prow image - we'll be moving to this version for the next release