### PR TITLE
Fix shellcheck warning in run_job.sh

### DIFF
--- a/prow/jobs/run_job.sh
+++ b/prow/jobs/run_job.sh
@@ -16,7 +16,7 @@
 
 # Simple script to start a Prow job.
 
-source $(dirname "${BASH_SOURCE[0]}")/../../vendor/knative.dev/hack/library.sh
+source "$(dirname "${BASH_SOURCE[0]}")"/../../vendor/knative.dev/hack/library.sh
 
 # First parameter is expected to be the prow job name
 JOB_NAME="$1"


### PR DESCRIPTION
**What this PR does, why we need it**:<br>
Fixes shellcheck warning in https://github.com/knative/test-infra/pull/3774
