### PR TITLE
we only care about patch versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,9 @@ updates:
   - package-ecosystem: "docker"
     directory: "/images/prow-tests/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
+    ignore:
+    - dependency-name: golang
+      update-types:
+      - "version-update:semver-major"
+      - "version-update:semver-minor"


### PR DESCRIPTION
Dependabot bumped our 1.19 image to 1.20 which is something we don't want.

I'm hoping this change will mean we'll only bump respective patches