### PR TITLE
[fix][s390x]:fixed the typo in configmap

### DIFF
--- a/prow/jobs/generated/knative-sandbox/kn-plugin-event-main.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-event-main.gen.yaml
@@ -70,7 +70,7 @@ periodics:
         cat /opt/cluster/ci-script > connect.sh
         chmod +x connect.sh
         ./connect.sh plugin_event-main
-        kubectl get cm s390x-config-plugin_event -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
+        kubectl get cm s390x-config-plugin-event -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
         chmod +x adjust.sh
         ./adjust.sh
         ./test/e2e-tests.sh --run-tests

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-event-release-1.7.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-event-release-1.7.gen.yaml
@@ -133,7 +133,7 @@ periodics:
         cat /opt/cluster/ci-script > connect.sh
         chmod +x connect.sh
         ./connect.sh plugin_event-17
-        kubectl get cm s390x-config-plugin_event -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
+        kubectl get cm s390x-config-plugin-event -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
         chmod +x adjust.sh
         ./adjust.sh
         ./test/e2e-tests.sh --run-tests

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-event-release-1.8.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-event-release-1.8.gen.yaml
@@ -144,7 +144,7 @@ periodics:
         cat /opt/cluster/ci-script > connect.sh
         chmod +x connect.sh
         ./connect.sh plugin_event-18
-        kubectl get cm s390x-config-plugin_event -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
+        kubectl get cm s390x-config-plugin-event -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
         chmod +x adjust.sh
         ./adjust.sh
         ./test/e2e-tests.sh --run-tests

--- a/prow/jobs/generated/knative-sandbox/kn-plugin-event-release-1.9.gen.yaml
+++ b/prow/jobs/generated/knative-sandbox/kn-plugin-event-release-1.9.gen.yaml
@@ -145,7 +145,7 @@ periodics:
         cat /opt/cluster/ci-script > connect.sh
         chmod +x connect.sh
         ./connect.sh plugin_event-19
-        kubectl get cm s390x-config-plugin_event -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
+        kubectl get cm s390x-config-plugin-event -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
         chmod +x adjust.sh
         ./adjust.sh
         ./test/e2e-tests.sh --run-tests

--- a/prow/jobs_config/knative-sandbox/kn-plugin-event-release-1.7.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-event-release-1.7.yaml
@@ -67,7 +67,7 @@ jobs:
     cat /opt/cluster/ci-script > connect.sh
     chmod +x connect.sh
     ./connect.sh plugin_event-17
-    kubectl get cm s390x-config-plugin_event -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
+    kubectl get cm s390x-config-plugin-event -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
     chmod +x adjust.sh
     ./adjust.sh
     ./test/e2e-tests.sh --run-tests

--- a/prow/jobs_config/knative-sandbox/kn-plugin-event-release-1.8.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-event-release-1.8.yaml
@@ -73,7 +73,7 @@ jobs:
     cat /opt/cluster/ci-script > connect.sh
     chmod +x connect.sh
     ./connect.sh plugin_event-18
-    kubectl get cm s390x-config-plugin_event -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
+    kubectl get cm s390x-config-plugin-event -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
     chmod +x adjust.sh
     ./adjust.sh
     ./test/e2e-tests.sh --run-tests

--- a/prow/jobs_config/knative-sandbox/kn-plugin-event-release-1.9.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-event-release-1.9.yaml
@@ -74,7 +74,7 @@ jobs:
     cat /opt/cluster/ci-script > connect.sh
     chmod +x connect.sh
     ./connect.sh plugin_event-19
-    kubectl get cm s390x-config-plugin_event -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
+    kubectl get cm s390x-config-plugin-event -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
     chmod +x adjust.sh
     ./adjust.sh
     ./test/e2e-tests.sh --run-tests

--- a/prow/jobs_config/knative-sandbox/kn-plugin-event.yaml
+++ b/prow/jobs_config/knative-sandbox/kn-plugin-event.yaml
@@ -34,7 +34,7 @@ jobs:
         cat /opt/cluster/ci-script > connect.sh
         chmod +x connect.sh
         ./connect.sh plugin_event-main
-        kubectl get cm s390x-config-plugin_event -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
+        kubectl get cm s390x-config-plugin-event -n default -o jsonpath='{.data.adjustment-script}' > adjust.sh
         chmod +x adjust.sh
         ./adjust.sh
         ./test/e2e-tests.sh --run-tests


### PR DESCRIPTION
This is the PR for s390x related prow job for kn-plugin-event. There was a typo in configmap for adjust.sh script. 