### PR TITLE
Drop the number of supported release branches to 2

### DIFF
--- a/tools/flaky-test-reporter/github_issue.go
+++ b/tools/flaky-test-reporter/github_issue.go
@@ -56,7 +56,7 @@ const (
 	<summary>%s</summary><p>
 
 %s
-</p></details>`  // The blank line is crucial for collapsible format
+</p></details>` // The blank line is crucial for collapsible format
 
 	// issueBodyTemplate is a template for issue body
 	issueBodyTemplate = `

--- a/tools/release-jobs-syncer/pkg/release.go
+++ b/tools/release-jobs-syncer/pkg/release.go
@@ -36,8 +36,8 @@ import (
 )
 
 const (
-	// The max number of release branches we keep for CI/CD is 3, current and previous 2.
-	maxReleaseBranches = 3
+	// The max number of release branches we keep for CI/CD is 2, current and previous 1.
+	maxReleaseBranches = 2
 
 	// Prefix for release branch names.
 	releaseBranchNamePrefix = "release-"


### PR DESCRIPTION
As per policy here - https://github.com/knative/community/blob/main/mechanics/RELEASE-VERSIONING-PRINCIPLES.md#knative-community-support-window-principle