### PR TITLE
[s390x]: Adjusted cron schedule for s390x e2e-eventing-reconciler tests

### DIFF
--- a/prow/jobs/generated/knative/eventing-release-1.10.gen.yaml
+++ b/prow/jobs/generated/knative/eventing-release-1.10.gen.yaml
@@ -138,7 +138,7 @@ periodics:
     testgrid-dashboards: knative-release-1.10
     testgrid-tab-name: eventing-s390x-e2e-reconciler-tests
   cluster: prow-build
-  cron: 20 5 * * *
+  cron: 20 9 * * *
   decorate: true
   extra_refs:
   - base_ref: release-1.10

--- a/prow/jobs_config/knative/eventing-release-1.10.yaml
+++ b/prow/jobs_config/knative/eventing-release-1.10.yaml
@@ -98,7 +98,7 @@ jobs:
     ./test/e2e-rekt-tests.sh --run-tests
   command:
   - runner.sh
-  cron: 20 5 * * *
+  cron: 20 9 * * *
   env:
   - name: SYSTEM_NAMESPACE
     value: knative-eventing


### PR DESCRIPTION
This PR fixes the cron schedule time for e2e-eventing-reconciler tests for 1.10.